### PR TITLE
fix(ui): cap grid item width on wide screens

### DIFF
--- a/src/components/views/ArtistDetailView.tsx
+++ b/src/components/views/ArtistDetailView.tsx
@@ -339,7 +339,7 @@ export function ArtistDetailView({
           <h2 className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase px-1">
             {t("artistDetail.similar.title")}
           </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4">
             {similar.map((s) => {
               const inLibrary = s.library_artist_id != null;
               const imgSrc = resolveRemoteImage(s.picture_path, s.picture_url);
@@ -399,7 +399,7 @@ export function ArtistDetailView({
           <h2 className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase px-1">
             {t("artistDetail.discography")}
           </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-5">
             {artist.albums.map((album) => (
               <button
                 key={album.id}

--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -516,7 +516,7 @@ export function HomeView({
             </EmptyState>
           </div>
         ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4">
             {recentPlays.map((play, idx) => {
               const isCurrent = play.track_id === currentTrack?.id;
               return (
@@ -583,7 +583,7 @@ export function HomeView({
               {t("home.seeAll")}
             </button>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4">
             {recentAlbums.map((album) => (
               <button
                 key={album.id}

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1351,7 +1351,7 @@ function AlbumGrid({
   return (
     <>
       <div
-        className={`grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5 ${
+        className={`grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-5 ${
           isLoading ? "opacity-50" : ""
         }`}
       >
@@ -1511,7 +1511,7 @@ function ArtistList({
   return (
     <div
       ref={gridRef}
-      className={`grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5 ${
+      className={`grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-5 ${
         isLoading ? "opacity-50" : ""
       }`}
     >
@@ -1609,7 +1609,7 @@ interface GenreListProps {
 function GenreList({ genres, isLoading, t }: GenreListProps) {
   return (
     <div
-      className={`grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 ${
+      className={`grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-4 ${
         isLoading ? "opacity-50" : ""
       }`}
     >


### PR DESCRIPTION
## Summary

On widescreen monitors (>1920px), the HomeView / LibraryView / ArtistDetailView grids were stretching cover art to ~330px square — way bigger than the Spotify / Apple Music reference. The grids capped at \`lg:grid-cols-5\` or \`lg:grid-cols-6\` and then let each cell expand to fill the remaining width, instead of growing the column count.

Switch to CSS Grid \`auto-fill\` with a \`minmax(N, 1fr)\` so items stay 160-220px regardless of viewport width and the column count naturally grows with screen size.

| View                                       | Old breakpoints                                | New                                       |
| ------------------------------------------ | ---------------------------------------------- | ----------------------------------------- |
| HomeView recently played / added           | \`grid-cols-2 sm:3 md:4 lg:6\`                   | \`auto-fill minmax(160px, 1fr)\`            |
| LibraryView albums / artists               | \`grid-cols-2 sm:3 md:4 lg:5\` (gap-5)           | \`auto-fill minmax(180px, 1fr)\`            |
| LibraryView genres                         | \`grid-cols-2 sm:3 md:4\` (gap-4)                | \`auto-fill minmax(180px, 1fr)\`            |
| ArtistDetailView similar / discography     | mix of lg:5 / lg:6                             | \`auto-fill minmax(160/180px, 1fr)\`        |

## Test plan

- [x] 1920×1080 (typical desktop): grid shows ~10-12 columns, covers around 160-180px
- [x] 1366×768 (laptop): grid shows ~7-8 columns
- [x] 768px (tablet): grid shows ~4 columns
- [x] 360px (mobile): grid shows 2 columns
- [x] Spot-check HomeView with empty recently-played → empty state still renders correctly
- [x] Spot-check LibraryView with <5 items → still left-aligned, no awkward stretching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive grid layouts across the app for better content display on different screen sizes, including adjustments to album and artist grids in the artist detail view, recently played and added sections in the home view, and album, artist, and genre grids in the library view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/22)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->