### PR TITLE
fix(artists): surface local sidecar images on the main Artists grid

### DIFF
--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -52,12 +52,20 @@ pub struct ArtistRow {
     pub name: String,
     pub track_count: i64,
     pub album_count: i64,
+    /// Absolute filesystem path to a locally-extracted artist image
+    /// (sidecar `artist.jpg` or `<name>.jpg` discovered next to the
+    /// tracks during scan). Mirrors `ArtistDetail.artwork_path`.
+    /// `None` when no local image was found.
+    pub artwork_path: Option<String>,
+    pub artwork_path_1x: Option<String>,
+    pub artwork_path_2x: Option<String>,
     /// Deezer CDN URL from the `metadata_artist` cache, if the artist
     /// has been enriched at least once. Kept as a fallback — the UI
-    /// should prefer `picture_path` when present.
+    /// should prefer `artwork_path`, then `picture_path`, then this
+    /// remote URL last.
     pub picture_url: Option<String>,
-    /// Absolute filesystem path to the locally-cached picture, when
-    /// the metadata cache holds a hash and the file still exists.
+    /// Absolute filesystem path to the locally-cached Deezer picture,
+    /// when the metadata cache holds a hash and the file still exists.
     pub picture_path: Option<String>,
     pub picture_path_1x: Option<String>,
     pub picture_path_2x: Option<String>,
@@ -69,6 +77,8 @@ struct ArtistRowRaw {
     name: String,
     track_count: i64,
     album_count: i64,
+    artwork_hash: Option<String>,
+    artwork_format: Option<String>,
     picture_url: Option<String>,
     picture_hash: Option<String>,
 }
@@ -327,11 +337,14 @@ pub async fn list_artists(
                ar.name,
                COUNT(DISTINCT t.id)       AS track_count,
                COUNT(DISTINCT t.album_id) AS album_count,
+               aw.hash                    AS artwork_hash,
+               aw.format                  AS artwork_format,
                da.picture_url             AS picture_url,
                da.picture_hash            AS picture_hash
           FROM artist ar
           JOIN track_artist ta ON ta.artist_id = ar.id
           JOIN track t ON t.id = ta.track_id
+          LEFT JOIN artwork aw ON aw.id = ar.artwork_id
           LEFT JOIN app.metadata_artist da ON da.deezer_id = ar.deezer_id
          WHERE (? IS NULL OR t.library_id = ?) AND t.is_available = 1
          GROUP BY ar.id
@@ -345,10 +358,24 @@ pub async fn list_artists(
         .fetch_all(&pool)
         .await?;
 
+    let profile_id = state.require_profile_id().await?;
+    let artwork_dir = state.paths.profile_artwork_dir(profile_id);
     let metadata_dir = &state.paths.metadata_artwork_dir;
     let rows = raw
         .into_iter()
         .map(|r| {
+            let (artwork_path, artwork_path_1x, artwork_path_2x) =
+                match (r.artwork_hash.as_deref(), r.artwork_format.as_deref()) {
+                    (Some(hash), Some(fmt)) => {
+                        let full = artwork_dir
+                            .join(format!("{hash}.{fmt}"))
+                            .to_string_lossy()
+                            .to_string();
+                        let (p1, p2) = crate::thumbnails::thumbnail_paths_for(&artwork_dir, hash);
+                        (Some(full), p1, p2)
+                    }
+                    _ => (None, None, None),
+                };
             let (picture_path_1x, picture_path_2x) = match r.picture_hash.as_deref() {
                 Some(h) => crate::thumbnails::thumbnail_paths_for(metadata_dir, h),
                 None => (None, None),
@@ -358,6 +385,9 @@ pub async fn list_artists(
                 name: r.name,
                 track_count: r.track_count,
                 album_count: r.album_count,
+                artwork_path,
+                artwork_path_1x,
+                artwork_path_2x,
                 picture_path: r
                     .picture_hash
                     .as_deref()

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1553,11 +1553,16 @@ function ArtistList({
     >
       {artists.map((artist, idx) => {
         const isMenuOpen = openMenuArtistId === artist.id;
+        // Local artwork wins over the Deezer cache so the user's own
+        // sidecar JPEGs surface here exactly like they do on the
+        // per-artist page (`ArtistDetailView`). When no local image
+        // exists we fall back to the Deezer picture, then to the
+        // remote URL — same precedence as the detail view.
         const artistPictureSrc = resolveArtwork(
           {
-            full: artist.picture_path,
-            x1: artist.picture_path_1x,
-            x2: artist.picture_path_2x,
+            full: artist.artwork_path ?? artist.picture_path,
+            x1: artist.artwork_path_1x ?? artist.picture_path_1x,
+            x2: artist.artwork_path_2x ?? artist.picture_path_2x,
             remoteUrl: artist.picture_url,
           },
           "2x",

--- a/src/lib/tauri/browse.ts
+++ b/src/lib/tauri/browse.ts
@@ -25,9 +25,15 @@ export interface ArtistRow {
   name: string;
   track_count: number;
   album_count: number;
+  /** Absolute filesystem path to a locally-extracted artist image
+   *  (sidecar `artist.jpg` / `<name>.jpg` next to the tracks). Prefer
+   *  this over `picture_path` / `picture_url` when present. */
+  artwork_path: string | null;
+  artwork_path_1x: string | null;
+  artwork_path_2x: string | null;
   /** Deezer CDN URL, populated after the artist has been enriched at least once. */
   picture_url: string | null;
-  /** Absolute filesystem path to the locally-cached picture, when available. */
+  /** Absolute filesystem path to the locally-cached Deezer picture, when available. */
   picture_path: string | null;
   picture_path_1x: string | null;
   picture_path_2x: string | null;


### PR DESCRIPTION
## Summary

Closes #50 — reported by @jo-el414. Local artist images (sidecar `artist.jpg` / `<name>.jpg` next to the tracks) were correctly scanned, written to the artwork table, and rendered on each individual artist's page — but the **main Artists grid** showed only the placeholder fallback.

## Root cause

[`commands::browse::list_artists`](src-tauri/src/commands/browse.rs) joined only `app.metadata_artist` (the shared Deezer cache keyed by `deezer_id`) and never touched the per-profile `artwork` table that `scan::link_local_artist_image` populates for local sidecars.

`get_artist_detail` already had the right shape — joining both `artwork` (local) and `metadata_artist` (Deezer) and returning two sets of paths so the frontend can pick "local wins, Deezer falls back". This PR ports the same pattern to the listing query.

## Changes

- **Backend** ([browse.rs](src-tauri/src/commands/browse.rs)): add `LEFT JOIN artwork aw ON aw.id = ar.artwork_id`, extend `ArtistRow` + `ArtistRowRaw` with `artwork_hash` / `artwork_format`, build `artwork_path*` from the per-profile `artwork_dir` exactly like `get_artist_detail` / `list_albums` do.
- **Bridge** ([browse.ts](src/lib/tauri/browse.ts)): mirror `artwork_path` / `_1x` / `_2x` on the `ArtistRow` interface.
- **Frontend** ([LibraryView.tsx](src/components/views/LibraryView.tsx)): use `artist.artwork_path ?? artist.picture_path` for `resolveArtwork`, matching the precedence already used in `ArtistDetailView`.

No DB migration needed — the `artwork_id` rows are already populated by the scanner.

## Test plan

- [x] `cargo check --all-targets`, `cargo clippy`, `cargo test` — clean
- [x] `bun run typecheck`, `bun run lint`
- [x] Profile with a folder containing `artist.jpg` sidecars + Deezer integration disabled → Artists grid shows the local images
- [x] Same with Deezer integration ON → local sidecars still win over Deezer pictures
- [x] Artist with no local image and no Deezer enrichment → placeholder unchanged