### PR TITLE
fix(layout): tighten chrome density for 1080p

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -255,7 +255,7 @@ export function TopBar({
   };
 
   return (
-    <div className="h-20 flex items-center justify-between px-8 z-10 sticky top-0 bg-zinc-50/80 backdrop-blur-md dark:bg-zinc-900/80">
+    <div className="h-16 flex items-center justify-between px-6 z-10 sticky top-0 bg-zinc-50/80 backdrop-blur-md dark:bg-zinc-900/80">
       {/* Navigation Arrows */}
       <div className="flex space-x-2">
         <button

--- a/src/components/views/AlbumDetailView.tsx
+++ b/src/components/views/AlbumDetailView.tsx
@@ -207,9 +207,12 @@ export function AlbumDetailView({
   const isMultiDisc = discNumbers.length > 1;
 
   return (
-    <div className="space-y-8 animate-fade-in pb-20">
-      {/* Header */}
-      <div className="flex items-start space-x-8">
+    <div className="space-y-6 animate-fade-in pb-12">
+      {/* Header. Sized for 1080p / 125 % DPI: cover at 11rem (176 px)
+          keeps the album visually anchored without dominating the
+          viewport, title wraps to a second line instead of truncating
+          when the side lyrics panel is open. */}
+      <div className="flex items-start space-x-6">
         <div
           onDoubleClick={() => {
             if (album.artwork_path) setIsLightboxOpen(true);
@@ -221,18 +224,18 @@ export function AlbumDetailView({
             path1x={album.artwork_path_1x}
             path2x={album.artwork_path_2x}
             size="full"
-            className="w-48 h-48 shadow-lg"
+            className="w-44 h-44 shadow-lg"
             iconSize={64}
             alt={album.title}
             rounded="2xl"
           />
         </div>
 
-        <div className="flex-1 min-w-0 pt-2">
+        <div className="flex-1 min-w-0 pt-1">
           <div className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase mb-1">
             {t("albumDetail.badge")}
           </div>
-          <h1 className="text-4xl font-bold mb-2 text-zinc-900 dark:text-white truncate">
+          <h1 className="text-3xl md:text-4xl font-bold mb-1 text-zinc-900 dark:text-white line-clamp-2">
             {album.title}
           </h1>
 
@@ -243,14 +246,14 @@ export function AlbumDetailView({
               onClick={() =>
                 album.artist_id != null && onNavigateToArtist(album.artist_id)
               }
-              className="text-lg font-medium text-emerald-600 dark:text-emerald-400 hover:underline mb-3"
+              className="text-lg font-medium text-emerald-600 dark:text-emerald-400 hover:underline mb-2"
             >
               {album.artist_name}
             </button>
           )}
 
           {/* Meta */}
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-zinc-500 mb-4">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-zinc-500 mb-3">
             {album.year && <span>{album.year}</span>}
             {album.year && label && <span>·</span>}
             {label && <span>{label}</span>}
@@ -264,7 +267,7 @@ export function AlbumDetailView({
 
           {/* Genres */}
           {album.genres.length > 0 && (
-            <div className="flex flex-wrap gap-2 mb-4">
+            <div className="flex flex-wrap gap-2 mb-3">
               {album.genres.map((genre) => (
                 <span
                   key={genre}
@@ -284,12 +287,12 @@ export function AlbumDetailView({
           )}
 
           {/* Actions */}
-          <div className="flex items-center space-x-3 mt-4">
+          <div className="flex flex-wrap items-center gap-2 mt-3">
             <button
               type="button"
               onClick={handlePlayAll}
               disabled={album.tracks.length === 0}
-              className="bg-emerald-500 hover:bg-emerald-600 text-white px-5 py-2.5 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm disabled:opacity-50"
+              className="bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm disabled:opacity-50"
             >
               <Play size={16} className="fill-current" />
               <span>{t("albumDetail.playAll")}</span>
@@ -298,7 +301,7 @@ export function AlbumDetailView({
               type="button"
               onClick={handleShufflePlay}
               disabled={album.tracks.length === 0}
-              className="border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-300 px-5 py-2.5 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm disabled:opacity-50"
+              className="border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-300 px-4 py-2 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm disabled:opacity-50"
             >
               <Shuffle size={16} />
               <span>{t("albumDetail.shuffle")}</span>
@@ -306,7 +309,7 @@ export function AlbumDetailView({
             <button
               type="button"
               onClick={() => setIsCoverPickerOpen(true)}
-              className="border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-300 px-5 py-2.5 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm"
+              className="border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-300 px-4 py-2 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm"
             >
               <ImageIcon size={16} />
               <span>{t("library.changeCover")}</span>

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -387,15 +387,15 @@ export function LibraryView({
     (activeTab === "dossiers" && folders.length > 0);
 
   return (
-    <div className="space-y-8 animate-fade-in pb-20">
+    <div className="space-y-6 animate-fade-in pb-12">
       {/* Header */}
       <div className="flex items-start justify-between">
-        <div className="flex items-center space-x-6">
-          <div className="w-24 h-24 rounded-2xl bg-emerald-100 text-emerald-600 dark:bg-emerald-950/60 dark:text-emerald-400 flex items-center justify-center shadow-sm">
-            <Music2 size={48} />
+        <div className="flex items-center space-x-5">
+          <div className="w-20 h-20 rounded-2xl bg-emerald-100 text-emerald-600 dark:bg-emerald-950/60 dark:text-emerald-400 flex items-center justify-center shadow-sm">
+            <Music2 size={40} />
           </div>
           <div>
-            <h1 className="text-4xl font-bold mb-2 text-zinc-900 dark:text-white">
+            <h1 className="text-3xl md:text-4xl font-bold mb-1 text-zinc-900 dark:text-white">
               {t("sidebar.myMusic.title")}
             </h1>
             <div className="flex items-center text-sm text-zinc-500 space-x-2">
@@ -410,7 +410,7 @@ export function LibraryView({
             type="button"
             onClick={handleImport}
             disabled={isImporting}
-            className="bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2.5 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm shadow-emerald-500/30 disabled:opacity-60 disabled:cursor-not-allowed"
+            className="bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm shadow-emerald-500/30 disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <Folder size={16} />
             <span>{t("library.header.addFolder")}</span>


### PR DESCRIPTION
## Summary

Sub-bug **D** of #54: the Library view (Album Detail in particular) felt crowded at 1920×1080, especially with the side lyrics panel open. The hero blocks were dimensioned for 4K — once the main column dropped to ~600 px the album title truncated mid-word and the page felt top-heavy.

## What changed

Three coordinated trims; no grammar change to the design language.

| File | Before | After |
|---|---|---|
| [TopBar.tsx](src/components/layout/TopBar.tsx) | `h-20 px-8` | `h-16 px-6` |
| [LibraryView.tsx](src/components/views/LibraryView.tsx) hero | `space-y-8 pb-20`, icon `w-24 h-24` (size=48), title `text-4xl mb-2`, button `px-4 py-2.5` | `space-y-6 pb-12`, icon `w-20 h-20` (size=40), title `text-3xl md:text-4xl mb-1`, button `px-4 py-2` |
| [AlbumDetailView.tsx](src/components/views/AlbumDetailView.tsx) hero | `space-y-8 pb-20`, cover `w-48 h-48`, `space-x-8`, title `text-4xl truncate`, three buttons `px-5 py-2.5` no wrap | `space-y-6 pb-12`, cover `w-44 h-44`, `space-x-6`, title `text-3xl md:text-4xl line-clamp-2`, buttons `px-4 py-2` with `flex-wrap gap-2` |

## Net effect

On a 1080p / 125 % DPI viewport:
- TopBar drops 16 px of vertical chrome above every view.
- AlbumDetail hero loses about 60 px of vertical bulk.
- Long album titles wrap to a second line instead of ellipsizing when the lyrics panel is open.
- Action buttons can wrap to a second row when the column gets narrow, rather than overflowing.

On a 4K / 100 % DPI display the heroes are very slightly more compact but still clearly the page anchor — the responsive `md:text-4xl` keeps the title at its original size on wide viewports.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] 1920×1080 with lyrics panel open: album title visible on two lines, no truncation; buttons fit (wrap if needed)
- [x] Same resolution, lyrics panel closed: title on one line, no wrap
- [x] 2560×1440: heroes look balanced, not "shrunk"
- [x] 3840×2160: heroes don't look out of proportion, title at `text-4xl`

## Related

Closes sub-bug **D** of #54. Sub-bug **E** (README screenshots) is the only piece of #54 still pending.