### PR TITLE
fix(library): stop popover clicks bubbling + clamp/flip portal placement

### DIFF
--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1360,12 +1360,15 @@ function AddToPlaylistPopover({
   memberPlaylistIds,
   anchorEl,
 }: AddToPlaylistPopoverProps) {
-  // Portal mode: track the anchor's viewport rect so the popover follows
-  // it on scroll / resize / virtualization recycling. `null` rect = first
-  // render before the layout effect runs; we keep the popover invisible
-  // until we know where it goes so it never flashes at (0,0).
+  // Portal mode: track the anchor's viewport rect AND the popover's own
+  // height so we can flip / clamp against the viewport. `null` rect =
+  // first render before the layout effect runs; we keep the popover
+  // invisible until we know where it goes so it never flashes at (0,0).
   const POPOVER_WIDTH = 224; // matches `w-56`
+  const VIEWPORT_MARGIN = 8;
+  const popoverRef = useRef<HTMLDivElement | null>(null);
   const [rect, setRect] = useState<DOMRect | null>(null);
+  const [popoverHeight, setPopoverHeight] = useState(0);
   useLayoutEffect(() => {
     if (!anchorEl) return;
     const update = () => setRect(anchorEl.getBoundingClientRect());
@@ -1380,22 +1383,66 @@ function AddToPlaylistPopover({
       window.removeEventListener("resize", update);
     };
   }, [anchorEl]);
+  // Measure the popover the first time it lays out and on resize so the
+  // flip-above check has a real height. Without this we'd default to 0
+  // and never flip until the popover overflows.
+  useLayoutEffect(() => {
+    if (!anchorEl) return;
+    const el = popoverRef.current;
+    if (!el) return;
+    const measure = () => setPopoverHeight(el.offsetHeight);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [anchorEl, rect]);
+
+  // Compute placement: prefer below, flip above when below would clip,
+  // then clamp horizontally so the first-column trigger doesn't push
+  // the popover off the left edge.
+  const placement = (() => {
+    if (!anchorEl || !rect) return null;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let top = rect.bottom + 4;
+    if (
+      popoverHeight > 0 &&
+      top + popoverHeight > vh - VIEWPORT_MARGIN &&
+      rect.top - 4 - popoverHeight >= VIEWPORT_MARGIN
+    ) {
+      top = rect.top - 4 - popoverHeight;
+    }
+    top = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(top, vh - popoverHeight - VIEWPORT_MARGIN),
+    );
+    let left = rect.right - POPOVER_WIDTH;
+    left = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(left, vw - POPOVER_WIDTH - VIEWPORT_MARGIN),
+    );
+    return { top, left };
+  })();
 
   const inner = (
     <div
+      ref={popoverRef}
       data-add-to-playlist-popover
       role="menu"
+      // Stop click + double-click + mousedown from bubbling to the
+      // album / artist tile underneath. Portals re-parent the DOM but
+      // React events still bubble through the React tree, so without
+      // this picking a playlist would also navigate to the album.
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
       onDoubleClick={(e) => e.stopPropagation()}
       style={
         anchorEl
-          ? rect
+          ? placement
             ? {
                 position: "fixed",
-                // Anchor the right edge to the trigger's right edge,
-                // matching the in-flow `right-0` behaviour. Drop 4 px
-                // below the trigger to match `mt-1`.
-                top: rect.bottom + 4,
-                left: rect.right - POPOVER_WIDTH,
+                top: placement.top,
+                left: placement.left,
                 width: POPOVER_WIDTH,
               }
             : { position: "fixed", visibility: "hidden" }

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1383,19 +1383,22 @@ function AddToPlaylistPopover({
       window.removeEventListener("resize", update);
     };
   }, [anchorEl]);
-  // Measure the popover the first time it lays out and on resize so the
-  // flip-above check has a real height. Without this we'd default to 0
-  // and never flip until the popover overflows.
+  // Measure the popover the first time it lays out and on content
+  // resize so the flip-above check has a real height. We intentionally
+  // do NOT depend on `rect` — scroll updates `rect` many times per
+  // second, and re-running this effect would tear down the
+  // ResizeObserver and force a synchronous `offsetHeight` reflow each
+  // tick. The ResizeObserver already covers every real height change
+  // (translated label wrap, scrollable list growth, etc.).
   useLayoutEffect(() => {
     if (!anchorEl) return;
     const el = popoverRef.current;
     if (!el) return;
-    const measure = () => setPopoverHeight(el.offsetHeight);
-    measure();
-    const ro = new ResizeObserver(measure);
+    setPopoverHeight(el.offsetHeight);
+    const ro = new ResizeObserver(() => setPopoverHeight(el.offsetHeight));
     ro.observe(el);
     return () => ro.disconnect();
-  }, [anchorEl, rect]);
+  }, [anchorEl]);
 
   // Compute placement: prefer below, flip above when below would clip,
   // then clamp horizontally so the first-column trigger doesn't push


### PR DESCRIPTION
## Summary
Follow-up to #77 — two issues caught by Qodo's review.

1. **React events bubble through portals**. The popover container only stopped `onDoubleClick`, so picking a playlist row also fired the album / artist tile `onClick` underneath and navigated away mid-pick. The DOM was re-parented but React's synthetic event system still propagates through the React tree.
2. **Portal placement had no viewport bounds**. `rect.bottom + 4` / `rect.right - width` could push the popover off the bottom of the viewport (last visible row) or off the left edge (first-column trigger where `rect.right < 224`).

## Fix
- Stop `onClick` and `onMouseDown` (in addition to existing `onDoubleClick`) at the popover root. Outside-click detection still works — those handlers use `document` listeners with `target.closest("[data-add-to-playlist-popover]")` which short-circuits before `stopPropagation` runs.
- Measure the popover via a second `ResizeObserver`; prefer placement below the trigger, flip above when below would clip and there's room, then clamp both axes with an 8 px viewport margin.

## Test plan
- [x] Click `+` on an album card, then click a playlist row → track added, page does **not** navigate to the album.
- [x] Same on an artist tile.
- [x] Open `+` on a card in the **first column** → popover stays inside the viewport on the left edge.
- [x] Open `+` on a card near the **bottom of the viewport** → popover flips above the trigger when there's no room below.
- [x] Resize the window while the popover is open → position / flip updates live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Amélioration du positionnement du popover "Ajouter à la playlist" pour éviter les débordements. Le popover se repositionne désormais automatiquement au-dessus du bouton si nécessaire et s'adapte correctement lors des changements de contenu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->