### PR TITLE
feat(community): wire up GitHub Discussions foundations

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,15 @@ contact_links:
   - name: Security disclosure
     url: https://github.com/InstaZDLL/WaveFlow/blob/main/.github/SECURITY.md
     about: Report a vulnerability privately — please do not open a public issue.
-  - name: Discussions
+  - name: Question or setup help
+    url: https://github.com/InstaZDLL/WaveFlow/discussions/categories/q-a
+    about: "Ask the community in Q&A — 'how do I…', 'is this a bug or by design?'"
+  - name: Feature idea or UX proposal
+    url: https://github.com/InstaZDLL/WaveFlow/discussions/categories/ideas
+    about: Discuss the idea first; concrete feature requests can graduate to an issue afterward.
+  - name: Show and tell
+    url: https://github.com/InstaZDLL/WaveFlow/discussions/categories/show-and-tell
+    about: Share screenshots, your setup, or a playlist you built with WaveFlow.
+  - name: General chat
     url: https://github.com/InstaZDLL/WaveFlow/discussions
-    about: Open-ended questions, design debates, "is this a bug or by design?"
+    about: Anything else — announcements, polls, off-topic.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Per-feature deep dives, architecture and storage layout live under [`docs/`](doc
 - **Architecture** — [audio engine](docs/architecture/audio.md) · [database & paths](docs/architecture/storage.md)
 - **Contributing** — [CONTRIBUTING.md](CONTRIBUTING.md) · [RELEASING.md](RELEASING.md)
 
+## Community
+
+- :bug: **Bug?** → [Bug report](https://github.com/InstaZDLL/WaveFlow/issues/new?template=bug_report.yml)
+- :sparkles: **Feature idea?** → [Discussions › Ideas](https://github.com/InstaZDLL/WaveFlow/discussions/categories/ideas) (chat first, graduate to a [feature request issue](https://github.com/InstaZDLL/WaveFlow/issues/new?template=feature_request.yml) once shape is clear)
+- :pray: **Setup help / how-to?** → [Discussions › Q&A](https://github.com/InstaZDLL/WaveFlow/discussions/categories/q-a)
+- :raised_hands: **Show off your setup or playlist?** → [Discussions › Show and tell](https://github.com/InstaZDLL/WaveFlow/discussions/categories/show-and-tell)
+- :lock: **Security?** → [Private disclosure](.github/SECURITY.md) — never post vulnerabilities publicly.
+
+English and French both welcome.
+
 ## License
 
 ```


### PR DESCRIPTION
## Summary

Closes #49 — the Discussions contact link in [ISSUE_TEMPLATE/config.yml](.github/ISSUE_TEMPLATE/config.yml) had been live but landed on a "Discussions are not enabled" 404 because the feature was never flipped on at the repo level.

Three things ship together:

1. **Discussions enabled** at the repo level (PATCH `repos/.../has_discussions: true`) — done out-of-tree, default 6 categories provisioned (Announcements, General, Ideas, Polls, Q&A, Show and tell).
2. **[Welcome announcement](https://github.com/InstaZDLL/WaveFlow/discussions/57) posted** in Announcements — maps each user intent to the right category, mentions both English and French are welcome, points back to the bug/feature issue templates and to SECURITY.md.
3. **In-repo wiring updates** (this PR):
   - `ISSUE_TEMPLATE/config.yml`: replace the single generic Discussions link with four category-specific ones (Q&A, Ideas, Show and tell, General). When a contributor clicks "New issue" we want to route them somewhere useful.
   - `README.md`: add a `Community` section listing each common intent (bug, idea, setup help, show-off, security) with the right URL — so users don't have to guess "issue vs discussion".

## Test plan

- [x] Discussions tab is reachable: https://github.com/InstaZDLL/WaveFlow/discussions
- [x] Welcome post visible in Announcements
- [x] After merge, "New issue" page shows the 4 new contact links + Security
- [x] README Community section renders on the repo homepage