### PR TITLE
fix(library): hoist album/artist grid row above siblings while + popover is open

### DIFF
--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1539,6 +1539,13 @@ function AlbumGrid({
         {virtualizer.getVirtualItems().map((row) => {
           const startIdx = row.index * colCount;
           const rowItems = albums.slice(startIdx, startIdx + colCount);
+          // Hoist the row that owns the open card popover above the rows
+          // rendered after it in DOM order. Same stacking-context trap as
+          // TrackTable: every virtualized row is `position: absolute`, so
+          // a `z-50` inside one card can't escape its row.
+          const rowHasOpenMenu = rowItems.some(
+            (album) => album.id === openMenuAlbumId,
+          );
           return (
             <div
               key={row.key}
@@ -1552,6 +1559,7 @@ function AlbumGrid({
                 gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))`,
                 gap: `${GAP}px`,
                 paddingBottom: `${GAP}px`,
+                zIndex: rowHasOpenMenu ? 20 : undefined,
               }}
             >
               {rowItems.map((album) => renderAlbumCard(album))}
@@ -1808,6 +1816,11 @@ function ArtistList({
       {virtualizer.getVirtualItems().map((row) => {
         const startIdx = row.index * colCount;
         const rowItems = artists.slice(startIdx, startIdx + colCount);
+        // Same stacking fix as TrackTable / AlbumGrid: bump the row that
+        // owns the open `+` popover above the rows rendered after it.
+        const rowHasOpenMenu = rowItems.some(
+          (artist) => artist.id === openMenuArtistId,
+        );
         return (
           <div
             key={row.key}
@@ -1821,6 +1834,7 @@ function ArtistList({
               gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))`,
               gap: `${GAP}px`,
               paddingBottom: `${GAP}px`,
+              zIndex: rowHasOpenMenu ? 20 : undefined,
             }}
           >
             {rowItems.map((artist, i) =>


### PR DESCRIPTION
## Summary
- Follow-up to #74, which fixed the same bug in `TrackTable`.
- `AlbumGrid` and `ArtistList` use the same virtualized-row pattern (`position: absolute` per row, no z-index). When the `+` popover opens on a card, sibling rows rendered after it in DOM order paint on top — the popover looks transparent and clicks on its items hit the cards below.
- Fix: when a row contains the card whose menu is open, bump its `zIndex` to `20`. Granular per-row because each grid row holds multiple cards.

## Test plan
- [x] Albums tab — open `+` popover on a card in the first row, click a playlist on the popover (must not trigger the album below).
- [x] Same on the last row of the viewport.
- [x] Artists tab — same checks.
- [x] Tracks tab — regression check, behaviour unchanged from #74.