### PR TITLE
feat(backup): optionally bundle shared Deezer artwork cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Deezer enrichment (pictures, covers, fans — cached 30 days in `deezer_artist` 
 
 ### Preferences & maintenance
 
-Autostart + close-to-tray + scan-on-start ([`commands/preferences.rs`](src-tauri/src/commands/preferences.rs)) · profile export/import (`.waveflow` zip via `commands/profile_io.rs` — bundles `data.db` + `artwork/` + manifest, runs `PRAGMA wal_checkpoint(TRUNCATE)` on the active profile first) · auto-backup ([`backup.rs`](src-tauri/src/backup.rs) tokio task that shares `profile_io::write_archive` with manual export) · stats JSON export · embedded changelog (parsed from `git log` at compile time in `build.rs`).
+Autostart + close-to-tray + scan-on-start ([`commands/preferences.rs`](src-tauri/src/commands/preferences.rs)) · profile export/import (`.waveflow` zip via `commands/profile_io.rs` — bundles `data.db` + `artwork/` + manifest, plus the shared `metadata_artwork/**` Deezer cache when `app_setting['backup.include_metadata_artwork']` is on (default), runs `PRAGMA wal_checkpoint(TRUNCATE)` on the active profile first) · auto-backup ([`backup.rs`](src-tauri/src/backup.rs) tokio task that shares `profile_io::write_archive` with manual export; the shared cache is bundled only into the first archive of each pass to avoid N× duplication across profiles) · stats JSON export · embedded changelog (parsed from `git log` at compile time in `build.rs`).
 
 ## Conventions
 

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -11,11 +11,12 @@
 //!
 //! | Key                       | Type   | Default                                  |
 //! |---------------------------|--------|------------------------------------------|
-//! | `backup.enabled`          | bool   | `false`                                  |
-//! | `backup.interval_days`    | int    | `7`                                      |
-//! | `backup.folder`           | string | `<documents>/WaveFlow Backups` if empty  |
-//! | `backup.retention`        | int    | `5` (per-profile; oldest pruned)         |
-//! | `backup.last_run_at`      | int ms | `0`                                      |
+//! | `backup.enabled`                  | bool   | `false`                                  |
+//! | `backup.interval_days`            | int    | `7`                                      |
+//! | `backup.folder`                   | string | `<documents>/WaveFlow Backups` if empty  |
+//! | `backup.retention`                | int    | `5` (per-profile; oldest pruned)         |
+//! | `backup.include_metadata_artwork` | bool   | `true`                                   |
+//! | `backup.last_run_at`              | int ms | `0`                                      |
 //!
 //! Wake-up model: the task loops on `tokio::select!` between a deadline
 //! computed from `last_run_at + interval` and a `Notify` woken by
@@ -62,6 +63,11 @@ pub struct BackupConfig {
     pub interval_days: i64,
     pub folder: String,
     pub retention: i64,
+    /// Bundle the shared Deezer cover/artist-picture cache into each
+    /// archive. Default `true` so a restore-on-another-machine works
+    /// fully offline; users with large libraries can disable to keep
+    /// archives lean (cache is rebuilt on demand).
+    pub include_metadata_artwork: bool,
     /// Epoch ms of the last successful run; `0` if never. Frontend
     /// formats with `Date(last_run_at)` so the user can verify the
     /// task actually fired.
@@ -101,12 +107,14 @@ pub async fn read_config(state: &AppState, handle: &AppHandle) -> AppResult<Back
     let mut interval_days = DEFAULT_INTERVAL_DAYS;
     let mut folder = String::new();
     let mut retention = DEFAULT_RETENTION;
+    let mut include_metadata_artwork = true;
     let mut last_run_at: i64 = 0;
 
     let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT key, value FROM app_setting WHERE key IN
             ('backup.enabled', 'backup.interval_days', 'backup.folder',
-             'backup.retention', 'backup.last_run_at')",
+             'backup.retention', 'backup.include_metadata_artwork',
+             'backup.last_run_at')",
     )
     .fetch_all(&state.app_db)
     .await?;
