### PR TITLE
ci(appimage): add manual workflow to build a test AppImage

### DIFF
--- a/.github/workflows/test-appimage.yml
+++ b/.github/workflows/test-appimage.yml
@@ -1,0 +1,95 @@
+name: Test AppImage build
+
+# Manual-only workflow used to produce a CI-built AppImage from any
+# branch for local testing. Mirrors the Linux portion of release.yml
+# (same OS image, same apt deps, same Rust/Bun setup) so the artifact
+# is directly comparable to what real releases ship, without going
+# through tag + signing + publication.
+#
+# Run via Actions tab → "Test AppImage build" → "Run workflow" → pick a branch.
+# Then download the artifact from the run summary.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  appimage:
+    name: Build AppImage (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libfuse2 \
+            libasound2-dev
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: src-tauri -> target
+          key: linux-test-appimage
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Report runner environment
+        run: |
+          echo "OS:"
+          cat /etc/os-release
+          echo
+          echo "webkit2gtk:"
+          dpkg -l | grep -E 'webkit2gtk|javascriptcoregtk' || true
+          echo
+          echo "rustc:"
+          rustc --version
+
+      - name: Build AppImage
+        # Skip the updater (no signing secrets here) and only bundle
+        # the AppImage to keep the test build fast.
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ""
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+        run: bun run tauri build --bundles appimage
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: WaveFlow-AppImage-${{ github.sha }}
+          path: src-tauri/target/release/bundle/appimage/*.AppImage
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Summary
Adds a `workflow_dispatch`-only workflow that mirrors the Linux portion of `release.yml` (ubuntu-latest, same apt deps, same Rust/Bun toolchain) but skips signing and publication. Lets us download a CI-built AppImage from any branch for local validation.

## Why
We can't `workflow_dispatch` a workflow that doesn't exist on the default branch. Merging this small PR unblocks dispatching the workflow on feature branches — needed right now to validate the Linux fixes in #36 against the same environment that ships official releases (Ubuntu 24 CI runner vs local Ubuntu 22 produced very different AppImages).

## Test plan
- [ ] After merge, go to Actions → "Test AppImage build" → "Run workflow" → pick a branch → download the artifact from the run summary