### PR TITLE
feat(player): switch between immersive now-playing and fullscreen lyrics

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,8 +1,0 @@
-runtimes:
-    - node@22.2.0
-    - python@3.11.11
-tools:
-    - eslint@9.39.4
-    - lizard@1.17.31
-    - opengrep@1.21.0
-    - trivy@0.70.0

--- a/src/components/layout/LyricsPanel.tsx
+++ b/src/components/layout/LyricsPanel.tsx
@@ -37,13 +37,21 @@ import { LyricsEditorModal } from "../common/LyricsEditorModal";
  */
 export function LyricsPanel() {
   const { t } = useTranslation();
-  const { isLyricsOpen, toggleLyrics, currentTrack, positionMs, seek } =
-    usePlayer();
+  const {
+    isLyricsOpen,
+    toggleLyrics,
+    currentTrack,
+    positionMs,
+    seek,
+    isFullscreenLyricsOpen,
+    openFullscreenLyrics,
+    closeFullscreenLyrics,
+    openFullscreenNowPlaying,
+  } = usePlayer();
 
   const [payload, setPayload] = useState<LyricsPayload | null>(null);
   const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isFullscreen, setIsFullscreen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
 
   const trackId = currentTrack?.id ?? null;
@@ -195,7 +203,7 @@ export function LyricsPanel() {
             </button>
             <button
               type="button"
-              onClick={() => setIsFullscreen(true)}
+              onClick={openFullscreenLyrics}
               aria-label={t("lyrics.actions.fullscreen")}
               title={t("lyrics.actions.fullscreen")}
               disabled={currentTrack == null}
@@ -306,8 +314,11 @@ export function LyricsPanel() {
         />
 
         {/* Fullscreen overlay — rendered as a sibling so it covers
-            the whole app, not just the panel. */}
-        {isFullscreen && currentTrack && (
+            the whole app, not just the panel. Toggled via PlayerContext
+            so the immersive Now Playing view can switch into karaoke
+            mode without unmounting the panel that owns the lyrics
+            state. */}
+        {isFullscreenLyricsOpen && currentTrack && (
           <FullscreenLyrics
             track={currentTrack}
             payload={payload}
@@ -316,7 +327,8 @@ export function LyricsPanel() {
             activeIndex={activeIndex}
             isFetching={isFetching}
             error={error}
-            onClose={() => setIsFullscreen(false)}
+            onClose={closeFullscreenLyrics}
+            onOpenNowPlaying={openFullscreenNowPlaying}
             onSeek={handleSeekToLine}
           />
         )}

--- a/src/components/player/FullscreenLyrics.tsx
+++ b/src/components/player/FullscreenLyrics.tsx
@@ -20,6 +20,10 @@ interface FullscreenLyricsProps {
   isFetching: boolean;
   error: string | null;
   onClose: () => void;
+  /** Clicking the header cover switches back to the immersive Now
+   *  Playing overlay. The parent flips the fullscreen mutex so this
+   *  view unmounts and FullscreenNowPlaying paints in its place. */
+  onOpenNowPlaying: () => void;
   onSeek: (line: LyricsLine) => void;
 }
 
@@ -42,6 +46,7 @@ export function FullscreenLyrics({
   isFetching,
   error,
   onClose,
+  onOpenNowPlaying,
   onSeek,
 }: FullscreenLyricsProps) {
   const { t } = useTranslation();
@@ -104,16 +109,24 @@ export function FullscreenLyrics({
         {/* Header */}
         <div className="flex items-center justify-between px-8 py-6 shrink-0">
           <div className="flex items-center gap-4 min-w-0">
-            <Artwork
-              path={track.artwork_path}
-              path1x={track.artwork_path_1x}
-              path2x={track.artwork_path_2x}
-              size="1x"
-              className="w-14 h-14 shadow-lg shrink-0"
-              iconSize={20}
-              alt={track.title}
-              rounded="lg"
-            />
+            <button
+              type="button"
+              onClick={onOpenNowPlaying}
+              aria-label={t("playerBar.openFullscreen")}
+              title={t("playerBar.openFullscreen")}
+              className="shrink-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            >
+              <Artwork
+                path={track.artwork_path}
+                path1x={track.artwork_path_1x}
+                path2x={track.artwork_path_2x}
+                size="1x"
+                className="w-14 h-14 shadow-lg"
+                iconSize={20}
+                alt={track.title}
+                rounded="lg"
+              />
+            </button>
             <div className="min-w-0">
               <div
                 id="fullscreen-lyrics-title"

--- a/src/components/player/FullscreenNowPlaying.tsx
+++ b/src/components/player/FullscreenNowPlaying.tsx
@@ -1,6 +1,15 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { X, Heart, Share2, Download, Copy, Loader2, Check } from "lucide-react";
+import {
+  X,
+  Heart,
+  Share2,
+  Download,
+  Copy,
+  Loader2,
+  Check,
+  Mic2,
+} from "lucide-react";
 import { useModalA11y } from "../../hooks/useModalA11y";
 import { Artwork } from "../common/Artwork";
 import { ArtistLink } from "../common/ArtistLink";
@@ -15,6 +24,7 @@ import { renderNowPlayingCard } from "../../lib/nowPlayingCard";
 
 interface FullscreenNowPlayingProps {
   onClose: () => void;
+  onOpenLyrics: () => void;
   onNavigateToArtist: (artistId: number) => void;
   isLiked: boolean;
   onToggleLike: () => void;
@@ -33,6 +43,7 @@ interface FullscreenNowPlayingProps {
  */
 export function FullscreenNowPlaying({
   onClose,
+  onOpenLyrics,
   onNavigateToArtist,
   isLiked,
   onToggleLike,
@@ -141,9 +152,20 @@ export function FullscreenNowPlaying({
 
       {/* Foreground */}
       <div className="relative h-full flex flex-col text-white">
-        {/* Top bar — share + close. Controls live at the bottom so
-            the cover gets the visual centre. */}
+        {/* Top bar — lyrics switcher + share + close. Controls live at
+            the bottom so the cover gets the visual centre. */}
         <div className="flex items-center justify-end gap-3 px-8 py-6 shrink-0">
+          {currentTrack && (
+            <button
+              type="button"
+              onClick={onOpenLyrics}
+              aria-label={t("playerBar.lyrics")}
+              title={t("playerBar.lyrics")}
+              className="p-2.5 rounded-full bg-white/10 hover:bg-white/20 transition-colors"
+            >
+              <Mic2 size={22} />
+            </button>
+          )}
           {currentTrack && (
             <div className="relative">
               <button

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -40,6 +40,10 @@ export function PlayerBar({ onNavigateToArtist }: PlayerBarProps) {
     volume,
     setVolume,
     activeProvider,
+    isFullscreenNowPlayingOpen,
+    openFullscreenNowPlaying,
+    closeFullscreenNowPlaying,
+    openFullscreenLyrics,
   } = usePlayer();
 
   const sleepTimer = useSleepTimer({ currentVolume: volume, setVolume });
@@ -156,11 +160,6 @@ export function PlayerBar({ onNavigateToArtist }: PlayerBarProps) {
 
   const title = currentTrack?.title ?? t("player.noTrack");
 
-  // Apple-Music-style immersive Now Playing overlay. Local UI state —
-  // not in PlayerContext because no other view needs to know about it
-  // (unlike the side panels which other components query).
-  const [isFullscreenOpen, setIsFullscreenOpen] = useState(false);
-
   return (
     <>
       <div className="flex flex-col z-50 border-t bg-[#FAFAFA] border-zinc-200 text-zinc-600 dark:bg-surface-dark-elevated dark:border-zinc-800 dark:text-zinc-300">
@@ -172,7 +171,7 @@ export function PlayerBar({ onNavigateToArtist }: PlayerBarProps) {
               loaded so the user doesn't open an empty card. */}
             <button
               type="button"
-              onClick={() => currentTrack && setIsFullscreenOpen(true)}
+              onClick={() => currentTrack && openFullscreenNowPlaying()}
               disabled={!currentTrack}
               aria-label={t("playerBar.openFullscreen")}
               title={t("playerBar.openFullscreen")}
@@ -334,7 +333,7 @@ export function PlayerBar({ onNavigateToArtist }: PlayerBarProps) {
 
             <button
               type="button"
-              onClick={() => currentTrack && setIsFullscreenOpen(true)}
+              onClick={() => currentTrack && openFullscreenNowPlaying()}
               disabled={!currentTrack}
               aria-label={t("playerBar.openFullscreen")}
               title={t("playerBar.openFullscreen")}
@@ -350,9 +349,10 @@ export function PlayerBar({ onNavigateToArtist }: PlayerBarProps) {
           />
         )}
       </div>
-      {isFullscreenOpen && currentTrack && (
+      {isFullscreenNowPlayingOpen && currentTrack && (
         <FullscreenNowPlaying
-          onClose={() => setIsFullscreenOpen(false)}
+          onClose={closeFullscreenNowPlaying}
+          onOpenLyrics={openFullscreenLyrics}
           onNavigateToArtist={onNavigateToArtist}
           isLiked={isLiked}
           onToggleLike={handleToggleLike}

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -132,6 +132,15 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const isLyricsOpen = activeRightPanel === "lyrics";
   const [isDeviceMenuOpen, setIsDeviceMenuOpen] = useState(false);
 
+  // Fullscreen overlays. Single nullable enum so the two are mutually
+  // exclusive by construction — switching from immersive to karaoke
+  // (or back) is just a single setter call.
+  const [fullscreenOverlay, setFullscreenOverlay] = useState<
+    "nowPlaying" | "lyrics" | null
+  >(null);
+  const isFullscreenNowPlayingOpen = fullscreenOverlay === "nowPlaying";
+  const isFullscreenLyricsOpen = fullscreenOverlay === "lyrics";
+
   // Cached output device list. Populated at boot + after every device
   // switch so the menu opens instantly with the up-to-date list — the
   // alternative (fetch-on-open) makes the first click feel laggy
@@ -516,6 +525,24 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  const openFullscreenNowPlaying = useCallback(() => {
+    setFullscreenOverlay("nowPlaying");
+  }, []);
+  const closeFullscreenNowPlaying = useCallback(() => {
+    setFullscreenOverlay((o) => (o === "nowPlaying" ? null : o));
+  }, []);
+  // Opening the lyrics overlay forces the right-edge panel onto
+  // "lyrics" so the LyricsPanel mounts: the karaoke overlay reuses the
+  // panel's parsed lyrics + active-line tracking instead of running a
+  // second fetch.
+  const openFullscreenLyrics = useCallback(() => {
+    setActiveRightPanel("lyrics");
+    setFullscreenOverlay("lyrics");
+  }, []);
+  const closeFullscreenLyrics = useCallback(() => {
+    setFullscreenOverlay((o) => (o === "lyrics" ? null : o));
+  }, []);
+
   const refreshOutputDevices = useCallback(async () => {
     try {
       const list = await playerListOutputDevices();
@@ -578,6 +605,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         toggleLyrics,
         isDeviceMenuOpen,
         toggleDeviceMenu,
+        isFullscreenNowPlayingOpen,
+        isFullscreenLyricsOpen,
+        openFullscreenNowPlaying,
+        closeFullscreenNowPlaying,
+        openFullscreenLyrics,
+        closeFullscreenLyrics,
         outputDevices,
         refreshOutputDevices,
         activeProvider,

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -534,13 +534,32 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   // Opening the lyrics overlay forces the right-edge panel onto
   // "lyrics" so the LyricsPanel mounts: the karaoke overlay reuses the
   // panel's parsed lyrics + active-line tracking instead of running a
-  // second fetch.
+  // second fetch. We snapshot the previous panel so closing the overlay
+  // can restore it — otherwise opening lyrics from the immersive view
+  // would silently flip the user's queue/now-playing panel to lyrics.
+  // `undefined` = no snapshot to restore (either we never forced a
+  // change, or fullscreen lyrics was opened from the panel's Maximize
+  // button while the lyrics panel was already active). `null` is a
+  // valid restore target meaning "no panel was open beforehand".
+  const rightPanelBeforeFullscreenLyricsRef = useRef<
+    "queue" | "nowPlaying" | "lyrics" | null | undefined
+  >(undefined);
   const openFullscreenLyrics = useCallback(() => {
-    setActiveRightPanel("lyrics");
+    setActiveRightPanel((prev) => {
+      if (prev !== "lyrics") {
+        rightPanelBeforeFullscreenLyricsRef.current = prev;
+      }
+      return "lyrics";
+    });
     setFullscreenOverlay("lyrics");
   }, []);
   const closeFullscreenLyrics = useCallback(() => {
     setFullscreenOverlay((o) => (o === "lyrics" ? null : o));
+    const previous = rightPanelBeforeFullscreenLyricsRef.current;
+    if (previous !== undefined) {
+      setActiveRightPanel(previous);
+      rightPanelBeforeFullscreenLyricsRef.current = undefined;
+    }
   }, []);
 
   const refreshOutputDevices = useCallback(async () => {

--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -23,6 +23,17 @@ interface PlayerContextValue {
   isDeviceMenuOpen: boolean;
   toggleDeviceMenu: () => void;
 
+  // Fullscreen overlays (immersive Now Playing + karaoke Lyrics) share
+  // a single mutex so the two never paint on top of each other. Opening
+  // the lyrics overlay also flips the right-edge panel to "lyrics" so
+  // the LyricsPanel mounts and feeds the overlay its parsed state.
+  isFullscreenNowPlayingOpen: boolean;
+  isFullscreenLyricsOpen: boolean;
+  openFullscreenNowPlaying: () => void;
+  closeFullscreenNowPlaying: () => void;
+  openFullscreenLyrics: () => void;
+  closeFullscreenLyrics: () => void;
+
   // Output device picker — pre-fetched at boot so the first click on
   // the device button paints instantly. `refreshOutputDevices` is
   // called by `DeviceMenu` in the background on each open to catch


### PR DESCRIPTION
## Summary

- Add a mic button in the immersive Now Playing view that switches into the fullscreen karaoke lyrics view, and make the lyrics overlay's header cover a button that pops back to the immersive view.
- Lift fullscreen overlay state into `PlayerContext` as a mutually-exclusive `fullscreenOverlay` enum so the two overlays never paint on top of each other. Opening the lyrics overlay auto-flips the right-edge panel to `lyrics` so `LyricsPanel` mounts and its parsed lyrics + active-line tracking feed straight into the overlay.
- `LyricsPanel`'s in-panel Maximize button and the immersive view's lifecycle now route through the same `openFullscreen*` / `closeFullscreen*` actions on context.

## Test plan

- [x] In the immersive view, click the new mic button → fullscreen karaoke lyrics opens with the same track's lyrics
- [x] In the fullscreen karaoke lyrics, click the header album cover → immersive Now Playing reopens
- [x] Existing path still works: open the lyrics side panel → click Maximize → fullscreen lyrics open, X closes back to the side panel
- [x] Closing the immersive view (X) after switching from lyrics leaves the lyrics side panel open behind it (expected)
- [x] `bun run typecheck` ✔
- [x] `bun run lint` ✔