### PR TITLE
fix(library): hoist track row above siblings while + popover is open

### DIFF
--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1083,6 +1083,13 @@ function TrackTable({
                 width: "100%",
                 height: `${virtualRow.size}px`,
                 transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+                // Hoist the row that owns the open "+" popover above its
+                // sibling rows so the popover isn't painted under (or
+                // click-blocked by) the rows rendered after it in DOM
+                // order. Every row is `position: absolute` without a
+                // z-index, so the popover's own `z-50` can't escape its
+                // row's stacking context — bumping the row itself does.
+                zIndex: isMenuOpen ? 20 : undefined,
               }}
               className={`group grid ${gridCols} gap-4 px-5 items-center select-none transition-colors cursor-pointer border-b border-zinc-100 dark:border-zinc-800/60 ${
                 isRowSelected


### PR DESCRIPTION
## Summary
- Fixes #72 — the small "Add to a playlist" popover that opens from the `+` button on a track row in the Songs view appeared semi-transparent and didn't accept clicks.
- Root cause: every virtualized row in `TrackTable` is `position: absolute` without a `z-index`. The popover's own `z-50` is scoped to its row's stacking context, so it could not climb above sibling rows rendered later in DOM order. Those rows painted on top of the popover, which simultaneously made it look transparent (the underlying row's duration / heart leaking through) and stole every click on a menu item.
- Fix: bump the owning row's `z-index` to `20` while its popover is open, so it stacks above every following row.

## Test plan
- [x] Open Songs view → hover a track row that isn't the last one → click the `+` button: popover is fully opaque, no duration/heart from rows below leaking through.
- [x] Click a playlist in the popover: the track is added (no longer silently absorbed by the row underneath).
- [x] Click "New playlist": modal opens with the track pre-staged.
- [x] Close + re-open on different rows (first, middle, last visible): no regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Corrections de bugs**
  * Correction de l'affichage du menu "Ajouter à la playlist" dans la vue des pistes pour qu'il s'affiche correctement au-dessus des autres éléments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->