### PR TITLE
fix(immersive): cap cover so the layout fits 1080p without overlap

### DIFF
--- a/src/components/player/FullscreenNowPlaying.tsx
+++ b/src/components/player/FullscreenNowPlaying.tsx
@@ -197,9 +197,16 @@ export function FullscreenNowPlaying({
           </button>
         </div>
 
-        {/* Cover hero */}
+        {/* Cover hero. The cover is sized so the full layout (top
+            bar + cover + metadata + visualizer + transport) fits a
+            1080p viewport at 125 % DPI without overflow. Previous cap
+            of `min(60vh, 32rem)` produced a 512 px square that pushed
+            the visualizer into the metadata on smaller screens
+            (reported in #54). 45 vh / 26 rem keeps the hero
+            visually dominant while leaving ~200 px for the controls
+            stack underneath. */}
         <div className="flex-1 flex flex-col items-center justify-center px-8 min-h-0">
-          <div className="w-full max-w-[min(60vh,32rem)] aspect-square mb-8">
+          <div className="w-full max-w-[min(45vh,26rem)] aspect-square mb-6">
             <Artwork
               path={currentTrack?.artwork_path ?? null}
               path1x={currentTrack?.artwork_path_1x ?? null}


### PR DESCRIPTION
## Summary

Sub-bug **C** of #54: in the immersive Now Playing view, the cover was sized at `min(60vh, 32rem)` — a 512 px square. On a 1080p / 125 % DPI laptop the logical viewport is around 864 px tall; once the top bar, title + artist block, spectrum visualizer, progress bar, controls and bottom padding are stacked together, the layout overflowed the viewport and the visualizer ended up rendering on top of the metadata line.

## Fix

Cap the cover to `min(45vh, 26rem)` (≈ 388 px at 1080p, 416 px max on tall screens) and trim the gap below it from `mb-8` to `mb-6`. The hero stays visually dominant on 4K monitors while leaving roughly 200 px of room for the transport stack on a 1080p / 125 % DPI viewport.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] 1920×1080 / 125 % DPI: visualizer + progress + controls visible below the title, no overlap
- [x] 2560×1440 / 100 % DPI: cover still looks like the centerpiece
- [x] 3840×2160: cover doesn't shrink below ~ 26rem and the layout stays balanced

## Related

Bundles with #63 (sidebar 1080p) as part of the wider #54 polish — #54 also has sub-bugs **D** (Library density at 1080p) and **E** (README screenshots) still to address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Optimisation du dimensionnement et de l'espacement de la couverture en mode plein écran pour une meilleure présentation sur les appareils de petite taille.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->