### PR TITLE
fix(library): fade artwork over its gradient placeholder instead of grey

### DIFF
--- a/src/components/common/Artwork.tsx
+++ b/src/components/common/Artwork.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Disc } from "lucide-react";
 import { resolveArtwork, type ArtworkSize } from "../../lib/tauri/artwork";
+import { FadeInImage } from "./FadeInImage";
 
 interface ArtworkProps {
   /**
@@ -36,7 +37,9 @@ interface ArtworkProps {
 /**
  * Render a hash-addressed cover image served via Tauri's `asset://`
  * protocol, picking the closest pre-resized variant for the requested
- * display `size`.
+ * display `size`. The image fades in over a gradient placeholder via
+ * [`FadeInImage`] so a tab full of fresh thumbnails never flashes
+ * through grey skeleton squares.
  */
 export function Artwork({
   path,
@@ -68,31 +71,36 @@ export function Artwork({
     xl: "rounded-xl",
     "2xl": "rounded-2xl",
   }[rounded];
+  // Gradient + border combo reused as the placeholder background, both
+  // when no image is available and behind the fading <img>.
+  const placeholderBg =
+    "bg-linear-to-br from-emerald-100 to-emerald-200 dark:from-emerald-900/40 dark:to-emerald-800/30 border border-emerald-200/60 dark:border-emerald-800/40";
+  const discIcon = (
+    <Disc
+      size={iconSize}
+      className="text-emerald-500/70 dark:text-emerald-400/60"
+    />
+  );
 
   if (!src) {
     return (
       <div
-        className={`${className} ${radiusClass} bg-linear-to-br from-emerald-100 to-emerald-200 dark:from-emerald-900/40 dark:to-emerald-800/30 border border-emerald-200/60 dark:border-emerald-800/40 flex items-center justify-center overflow-hidden shrink-0`}
+        className={`${className} ${radiusClass} ${placeholderBg} flex items-center justify-center overflow-hidden shrink-0`}
         aria-hidden={alt ? undefined : true}
         aria-label={alt}
         role={alt ? "img" : undefined}
       >
-        <Disc
-          size={iconSize}
-          className="text-emerald-500/70 dark:text-emerald-400/60"
-        />
+        {discIcon}
       </div>
     );
   }
 
   return (
-    <img
+    <FadeInImage
       src={src}
       alt={alt ?? ""}
-      loading="lazy"
-      decoding="async"
-      draggable={false}
-      className={`${className} ${radiusClass} object-cover shrink-0 bg-zinc-100 dark:bg-zinc-800`}
+      wrapperClassName={`${className} ${radiusClass} ${placeholderBg} shrink-0`}
+      placeholder={discIcon}
     />
   );
 }

--- a/src/components/common/FadeInImage.tsx
+++ b/src/components/common/FadeInImage.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+
+interface FadeInImageProps {
+  /** Resolved `asset://` (or http) URL. */
+  src: string;
+  alt: string;
+  /** Tailwind classes for the wrapper that hosts the placeholder
+   *  gradient and clips the image. */
+  wrapperClassName: string;
+  /** Tailwind classes for the `<img>` itself. Should NOT carry sizing
+   *  — the wrapper handles that. */
+  imgClassName?: string;
+  /** Optional placeholder children rendered behind the image (e.g. a
+   *  fallback initial or a Disc icon). Hidden once the image fades in. */
+  placeholder?: React.ReactNode;
+}
+
+/**
+ * Render an `<img>` that fades in over an underlying placeholder once
+ * the browser has decoded it. Replaces the classic "flash from grey
+ * to image" you get when a whole grid of fresh thumbnails mounts and
+ * each tile pops in independently.
+ *
+ * Why a wrapper instead of just a CSS transition: the image hasn't
+ * decoded yet on first paint, so we have to gate `opacity` on the
+ * `onLoad` event. We also handle the WebView-cached case via `ref`,
+ * where `complete` is already true and `onLoad` would never fire.
+ */
+export function FadeInImage({
+  src,
+  alt,
+  wrapperClassName,
+  imgClassName = "",
+  placeholder,
+}: FadeInImageProps) {
+  // Reset the fade gate when the underlying URL changes (e.g. a tile
+  // gets recycled by a virtualized list, or the same component
+  // re-renders with a different artist). React's documented pattern
+  // for "reset state when prop changes" is to compare against a prev
+  // ref in render rather than chaining a useEffect — avoids the
+  // double-render that eslint-plugin-react-hooks flags.
+  const [loaded, setLoaded] = useState(false);
+  const [prevSrc, setPrevSrc] = useState(src);
+  if (prevSrc !== src) {
+    setPrevSrc(src);
+    setLoaded(false);
+  }
+
+  return (
+    <div className={`relative overflow-hidden ${wrapperClassName}`}>
+      {placeholder ? (
+        <div
+          aria-hidden
+          className={`absolute inset-0 flex items-center justify-center transition-opacity duration-200 ${
+            loaded ? "opacity-0" : "opacity-100"
+          }`}
+        >
+          {placeholder}
+        </div>
+      ) : null}
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
+        decoding="async"
+        draggable={false}
+        onLoad={() => setLoaded(true)}
+        ref={(el) => {
+          // The WebView cache can serve the bytes synchronously — the
+          // <img> is already `complete` before React even attaches an
+          // onLoad handler. Pin the fade open from the ref callback in
+          // that case so we don't stay stuck at opacity-0.
+          if (el && el.complete && el.naturalWidth > 0) {
+            setLoaded(true);
+          }
+        }}
+        className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-200 ${
+          loaded ? "opacity-100" : "opacity-0"
+        } ${imgClassName}`}
+      />
+    </div>
+  );
+}

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -53,6 +53,7 @@ import { useTrackUpdated } from "../../hooks/useTrackUpdated";
 import { useMultiSelect } from "../../hooks/useMultiSelect";
 import { resolvePlaylistColor } from "../../lib/playlistVisuals";
 import { resolveArtwork } from "../../lib/tauri/artwork";
+import { FadeInImage } from "../common/FadeInImage";
 import { PlaylistIcon } from "../../lib/PlaylistIcon";
 import type { Playlist } from "../../lib/tauri/playlist";
 import { pickFolder } from "../../lib/tauri/dialog";
@@ -1576,11 +1577,15 @@ function ArtistList({
           >
             <div className="relative w-full">
               {artistPictureSrc ? (
-                <img
+                <FadeInImage
                   src={artistPictureSrc}
                   alt={artist.name}
-                  loading="lazy"
-                  className="w-full aspect-square rounded-full object-cover shadow-sm group-hover:shadow-md transition-shadow"
+                  wrapperClassName="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 border border-violet-200/60 dark:border-violet-800/40 shadow-sm group-hover:shadow-md transition-shadow"
+                  placeholder={
+                    <span className="text-5xl font-bold text-violet-500/70 dark:text-violet-400/60">
+                      {artist.name.trim().charAt(0).toUpperCase() || "?"}
+                    </span>
+                  }
                 />
               ) : (
                 <div className="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 border border-violet-200/60 dark:border-violet-800/40 flex items-center justify-center overflow-hidden shadow-sm group-hover:shadow-md transition-shadow">

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1708,6 +1708,10 @@ function ArtistList({
 
   const renderArtistTile = (artist: ArtistRow, idx: number) => {
     const isMenuOpen = openMenuArtistId === artist.id;
+    // Use the full-resolution source so HiDPI screens render the
+    // avatar crisp at any column width — same trade-off documented on
+    // `AlbumGrid`'s Artwork usage. The 128 px 2x thumbnail upscaled
+    // soft on the 180–220 px artist tiles users actually see.
     const artistPictureSrc = resolveArtwork(
       {
         full: artist.artwork_path ?? artist.picture_path,
@@ -1715,7 +1719,7 @@ function ArtistList({
         x2: artist.artwork_path_2x ?? artist.picture_path_2x,
         remoteUrl: artist.picture_url,
       },
-      "2x",
+      "full",
     );
     return (
       <div

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -204,7 +204,10 @@ export function LibraryView({
   }, []);
 
   // Scroll target for the AlphabetIndex (artists tab uses it).
-  const artistGridRef = useRef<HTMLDivElement>(null);
+  // Callback ref populated by the virtualized ArtistList so the
+  // alphabet jump index can scroll a specific artist into view without
+  // relying on a `querySelector` that can't reach off-screen rows.
+  const artistScrollToIndexRef = useRef<((idx: number) => void) | null>(null);
 
   const trackContextMenu = useTrackContextMenu({
     likedIds,
@@ -630,23 +633,13 @@ export function LibraryView({
                     setIsCreatePlaylistModalOpen(true);
                   }}
                   onArtistClick={onNavigateToArtist}
-                  gridRef={artistGridRef}
+                  scrollToIndexRef={artistScrollToIndexRef}
                 />
                 {artistsSort.sort.orderBy === "name" && artists.length > 0 && (
                   <AlphabetIndex
                     items={artists}
                     onLetterClick={(idx) => {
-                      const grid = artistGridRef.current;
-                      if (!grid) return;
-                      const target = grid.querySelector<HTMLElement>(
-                        `[data-artist-index="${idx}"]`,
-                      );
-                      if (target) {
-                        target.scrollIntoView({
-                          behavior: "smooth",
-                          block: "start",
-                        });
-                      }
+                      artistScrollToIndexRef.current?.(idx);
                     }}
                     className="hidden md:flex fixed right-6 top-1/2 -translate-y-1/2 z-30 bg-white/80 dark:bg-zinc-900/70 backdrop-blur-sm rounded-full py-2 px-1.5 shadow-sm"
                   />
@@ -1342,6 +1335,7 @@ function AlbumGrid({
   onAlbumClick,
   onChangeCover,
 }: AlbumGridProps) {
+  "use no memo";
   const unknown = t("library.table.unknown");
   const [openMenuAlbumId, setOpenMenuAlbumId] = useState<number | null>(null);
   const [contextMenu, setContextMenu] = useState<{
@@ -1349,6 +1343,68 @@ function AlbumGrid({
     x: number;
     y: number;
   } | null>(null);
+
+  // Virtual-grid plumbing — without this a 800-album library mounts 800
+  // <Artwork> components on every tab switch, blowing the main thread
+  // for ~1 s before the first paint.
+  const pageScrollRef = usePageScroll();
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [colCount, setColCount] = useState(1);
+  const [tileWidth, setTileWidth] = useState(180);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  // Match the original Tailwind grid: `auto-fill,minmax(180px,1fr)` + gap-5.
+  const MIN_TILE = 180;
+  const GAP = 20;
+  // Tile = aspect-square cover (width = column width) + ~70 px of text
+  // beneath it (title + artist + meta + the space-y-2 separator).
+  const tileHeight = tileWidth + 70;
+
+  useLayoutEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const recompute = () => {
+      const width = el.getBoundingClientRect().width;
+      if (width === 0) return;
+      const n = Math.max(1, Math.floor((width + GAP) / (MIN_TILE + GAP)));
+      const actual = (width - (n - 1) * GAP) / n;
+      setColCount(n);
+      setTileWidth(actual);
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Mirror TrackTable's scrollMargin trick so the virtual row offsets
+  // line up with the actual position of this grid inside the page
+  // scroller.
+  useLayoutEffect(() => {
+    const parent = parentRef.current;
+    const scroller = pageScrollRef?.current;
+    if (!parent || !scroller) return;
+    const recompute = () => {
+      const pr = parent.getBoundingClientRect();
+      const sr = scroller.getBoundingClientRect();
+      setScrollMargin(pr.top - sr.top + scroller.scrollTop);
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(parent);
+    ro.observe(scroller);
+    return () => ro.disconnect();
+  }, [pageScrollRef, albums.length]);
+
+  const rowCount = Math.ceil(albums.length / colCount);
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => pageScrollRef?.current ?? null,
+    estimateSize: () => tileHeight + GAP,
+    overscan: 2,
+    scrollMargin,
+  });
 
   useEffect(() => {
     if (contextMenu == null) return;
@@ -1385,94 +1441,120 @@ function AlbumGrid({
     };
   }, [openMenuAlbumId]);
 
+  const renderAlbumCard = (album: AlbumRow) => {
+    const isMenuOpen = openMenuAlbumId === album.id;
+    return (
+      <div
+        key={album.id}
+        onClick={() => onAlbumClick(album.id)}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setContextMenu({
+            albumId: album.id,
+            x: e.clientX,
+            y: e.clientY,
+          });
+        }}
+        className="group flex flex-col space-y-2 cursor-pointer relative"
+      >
+        <div className="relative">
+          <Artwork
+            path={album.artwork_path}
+            path1x={album.artwork_path_1x}
+            path2x={album.artwork_path_2x}
+            // Album grid tile renders ~150-200 px wide; the 128 px
+            // 2x thumbnail upscales soft on a HiDPI display. Source
+            // originals are 600-1500 px square — small enough to
+            // decode instantly and crisp at any tile size.
+            size="full"
+            alt={album.title}
+            className="w-full aspect-square shadow-sm group-hover:shadow-md transition-shadow"
+            iconSize={44}
+            rounded="2xl"
+          />
+          <HiResBadge
+            bitDepth={album.max_bit_depth}
+            sampleRate={album.max_sample_rate}
+          />
+          <button
+            type="button"
+            data-add-to-playlist-trigger
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpenMenuAlbumId(isMenuOpen ? null : album.id);
+            }}
+            aria-label={t("trackActions.addToPlaylist")}
+            className={`absolute bottom-2 right-2 p-1.5 rounded-full shadow-sm transition-all ${
+              isMenuOpen
+                ? "opacity-100 bg-emerald-500 text-white"
+                : "opacity-0 group-hover:opacity-100 bg-white/90 dark:bg-zinc-800/90 text-zinc-600 dark:text-zinc-300 hover:bg-emerald-500 hover:text-white"
+            }`}
+          >
+            <Plus size={16} />
+          </button>
+        </div>
+        <div className="px-1">
+          <div className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 truncate">
+            {album.title}
+          </div>
+          <div className="text-xs text-zinc-500 truncate">
+            {album.artist_name ?? unknown}
+          </div>
+          <div className="text-[11px] text-zinc-400 mt-1">
+            {t("library.albumGrid.trackCount", {
+              count: album.track_count,
+            })}
+            {album.year ? ` · ${album.year}` : ""}
+          </div>
+        </div>
+        {isMenuOpen && (
+          <AddToPlaylistPopover
+            playlists={playlists}
+            trackId={album.id}
+            onPick={(playlistId) => {
+              onAddToPlaylist(playlistId, album.id);
+              setOpenMenuAlbumId(null);
+            }}
+            onCreate={() => {
+              setOpenMenuAlbumId(null);
+              onCreatePlaylist(album.id);
+            }}
+            t={t}
+          />
+        )}
+      </div>
+    );
+  };
+
   return (
     <>
       <div
-        className={`grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-5 ${
-          isLoading ? "opacity-50" : ""
-        }`}
+        ref={parentRef}
+        className={isLoading ? "opacity-50" : ""}
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          position: "relative",
+        }}
       >
-        {albums.map((album) => {
-          const isMenuOpen = openMenuAlbumId === album.id;
+        {virtualizer.getVirtualItems().map((row) => {
+          const startIdx = row.index * colCount;
+          const rowItems = albums.slice(startIdx, startIdx + colCount);
           return (
             <div
-              key={album.id}
-              onClick={() => onAlbumClick(album.id)}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                setContextMenu({
-                  albumId: album.id,
-                  x: e.clientX,
-                  y: e.clientY,
-                });
+              key={row.key}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${row.start - scrollMargin}px)`,
+                display: "grid",
+                gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))`,
+                gap: `${GAP}px`,
+                paddingBottom: `${GAP}px`,
               }}
-              className="group flex flex-col space-y-2 cursor-pointer relative"
             >
-              <div className="relative">
-                <Artwork
-                  path={album.artwork_path}
-                  path1x={album.artwork_path_1x}
-                  path2x={album.artwork_path_2x}
-                  // Album grid tile renders ~150-200 px wide; the 128 px
-                  // 2x thumbnail upscales soft on a HiDPI display. Source
-                  // originals are 600-1500 px square — small enough to
-                  // decode instantly and crisp at any tile size.
-                  size="full"
-                  alt={album.title}
-                  className="w-full aspect-square shadow-sm group-hover:shadow-md transition-shadow"
-                  iconSize={44}
-                  rounded="2xl"
-                />
-                <HiResBadge
-                  bitDepth={album.max_bit_depth}
-                  sampleRate={album.max_sample_rate}
-                />
-                <button
-                  type="button"
-                  data-add-to-playlist-trigger
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setOpenMenuAlbumId(isMenuOpen ? null : album.id);
-                  }}
-                  aria-label={t("trackActions.addToPlaylist")}
-                  className={`absolute bottom-2 right-2 p-1.5 rounded-full shadow-sm transition-all ${
-                    isMenuOpen
-                      ? "opacity-100 bg-emerald-500 text-white"
-                      : "opacity-0 group-hover:opacity-100 bg-white/90 dark:bg-zinc-800/90 text-zinc-600 dark:text-zinc-300 hover:bg-emerald-500 hover:text-white"
-                  }`}
-                >
-                  <Plus size={16} />
-                </button>
-              </div>
-              <div className="px-1">
-                <div className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 truncate">
-                  {album.title}
-                </div>
-                <div className="text-xs text-zinc-500 truncate">
-                  {album.artist_name ?? unknown}
-                </div>
-                <div className="text-[11px] text-zinc-400 mt-1">
-                  {t("library.albumGrid.trackCount", {
-                    count: album.track_count,
-                  })}
-                  {album.year ? ` · ${album.year}` : ""}
-                </div>
-              </div>
-              {isMenuOpen && (
-                <AddToPlaylistPopover
-                  playlists={playlists}
-                  trackId={album.id}
-                  onPick={(playlistId) => {
-                    onAddToPlaylist(playlistId, album.id);
-                    setOpenMenuAlbumId(null);
-                  }}
-                  onCreate={() => {
-                    setOpenMenuAlbumId(null);
-                    onCreatePlaylist(album.id);
-                  }}
-                  t={t}
-                />
-              )}
+              {rowItems.map((album) => renderAlbumCard(album))}
             </div>
           );
         })}
@@ -1511,7 +1593,13 @@ interface ArtistListProps {
   onAddToPlaylist: (playlistId: number, artistId: number) => void;
   onCreatePlaylist: (artistId: number) => void;
   onArtistClick: (artistId: number) => void;
-  gridRef?: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Mutable ref the grid populates with a `(idx) => void` callback that
+   * scrolls a specific artist into view. Used by the alphabet jump
+   * index — `scrollIntoView` on the DOM no longer works because
+   * off-screen rows aren't rendered.
+   */
+  scrollToIndexRef?: React.MutableRefObject<((idx: number) => void) | null>;
 }
 
 function ArtistList({
@@ -1522,9 +1610,82 @@ function ArtistList({
   onAddToPlaylist,
   onCreatePlaylist,
   onArtistClick,
-  gridRef,
+  scrollToIndexRef,
 }: ArtistListProps) {
+  "use no memo";
   const [openMenuArtistId, setOpenMenuArtistId] = useState<number | null>(null);
+
+  // Virtual-grid plumbing — see AlbumGrid for the rationale; same math
+  // applies to the artist tiles (same `minmax(180px,1fr)` + gap-5).
+  const pageScrollRef = usePageScroll();
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [colCount, setColCount] = useState(1);
+  const [tileWidth, setTileWidth] = useState(180);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  const MIN_TILE = 180;
+  const GAP = 20;
+  // Round avatar (width = column width) + space-y-3 (12 px) + 2 lines
+  // of text underneath (~40 px) → ~ width + 52.
+  const tileHeight = tileWidth + 52;
+
+  useLayoutEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const recompute = () => {
+      const width = el.getBoundingClientRect().width;
+      if (width === 0) return;
+      const n = Math.max(1, Math.floor((width + GAP) / (MIN_TILE + GAP)));
+      const actual = (width - (n - 1) * GAP) / n;
+      setColCount(n);
+      setTileWidth(actual);
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  useLayoutEffect(() => {
+    const parent = parentRef.current;
+    const scroller = pageScrollRef?.current;
+    if (!parent || !scroller) return;
+    const recompute = () => {
+      const pr = parent.getBoundingClientRect();
+      const sr = scroller.getBoundingClientRect();
+      setScrollMargin(pr.top - sr.top + scroller.scrollTop);
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(parent);
+    ro.observe(scroller);
+    return () => ro.disconnect();
+  }, [pageScrollRef, artists.length]);
+
+  const rowCount = Math.ceil(artists.length / colCount);
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => pageScrollRef?.current ?? null,
+    estimateSize: () => tileHeight + GAP,
+    overscan: 2,
+    scrollMargin,
+  });
+
+  // Expose a scroll-to-artist-index method for the AlphabetIndex (the
+  // off-screen rows aren't in the DOM anymore, so the previous
+  // `querySelector + scrollIntoView` path can't see them).
+  useEffect(() => {
+    if (!scrollToIndexRef) return;
+    scrollToIndexRef.current = (idx) => {
+      virtualizer.scrollToIndex(Math.floor(idx / Math.max(colCount, 1)), {
+        align: "start",
+      });
+    };
+    return () => {
+      scrollToIndexRef.current = null;
+    };
+  }, [scrollToIndexRef, virtualizer, colCount]);
 
   useEffect(() => {
     if (openMenuArtistId == null) return;
@@ -1545,99 +1706,121 @@ function ArtistList({
     };
   }, [openMenuArtistId]);
 
+  const renderArtistTile = (artist: ArtistRow, idx: number) => {
+    const isMenuOpen = openMenuArtistId === artist.id;
+    const artistPictureSrc = resolveArtwork(
+      {
+        full: artist.artwork_path ?? artist.picture_path,
+        x1: artist.artwork_path_1x ?? artist.picture_path_1x,
+        x2: artist.artwork_path_2x ?? artist.picture_path_2x,
+        remoteUrl: artist.picture_url,
+      },
+      "2x",
+    );
+    return (
+      <div
+        key={artist.id}
+        data-artist-index={idx}
+        onClick={() => onArtistClick(artist.id)}
+        className="group flex flex-col items-center space-y-3 cursor-pointer relative"
+      >
+        <div className="relative w-full">
+          {artistPictureSrc ? (
+            <FadeInImage
+              src={artistPictureSrc}
+              alt={artist.name}
+              wrapperClassName="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 border border-violet-200/60 dark:border-violet-800/40 shadow-sm group-hover:shadow-md transition-shadow"
+              placeholder={
+                <span className="text-5xl font-bold text-violet-500/70 dark:text-violet-400/60">
+                  {artist.name.trim().charAt(0).toUpperCase() || "?"}
+                </span>
+              }
+            />
+          ) : (
+            <div className="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 border border-violet-200/60 dark:border-violet-800/40 flex items-center justify-center overflow-hidden shadow-sm group-hover:shadow-md transition-shadow">
+              <span className="text-5xl font-bold text-violet-500/70 dark:text-violet-400/60">
+                {artist.name.trim().charAt(0).toUpperCase() || "?"}
+              </span>
+            </div>
+          )}
+          <button
+            type="button"
+            data-add-to-playlist-trigger
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpenMenuArtistId(isMenuOpen ? null : artist.id);
+            }}
+            aria-label={t("trackActions.addToPlaylist")}
+            className={`absolute bottom-1 right-1 p-1.5 rounded-full shadow-sm transition-all ${
+              isMenuOpen
+                ? "opacity-100 bg-emerald-500 text-white"
+                : "opacity-0 group-hover:opacity-100 bg-white/90 dark:bg-zinc-800/90 text-zinc-600 dark:text-zinc-300 hover:bg-emerald-500 hover:text-white"
+            }`}
+          >
+            <Plus size={16} />
+          </button>
+        </div>
+        <div className="text-center px-1 w-full">
+          <div className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 truncate">
+            {artist.name}
+          </div>
+          <div className="text-xs text-zinc-500">
+            {t("library.artistList.trackCount", {
+              count: artist.track_count,
+            })}
+            {artist.album_count > 0
+              ? ` · ${t("library.artistList.albumCount", { count: artist.album_count })}`
+              : ""}
+          </div>
+        </div>
+        {isMenuOpen && (
+          <AddToPlaylistPopover
+            playlists={playlists}
+            trackId={artist.id}
+            onPick={(playlistId) => {
+              onAddToPlaylist(playlistId, artist.id);
+              setOpenMenuArtistId(null);
+            }}
+            onCreate={() => {
+              setOpenMenuArtistId(null);
+              onCreatePlaylist(artist.id);
+            }}
+            t={t}
+          />
+        )}
+      </div>
+    );
+  };
+
   return (
     <div
-      ref={gridRef}
-      className={`grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-5 ${
-        isLoading ? "opacity-50" : ""
-      }`}
+      ref={parentRef}
+      className={isLoading ? "opacity-50" : ""}
+      style={{
+        height: `${virtualizer.getTotalSize()}px`,
+        position: "relative",
+      }}
     >
-      {artists.map((artist, idx) => {
-        const isMenuOpen = openMenuArtistId === artist.id;
-        // Local artwork wins over the Deezer cache so the user's own
-        // sidecar JPEGs surface here exactly like they do on the
-        // per-artist page (`ArtistDetailView`). When no local image
-        // exists we fall back to the Deezer picture, then to the
-        // remote URL — same precedence as the detail view.
-        const artistPictureSrc = resolveArtwork(
-          {
-            full: artist.artwork_path ?? artist.picture_path,
-            x1: artist.artwork_path_1x ?? artist.picture_path_1x,
-            x2: artist.artwork_path_2x ?? artist.picture_path_2x,
-            remoteUrl: artist.picture_url,
-          },
-          "2x",
-        );
+      {virtualizer.getVirtualItems().map((row) => {
+        const startIdx = row.index * colCount;
+        const rowItems = artists.slice(startIdx, startIdx + colCount);
         return (
           <div
-            key={artist.id}
-            data-artist-index={idx}
-            onClick={() => onArtistClick(artist.id)}
-            className="group flex flex-col items-center space-y-3 cursor-pointer relative"
+            key={row.key}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${row.start - scrollMargin}px)`,
+              display: "grid",
+              gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))`,
+              gap: `${GAP}px`,
+              paddingBottom: `${GAP}px`,
+            }}
           >
-            <div className="relative w-full">
-              {artistPictureSrc ? (
-                <FadeInImage
-                  src={artistPictureSrc}
-                  alt={artist.name}
-                  wrapperClassName="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 border border-violet-200/60 dark:border-violet-800/40 shadow-sm group-hover:shadow-md transition-shadow"
-                  placeholder={
-                    <span className="text-5xl font-bold text-violet-500/70 dark:text-violet-400/60">
-                      {artist.name.trim().charAt(0).toUpperCase() || "?"}
-                    </span>
-                  }
-                />
-              ) : (
-                <div className="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 border border-violet-200/60 dark:border-violet-800/40 flex items-center justify-center overflow-hidden shadow-sm group-hover:shadow-md transition-shadow">
-                  <span className="text-5xl font-bold text-violet-500/70 dark:text-violet-400/60">
-                    {artist.name.trim().charAt(0).toUpperCase() || "?"}
-                  </span>
-                </div>
-              )}
-              <button
-                type="button"
-                data-add-to-playlist-trigger
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setOpenMenuArtistId(isMenuOpen ? null : artist.id);
-                }}
-                aria-label={t("trackActions.addToPlaylist")}
-                className={`absolute bottom-1 right-1 p-1.5 rounded-full shadow-sm transition-all ${
-                  isMenuOpen
-                    ? "opacity-100 bg-emerald-500 text-white"
-                    : "opacity-0 group-hover:opacity-100 bg-white/90 dark:bg-zinc-800/90 text-zinc-600 dark:text-zinc-300 hover:bg-emerald-500 hover:text-white"
-                }`}
-              >
-                <Plus size={16} />
-              </button>
-            </div>
-            <div className="text-center px-1 w-full">
-              <div className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 truncate">
-                {artist.name}
-              </div>
-              <div className="text-xs text-zinc-500">
-                {t("library.artistList.trackCount", {
-                  count: artist.track_count,
-                })}
-                {artist.album_count > 0
-                  ? ` · ${t("library.artistList.albumCount", { count: artist.album_count })}`
-                  : ""}
-              </div>
-            </div>
-            {isMenuOpen && (
-              <AddToPlaylistPopover
-                playlists={playlists}
-                trackId={artist.id}
-                onPick={(playlistId) => {
-                  onAddToPlaylist(playlistId, artist.id);
-                  setOpenMenuArtistId(null);
-                }}
-                onCreate={() => {
-                  setOpenMenuArtistId(null);
-                  onCreatePlaylist(artist.id);
-                }}
-                t={t}
-              />
+            {rowItems.map((artist, i) =>
+              renderArtistTile(artist, startIdx + i),
             )}
           </div>
         );


### PR DESCRIPTION
## Summary

Two-part fix for the Library tab flicker reported by Daisy:

1. **Virtualize Albums and Artists grids** — with an 800-item library, the previous flat-grid render mounted 800 React subtrees at once, each carrying an `<Artwork>`/`<FadeInImage>` (state + useMemo) and a popover button. Main thread stalled ~1 s before the first paint, then the `<img>` tags fanned out and filled in. No amount of fade-in could disguise the layout cost.

2. **Fade artwork in over its gradient placeholder** — once virtualization keeps the DOM size sane, individual tile pop-in is the only remaining glitch. Each `<img>` now mounts at `opacity-0` over the same coloured gradient already used as the "no image" fallback, then fades to `100` on `onLoad`. WebView-cached images skip the fade entirely (handled in the `ref` callback when `complete && naturalWidth > 0`).

## What changed

**[`src/components/views/LibraryView.tsx`](src/components/views/LibraryView.tsx)** — `AlbumGrid` and `ArtistList`:
- Wrap rendering in `useVirtualizer` keyed on row count (rows × cols)
- `ResizeObserver` recomputes `colCount` from the container width to match the original `auto-fill,minmax(180px,1fr)` Tailwind math
- Each virtual row renders `colCount` tiles via inline grid styles
- Both share `usePageScroll()` so the page-driven scrollbar stays (per the cross-cutting rule)
- `AlphabetIndex` switches from `querySelector + scrollIntoView` to a `scrollToIndexRef` callback that drives `virtualizer.scrollToIndex(floor(idx / cols))` — off-screen artists aren't in the DOM anymore

**[`src/components/common/FadeInImage.tsx`](src/components/common/FadeInImage.tsx)** *(new)* — shared primitive:
- Wrapper hosts the gradient placeholder + clip
- Image mounts at `opacity-0`, fades to `100` on `onLoad`
- `ref` callback pins the fade open when the WebView serves bytes synchronously
- Resets the gate when `src` changes via the documented "compare prev prop in render" pattern (satisfies `react-hooks/set-state-in-effect`)

**[`src/components/common/Artwork.tsx`](src/components/common/Artwork.tsx)** — delegates the image rendering to `FadeInImage`, keeps the existing API.

**[`src/components/views/LibraryView.tsx`](src/components/views/LibraryView.tsx)** — artist tile inside `ArtistList` uses `FadeInImage` directly with the violet gradient + first-letter as `placeholder`.

`GenreList` is intentionally untouched: ~30-50 items in practice, no per-tile state, virtualization would be all cost and no benefit.

## Net effect

- Switching to Albums or Artists tabs: only ~`rowsVisible × cols` tiles in the DOM at any time
- Each cover/avatar fades in from its coloured gradient over 200 ms instead of flashing from grey
- Already-decoded covers (re-visit) appear at full opacity immediately

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Library with ~800 artists → click Artistes tab → first paint within frame budget, tiles fade in cleanly
- [x] Library with ~800 albums → same expectation
- [x] Alphabet jump on Artistes (sort = name): clicking a letter scrolls to the first artist of that letter
- [x] Resize window → tile count per row updates without breaking the virtual offset
- [x] Songs / Genres / Folders unaffected