### PR TITLE
fix(ui): open cover/artist lightbox on single click

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "prettier": "^3.8.3",
         "sharp": "^0.34.5",
         "typescript": "~6.0.3",
-        "typescript-eslint": "^8.59.3",
+        "typescript-eslint": "^8.59.4",
         "vite": "^8.0.13",
       },
     },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3146,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -5508,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/src/components/layout/NowPlayingPanel.tsx
+++ b/src/components/layout/NowPlayingPanel.tsx
@@ -140,7 +140,7 @@ export function NowPlayingPanel({ onNavigateToArtist }: NowPlayingPanelProps) {
           <div className="p-6 space-y-6">
             {/* Large artwork */}
             <div
-              onDoubleClick={() => {
+              onClick={() => {
                 if (currentTrack.artwork_path) setIsLightboxOpen(true);
               }}
               className={

--- a/src/components/views/AlbumDetailView.tsx
+++ b/src/components/views/AlbumDetailView.tsx
@@ -214,7 +214,7 @@ export function AlbumDetailView({
           when the side lyrics panel is open. */}
       <div className="flex items-start space-x-6">
         <div
-          onDoubleClick={() => {
+          onClick={() => {
             if (album.artwork_path) setIsLightboxOpen(true);
           }}
           className={album.artwork_path ? "cursor-zoom-in" : undefined}

--- a/src/components/views/ArtistDetailView.tsx
+++ b/src/components/views/ArtistDetailView.tsx
@@ -257,7 +257,7 @@ export function ArtistDetailView({
             <img
               src={pictureSrc}
               alt={artist.name}
-              onDoubleClick={() => setIsLightboxOpen(true)}
+              onClick={() => setIsLightboxOpen(true)}
               className="w-48 h-48 rounded-full object-cover shadow-lg cursor-zoom-in"
             />
           ) : (
@@ -268,7 +268,7 @@ export function ArtistDetailView({
             </div>
           )}
           {/* The wrapper is pointer-events-none so the underlying <img>
-              keeps receiving onDoubleClick (lightbox); the inner button
+              keeps receiving onClick (lightbox); the inner button
               re-enables pointer events for the small pencil hit area. */}
           <div className="absolute right-2 bottom-2 pointer-events-none">
             <button


### PR DESCRIPTION
## Summary
- Three zoomable images (NowPlayingPanel cover, ArtistDetailView photo, AlbumDetailView cover) showed `cursor-zoom-in` but were wired to `onDoubleClick`, so a single click did nothing and double-click only landed half the time.
- Swap the three handlers to `onClick` so the interaction matches the cursor cue and the lightbox opens on the first try.
- The artist edit-pencil button is unaffected — it already lives inside the standard `pointer-events-none` wrapper + `pointer-events-auto` button pattern.

## Test plan
- [x] `bun run tauri dev`
- [x] Open « En cours de lecture » → 1 clic sur la pochette ouvre la lightbox immédiatement.
- [x] Sur la page artiste, 1 clic sur la photo ronde ouvre la lightbox (le crayon en bas à droite reste cliquable et indépendant).
- [x] Sur la page album, 1 clic sur la pochette ouvre la lightbox.
- [x] `bun run typecheck && bun run lint` — déjà verts en local.