### PR TITLE
fix(sidebar): give Ma musique + Playlists a shared scroll at 1080p

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -257,27 +257,35 @@ export function Sidebar({
         </button>
       </div>
 
-      <div className="flex-1 flex flex-col p-4 space-y-4 overflow-hidden">
-        {/* Navigation */}
-        <div className="space-y-1 shrink-0">
+      {/* Top navigation stays pinned: Home + Spotify shortcut are
+          one-click destinations the user wants at hand regardless of
+          how deep into the playlist list they've scrolled. */}
+      <div className="px-4 pt-4 pb-2 space-y-1 shrink-0">
+        <NavItem
+          icon={<Home size={18} />}
+          label={t("sidebar.nav.home")}
+          active={activeView === "home"}
+          onClick={() => setActiveView("home")}
+        />
+        {showSpotify && (
           <NavItem
-            icon={<Home size={18} />}
-            label={t("sidebar.nav.home")}
-            active={activeView === "home"}
-            onClick={() => setActiveView("home")}
+            icon={<Headphones size={18} />}
+            label={t("sidebar.nav.spotify", "Spotify")}
+            active={activeView === "spotify"}
+            onClick={() => setActiveView("spotify")}
           />
-          {showSpotify && (
-            <NavItem
-              icon={<Headphones size={18} />}
-              label={t("sidebar.nav.spotify", "Spotify")}
-              active={activeView === "spotify"}
-              onClick={() => setActiveView("spotify")}
-            />
-          )}
-        </div>
+        )}
+      </div>
 
+      {/* Single scroll surface for everything below the pinned nav so
+          Ma musique and Playlists share the leftover vertical space
+          instead of fighting over it. Reported in #54: at 1080p with
+          Spotify enabled the playlist section collapsed to ~0 px
+          because `shrink-0` on Ma musique pinned its full 5-row
+          height. */}
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 pb-4 space-y-4 scrollbar-hide">
         {/* ─── MA MUSIQUE ─── */}
-        <div className="space-y-1 shrink-0">
+        <div className="space-y-1">
           <div className="flex items-center justify-between text-[10px] font-bold tracking-widest text-zinc-400 mb-1 px-2 uppercase">
             <span>{t("sidebar.myMusic.title")}</span>
             <button
@@ -338,8 +346,8 @@ export function Sidebar({
         </div>
 
         {/* ─── PLAYLISTS ─── */}
-        <div className="flex-1 flex flex-col min-h-0">
-          <div className="flex items-center justify-between text-[10px] font-bold tracking-widest text-zinc-400 mb-1 px-2 uppercase shrink-0">
+        <div>
+          <div className="flex items-center justify-between text-[10px] font-bold tracking-widest text-zinc-400 mb-1 px-2 uppercase">
             <span>{t("sidebar.playlistSection.title")}</span>
             <div className="flex items-center gap-1">
               <button
@@ -371,7 +379,7 @@ export function Sidebar({
             </div>
           </div>
 
-          <div className="flex-1 min-h-0 overflow-y-auto space-y-1 scrollbar-hide pr-1">
+          <div className="space-y-1">
             {/* Pinned: Liked + Recent */}
             {pinnedRows.map((row) => (
               <SidebarRow


### PR DESCRIPTION
## Summary

Partial fix for #54 — addresses sub-bugs **A** and **B** (sidebar usability at 1080p). The "Library crowded", "immersive visualizer overlap" and "README screenshots" parts of #54 remain.

### Bug

Reported in #54 (screenshots in the issue):
- **Spotify shortcut ON** → Playlists section header is visible but **every row is clipped**: no Liked posts, no Recently played, no real playlist.
- **Spotify shortcut OFF** → Only **one row at a time** is reachable; the section is essentially a peephole.

### Cause

`Sidebar.tsx` wrapped Navigation + Ma musique + Playlists in a single `flex-1 ... overflow-hidden` container. Navigation and Ma musique carried `shrink-0`, pinning their full 2-row + 5-row heights. Playlists, with `flex-1`, only got the leftover — and on 1080p with 125 % DPI that leftover is zero or one row, depending on whether the Spotify shortcut is pinned.

### Fix

Restructure the sidebar into three zones with one shared scroll boundary:

- **Fixed header** — brand + profile (unchanged).
- **Fixed top nav** — Home + Spotify, always reachable in one click.
- **Scroll surface** — Ma musique + Playlists, sharing the leftover vertical space.

The pinned Liked / Recently-played rows and the real playlist list no longer live in their own nested `overflow-y-auto`. The outer surface handles everything below the top nav, so the user can simply scroll past Ma musique to reach the playlists when the viewport is short.

On a tall screen nothing changes visually because everything fits.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Confirm at 1920×1080 with Spotify shortcut ON: Liked / Recently played / playlists reachable via scroll
- [x] At 1920×1080 with Spotify shortcut OFF: same expectation, no truncation
- [x] On a 4K/tall screen: no visible regression (everything fits without scroll)