### PR TITLE
fix(profile): roll back partial import on checksum/migrate failure

### DIFF
--- a/src-tauri/src/commands/profile_io.rs
+++ b/src-tauri/src/commands/profile_io.rs
@@ -202,14 +202,7 @@ pub async fn import_profile(
     .map_err(|e| AppError::Other(format!("import extract join: {e}")))?;
 
     if let Err(err) = extract_result {
-        // Best-effort cleanup. If either of these fails, we log and
-        // surface the original error; the user can re-try from a
-        // clean state by deleting the partial directory manually.
-        let _ = std::fs::remove_dir_all(state.paths.profile_dir(new_profile_id));
-        let _ = sqlx::query("DELETE FROM profile WHERE id = ?")
-            .bind(new_profile_id)
-            .execute(&state.app_db)
-            .await;
+        cleanup_partial_profile(&state, new_profile_id).await;
         return Err(err);
     }
 
@@ -223,17 +216,46 @@ pub async fn import_profile(
     //    this step sqlx refuses the import with
     //    "migration X was previously applied but has been modified".
     //    See `.gitattributes` for the forward fix.
-    normalise_migration_checksums(&state.paths.profile_db(new_profile_id)).await?;
+    if let Err(err) =
+        normalise_migration_checksums(&state.paths.profile_db(new_profile_id)).await
+    {
+        cleanup_partial_profile(&state, new_profile_id).await;
+        return Err(err);
+    }
 
     // 5. Open + close the imported pool once so any pending migrations
     //    (the source might be older than the local schema) replay
     //    immediately. This matches the create_profile flow and gives
     //    the user a usable profile by the time the call returns.
-    let pool =
-        db::profile_db::open(&state.paths.profile_db(new_profile_id), &state.paths.app_db).await?;
+    let pool = match db::profile_db::open(
+        &state.paths.profile_db(new_profile_id),
+        &state.paths.app_db,
+    )
+    .await
+    {
+        Ok(pool) => pool,
+        Err(err) => {
+            cleanup_partial_profile(&state, new_profile_id).await;
+            return Err(err);
+        }
+    };
     pool.close().await;
 
     Ok(new_profile_id)
+}
+
+/// Roll back a half-imported profile: remove the on-disk directory and
+/// the `profile` row. Best-effort — failures are swallowed so the caller
+/// can surface the *original* import error rather than a cleanup error
+/// masking it. User can wipe `<app_data>/profiles/<id>/` by hand if the
+/// fs delete failed (rare; usually a held file handle from a panicked
+/// pool).
+async fn cleanup_partial_profile(state: &AppState, profile_id: i64) {
+    let _ = std::fs::remove_dir_all(state.paths.profile_dir(profile_id));
+    let _ = sqlx::query("DELETE FROM profile WHERE id = ?")
+        .bind(profile_id)
+        .execute(&state.app_db)
+        .await;
 }
 
 // ── zip plumbing ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #27. The post-extract steps `normalise_migration_checksums` and `db::profile_db::open` used a bare `?` to propagate errors, which skipped the cleanup that the extract step already performed. A failure there left the freshly inserted `profile` row and the partial profile directory on disk — the user would see a phantom profile in the selector pointing at a half-imported DB.

- Factor the existing best-effort cleanup into `cleanup_partial_profile(state, profile_id)`.
- Call it from all three post-insert failure paths (extract, normalise, open) and re-raise the original error so the message the user sees is the real cause, not a cleanup error.
- `pool.close()` on the success path is unchanged.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] Manually corrupt the bundled `data.db` inside a test archive, attempt import, confirm the profile row + directory are gone afterwards.
- [x] Manually inject an unknown migration version in the bundled `_sqlx_migrations`, attempt import, confirm the rejection path also cleans up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened profile import reliability with enhanced error recovery. The import process now ensures thorough cleanup of partial profiles when failures occur during extraction, validation, or migration stages. This prevents incomplete profile data and orphaned entries from remaining in the system after unsuccessful import attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->