### PR TITLE
fix(playlist): preserve real image extension on cover upload temp file

### DIFF
--- a/src-tauri/src/commands/playlist_cover.rs
+++ b/src-tauri/src/commands/playlist_cover.rs
@@ -82,11 +82,11 @@ pub async fn set_playlist_cover_from_file(
             MAX_UPLOAD_BYTES
         )));
     }
-    if detect_image_format(&bytes).is_none() {
+    let Some(ext) = detect_image_format(&bytes) else {
         return Err(AppError::Other(
             "unsupported image format (expected jpg/png/webp)".into(),
         ));
-    }
+    };
     // We don't keep the original extension in the metadata cache because
     // every smart-playlist cover is JPEG. Re-encode through the compositor
     // pipeline (single-tile fill) for two wins:
@@ -95,9 +95,13 @@ pub async fn set_playlist_cover_from_file(
     //   2. Resize-to-canvas — uploads larger than 640×640 get downscaled
     //      to the on-disk standard, capping disk usage and keeping the
     //      sidebar / carousel render fast.
+    // `image::open` infers the codec from the path extension, so the temp
+    // file MUST carry the real image extension — `.bin` falls back to
+    // PathExtension(Format) and the compositor rejects the input.
     let tmp = std::env::temp_dir().join(format!(
-        "waveflow-upload-{}.bin",
-        blake3::hash(&bytes).to_hex()
+        "waveflow-upload-{}.{}",
+        blake3::hash(&bytes).to_hex(),
+        ext
     ));
     std::fs::write(&tmp, &bytes).map_err(|e| AppError::Other(format!("temp write: {e}")))?;
     let result = cover::build_composite_cover(


### PR DESCRIPTION
## Summary
- Fixes #71 — uploading a custom cover from the edit-playlist modal failed silently with `smart cover: no decodable input images`.
- Root cause: `set_playlist_cover_from_file` wrote the validated bytes to a temp file named `waveflow-upload-<hash>.bin`, then passed that path to `cover::build_composite_cover`, which calls `image::open`. The `image` crate infers the codec from the path extension, so `.bin` resolved to `Unsupported(PathExtension("bin"))` and the compositor dropped the only input.
- Fix: reuse the extension already detected by the magic-byte validator (`jpg` / `png` / `webp`) when naming the temp file. No new allocations, no new branches.

## Test plan
- [x] Open a regular playlist → Edit → click the cover → pick a JPG: cover updates, `cover_is_auto` flips to 0.
- [x] Repeat with a PNG and a WebP.
- [x] Add a track to the playlist → custom cover stays (auto-regen short-circuits on `cover_is_auto = 0`).
- [x] Click "Remove photo" → auto-cover regenerates from the first 4 tracks' artworks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Correctifs

* **Gestion des couvertures de liste de lecture** : Amélioration de la validation des formats d'image lors de l'import. Le système détecte désormais correctement le type d'image, fournit des messages d'erreur explicites pour les formats non supportés, et traite chaque fichier selon son format réel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->