### PR TITLE
feat(library): toggle playlist membership from track + popover

### DIFF
--- a/src-tauri/src/commands/playlist.rs
+++ b/src-tauri/src/commands/playlist.rs
@@ -416,6 +416,31 @@ pub async fn list_playlist_tracks(
     Ok(tracks)
 }
 
+/// Return the IDs of every user playlist that currently contains `track_id`.
+/// Smart playlists are excluded — their membership is computed on the fly
+/// from rules and would be misleading to expose as a toggle target.
+///
+/// Used by the `+` popover to render a checkmark on rows the track is
+/// already in (and to flip the click handler from "add" to "remove").
+#[tauri::command]
+pub async fn list_playlists_containing_track(
+    state: tauri::State<'_, AppState>,
+    track_id: i64,
+) -> AppResult<Vec<i64>> {
+    let pool = state.require_profile_pool().await?;
+    let rows: Vec<(i64,)> = sqlx::query_as(
+        "SELECT pt.playlist_id
+           FROM playlist_track pt
+           JOIN playlist p ON p.id = pt.playlist_id
+          WHERE pt.track_id = ?
+            AND p.is_smart = 0",
+    )
+    .bind(track_id)
+    .fetch_all(&pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
 /// Append a single track to the end of a playlist. Idempotent — if the track
 /// is already in the playlist the existing row is preserved and `updated_at`
 /// is still bumped so the UI reflects the user's intent.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -468,6 +468,7 @@ pub fn run() {
             commands::playlist::update_playlist,
             commands::playlist::delete_playlist,
             commands::playlist::list_playlist_tracks,
+            commands::playlist::list_playlists_containing_track,
             commands::playlist::add_track_to_playlist,
             commands::playlist::add_tracks_to_playlist,
             commands::playlist::remove_track_from_playlist,

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -55,7 +55,10 @@ import { resolvePlaylistColor } from "../../lib/playlistVisuals";
 import { resolveArtwork } from "../../lib/tauri/artwork";
 import { FadeInImage } from "../common/FadeInImage";
 import { PlaylistIcon } from "../../lib/PlaylistIcon";
-import type { Playlist } from "../../lib/tauri/playlist";
+import {
+  listPlaylistsContainingTrack,
+  type Playlist,
+} from "../../lib/tauri/playlist";
 import { pickFolder } from "../../lib/tauri/dialog";
 import {
   removeFolderFromLibrary,
@@ -137,6 +140,7 @@ export function LibraryView({
   const {
     playlists,
     addTracksToPlaylist,
+    removeTrackFromPlaylist,
     addSourceToPlaylist,
     createPlaylist,
   } = usePlaylist();
@@ -539,6 +543,16 @@ export function LibraryView({
                     await addTracksToPlaylist(playlistId, [trackId]);
                   } catch (err) {
                     console.error("[LibraryView] add to playlist failed", err);
+                  }
+                }}
+                onRemoveFromPlaylist={async (playlistId, trackId) => {
+                  try {
+                    await removeTrackFromPlaylist(playlistId, trackId);
+                  } catch (err) {
+                    console.error(
+                      "[LibraryView] remove from playlist failed",
+                      err,
+                    );
                   }
                 }}
                 onCreatePlaylist={(trackId) => {
@@ -945,7 +959,11 @@ interface TrackTableProps {
   likedIds: Set<number>;
   onToggleLike: (trackId: number) => void;
   playlists: Playlist[];
-  onAddToPlaylist: (playlistId: number, trackId: number) => void;
+  onAddToPlaylist: (playlistId: number, trackId: number) => Promise<void> | void;
+  onRemoveFromPlaylist: (
+    playlistId: number,
+    trackId: number,
+  ) => Promise<void> | void;
   onCreatePlaylist: (trackId: number) => void;
   onNavigateToAlbum: (albumId: number) => void;
   onNavigateToArtist: (artistId: number) => void;
@@ -966,6 +984,7 @@ function TrackTable({
   onToggleLike,
   playlists,
   onAddToPlaylist,
+  onRemoveFromPlaylist,
   onCreatePlaylist,
   onNavigateToAlbum,
   onNavigateToArtist,
@@ -976,6 +995,13 @@ function TrackTable({
   "use no memo";
   const unknown = t("library.table.unknown");
   const [openMenuTrackId, setOpenMenuTrackId] = useState<number | null>(null);
+  // Per-track playlist membership snapshot, fetched the first time the
+  // user opens the `+` popover for a given track. Entry stays cached for
+  // the lifetime of the table so reopening the menu is instant. Optimistic
+  // updates flip the set on toggle.
+  const [trackMembership, setTrackMembership] = useState<
+    Map<number, Set<number>>
+  >(new Map());
   const [ratingOverrides, setRatingOverrides] = useState<
     Map<number, number | null>
   >(new Map());
@@ -1208,7 +1234,27 @@ function TrackTable({
                   data-add-to-playlist-trigger
                   onClick={(e) => {
                     e.stopPropagation();
-                    setOpenMenuTrackId(isMenuOpen ? null : track.id);
+                    const opening = !isMenuOpen;
+                    setOpenMenuTrackId(opening ? track.id : null);
+                    // Lazy-fetch membership the first time this track's
+                    // popover is opened. Subsequent opens reuse the cached
+                    // set (kept in sync via optimistic updates on toggle).
+                    if (opening && !trackMembership.has(track.id)) {
+                      listPlaylistsContainingTrack(track.id)
+                        .then((ids) => {
+                          setTrackMembership((prev) => {
+                            const next = new Map(prev);
+                            next.set(track.id, new Set(ids));
+                            return next;
+                          });
+                        })
+                        .catch((err) => {
+                          console.error(
+                            "[LibraryView] load membership failed",
+                            err,
+                          );
+                        });
+                    }
                   }}
                   aria-label={t("trackActions.addToPlaylist")}
                   aria-haspopup="menu"
@@ -1225,8 +1271,28 @@ function TrackTable({
                   <AddToPlaylistPopover
                     playlists={playlists}
                     trackId={track.id}
+                    memberPlaylistIds={trackMembership.get(track.id)}
                     onPick={(playlistId) => {
-                      onAddToPlaylist(playlistId, track.id);
+                      const members = trackMembership.get(track.id);
+                      const isMember = members?.has(playlistId) ?? false;
+                      // Optimistic membership flip — the underlying mutations
+                      // are idempotent on the backend, so a failed RPC just
+                      // means the visual state will drift until the next
+                      // popover open, which is the worst-case loss for a
+                      // single click.
+                      setTrackMembership((prev) => {
+                        const next = new Map(prev);
+                        const set = new Set(next.get(track.id) ?? []);
+                        if (isMember) set.delete(playlistId);
+                        else set.add(playlistId);
+                        next.set(track.id, set);
+                        return next;
+                      });
+                      if (isMember) {
+                        void onRemoveFromPlaylist(playlistId, track.id);
+                      } else {
+                        void onAddToPlaylist(playlistId, track.id);
+                      }
                       setOpenMenuTrackId(null);
                     }}
                     onCreate={() => {
@@ -1251,6 +1317,14 @@ interface AddToPlaylistPopoverProps {
   onPick: (playlistId: number) => void;
   onCreate: () => void;
   t: Translator;
+  /**
+   * Optional set of playlist IDs the target is already in. Only meaningful
+   * for the track popover — when provided, matching rows render a green
+   * checkmark and the caller is expected to toggle (remove) rather than
+   * add on click. Albums/artists/folders skip this prop because their
+   * "+ to playlist" action is a bulk add with no symmetric remove.
+   */
+  memberPlaylistIds?: ReadonlySet<number>;
 }
 
 /**
@@ -1266,6 +1340,7 @@ function AddToPlaylistPopover({
   onPick,
   onCreate,
   t,
+  memberPlaylistIds,
 }: AddToPlaylistPopoverProps) {
   return (
     <div
@@ -1285,11 +1360,19 @@ function AddToPlaylistPopover({
         ) : (
           playlists.map((pl) => {
             const color = resolvePlaylistColor(pl.color_id);
+            const isMember = memberPlaylistIds?.has(pl.id) ?? false;
             return (
               <button
                 key={pl.id}
                 type="button"
                 role="menuitem"
+                aria-label={
+                  isMember
+                    ? t("trackActions.removeFromPlaylistNamed", {
+                        name: pl.name,
+                      })
+                    : t("trackActions.addToPlaylistNamed", { name: pl.name })
+                }
                 onClick={() => onPick(pl.id)}
                 className="w-full flex items-center space-x-2 p-2 rounded-lg text-left hover:bg-zinc-50 dark:hover:bg-zinc-700/30 transition-colors"
               >
@@ -1298,9 +1381,16 @@ function AddToPlaylistPopover({
                 >
                   <PlaylistIcon iconId={pl.icon_id} size={14} />
                 </div>
-                <span className="text-sm font-medium text-zinc-800 dark:text-zinc-200 truncate">
+                <span className="flex-1 text-sm font-medium text-zinc-800 dark:text-zinc-200 truncate">
                   {pl.name}
                 </span>
+                {isMember && (
+                  <Check
+                    size={14}
+                    className="shrink-0 text-emerald-500"
+                    aria-hidden="true"
+                  />
+                )}
               </button>
             );
           })

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -727,7 +727,9 @@
     "startRadio": "تشغيل الراديو",
     "rating": "التقييم",
     "ratingNone": "بدون تقييم",
-    "batchEdit": "تعديل علامات {{count}} مقطوعات…"
+    "batchEdit": "تعديل علامات {{count}} مقطوعات…",
+    "addToPlaylistNamed": "إضافة إلى \"{{name}}\"",
+    "removeFromPlaylistNamed": "إزالة من \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "تحرير العلامات بشكل جماعي",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -727,7 +727,9 @@
     "startRadio": "Radio starten",
     "rating": "Bewertung",
     "ratingNone": "Keine Bewertung",
-    "batchEdit": "Tags für {{count}} Titel bearbeiten…"
+    "batchEdit": "Tags für {{count}} Titel bearbeiten…",
+    "addToPlaylistNamed": "Zu \"{{name}}\" hinzufügen",
+    "removeFromPlaylistNamed": "Aus \"{{name}}\" entfernen"
   },
   "batchTagEdit": {
     "title": "Tags im Stapel bearbeiten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -735,7 +735,9 @@
     "startRadio": "Start radio",
     "rating": "Rating",
     "ratingNone": "No rating",
-    "batchEdit": "Edit tags for {{count}} tracks…"
+    "batchEdit": "Edit tags for {{count}} tracks…",
+    "addToPlaylistNamed": "Add to \"{{name}}\"",
+    "removeFromPlaylistNamed": "Remove from \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Batch edit tags",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -727,7 +727,9 @@
     "startRadio": "Iniciar la radio",
     "rating": "Valoración",
     "ratingNone": "Sin valoración",
-    "batchEdit": "Editar etiquetas de {{count}} canciones…"
+    "batchEdit": "Editar etiquetas de {{count}} canciones…",
+    "addToPlaylistNamed": "Añadir a \"{{name}}\"",
+    "removeFromPlaylistNamed": "Quitar de \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Editar etiquetas en lote",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -735,7 +735,9 @@
     "startRadio": "Démarrer la radio",
     "rating": "Note",
     "ratingNone": "Aucune note",
-    "batchEdit": "Modifier les tags de {{count}} morceaux…"
+    "batchEdit": "Modifier les tags de {{count}} morceaux…",
+    "addToPlaylistNamed": "Ajouter \"{{name}}\" à cette playlist",
+    "removeFromPlaylistNamed": "Retirer \"{{name}}\" de cette playlist"
   },
   "batchTagEdit": {
     "title": "Modifier les tags en lot",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -727,7 +727,9 @@
     "startRadio": "रेडियो शुरू करें",
     "rating": "रेटिंग",
     "ratingNone": "कोई रेटिंग नहीं",
-    "batchEdit": "{{count}} ट्रैक के टैग संपादित करें…"
+    "batchEdit": "{{count}} ट्रैक के टैग संपादित करें…",
+    "addToPlaylistNamed": "\"{{name}}\" में जोड़ें",
+    "removeFromPlaylistNamed": "\"{{name}}\" से हटाएं"
   },
   "batchTagEdit": {
     "title": "एकसाथ टैग संपादन",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -727,7 +727,9 @@
     "startRadio": "Mulai radio",
     "rating": "Peringkat",
     "ratingNone": "Tanpa peringkat",
-    "batchEdit": "Edit tag untuk {{count}} lagu…"
+    "batchEdit": "Edit tag untuk {{count}} lagu…",
+    "addToPlaylistNamed": "Tambahkan ke \"{{name}}\"",
+    "removeFromPlaylistNamed": "Hapus dari \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Edit tag massal",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -727,7 +727,9 @@
     "startRadio": "Avvia radio",
     "rating": "Valutazione",
     "ratingNone": "Nessuna valutazione",
-    "batchEdit": "Modifica tag per {{count}} brani…"
+    "batchEdit": "Modifica tag per {{count}} brani…",
+    "addToPlaylistNamed": "Aggiungi a \"{{name}}\"",
+    "removeFromPlaylistNamed": "Rimuovi da \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Modifica tag in blocco",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -727,7 +727,9 @@
     "startRadio": "ラジオを開始",
     "rating": "評価",
     "ratingNone": "評価なし",
-    "batchEdit": "{{count}}曲のタグを編集…"
+    "batchEdit": "{{count}}曲のタグを編集…",
+    "addToPlaylistNamed": "「{{name}}」に追加",
+    "removeFromPlaylistNamed": "「{{name}}」から削除"
   },
   "batchTagEdit": {
     "title": "タグの一括編集",

--- a/src/i18n/locales/kr.json
+++ b/src/i18n/locales/kr.json
@@ -727,7 +727,9 @@
     "startRadio": "라디오 시작",
     "rating": "평점",
     "ratingNone": "평점 없음",
-    "batchEdit": "{{count}}곡의 태그 편집…"
+    "batchEdit": "{{count}}곡의 태그 편집…",
+    "addToPlaylistNamed": "\"{{name}}\"에 추가",
+    "removeFromPlaylistNamed": "\"{{name}}\"에서 제거"
   },
   "batchTagEdit": {
     "title": "태그 일괄 편집",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -727,7 +727,9 @@
     "startRadio": "Start radio",
     "rating": "Beoordeling",
     "ratingNone": "Geen beoordeling",
-    "batchEdit": "Tags voor {{count}} nummers bewerken…"
+    "batchEdit": "Tags voor {{count}} nummers bewerken…",
+    "addToPlaylistNamed": "Toevoegen aan \"{{name}}\"",
+    "removeFromPlaylistNamed": "Verwijderen uit \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Tags in batch bewerken",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -727,7 +727,9 @@
     "startRadio": "Iniciar rádio",
     "rating": "Classificação",
     "ratingNone": "Sem classificação",
-    "batchEdit": "Editar tags de {{count}} faixas…"
+    "batchEdit": "Editar tags de {{count}} faixas…",
+    "addToPlaylistNamed": "Adicionar a \"{{name}}\"",
+    "removeFromPlaylistNamed": "Remover de \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Editar tags em lote",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -727,7 +727,9 @@
     "startRadio": "Iniciar rádio",
     "rating": "Classificação",
     "ratingNone": "Sem classificação",
-    "batchEdit": "Editar tags de {{count}} faixas…"
+    "batchEdit": "Editar tags de {{count}} faixas…",
+    "addToPlaylistNamed": "Adicionar a \"{{name}}\"",
+    "removeFromPlaylistNamed": "Remover de \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Editar etiquetas em lote",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -727,7 +727,9 @@
     "startRadio": "Включить радио",
     "rating": "Оценка",
     "ratingNone": "Без оценки",
-    "batchEdit": "Изменить теги для {{count}} треков…"
+    "batchEdit": "Изменить теги для {{count}} треков…",
+    "addToPlaylistNamed": "Добавить в \"{{name}}\"",
+    "removeFromPlaylistNamed": "Удалить из \"{{name}}\""
   },
   "batchTagEdit": {
     "title": "Массовое редактирование тегов",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -727,7 +727,9 @@
     "startRadio": "Radyoyu başlat",
     "rating": "Puan",
     "ratingNone": "Puan yok",
-    "batchEdit": "{{count}} parça için etiketleri düzenle…"
+    "batchEdit": "{{count}} parça için etiketleri düzenle…",
+    "addToPlaylistNamed": "\"{{name}}\" listesine ekle",
+    "removeFromPlaylistNamed": "\"{{name}}\" listesinden çıkar"
   },
   "batchTagEdit": {
     "title": "Toplu etiket düzenleme",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -727,7 +727,9 @@
     "startRadio": "开始电台",
     "rating": "评分",
     "ratingNone": "无评分",
-    "batchEdit": "编辑 {{count}} 首曲目的标签…"
+    "batchEdit": "编辑 {{count}} 首曲目的标签…",
+    "addToPlaylistNamed": "添加到\"{{name}}\"",
+    "removeFromPlaylistNamed": "从\"{{name}}\"中移除"
   },
   "batchTagEdit": {
     "title": "批量编辑标签",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -727,7 +727,9 @@
     "startRadio": "開始電台",
     "rating": "評分",
     "ratingNone": "無評分",
-    "batchEdit": "編輯 {{count}} 首曲目的標籤…"
+    "batchEdit": "編輯 {{count}} 首曲目的標籤…",
+    "addToPlaylistNamed": "加入「{{name}}」",
+    "removeFromPlaylistNamed": "從「{{name}}」移除"
   },
   "batchTagEdit": {
     "title": "批次編輯標籤",

--- a/src/lib/tauri/playlist.ts
+++ b/src/lib/tauri/playlist.ts
@@ -96,6 +96,18 @@ export function removeTrackFromPlaylist(
   return invoke<void>("remove_track_from_playlist", { playlistId, trackId });
 }
 
+/**
+ * Return the IDs of every user playlist that currently contains the track.
+ * Smart playlists are excluded — their membership is rule-driven and not
+ * a toggle target. Used by the `+` popover to mark existing memberships
+ * with a checkmark and switch the click handler from add to remove.
+ */
+export function listPlaylistsContainingTrack(
+  trackId: number,
+): Promise<number[]> {
+  return invoke<number[]>("list_playlists_containing_track", { trackId });
+}
+
 export function reorderPlaylistTrack(
   playlistId: number,
   trackId: number,


### PR DESCRIPTION
## Summary
- Open the `+` popover on a track row in the Songs view: playlists that already contain the track render a green checkmark on the right, and clicking such a row removes the track instead of re-adding it (Spotify-style toggle).
- No confirmation modal — the action is trivially reversible by re-clicking. Visual state updates optimistically; the underlying add/remove backend commands are idempotent so a failed RPC only drifts the cache until the next popover open.
- Albums / artists / folders popovers are unchanged: they bulk-add a source and have no symmetric remove operation, so the membership UI is opt-in via a new prop.

## Backend
- New `list_playlists_containing_track(track_id) -> Vec<i64>` command in `commands/playlist.rs`. Smart playlists are excluded (their membership is rule-driven, not a toggle target).

## Frontend
- `TrackTable` lazy-fetches membership on first popover open per track and caches it for the table's lifetime. Toggling flips the cached set + dispatches `addTracksToPlaylist` or `removeTrackFromPlaylist` accordingly.
- `AddToPlaylistPopover` gains an optional `memberPlaylistIds: ReadonlySet<number>` prop. When provided, matching rows render `<Check>` and aria-labels switch between `addToPlaylistNamed` / `removeFromPlaylistNamed`.
- New i18n keys propagated to all 17 locales.

## Test plan
- [x] Open `+` popover on a track that's already in one or more playlists → those rows show a green checkmark, others don't.
- [x] Click a checked row → checkmark disappears immediately, track is removed from that playlist (verify via the playlist view).
- [x] Click an unchecked row → checkmark appears immediately, track is added.
- [x] Reopen the popover for the same track → state matches the latest toggles.
- [x] Smart playlists never appear in the membership list, even when their rule-set would match the track.
- [x] Album / artist `+` popover still works as a plain add (no checkmarks).