### PR TITLE
perf(library): prefetch inactive tabs so switching feels instant

### DIFF
--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -233,50 +234,124 @@ export function LibraryView({
     clearSelection();
   }, [activeTab, clearSelection]);
 
+  // Per-tab cache key — bumped whenever the active library set, sort,
+  // filter or last edit invalidates a tab's previously fetched data.
+  // We compare against the foreground loader's snapshot to decide if
+  // a tab still needs a refresh OR if its persisted state array is
+  // already up to date (in which case switching to it is instant).
+  const tabCacheKeys: Record<LibraryTab, string> = useMemo(
+    () => ({
+      morceaux: `${librariesSignature}|${tracksSort.sort.orderBy}:${tracksSort.sort.direction}|${editRefetch}`,
+      albums: `${librariesSignature}|${albumsSort.sort.orderBy}:${albumsSort.sort.direction}|${albumsNoCoverFilter}|${coverReloadKey}|${editRefetch}`,
+      artistes: `${librariesSignature}|${artistsSort.sort.orderBy}:${artistsSort.sort.direction}|${editRefetch}`,
+      genres: `${librariesSignature}|${editRefetch}`,
+      dossiers: `${librariesSignature}|${editRefetch}`,
+    }),
+    [
+      librariesSignature,
+      tracksSort.sort.orderBy,
+      tracksSort.sort.direction,
+      albumsSort.sort.orderBy,
+      albumsSort.sort.direction,
+      albumsNoCoverFilter,
+      coverReloadKey,
+      artistsSort.sort.orderBy,
+      artistsSort.sort.direction,
+      editRefetch,
+    ],
+  );
+
+  // Tracks which key was fetched into each tab's state array, so the
+  // foreground loader and the background prefetcher both know when a
+  // tab is up to date. A ref (not state) so updating it doesn't
+  // re-trigger effects.
+  const loadedKeysRef = useRef<Record<LibraryTab, string | null>>({
+    morceaux: null,
+    albums: null,
+    artistes: null,
+    genres: null,
+    dossiers: null,
+  });
+
+  // Per-tab fetcher — returns the populated list, doesn't touch state
+  // itself so both the foreground and background paths can share it.
+  const fetchTab = useCallback(
+    async (tab: LibraryTab) => {
+      switch (tab) {
+        case "morceaux":
+          return await listTracks(null, tracksSort.sort);
+        case "albums":
+          return await listAlbums(null, {
+            filterNoCover: albumsNoCoverFilter,
+            orderBy: albumsSort.sort.orderBy,
+            direction: albumsSort.sort.direction,
+          });
+        case "artistes":
+          return await listArtists(null, artistsSort.sort);
+        case "genres":
+          return await listGenres(null);
+        case "dossiers":
+          return await listFolders(null);
+      }
+    },
+    [
+      tracksSort.sort,
+      albumsSort.sort,
+      artistsSort.sort,
+      albumsNoCoverFilter,
+    ],
+  );
+
+  // Assign a fetched payload to the correct state setter. Centralised
+  // so neither the foreground nor the background path has to repeat
+  // the switch.
+  const applyTab = useCallback(
+    (tab: LibraryTab, payload: unknown) => {
+      switch (tab) {
+        case "morceaux":
+          setTracks(payload as Track[]);
+          break;
+        case "albums":
+          setAlbums(payload as AlbumRow[]);
+          break;
+        case "artistes":
+          setArtists(payload as ArtistRow[]);
+          break;
+        case "genres":
+          setGenres(payload as GenreRow[]);
+          break;
+        case "dossiers":
+          setFolders(payload as FolderRow[]);
+          break;
+      }
+    },
+    [],
+  );
+
+  // Foreground loader: fetches the active tab when its cache key
+  // changes. Only flips `isLoading` for the active tab so the user
+  // sees a spinner only on the surface they're looking at.
   useEffect(() => {
-    // Hold off the first fetch until the relevant sort memory has
-    // resolved — otherwise we'd query the default ordering and then
-    // re-query the persisted one a tick later.
     if (activeTab === "morceaux" && !tracksSort.isLoaded) return;
     if (activeTab === "albums" && !albumsSort.isLoaded) return;
     if (activeTab === "artistes" && !artistsSort.isLoaded) return;
+
+    const desiredKey = tabCacheKeys[activeTab];
+    if (loadedKeysRef.current[activeTab] === desiredKey) {
+      // Already up to date from a previous foreground load OR a
+      // background prefetch — nothing to do, the user sees instant
+      // content.
+      return;
+    }
 
     let cancelled = false;
     (async () => {
       setIsLoading(true);
       try {
-        // Pass null → aggregate across ALL libraries ("Ma musique" mode).
-        switch (activeTab) {
-          case "morceaux": {
-            const list = await listTracks(null, tracksSort.sort);
-            if (!cancelled) setTracks(list);
-            break;
-          }
-          case "albums": {
-            const list = await listAlbums(null, {
-              filterNoCover: albumsNoCoverFilter,
-              orderBy: albumsSort.sort.orderBy,
-              direction: albumsSort.sort.direction,
-            });
-            if (!cancelled) setAlbums(list);
-            break;
-          }
-          case "artistes": {
-            const list = await listArtists(null, artistsSort.sort);
-            if (!cancelled) setArtists(list);
-            break;
-          }
-          case "genres": {
-            const list = await listGenres(null);
-            if (!cancelled) setGenres(list);
-            break;
-          }
-          case "dossiers": {
-            const list = await listFolders(null);
-            if (!cancelled) setFolders(list);
-            break;
-          }
-        }
+        const payload = await fetchTab(activeTab);
+        if (cancelled) return;
+        applyTab(activeTab, payload);
+        loadedKeysRef.current[activeTab] = desiredKey;
       } catch (err) {
         if (!cancelled) {
           console.error("[LibraryView] failed to load tab data", err);
@@ -290,16 +365,65 @@ export function LibraryView({
     };
   }, [
     activeTab,
-    librariesSignature,
-    albumsNoCoverFilter,
-    coverReloadKey,
+    tabCacheKeys,
+    fetchTab,
+    applyTab,
     tracksSort.isLoaded,
-    tracksSort.sort,
     albumsSort.isLoaded,
-    albumsSort.sort,
     artistsSort.isLoaded,
-    artistsSort.sort,
-    editRefetch,
+  ]);
+
+  // Background prefetch: ~200 ms after the active tab settles, warm
+  // every other tab whose cache is stale so the first user-driven
+  // switch feels instant. Best-effort — failures fall back to the
+  // foreground loader on click. Runs serially (not parallel) so a
+  // large `list_tracks` query doesn't fight the active tab's SQLite
+  // pool for connection time.
+  useEffect(() => {
+    if (isLoading) return;
+    if (!tracksSort.isLoaded || !albumsSort.isLoaded || !artistsSort.isLoaded) {
+      return;
+    }
+
+    const others: LibraryTab[] = (
+      ["morceaux", "albums", "artistes", "genres", "dossiers"] as LibraryTab[]
+    ).filter(
+      (tab) =>
+        tab !== activeTab && loadedKeysRef.current[tab] !== tabCacheKeys[tab],
+    );
+    if (others.length === 0) return;
+
+    let cancelled = false;
+    const timer = window.setTimeout(async () => {
+      for (const tab of others) {
+        if (cancelled) return;
+        const desired = tabCacheKeys[tab];
+        if (loadedKeysRef.current[tab] === desired) continue;
+        try {
+          const payload = await fetchTab(tab);
+          if (cancelled) return;
+          applyTab(tab, payload);
+          loadedKeysRef.current[tab] = desired;
+        } catch {
+          // Swallow — foreground loader will retry when user clicks
+          // the tab.
+        }
+      }
+    }, 200);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [
+    isLoading,
+    activeTab,
+    tabCacheKeys,
+    fetchTab,
+    applyTab,
+    tracksSort.isLoaded,
+    albumsSort.isLoaded,
+    artistsSort.isLoaded,
   ]);
 
   // Load liked track IDs once on mount so the TrackTable can show


### PR DESCRIPTION
## Summary

User-reported pain: clicking **Artistes / Albums / Morceaux** for the first time leaves the user staring at a blank tab for 1–2 s while the backend runs the corresponding `list_*` query and the JSON crosses Tauri's IPC bridge. Subsequent visits to the same tab were already instant — each tab's state array persists across `activeTab` switches — but the cold-cache first click was painful.

## Approach

Reshape the loading logic in [LibraryView](src/components/views/LibraryView.tsx) so the user only pays the fetch cost once per cache-invalidation, regardless of which tab they click first:

1. **`tabCacheKeys` memo** — derives one stable key per tab from the inputs that legitimately invalidate its data (library set, sort, `filterNoCover`, cover-reload signal, edit signal).
2. **`loadedKeysRef`** — records which key currently lives in each tab's state array. The foreground loader short-circuits when the active tab already matches its desired key (e.g. the user clicked back to a tab that just got prefetched).
3. **Background prefetch effect** — waits 200 ms after the active tab settles, then *serially* fetches each non-active tab whose stored key is stale. Serial (not parallel) so a large `list_tracks` query doesn't fight the active tab for SQLite pool slots.
4. **`fetchTab` / `applyTab` helpers** — centralise the per-tab switch so the two paths can't drift apart on the next refactor.

## Net effect

- The very first foreground tab loads exactly as before.
- Every subsequent tab switch renders the cached data **instantly**.
- A silent refresh runs in the background only when the cache key has actually invalidated (sort change, library change, edit, etc.).
- Failures in the background path are swallowed and fall back to the foreground loader on user click — no regression on the worst case.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] Cold launch → first tab (Songs/Tracks) loads normally → click Albums within 200 ms+~query time → instant render
- [ ] Change sort on Albums → background prefetch refreshes other tabs (verify by switching back to Songs and checking the data picks up the same `editRefetch`/sort changes)
- [ ] Edit a track in Library → all tabs visible data refreshes within ~200 ms after the foreground load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimisé le chargement des onglets de la bibliothèque avec des mécanismes de mise en cache améliorés et une pré-récupération des données en arrière-plan, offrant une navigation par onglets plus fluide et réactive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->