### PR TITLE
chore(deps): bump wasapi from 0.17 to 0.23

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6640,16 +6640,15 @@ dependencies = [
 
 [[package]]
 name = "wasapi"
-version = "0.17.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9212e7fd6f3eb702e9ae177210c1e810a1c10b57202eb8a3e0eb154e111c2084"
+checksum = "80c3aa5d6b0e7acc3ea10cb19c334df0c8d825060f14a30d9e3b03385e6e5175"
 dependencies = [
  "log",
  "num-integer",
  "thiserror 2.0.18",
- "widestring",
- "windows 0.59.0",
- "windows-core 0.59.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6951,7 +6950,7 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
 ]
 
@@ -6992,12 +6991,6 @@ dependencies = [
  "libredox",
  "wasite",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -7065,16 +7058,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
-dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7118,24 +7101,11 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface",
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -7148,7 +7118,7 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7175,17 +7145,6 @@ dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
  "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -7258,15 +7217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -226,7 +226,7 @@ libc = "0.2"
 # event-handle APIs from the exclusive-mode output thread without
 # going through `wasapi`'s less ergonomic wrappers.
 [target.'cfg(target_os = "windows")'.dependencies]
-wasapi = "0.17"
+wasapi = "0.23"
 windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_System_Com",

--- a/src-tauri/src/audio/wasapi_exclusive.rs
+++ b/src-tauri/src/audio/wasapi_exclusive.rs
@@ -38,8 +38,8 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 use rtrb::{Consumer, Producer, RingBuffer};
 use tauri::AppHandle;
 use wasapi::{
-    get_default_device, AudioClient, AudioRenderClient, Device, DeviceCollection, Direction,
-    Handle, SampleType, ShareMode, StreamMode, WaveFormat,
+    AudioClient, AudioRenderClient, Device, DeviceEnumerator, Direction, Handle, SampleType,
+    ShareMode, StreamMode, WaveFormat,
 };
 
 use super::output::{OutputHandle, RING_CAPACITY};
@@ -260,11 +260,17 @@ fn open_exclusive_session(
 }
 
 fn pick_device(device_name: &Option<String>) -> AppResult<Device> {
+    // wasapi 0.23 removed the free `get_default_device` / `DeviceCollection`
+    // entry points; everything now goes through a `DeviceEnumerator`
+    // (which owns the underlying `IMMDeviceEnumerator` COM pointer).
+    let enumerator = DeviceEnumerator::new()
+        .map_err(|e| AppError::Audio(format!("DeviceEnumerator::new: {e:?}")))?;
     if let Some(name) = device_name.as_deref().filter(|n| !n.is_empty()) {
-        // Iterate the render collection until we find a friendlyname
-        // match. The Linux ALSA story has the same pattern — name
-        // strings are how we pin a specific endpoint across reboots.
-        let coll = DeviceCollection::new(&Direction::Render)
+        // Friendly-name lookup lives on the collection, not the
+        // enumerator (the enumerator's `get_device` wants an opaque
+        // device-id, not the human-readable name we persist).
+        let coll = enumerator
+            .get_device_collection(&Direction::Render)
             .map_err(|e| AppError::Audio(format!("enumerate render devices: {e:?}")))?;
         if let Ok(dev) = coll.get_device_with_name(name) {
             return Ok(dev);
@@ -274,7 +280,8 @@ fn pick_device(device_name: &Option<String>) -> AppResult<Device> {
             "wasapi exclusive: requested device not found, falling back to default"
         );
     }
-    get_default_device(&Direction::Render)
+    enumerator
+        .get_default_device(&Direction::Render)
         .map_err(|e| AppError::Audio(format!("default render device: {e:?}")))
 }
 


### PR DESCRIPTION
## Summary

Same shape as the symphonia 0.6 PR (#53): the dependabot bump alone can't compile against the new release because the device-lookup API was reshaped.

wasapi 0.23 removed the free `get_default_device` function and the `DeviceCollection::new` constructor. Device lookup now flows through a `DeviceEnumerator` that owns the `IMMDeviceEnumerator` COM pointer.

Closes #48 (dependabot — bare version bump, no migration).

## Migration

Only [`src-tauri/src/audio/wasapi_exclusive.rs::pick_device`](src-tauri/src/audio/wasapi_exclusive.rs) needed changes:

- Build a `DeviceEnumerator` once
- Default device: `enumerator.get_default_device(&Direction::Render)`
- Friendly-name lookup: `enumerator.get_device_collection(&Direction::Render)?.get_device_with_name(name)` — `enumerator.get_device(name)` looks tempting but it takes an opaque device-id, not the human-readable name we persist in `app_setting['audio.output_device']`. Going through the collection keeps the existing behaviour.

Everything else (`AudioClient` init, `is_supported`, `write_to_device`, the event loop) is API-stable across this bump.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets --no-deps` — clean
- [x] `cargo test` — 97 passed / 0 failed
- [x] Manual WASAPI Exclusive playback test on Windows (requires opt-in toggle in Settings)