### PR TITLE
fix(theme): persist preference before view transition

### DIFF
--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,21 +1,63 @@
 import {
+  useCallback,
   useState,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from "react";
 import { ThemeContext } from "../hooks/useTheme";
 
-export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [isDark, setIsDark] = useState(false);
+const THEME_STORAGE_KEY = "waveflow.theme.is_dark";
 
-  const toggleTheme = (event?: ReactMouseEvent) => {
-    const flipTheme = () => setIsDark((prev) => !prev);
+// Read the persisted preference synchronously so the very first render already
+// matches the user's last choice. Survives crashes during the View Transitions
+// animation (issue #34): even if the webview dies mid-toggle, the new value
+// has already been written to localStorage before startViewTransition runs.
+const readStoredTheme = (): boolean => {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(THEME_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+};
+
+const writeStoredTheme = (isDark: boolean) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, isDark ? "true" : "false");
+  } catch {
+    // localStorage unavailable (private mode, quota) — preference simply
+    // won't survive the next launch. Not worth surfacing to the user.
+  }
+};
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [isDark, setIsDark] = useState<boolean>(readStoredTheme);
+
+  const toggleTheme = useCallback((event?: ReactMouseEvent) => {
+    let nextValue = false;
+    const flipTheme = () =>
+      setIsDark((prev) => {
+        nextValue = !prev;
+        return nextValue;
+      });
+
+    // Persist BEFORE triggering any animation. Some Linux WebKitGTK builds
+    // crash the webview during startViewTransition on certain GPU/Wayland
+    // stacks (issue #34) — writing first guarantees the next launch picks
+    // up the new theme even if this transition kills the process.
+    const persistNext = (value: boolean) => writeStoredTheme(value);
 
     // Fallback: no View Transitions API support → instant swap
     if (typeof document === "undefined" || !document.startViewTransition) {
       flipTheme();
+      persistNext(nextValue);
       return;
     }
+
+    // Compute & persist the future value before the animation starts so the
+    // write lands even if the compositor crashes mid-transition.
+    persistNext(!isDark);
 
     const transition = document.startViewTransition(flipTheme);
 
@@ -48,7 +90,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
           // Animation failed — the theme has still toggled via flipTheme()
         });
     }
-  };
+  }, [isDark]);
 
   return (
     <ThemeContext.Provider value={{ isDark, toggleTheme }}>


### PR DESCRIPTION
## Summary
- Persist the next theme value to \`localStorage\` **before** calling \`document.startViewTransition\`, so a crash inside WebKitGTK's View Transitions implementation no longer eats the user's choice
- Restore the stored value on mount, so dark mode now survives a restart on every platform (previously \`useState(false)\` reset on every launch)
- No regression for Windows/macOS or working Linux setups — the radial-reveal animation still runs everywhere

## Context
Issue #34: on CachyOS (Arch + KDE Plasma Wayland + NVIDIA), clicking the dark-mode toggle freezes the webview process — KWin shows the "not responding" dialog. The crash happens inside WebKitGTK's \`startViewTransition\` compositor path; the JS event loop is fine.

We can't reliably feature-detect which webkit2gtk builds are buggy, and gating on \`navigator.userAgent.includes("linux")\` would kill the animation for every Linux user (Debian, Fedora, working Arch setups) as a regression to fix one bad config. Instead we keep the animation everywhere but make the crash a one-time annoyance: click → write localStorage → (possibly crash) → relaunch → dark mode applied.

Closes #34

## Test plan
- [x] Toggle theme on Windows — animation still plays, persists across restart
- [x] Toggle theme on macOS — animation still plays, persists across restart
- [x] Toggle theme on a working Linux build (Debian/Fedora) — animation still plays
- [x] On the buggy CachyOS setup from #34: click → (possibly crash) → relaunch → app opens in the newly-selected theme