@@ -116,6 +124,7 @@ pub async fn read_config(state: &AppState, handle: &AppHandle) -> AppResult<Back
             "backup.interval_days" => interval_days = v.parse().unwrap_or(DEFAULT_INTERVAL_DAYS),
             "backup.folder" => folder = v,
             "backup.retention" => retention = v.parse().unwrap_or(DEFAULT_RETENTION),
+            "backup.include_metadata_artwork" => include_metadata_artwork = v == "true" || v == "1",
             "backup.last_run_at" => last_run_at = v.parse().unwrap_or(0),
             _ => {}
         }
@@ -126,6 +135,7 @@ pub async fn read_config(state: &AppState, handle: &AppHandle) -> AppResult<Back
         interval_days: interval_days.clamp(MIN_INTERVAL_DAYS, MAX_INTERVAL_DAYS),
         folder,
         retention: retention.clamp(MIN_RETENTION, MAX_RETENTION),
+        include_metadata_artwork,
         last_run_at,
         default_folder,
     })
@@ -141,6 +151,7 @@ pub async fn write_config(
     interval_days: i64,
     folder: String,
     retention: i64,
+    include_metadata_artwork: bool,
 ) -> AppResult<()> {
     let interval = interval_days.clamp(MIN_INTERVAL_DAYS, MAX_INTERVAL_DAYS);
     let retention = retention.clamp(MIN_RETENTION, MAX_RETENTION);
@@ -156,6 +167,11 @@ pub async fn write_config(
         ("backup.interval_days", interval.to_string(), "int"),
         ("backup.folder", folder, "string"),
         ("backup.retention", retention.to_string(), "int"),
+        (
+            "backup.include_metadata_artwork",
+            if include_metadata_artwork { "true" } else { "false" }.to_string(),
+            "bool",
+        ),
     ] {
         sqlx::query(
             "INSERT INTO app_setting (key, value, value_type, updated_at)
@@ -261,6 +277,13 @@ pub async fn run_one_backup(
     let app_version = env!("CARGO_PKG_VERSION").to_string();
     let mut created = Vec::with_capacity(profiles.len());
 
+    // The metadata_artwork cache is shared across all profiles, so we
+    // bundle it once — in the first archive of the pass. The others stay
+    // lean. On restore the user only needs to import any one of them to
+    // refill the shared cache; the rest restore their per-profile data
+    // as usual.
+    let mut bundle_metadata_artwork = config.include_metadata_artwork;
+
     for (profile_id, profile_name) in profiles {
         let safe = sanitize_for_filename(&profile_name);
         let target = folder.join(format!("{safe}-{ts}.waveflow"));
@@ -276,6 +299,11 @@ pub async fn run_one_backup(
         let profile_dir = state.paths.profile_dir(profile_id);
         let db_path = state.paths.profile_db(profile_id);
         let artwork_dir = state.paths.profile_artwork_dir(profile_id);
+        let metadata_artwork_dir = if bundle_metadata_artwork {
+            Some(state.paths.metadata_artwork_dir.clone())
+        } else {
+            None
+        };
         let target_owned = target.clone();
 
         let result = tokio::task::spawn_blocking(move || -> AppResult<()> {
@@ -284,11 +312,15 @@ pub async fn run_one_backup(
                 &profile_dir,
                 &db_path,
                 &artwork_dir,
+                metadata_artwork_dir.as_deref(),
                 &manifest,
             )
         })
         .await
         .map_err(|e| AppError::Other(format!("backup task join: {e}")))?;
+
+        // Only the first archive carries the shared cache.
+        bundle_metadata_artwork = false;
 
         match result {
             Ok(()) => {

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -306,6 +306,7 @@ pub async fn run_one_backup(
         };
         let target_owned = target.clone();
 
+        let attempted_with_cache = bundle_metadata_artwork;
         let result = tokio::task::spawn_blocking(move || -> AppResult<()> {
             write_archive(
                 &target_owned,
@@ -319,13 +320,17 @@ pub async fn run_one_backup(
         .await
         .map_err(|e| AppError::Other(format!("backup task join: {e}")))?;
 
-        // Only the first archive carries the shared cache.
-        bundle_metadata_artwork = false;
-
         match result {
             Ok(()) => {
                 tracing::info!(profile_id, target = %target.display(), "auto backup ok");
                 created.push(target.to_string_lossy().to_string());
+                // Clear the flag only after a successful write that
+                // actually carried the cache — otherwise a failure on
+                // the first profile would silently strip the cache from
+                // every subsequent archive in the same pass.
+                if attempted_with_cache {
+                    bundle_metadata_artwork = false;
+                }
             }
             Err(err) => {
                 tracing::warn!(profile_id, ?err, "auto backup failed");

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -22,6 +22,7 @@ pub struct BackupConfigInput {
     pub interval_days: i64,
     pub folder: String,
     pub retention: i64,
+    pub include_metadata_artwork: bool,
 }
 
 #[tauri::command]
@@ -37,6 +38,7 @@ pub async fn set_backup_config(
         input.interval_days,
         input.folder,
         input.retention,
+        input.include_metadata_artwork,
     )
     .await
 }

--- a/src-tauri/src/commands/profile_io.rs
+++ b/src-tauri/src/commands/profile_io.rs
@@ -10,12 +10,17 @@
 //!   - `data.db` — the per-profile SQLite database (playlists, liked,
 //!     stats, EQ, sleep-timer / A-B visibility, shortcut overrides…).
 //!   - `artwork/**` — manual covers the user uploaded.
+//!   - `metadata_artwork/**` — *optional*, gated by the
+//!     `backup.include_metadata_artwork` app setting (default ON). This
+//!     is the shared Deezer cover/artist-picture cache; bundling it
+//!     means a restore on an offline machine still shows the artwork
+//!     immediately. Users who want lean archives can disable the toggle
+//!     in Settings → Sauvegardes and re-fetch on demand via "Récupérer
+//!     toutes les pochettes manquantes".
 //!
 //! What we deliberately **don't** bundle:
 //!   - The shared `app.db` (Last.fm key, Discord opt-in, app-wide
 //!     settings) — those belong to the install, not the profile.
-//!   - The shared `metadata_artwork/` cache (Deezer pictures, etc.) —
-//!     re-fetchable from the network on first play.
 //!   - WAL / SHM sidecars — we run a `WAL_CHECKPOINT(TRUNCATE)` before
 //!     copying so the bundled `data.db` is self-contained.
 
@@ -98,6 +103,11 @@ pub async fn export_profile(
     let profile_dir = state.paths.profile_dir(profile_id);
     let db_path = state.paths.profile_db(profile_id);
     let artwork_dir = state.paths.profile_artwork_dir(profile_id);
+    let metadata_artwork_dir = if read_include_metadata_artwork(&state.app_db).await? {
+        Some(state.paths.metadata_artwork_dir.clone())
+    } else {
+        None
+    };
 
     let manifest = ArchiveManifest {
         archive_version: ARCHIVE_VERSION,
@@ -117,6 +127,7 @@ pub async fn export_profile(
             &profile_dir,
             &db_path,
             &artwork_dir,
+            metadata_artwork_dir.as_deref(),
             &manifest,
         )
     })
@@ -124,6 +135,22 @@ pub async fn export_profile(
     .map_err(|e| AppError::Other(format!("export task join: {e}")))??;
 
     Ok(())
+}
+
+/// Read the `backup.include_metadata_artwork` app setting. Defaults to
+/// `true` so a fresh install + first manual export produces a complete
+/// archive without the user having to opt in.
+pub(crate) async fn read_include_metadata_artwork(
+    app_db: &SqlitePool,
+) -> AppResult<bool> {
+    let row: Option<String> = sqlx::query_scalar(
+        "SELECT value FROM app_setting WHERE key = 'backup.include_metadata_artwork'",
+    )
+    .fetch_optional(app_db)
+    .await?;
+    Ok(row
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(true))
 }
 
 /// Import a `.waveflow` archive as a brand-new profile. The new
@@ -186,6 +213,7 @@ pub async fn import_profile(
     let new_profile_dir = state.paths.profile_dir(new_profile_id);
     let new_db_path = state.paths.profile_db(new_profile_id);
     let new_artwork_dir = state.paths.profile_artwork_dir(new_profile_id);
+    let metadata_artwork_dir = state.paths.metadata_artwork_dir.clone();
 
     // 3. Extract — also blocking. On any failure, roll the profile row
     //    back so the user doesn't end up with a stub profile that
@@ -196,6 +224,7 @@ pub async fn import_profile(
             &new_profile_dir,
             &new_db_path,
             &new_artwork_dir,
+            &metadata_artwork_dir,
         )
     })
     .await
@@ -256,11 +285,16 @@ async fn cleanup_partial_profile(state: &AppState, profile_id: i64) {
 
 // ── zip plumbing ────────────────────────────────────────────────────
 
+// `metadata_artwork_dir`: when `Some`, the shared Deezer artwork cache
+// is bundled under `metadata_artwork/**` so a restore on another machine
+// doesn't have to re-fetch every cover. When `None`, the archive stays
+// lean and the cache will be rebuilt lazily after restore.
 pub(crate) fn write_archive(
     target: &Path,
     profile_dir: &Path,
     db_path: &Path,
     artwork_dir: &Path,
+    metadata_artwork_dir: Option<&Path>,
     manifest: &ArchiveManifest,
 ) -> AppResult<()> {
     if let Some(parent) = target.parent() {
@@ -306,6 +340,27 @@ pub(crate) fn write_archive(
         }
     }
 
+    // 4. metadata_artwork/** — shared Deezer cache, opt-out. Files are
+    //    already JPEG/PNG/WebP so deflate barely helps, but we keep the
+    //    same compression setting for archive uniformity.
+    if let Some(meta_dir) = metadata_artwork_dir {
+        if meta_dir.exists() {
+            for entry in WalkDir::new(meta_dir).into_iter().flatten() {
+                let entry_path = entry.path();
+                if !entry_path.is_file() {
+                    continue;
+                }
+                let rel = entry_path
+                    .strip_prefix(meta_dir)
+                    .map_err(|e| AppError::Other(format!("metadata_artwork rel: {e}")))?;
+                let zip_name = format!("metadata_artwork/{}", rel.to_string_lossy().replace('\\', "/"));
+                zip.start_file(&zip_name, opts)?;
+                let mut src = File::open(entry_path)?;
+                std::io::copy(&mut src, &mut zip)?;
+            }
+        }
+    }
+
     zip.finish()?;
     Ok(())
 }
@@ -324,11 +379,16 @@ fn read_manifest(source: &Path) -> AppResult<ArchiveManifest> {
     Ok(manifest)
 }
 
+// `metadata_artwork_dir`: destination for `metadata_artwork/**` entries
+// — the shared cache directory, NOT the per-profile one. Existing files
+// in the cache are preserved (overwritten only if the archive carries
+// them).
 fn extract_archive(
     source: &Path,
     profile_dir: &Path,
     db_path: &Path,
     artwork_dir: &Path,
+    metadata_artwork_dir: &Path,
 ) -> AppResult<()> {
     let file = File::open(source)?;
     let mut archive =
@@ -365,6 +425,18 @@ fn extract_archive(
                 .strip_prefix("artwork")
                 .map_err(|e| AppError::Other(format!("artwork strip: {e}")))?;
             let dest = artwork_dir.join(rel_in_artwork);
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let mut out = File::create(&dest)?;
+            std::io::copy(&mut entry, &mut out)?;
+            continue;
+        }
+        if name.starts_with("metadata_artwork/") || name.starts_with("metadata_artwork\\") {
+            let rel_in_meta = rel
+                .strip_prefix("metadata_artwork")
+                .map_err(|e| AppError::Other(format!("metadata_artwork strip: {e}")))?;
+            let dest = metadata_artwork_dir.join(rel_in_meta);
             if let Some(parent) = dest.parent() {
                 std::fs::create_dir_all(parent)?;
             }

--- a/src/components/views/settings/BackupCard.tsx
+++ b/src/components/views/settings/BackupCard.tsx
@@ -66,6 +66,7 @@ export function BackupCard({ language }: BackupCardProps) {
         interval_days: next.interval_days,
         folder: next.folder,
         retention: next.retention,
+        include_metadata_artwork: next.include_metadata_artwork,
       });
       setStatus(null);
     } catch (err) {
@@ -193,6 +194,31 @@ export function BackupCard({ language }: BackupCardProps) {
                 </option>
               ))}
             </select>
+          </div>
+
+          {/* Include shared Deezer artwork cache */}
+          <div className="flex items-start justify-between gap-4">
+            <label
+              htmlFor="backup-include-meta"
+              className="text-sm text-zinc-600 dark:text-zinc-300 cursor-pointer select-none flex-1"
+            >
+              <span className="block">
+                {t("settings.backup.includeMetadataArtworkLabel")}
+              </span>
+              <span className="block text-xs text-zinc-400 mt-0.5">
+                {t("settings.backup.includeMetadataArtworkHint")}
+              </span>
+            </label>
+            <input
+              id="backup-include-meta"
+              type="checkbox"
+              checked={config.include_metadata_artwork}
+              onChange={(e) =>
+                persist({ include_metadata_artwork: e.target.checked })
+              }
+              disabled={saving}
+              className="mt-1 h-4 w-4 accent-emerald-500 cursor-pointer disabled:opacity-50"
+            />
           </div>
 
           {/* Folder + actions */}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1306,6 +1306,8 @@
       "retentionLabel": "الأرشيفات المحفوظة",
       "retentionKeep_one": "أرشيف واحد لكل ملف",
       "retentionKeep_other": "{{count}} أرشيفات لكل ملف",
+      "includeMetadataArtworkLabel": "تضمين ذاكرة التخزين المؤقت لصور Deezer",
+      "includeMetadataArtworkHint": "نسخة احتياطية أكبر، استعادة دون اتصال بالكامل. ألغِ التحديد للحصول على أرشيفات خفيفة (سيتم إعادة جلب ذاكرة التخزين المؤقت عند الطلب).",
       "changeFolder": "تغيير المجلد",
       "pickFolderTitle": "اختر مجلد النسخ الاحتياطي",
       "lastRun": "آخر نسخة: {{when}}",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1302,6 +1302,8 @@
       "retentionLabel": "Aufbewahrte Archive",
       "retentionKeep_one": "{{count}} Archiv pro Profil",
       "retentionKeep_other": "{{count}} Archive pro Profil",
+      "includeMetadataArtworkLabel": "Deezer-Bildcache einbeziehen",
+      "includeMetadataArtworkHint": "Größere Sicherung, vollständig offline wiederherstellbar. Deaktivieren für schlanke Archive (Cache wird bei Bedarf neu geladen).",
       "changeFolder": "Ordner ändern",
       "pickFolderTitle": "Backup-Ordner wählen",
       "lastRun": "Letztes Backup: {{when}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1368,6 +1368,8 @@
       "retentionLabel": "Archives kept",
       "retentionKeep_one": "{{count}} archive per profile",
       "retentionKeep_other": "{{count}} archives per profile",
+      "includeMetadataArtworkLabel": "Include Deezer artwork cache",
+      "includeMetadataArtworkHint": "Larger backup, fully offline restore. Uncheck for lean archives (cache will be re-fetched on demand).",
       "changeFolder": "Change folder",
       "pickFolderTitle": "Pick the backup folder",
       "lastRun": "Last backup: {{when}}",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1302,6 +1302,8 @@
       "retentionLabel": "Archivos conservados",
       "retentionKeep_one": "{{count}} archivo por perfil",
       "retentionKeep_other": "{{count}} archivos por perfil",
+      "includeMetadataArtworkLabel": "Incluir caché de imágenes Deezer",
+      "includeMetadataArtworkHint": "Copia de seguridad más grande, restauración totalmente sin conexión. Desactivar para archivos ligeros (el caché se volverá a descargar a petición).",
       "changeFolder": "Cambiar carpeta",
       "pickFolderTitle": "Elige la carpeta de copias",
       "lastRun": "Última copia: {{when}}",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1294,6 +1294,8 @@
       "retentionLabel": "Archives conservées",
       "retentionKeep_one": "{{count}} archive par profil",
       "retentionKeep_other": "{{count}} archives par profil",
+      "includeMetadataArtworkLabel": "Inclure le cache dimages Deezer",
+      "includeMetadataArtworkHint": "Sauvegarde plus volumineuse, restauration entièrement hors-ligne. Décochez pour des archives légères (le cache sera retéléchargé à la demande).",
       "changeFolder": "Changer de dossier",
       "pickFolderTitle": "Choisir le dossier de sauvegarde",
       "lastRun": "Dernière sauvegarde : {{when}}",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1294,7 +1294,7 @@
       "retentionLabel": "Archives conservées",
       "retentionKeep_one": "{{count}} archive par profil",
       "retentionKeep_other": "{{count}} archives par profil",
-      "includeMetadataArtworkLabel": "Inclure le cache dimages Deezer",
+      "includeMetadataArtworkLabel": "Inclure le cache d'images Deezer",
       "includeMetadataArtworkHint": "Sauvegarde plus volumineuse, restauration entièrement hors-ligne. Décochez pour des archives légères (le cache sera retéléchargé à la demande).",
       "changeFolder": "Changer de dossier",
       "pickFolderTitle": "Choisir le dossier de sauvegarde",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1302,6 +1302,8 @@
       "retentionLabel": "रखे गए आर्काइव",
       "retentionKeep_one": "प्रति प्रोफ़ाइल {{count}} आर्काइव",
       "retentionKeep_other": "प्रति प्रोफ़ाइल {{count}} आर्काइव",
+      "includeMetadataArtworkLabel": "Deezer छवि कैश शामिल करें",
+      "includeMetadataArtworkHint": "बड़ा बैकअप, पूर्णतः ऑफ़लाइन पुनर्स्थापना। हल्के संग्रह के लिए अनचेक करें (कैश माँग पर पुनः डाउनलोड हो जाएगा)।",
       "changeFolder": "फ़ोल्डर बदलें",
       "pickFolderTitle": "बैकअप फ़ोल्डर चुनें",
       "lastRun": "अंतिम बैकअप: {{when}}",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1301,6 +1301,8 @@
       "retentionLabel": "Arsip disimpan",
       "retentionKeep_one": "{{count}} arsip per profil",
       "retentionKeep_other": "{{count}} arsip per profil",
+      "includeMetadataArtworkLabel": "Sertakan cache gambar Deezer",
+      "includeMetadataArtworkHint": "Cadangan lebih besar, pemulihan sepenuhnya luring. Hapus centang untuk arsip ringan (cache akan diambil ulang sesuai permintaan).",
       "changeFolder": "Ubah folder",
       "pickFolderTitle": "Pilih folder cadangan",
       "lastRun": "Cadangan terakhir: {{when}}",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1302,6 +1302,8 @@
       "retentionLabel": "Archivi conservati",
       "retentionKeep_one": "{{count}} archivio per profilo",
       "retentionKeep_other": "{{count}} archivi per profilo",
+      "includeMetadataArtworkLabel": "Includi cache immagini Deezer",
+      "includeMetadataArtworkHint": "Backup più grande, ripristino completamente offline. Deseleziona per archivi leggeri (la cache verrà riscaricata su richiesta).",
       "changeFolder": "Cambia cartella",
       "pickFolderTitle": "Scegli la cartella di backup",
       "lastRun": "Ultimo backup: {{when}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1301,6 +1301,8 @@
       "retentionLabel": "保持するアーカイブ",
       "retentionKeep_one": "プロファイルあたり{{count}}件",
       "retentionKeep_other": "プロファイルあたり{{count}}件",
+      "includeMetadataArtworkLabel": "Deezer 画像キャッシュを含める",
+      "includeMetadataArtworkHint": "バックアップは大きくなりますが、完全オフラインで復元できます。チェックを外すと軽量なアーカイブになります（必要に応じてキャッシュを再取得）。",
       "changeFolder": "フォルダを変更",
       "pickFolderTitle": "バックアップフォルダを選択",
       "lastRun": "最終バックアップ:{{when}}",

--- a/src/i18n/locales/kr.json
+++ b/src/i18n/locales/kr.json
@@ -1301,6 +1301,8 @@
       "retentionLabel": "보관할 아카이브",
       "retentionKeep_one": "프로필당 {{count}}개",
       "retentionKeep_other": "프로필당 {{count}}개",
+      "includeMetadataArtworkLabel": "Deezer 이미지 캐시 포함",
+      "includeMetadataArtworkHint": "백업이 커지지만 완전 오프라인으로 복원할 수 있습니다. 가벼운 아카이브를 원하면 체크 해제하세요(필요 시 캐시가 다시 다운로드됩니다).",
       "changeFolder": "폴더 변경",
       "pickFolderTitle": "백업 폴더 선택",
       "lastRun": "마지막 백업: {{when}}",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1302,6 +1302,8 @@
       "retentionLabel": "Bewaarde archieven",
       "retentionKeep_one": "{{count}} archief per profiel",
       "retentionKeep_other": "{{count}} archieven per profiel",
+      "includeMetadataArtworkLabel": "Deezer-afbeeldingscache opnemen",
+      "includeMetadataArtworkHint": "Grotere back-up, volledig offline herstel. Vink uit voor compacte archieven (cache wordt op aanvraag opnieuw opgehaald).",
       "changeFolder": "Map wijzigen",
       "pickFolderTitle": "Kies de back-upmap",
       "lastRun": "Laatste back-up: {{when}}",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1302,6 +1302,8 @@
       "retentionLabel": "Backups mantidos",
       "retentionKeep_one": "{{count}} arquivo por perfil",
       "retentionKeep_other": "{{count}} arquivos por perfil",
+      "includeMetadataArtworkLabel": "Incluir cache de imagens Deezer",
+      "includeMetadataArtworkHint": "Backup maior, restauração totalmente offline. Desmarque para arquivos leves (o cache será baixado novamente sob demanda).",
       "changeFolder": "Alterar pasta",
       "pickFolderTitle": "Escolher pasta do backup",
       "lastRun": "Último backup: {{when}}",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1302,6 +1302,8 @@
       "retentionLabel": "Cópias mantidas",
       "retentionKeep_one": "{{count}} arquivo por perfil",
       "retentionKeep_other": "{{count}} arquivos por perfil",
+      "includeMetadataArtworkLabel": "Incluir cache de imagens Deezer",
+      "includeMetadataArtworkHint": "Cópia de segurança maior, restauro totalmente offline. Desmarque para arquivos leves (o cache será obtido novamente sob pedido).",
       "changeFolder": "Alterar pasta",
       "pickFolderTitle": "Escolher a pasta de cópias",
       "lastRun": "Última cópia: {{when}}",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1304,6 +1304,8 @@
       "retentionLabel": "Хранить архивов",
       "retentionKeep_one": "{{count}} архив на профиль",
       "retentionKeep_other": "{{count}} архивов на профиль",
+      "includeMetadataArtworkLabel": "Включить кеш изображений Deezer",
+      "includeMetadataArtworkHint": "Большая резервная копия, полностью офлайн-восстановление. Снимите флажок для лёгких архивов (кеш будет загружен заново по требованию).",
       "changeFolder": "Сменить папку",
       "pickFolderTitle": "Выберите папку для резервных копий",
       "lastRun": "Последняя копия: {{when}}",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1301,6 +1301,8 @@
       "retentionLabel": "Tutulan arşivler",
       "retentionKeep_one": "Profil başına {{count}} arşiv",
       "retentionKeep_other": "Profil başına {{count}} arşiv",
+      "includeMetadataArtworkLabel": "Deezer kapak önbelleğini dahil et",
+      "includeMetadataArtworkHint": "Daha büyük yedek, tamamen çevrimdışı geri yükleme. Hafif arşivler için işareti kaldırın (önbellek istendiğinde yeniden indirilir).",
       "changeFolder": "Klasörü değiştir",
       "pickFolderTitle": "Yedekleme klasörünü seç",
       "lastRun": "Son yedekleme: {{when}}",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1301,6 +1301,8 @@
       "retentionLabel": "保留存档",
       "retentionKeep_one": "每个配置文件 {{count}} 个",
       "retentionKeep_other": "每个配置文件 {{count}} 个",
+      "includeMetadataArtworkLabel": "包含 Deezer 封面缓存",
+      "includeMetadataArtworkHint": "备份更大，可完全离线还原。取消勾选可获得精简归档（缓存将按需重新下载）。",
       "changeFolder": "更改文件夹",
       "pickFolderTitle": "选择备份文件夹",
       "lastRun": "上次备份:{{when}}",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1301,6 +1301,8 @@
       "retentionLabel": "保留封存",
       "retentionKeep_one": "每個設定檔 {{count}} 個",
       "retentionKeep_other": "每個設定檔 {{count}} 個",
+      "includeMetadataArtworkLabel": "包含 Deezer 封面快取",
+      "includeMetadataArtworkHint": "備份較大，可完全離線還原。取消勾選可獲得精簡封存檔（快取將依需求重新下載）。",
       "changeFolder": "變更資料夾",
       "pickFolderTitle": "選擇備份資料夾",
       "lastRun": "上次備份:{{when}}",

--- a/src/lib/tauri/backup.ts
+++ b/src/lib/tauri/backup.ts
@@ -6,6 +6,8 @@ export interface BackupConfig {
   interval_days: number;
   folder: string;
   retention: number;
+  /** Bundle the shared Deezer artwork cache into each archive. */
+  include_metadata_artwork: boolean;
   /** Epoch ms of the last successful run; `0` if never. */
   last_run_at: number;
   /** Server-resolved default folder to suggest in the picker. */
@@ -21,6 +23,7 @@ export function setBackupConfig(input: {
   interval_days: number;
   folder: string;
   retention: number;
+  include_metadata_artwork: boolean;
 }): Promise<void> {
   return invoke<void>("set_backup_config", { input });
 }


### PR DESCRIPTION
## Summary

Profile archives (manual `.waveflow` exports + auto-backup) now embed the shared `metadata_artwork/` cache (Deezer covers + artist pictures) by default, so a restore on another machine doesn't have to re-fetch every image. Gated behind a new `backup.include_metadata_artwork` setting (default ON) exposed as a checkbox in Settings → Sauvegardes — users who want lean archives can opt out.

- New checkbox in the backup card; persisted in `app_setting`, default ON.
- `write_archive` / `extract_archive` round-trip the cache under `metadata_artwork/**` in the zip.
- Auto-backup bundles the shared cache **only into the first archive of each pass** to avoid N× duplication on multi-profile installs; importing any of the archives refills the cache.
- New i18n keys `settings.backup.includeMetadataArtworkLabel` + `includeMetadataArtworkHint` propagated to all 17 locales.
- `CLAUDE.md` + `profile_io.rs` header updated to reflect the new contract.

## Test plan

- [x] `bun run typecheck` clean
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets` clean
- [x] Toggle "Inclure le cache d'images Deezer" off → run a manual export → archive does not contain `metadata_artwork/`
- [x] Toggle on (default) → run a manual export → archive contains `metadata_artwork/<hash>.jpg` entries
- [x] Import the archive on a fresh install → covers render immediately without network access
- [x] Auto-backup pass with 2+ profiles: only the first `.waveflow` carries `metadata_artwork/`, the others stay lean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles Fonctionnalités**
  * Ajout d'une option de sauvegarde pour inclure optionnellement le cache des pochettes Deezer dans les archives de profil. Les archives contiennent désormais le cache partagé des métadonnées pour une restauration complètement hors ligne, avec la possibilité de le désactiver pour réduire la taille des archives.

* **Documentation**
  * Ajout des traductions multilingues pour la nouvelle option de sauvegarde et ses descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->