### PR TITLE
fix(locales): overhaul chinese translations (zh-CN, zh-TW)

### DIFF
--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -128,7 +128,7 @@
     "library": {
       "tracksCount_zero": "0 首曲目",
       "tracksCount_one": "{{count}} 曲目",
-      "tracksCount_other": "{{count}} 标题",
+      "tracksCount_other": "{{count}} 曲目",
       "createLibraryAria": "新建音乐库",
       "none": "暂无音乐库",
       "popover": {
@@ -137,7 +137,7 @@
         "countLine": "{{tracks}} · {{albums}}",
         "tracks_zero": "0 首曲目",
         "tracks_one": "{{count}} 曲目",
-        "tracks_other": "{{count}} 标题",
+        "tracks_other": "{{count}} 曲目",
         "albums_zero": "0 张专辑",
         "albums_one": "{{count}} 专辑",
         "albums_other": "{{count}} 专辑",
@@ -160,7 +160,7 @@
       "recent": "最近播放的",
       "emptySubtext_zero": "0 首曲目",
       "emptySubtext_one": "{{count}} 曲目",
-      "emptySubtext_other": "{{count}} 标题",
+      "emptySubtext_other": "{{count}} 曲目",
       "createSmartAria": "创建智能播放列表"
     },
     "myMusic": {
@@ -178,7 +178,7 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 首曲目",
       "playlistSubtext_one": "{{count}} 曲目",
-      "playlistSubtext_other": "{{count}} 标题"
+      "playlistSubtext_other": "{{count}} 曲目"
     }
   },
   "topbar": {
@@ -380,12 +380,12 @@
     "albumGrid": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 标题"
+      "trackCount_other": "{{count}} 曲目"
     },
     "artistList": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 标题",
+      "trackCount_other": "{{count}} 曲目",
       "albumCount_zero": "0 张专辑",
       "albumCount_one": "{{count}} 张专辑",
       "albumCount_other": "{{count}} 张专辑"
@@ -393,12 +393,12 @@
     "genreList": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 标题"
+      "trackCount_other": "{{count}} 曲目"
     },
     "folderList": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 标题",
+      "trackCount_other": "{{count}} 曲目",
       "lastScanned": "扫描自：{{date}}",
       "neverScanned": "从来没有",
       "watched": "受监控",
@@ -418,7 +418,7 @@
     "title": "已喜欢的曲目",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
-    "count_other": "{{count}} 标题",
+    "count_other": "{{count}} 曲目",
     "emptyTitle": "没有收藏的曲目",
     "emptyDescription": "你喜欢的歌曲将显示在这里。浏览你的音乐库,将喜欢的曲目加入收藏。",
     "playAll": "全部播放",
@@ -452,7 +452,7 @@
     "title": "最近播放的",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
-    "count_other": "{{count}} 标题",
+    "count_other": "{{count}} 曲目",
     "emptyTitle": "没有最近播放的曲目",
     "emptyDescription": "您正在收听的歌曲会自动显示在此处。"
   },
@@ -472,9 +472,9 @@
       "totalPlays": "播放次数",
       "totalTime": "收听时长",
       "uniqueTracks": "独立曲目",
-      "uniqueArtists_zero": "0位艺术家",
-      "uniqueArtists_one": "{{count}} 艺术家",
-      "uniqueArtists_other": "{{count}} 艺术家",
+      "uniqueArtists_zero": "0 位艺人",
+      "uniqueArtists_one": "{{count}} 艺人",
+      "uniqueArtists_other": "{{count}} 艺人",
       "completionRate": "完整收听率"
     },
     "byDay": {
@@ -763,7 +763,7 @@
     "badge": "播放列表",
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
-    "trackCount_other": "{{count}} 标题",
+    "trackCount_other": "{{count}} 曲目",
     "actions": {
       "play": "播放",
       "shuffle": "随机播放",
@@ -889,7 +889,7 @@
     "shuffle": "随机播放",
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
-    "trackCount_other": "{{count}} 标题",
+    "trackCount_other": "{{count}} 曲目",
     "discHeader": "第 {{number}} 张",
     "releaseDate": "发行日期",
     "emptyTitle": "找不到该专辑",
@@ -902,16 +902,16 @@
     "playAll": "全部播放",
     "shuffle": "随机播放",
     "discography": "专辑列表",
-    "allTracks": "所有标题",
+    "allTracks": "所有曲目",
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
-    "trackCount_other": "{{count}} 标题",
-    "albumCount_zero": "0 个相册",
-    "albumCount_one": "{{count}} 专辑",
-    "albumCount_other": "{{count}} 专辑",
+    "trackCount_other": "{{count}} 曲目",
+    "albumCount_zero": "0 张专辑",
+    "albumCount_one": "{{count}} 张专辑",
+    "albumCount_other": "{{count}} 张专辑",
     "albumTrackCount_zero": "0 首曲目",
     "albumTrackCount_one": "{{count}} 曲目",
-    "albumTrackCount_other": "{{count}} 标题",
+    "albumTrackCount_other": "{{count}} 曲目",
     "emptyTitle": "未找到该艺人",
     "emptyDescription": "该艺人已不在当前的个人资料中。",
     "bio": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -118,36 +118,36 @@
     },
     "sections": {
       "open": "打开",
-      "library": "图书馆",
+      "library": "音乐库",
       "playlists": "播放列表"
     },
     "open": {
       "file": "文件",
-      "folder": "专题"
+      "folder": "文件夹"
     },
     "library": {
       "tracksCount_zero": "0 首曲目",
       "tracksCount_one": "{{count}} 曲目",
       "tracksCount_other": "{{count}} 标题",
-      "createLibraryAria": "创建新库",
-      "none": "没有图书馆",
+      "createLibraryAria": "新建音乐库",
+      "none": "暂无音乐库",
       "popover": {
-        "label": "图书馆选择",
-        "header": "图书馆",
+        "label": "选择音乐库",
+        "header": "音乐库",
         "countLine": "{{tracks}} · {{albums}}",
         "tracks_zero": "0 首曲目",
         "tracks_one": "{{count}} 曲目",
         "tracks_other": "{{count}} 标题",
-        "albums_zero": "0 个相册",
+        "albums_zero": "0 张专辑",
         "albums_one": "{{count}} 专辑",
         "albums_other": "{{count}} 专辑",
         "see": "查看",
-        "new": "新闻"
+        "new": "新建"
       },
       "nav": {
         "tracks": "曲目",
         "albums": "专辑",
-        "artists": "艺术家",
+        "artists": "艺人",
         "genres": "类型",
         "explorer": "资源管理器"
       }
@@ -156,19 +156,19 @@
       "createPlaylistAria": "创建新播放列表",
       "importM3uAria": "导入 M3U 播放列表",
       "importDialogTitle": "导入 M3U 播放列表",
-      "liked": "点赞的帖子",
+      "liked": "已喜欢的曲目",
       "recent": "最近播放的",
       "emptySubtext_zero": "0 首曲目",
       "emptySubtext_one": "{{count}} 曲目",
       "emptySubtext_other": "{{count}} 标题",
-      "createSmartAria": "Create a smart playlist"
+      "createSmartAria": "创建智能播放列表"
     },
     "myMusic": {
       "title": "我的音乐",
       "addFolderAria": "导入文件夹",
       "tracks": "曲目",
       "albums": "专辑",
-      "artists": "艺术家",
+      "artists": "艺人",
       "genres": "类型",
       "folders": "文件"
     },
@@ -226,15 +226,15 @@
       "badge": "准备好聆听了",
       "subtitle": "发现您最爱的音乐，探索全新音效。",
       "openFile": "打开文件",
-      "openFolder": "新建文件夹",
+      "openFolder": "打开文件夹",
       "importFiles": "导入文件",
-      "importFolder": "导入文件",
+      "importFolder": "导入文件夹",
       "browseLibrary": "浏览我的资料库"
     },
     "stats": {
-      "library": "图书馆",
-      "liked": "点赞的帖子",
-      "recent": "最近游玩过的",
+      "library": "音乐库",
+      "liked": "已喜欢的曲目",
+      "recent": "最近播放",
       "playlists": "播放列表"
     },
     "moodRadio": {
@@ -268,7 +268,7 @@
     "recentlyPlayed": {
       "title": "最近播放的",
       "emptyTitle": "尚未收听任何歌曲",
-      "emptyDescription": "输入歌名，它就会显示在这里。随着您不断发现新歌，您的播放记录也会随之更新。"
+      "emptyDescription": "播放一首歌曲后它会出现在这里。随着你不断探索,收听记录会逐渐累积。"
     },
     "recentlyAdded": {
       "title": "最近添加"
@@ -301,27 +301,27 @@
         "albums_zero": "0 张专辑",
         "albums_one": "{{count}} 专辑",
         "albums_other": "{{count}} 专辑",
-        "artistes_zero": "0 位艺术家",
-        "artistes_one": "{{count}} 艺术家",
-        "artistes_other": "{{count}} 艺术家",
+        "artistes_zero": "0 位艺人",
+        "artistes_one": "{{count}} 位艺人",
+        "artistes_other": "{{count}} 位艺人",
         "genres_zero": "0 类型",
         "genres_one": "{{count}} 类型",
         "genres_other": "{{count}} 类型",
-        "dossiers_zero": "0 文件夹",
-        "dossiers_one": "{{count}} 专题",
-        "dossiers_other": "{{count}} 文件"
+        "dossiers_zero": "0 个文件夹",
+        "dossiers_one": "{{count}} 个文件夹",
+        "dossiers_other": "{{count}} 个文件夹"
       }
     },
     "tabs": {
       "morceaux": "曲目",
       "albums": "专辑",
-      "artistes": "艺术家",
+      "artistes": "艺人",
       "genres": "类型",
       "dossiers": "文件"
     },
     "empty": {
       "morceaux": {
-        "title": "空书架",
+        "title": "音乐库为空",
         "description": "导入音频文件或文件夹，以丰富您的媒体库。"
       },
       "albums": {
@@ -329,8 +329,8 @@
         "description": "导入音频文件以自动生成专辑。"
       },
       "artistes": {
-        "title": "未找到任何艺术家",
-        "description": "首先导入音频文件。"
+        "title": "未找到艺人",
+        "description": "请先导入音频文件。"
       },
       "genres": {
         "title": "未找到任何类型",
@@ -345,11 +345,11 @@
       "importFiles": "导入文件",
       "importFolder": "导入文件夹",
       "share": "分享（即将推出）",
-      "rescan": "重新扫描书库",
-      "rescanning": "正在重新扫描……",
+      "rescan": "重新扫描音乐库",
+      "rescanning": "正在重新扫描音乐库…",
       "changeArtwork": "更换图片（即将推出）",
-      "edit": "编辑库",
-      "delete": "删除库",
+      "edit": "编辑音乐库",
+      "delete": "删除音乐库",
       "deleteConfirm": "再次点击以确认",
       "importing": "正在导入…"
     },
@@ -364,12 +364,13 @@
     "table": {
       "number": "#",
       "title": "标题",
-      "artist": "艺术家",
+      "artist": "艺人",
       "album": "专辑",
       "duration": "时长",
-      "unknown": "—"
+      "unknown": "—",
+      "rating": "评分"
     },
-    "rating": "注",
+    "rating": "评分",
     "noRating": "无评分",
     "viewToggle": {
       "label": "显示模式",
@@ -385,9 +386,9 @@
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
       "trackCount_other": "{{count}} 标题",
-      "albumCount_zero": "0 个相册",
-      "albumCount_one": "{{count}} 专辑",
-      "albumCount_other": "{{count}} 专辑"
+      "albumCount_zero": "0 张专辑",
+      "albumCount_one": "{{count}} 张专辑",
+      "albumCount_other": "{{count}} 张专辑"
     },
     "genreList": {
       "trackCount_zero": "0 首曲目",
@@ -403,21 +404,26 @@
       "watched": "受监控",
       "watchOn": "自动监控更改",
       "watchOff": "停止监控",
-      "remove": "从库中移除文件夹",
+      "remove": "从音乐库中移除文件夹",
       "removeConfirm": "再次点击确认"
+    },
+    "library": {
+      "nav": {
+        "artists": "艺人"
+      }
     }
   },
   "liked": {
-    "badge": "系列",
-    "title": "点赞的帖子",
+    "badge": "收藏",
+    "title": "已喜欢的曲目",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
     "count_other": "{{count}} 标题",
     "emptyTitle": "没有收藏的曲目",
-    "emptyDescription": "您喜欢的歌曲将显示在此处。浏览您的音乐库，并为心仪的歌曲点赞。",
+    "emptyDescription": "你喜欢的歌曲将显示在这里。浏览你的音乐库,将喜欢的曲目加入收藏。",
     "playAll": "全部播放",
-    "unlike": "取消点赞",
-    "like": "添加到收藏"
+    "unlike": "取消喜欢",
+    "like": "加入已喜欢"
   },
   "history": {
     "badge": "历史",
@@ -442,7 +448,7 @@
     }
   },
   "recent": {
-    "badge": "历史沿革",
+    "badge": "历史",
     "title": "最近播放的",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
@@ -463,9 +469,9 @@
       "all": "全部"
     },
     "kpi": {
-      "totalPlays": "监听",
+      "totalPlays": "播放次数",
       "totalTime": "收听时长",
-      "uniqueTracks": "唯一标题",
+      "uniqueTracks": "独立曲目",
       "uniqueArtists_zero": "0位艺术家",
       "uniqueArtists_one": "{{count}} 艺术家",
       "uniqueArtists_other": "{{count}} 艺术家",
@@ -473,15 +479,15 @@
     },
     "byDay": {
       "title": "每日活动",
-      "empty": "该期间未进行监听。"
+      "empty": "该期间无收听记录。"
     },
     "byHour": {
       "title": "最喜欢的时段",
-      "empty": "该期间未进行监听。",
-      "tooltip": "{{hour}} h — {{plays}} 次收听"
+      "empty": "该期间无收听记录。",
+      "tooltip": "{{hour}} 点 — {{plays}} 次播放"
     },
     "topTracks": {
-      "title": "热门头条",
+      "title": "热门曲目",
       "empty": "未播放任何歌曲。"
     },
     "topArtists": {
@@ -499,9 +505,9 @@
       "less": "较少",
       "more": "较多"
     },
-    "plays_zero": "0 次收听",
-    "plays_one": "{{count}} 请听",
-    "plays_other": "{{count}} 监听",
+    "plays_zero": "0 次播放",
+    "plays_one": "{{count}} 次播放",
+    "plays_other": "{{count}} 次播放",
     "export": {
       "label": "导出统计",
       "action": "导出",
@@ -551,12 +557,12 @@
     },
     "activeDay": {
       "eyebrow": "你的高峰日",
-      "subtitle": "{{duration}} 的收听,{{count}} 首曲目"
+      "subtitle": "收听 {{duration}} · {{count}} 首曲目"
     },
     "mood": {
-      "eyebrow": "你的平均 BPM",
+      "eyebrow": "你的平均节奏",
       "subtitle": "陪伴你一年的节奏",
-      "loudness": "平均响度:{{lufs}} LUFS",
+      "loudness": "平均响度: {{lufs}} LUFS",
       "energy": {
         "chill": "舒缓",
         "warm": "温暖",
@@ -601,7 +607,7 @@
     "hero": {
       "subtitle": "多平台高清音乐播放器",
       "checkUpdates": "检查更新",
-      "developedBy": "由……开发"
+      "developedBy": "开发者"
     },
     "sections": {
       "frameworkDesktop": "桌面框架",
@@ -609,14 +615,15 @@
       "backend": "后端（Rust）",
       "audio": "音频",
       "shortcuts": "键盘快捷键",
-      "credits": "鸣谢"
+      "credits": "鸣谢",
+      "changelog": "更新日志"
     },
     "shortcuts": {
       "playPause": "播放/暂停",
       "previousTrack": "上一首",
       "nextTrack": "下一首",
-      "volume": "卷",
-      "mute": "关闭声音",
+      "volume": "音量",
+      "mute": "静音",
       "keys": {
         "space": "空格"
       }
@@ -624,6 +631,13 @@
     "credits": {
       "text": "满怀热情地设计与开发。基于开源技术构建。",
       "icons": "图标由Lucide、Phosphor、Mynaui和Iconify提供。"
+    },
+    "changelog": {
+      "loading": "加载中…",
+      "empty": "暂无记录",
+      "expand": "显示其余 {{count}} 条",
+      "collapse": "收起",
+      "breaking": "重大变更"
     }
   },
   "feedback": {
@@ -643,8 +657,8 @@
     "controls": {
       "play": "播放",
       "pause": "暂停",
-      "previous": "上一页",
-      "next": "下一页",
+      "previous": "上一首",
+      "next": "下一首",
       "shuffleOn": "禁用随机播放",
       "shuffleOff": "启用随机播放",
       "repeatOff": "启用循环播放",
@@ -652,7 +666,7 @@
       "repeatOne": "关闭重复播放"
     },
     "volume": {
-      "label": "卷",
+      "label": "音量",
       "mute": "关闭声音",
       "unmute": "打开声音"
     },
@@ -666,17 +680,17 @@
     "seek": "播放位置"
   },
   "queue": {
-    "title": "播放列表",
+    "title": "播放队列",
     "inactive": "已停用",
     "count_zero": "0 首曲目",
-    "count_one": "{{count}} 曲目",
-    "count_other": "{{count}} 片段",
+    "count_one": "{{count}} 首",
+    "count_other": "{{count}} 首",
     "emptyTitle": "没什么可听的",
-    "emptyDescription": "从您的音乐库中选择一首歌曲，将其加入播放列表。",
+    "emptyDescription": "从你的音乐库选取一首歌,加入播放队列。",
     "nowPlaying": "进行中",
     "upNext_zero": "接下来",
-    "upNext_one": "接下来 · {{count}} track",
-    "upNext_other": "下一页 - {{count}} 曲目",
+    "upNext_one": "接下来 · {{count}} 首",
+    "upNext_other": "接下来 · {{count}} 首",
     "radio": {
       "label": "电台",
       "basedOn": "基于「{{title}}」"
@@ -712,15 +726,15 @@
     }
   },
   "libraryModal": {
-    "title": "创建一个库",
-    "editTitle": "编辑库",
-    "previewDefault": "创建一个库",
+    "title": "新建音乐库",
+    "editTitle": "编辑音乐库",
+    "previewDefault": "新建音乐库",
     "previewSubtitle": "0 首曲目 · 音乐库",
-    "nameLabel": "图书馆名称",
+    "nameLabel": "音乐库名称",
     "namePlaceholder": "例如：摇滚、爵士、古典……",
     "descriptionLabel": "描述",
     "descriptionPlaceholder": "简要介绍……",
-    "submit": "创建一个库",
+    "submit": "新建音乐库",
     "submitEdit": "保存"
   },
   "playlistModal": {
@@ -728,7 +742,7 @@
     "editTitle": "编辑播放列表",
     "previewDefault": "新歌单",
     "previewSubtitle": "0 首曲目 · 播放列表",
-    "nameLabel": "姓名",
+    "nameLabel": "名称",
     "namePlaceholder": "例如：Chill Vibes、Workout Mix...",
     "descriptionLabel": "描述",
     "descriptionPlaceholder": "简要介绍……",
@@ -775,11 +789,11 @@
     "createPlaylist": "新歌单",
     "playNext": "播放下一首",
     "addToQueue": "添加到队列",
-    "like": "添加到“已点赞的歌曲”中",
-    "unlike": "取消点赞",
+    "like": "加入已喜欢",
+    "unlike": "从已喜欢中移除",
     "removeFromPlaylist": "从该播放列表中移除",
-    "goToAlbum": "前往相册",
-    "goToArtist": "前往该艺术家",
+    "goToAlbum": "前往专辑",
+    "goToArtist": "前往艺人",
     "showInExplorer": "在资源管理器中显示",
     "copyPath": "复制文件路径",
     "properties": "属性",
@@ -796,7 +810,7 @@
     "help": "勾选要应用到整个选择的字段。未勾选的字段保持每首曲目原值。",
     "submit": "应用（{{count}} 个字段）",
     "fields": {
-      "artist": "艺术家",
+      "artist": "艺人",
       "album": "专辑",
       "year": "年份",
       "genre": "流派"
@@ -821,9 +835,9 @@
       "file": "文件"
     },
     "bpm": "BPM",
-    "loudness": "音量",
+    "loudness": "响度",
     "replayGain": "ReplayGain",
-    "peak": "Peak",
+    "peak": "峰值",
     "analyze": "分析",
     "reanalyze": "重新分析",
     "analyzing": "分析……",
@@ -831,12 +845,12 @@
     "trackNumber": "曲目编号",
     "duration": "时长",
     "codec": "编解码器",
-    "bitDepth": "深度",
-    "sampleRate": "采样",
-    "channels": "频道",
-    "bitrate": "流量",
+    "bitDepth": "位深度",
+    "sampleRate": "采样率",
+    "channels": "声道",
+    "bitrate": "码率",
     "key": "调性",
-    "fileSize": "尺寸",
+    "fileSize": "大小",
     "addedAt": "添加于",
     "filePath": "路径",
     "showInExplorer": "在资源管理器中显示",
@@ -847,20 +861,21 @@
     "saving": "保存中…",
     "fields": {
       "title": "标题",
-      "artist": "艺术家",
+      "artist": "艺人",
       "album": "专辑",
       "trackNumber": "曲目号",
       "discNumber": "碟片号",
       "genre": "流派",
       "genrePlaceholder": "流行、摇滚、爵士…"
     },
-    "changeCover": "更换封面"
+    "changeCover": "更换封面",
+    "properties": "属性"
   },
   "selection": {
-    "toolbarLabel": "筛选操作",
-    "count_zero": "0 件已选中",
-    "count_one": "{{count}} 已选中",
-    "count_other": "{{count}} 入选",
+    "toolbarLabel": "选择操作",
+    "count_zero": "未选择",
+    "count_one": "已选 {{count}} 项",
+    "count_other": "已选 {{count}} 项",
     "play": "播放",
     "addToQueue": "加入队列",
     "playNext": "播放下一首",
@@ -875,15 +890,15 @@
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
     "trackCount_other": "{{count}} 标题",
-    "discHeader": "{{number}} 硬盘",
-    "releaseDate": "退出",
+    "discHeader": "第 {{number}} 张",
+    "releaseDate": "发行日期",
     "emptyTitle": "找不到该专辑",
-    "emptyDescription": "该相册在当前个人资料中已不存在。",
+    "emptyDescription": "此专辑已不在当前的个人资料中。",
     "emptyTracksTitle": "没有歌曲",
     "emptyTracksDescription": "该专辑中没有可播放的歌曲。"
   },
   "artistDetail": {
-    "badge": "艺术家",
+    "badge": "艺人",
     "playAll": "全部播放",
     "shuffle": "随机播放",
     "discography": "专辑列表",
@@ -897,13 +912,13 @@
     "albumTrackCount_zero": "0 首曲目",
     "albumTrackCount_one": "{{count}} 曲目",
     "albumTrackCount_other": "{{count}} 标题",
-    "emptyTitle": "找不到该艺术家",
-    "emptyDescription": "该艺术家已不在活跃用户列表中。",
+    "emptyTitle": "未找到该艺人",
+    "emptyDescription": "该艺人已不在当前的个人资料中。",
     "bio": {
       "title": "个人简介"
     },
     "similar": {
-      "title": "相似艺术家",
+      "title": "相似艺人",
       "inLibrary": "在你的曲库中",
       "notInLibrary": "不在你的曲库中"
     }
@@ -912,7 +927,8 @@
     "title": "更改艺人图片",
     "editAria": "更改艺人照片",
     "removeAction": "移除图片",
-    "fansCount_other": "{{display}} 粉丝"
+    "fansCount_other": "{{display}} 位粉丝",
+    "fansCount_one": "{{display}} 位粉丝"
   },
   "genreDetail": {
     "badge": "流派",
@@ -929,10 +945,10 @@
   "nowPlaying": {
     "title": "正在播放",
     "empty": "没有正在播放的曲目",
-    "aboutArtist": "关于艺术家",
+    "aboutArtist": "关于艺人",
     "readMore": "阅读更多",
-    "readLess": "缩小",
-    "noBio": "没有传记信息。请在设置中配置你的Last.fm密钥。",
+    "readLess": "收起",
+    "noBio": "没有传记信息。请在设置中配置你的 Last.fm 密钥。",
     "nextInQueue": "队列中的下一首",
     "openQueue": "打开队列",
     "lyrics": {
@@ -957,7 +973,8 @@
     "next": "下一曲",
     "devices": "输出设备",
     "moreActions": "更多操作",
-    "abLoop": "A-B 循环"
+    "abLoop": "A-B 循环",
+    "openFullscreen": "沉浸式视图"
   },
   "miniPlayer": {
     "idle": "未播放任何曲目",
@@ -1007,16 +1024,16 @@
     }
   },
   "duplicates": {
-    "title": "Duplicates detected",
-    "summary": "{{groups}} groups · {{duplicates}} duplicates to remove",
-    "scanning": "Scanning…",
-    "empty": "No duplicates",
-    "emptyHint": "Your library is clean.",
-    "rescan": "Rescan",
-    "deleteOthers_zero": "Nothing to delete",
-    "deleteOthers_one": "Delete {{count}} duplicate",
-    "deleteOthers_other": "Delete {{count}} duplicates",
-    "keepAria": "Keep {{title}}"
+    "title": "检测到重复文件",
+    "summary": "{{groups}} 组 · {{duplicates}} 个重复文件待移除",
+    "scanning": "扫描中…",
+    "empty": "没有重复文件",
+    "emptyHint": "你的音乐库没有重复文件。",
+    "rescan": "重新扫描",
+    "deleteOthers_zero": "没有可删除的文件",
+    "deleteOthers_one": "删除 {{count}} 个重复文件",
+    "deleteOthers_other": "删除 {{count}} 个重复文件",
+    "keepAria": "保留 {{title}}"
   },
   "dragDrop": {
     "dropHint": "放下以导入",
@@ -1029,48 +1046,48 @@
     "armed": "A-B 循环已启用：{{a}} → {{b}} (点击清除)"
   },
   "smartPlaylistEditor": {
-    "createTitle": "New smart playlist",
-    "editTitle": "Edit smart playlist",
-    "create": "Create",
-    "preview": "Preview",
-    "previewCount": "{{count}} tracks match",
-    "nameRequired": "Name is required",
+    "createTitle": "新建智能播放列表",
+    "editTitle": "编辑智能播放列表",
+    "create": "新建",
+    "preview": "预览",
+    "previewCount": "{{count}} 首匹配",
+    "nameRequired": "名称为必填项",
     "fields": {
-      "name": "Name",
-      "description": "Description",
-      "title": "Title contains",
-      "artist": "Artist contains",
-      "album": "Album contains",
-      "year": "Year",
+      "name": "名称",
+      "description": "描述",
+      "title": "标题包含",
+      "artist": "艺人包含",
+      "album": "专辑包含",
+      "year": "年份",
       "bpm": "BPM",
-      "durationMin": "Duration in minutes",
-      "hiRes": "Hi-Res only",
-      "liked": "Liked tracks only",
-      "formats": "Formats",
-      "genres": "Genres",
-      "sort": "Sort by",
-      "limit": "Max tracks",
+      "durationMin": "时长(分钟)",
+      "hiRes": "仅 Hi-Res",
+      "liked": "仅已喜欢的曲目",
+      "formats": "格式",
+      "genres": "流派",
+      "sort": "排序方式",
+      "limit": "曲目上限",
       "minRating": "最低评分"
     },
     "placeholders": {
-      "name": "My 2024 favourites",
-      "description": "Optional",
-      "noLimit": "Unlimited"
+      "name": "我的 2024 最爱",
+      "description": "选填",
+      "noLimit": "无上限"
     },
     "sections": {
-      "match": "Match",
-      "ranges": "Ranges",
-      "attributes": "Attributes",
-      "output": "Sort & limit"
+      "match": "匹配",
+      "ranges": "范围",
+      "attributes": "属性",
+      "output": "排序与限制"
     },
     "sortOptions": {
-      "addedDesc": "Recently added",
-      "addedAsc": "Oldest added",
-      "yearDesc": "Year (descending)",
-      "yearAsc": "Year (ascending)",
-      "titleAsc": "Title (A → Z)",
-      "artistAsc": "Artist (A → Z)",
-      "random": "Random"
+      "addedDesc": "最近添加",
+      "addedAsc": "最早添加",
+      "yearDesc": "年份(降序)",
+      "yearAsc": "年份(升序)",
+      "titleAsc": "标题(A → Z)",
+      "artistAsc": "艺人(A → Z)",
+      "random": "随机"
     },
     "tree": {
       "sectionTitle": "规则",
@@ -1119,7 +1136,7 @@
     "plainPlaceholder": "逐行输入歌词…",
     "linePlaceholder": "行文本",
     "capture": "捕获",
-    "captureHint": "开始播放后按空格（或捕获）将当前行锚定到当前时间",
+    "captureHint": "开始播放后按空格(或捕获)将当前行锚定到播放点",
     "captureNow": "立即捕获",
     "recapture": "重新锚定到当前位置",
     "seekToLine": "跳转到该行",
@@ -1142,18 +1159,21 @@
   },
   "sort": {
     "title": "标题",
-    "artist": "艺术家",
+    "artist": "艺人",
     "album": "专辑",
     "duration": "时长",
     "year": "年份",
     "addedAt": "最近添加",
-    "rating": "注",
-    "name": "姓名",
+    "rating": "评分",
+    "name": "名称",
     "albumsCount": "专辑数量",
-    "tracksCount": "曲目数",
+    "tracksCount": "曲目数量",
     "ascending": "升序",
     "descending": "降序",
-    "filename": "文件名"
+    "filename": "文件名",
+    "customOrder": "自定义顺序",
+    "recentlyAdded": "最近添加",
+    "menuTitle": "排序方式"
   },
   "settings": {
     "title": "设置",
@@ -1224,7 +1244,7 @@
       "subtitle": "将音量过大的片段调低，以保持音量一致"
     },
     "replayGain": {
-      "title": "申请 ReplayGain",
+      "title": "应用 ReplayGain",
       "subtitle": "使用每首曲目的分析增益值来平衡感知音量"
     },
     "exclusive": {
@@ -1265,17 +1285,17 @@
       "subtitle": "关闭后仍可从「…」菜单访问 A-B 循环"
     },
     "duplicates": {
-      "title": "Detect duplicates",
-      "subtitle": "Find byte-identical files (same blake3) in your library",
-      "action": "Search"
+      "title": "检测重复文件",
+      "subtitle": "在音乐库中查找字节相同的文件 (blake3 哈希相同)",
+      "action": "搜索"
     },
     "rescan": {
-      "title": "重新扫描书库",
+      "title": "重新扫描音乐库",
       "subtitle": "重新扫描所有文件夹并导入新文件",
       "action": "重新扫描"
     },
     "analyze": {
-      "title": "分析库",
+      "title": "分析音乐库",
       "subtitle": "计算未分析曲目的BPM、音量和峰值",
       "action": "分析",
       "autoTitle": "自动分析",
@@ -1284,7 +1304,7 @@
       "failed_other": "{{count}} 失败"
     },
     "artistImages": {
-      "title": "艺术家作品",
+      "title": "艺人图片",
       "subtitle": "从 Deezer 下载艺人专辑封面",
       "action": "恢复",
       "progress": "已处理 {{current}}/{{total}}"
@@ -1296,7 +1316,7 @@
       "done": "已为 {{considered}} 位艺人中的 {{linked}} 位关联本地图片"
     },
     "dataFolder": {
-      "title": "数据文件",
+      "title": "数据文件夹",
       "subtitle": "打开包含数据库和封面图片的文件夹",
       "action": "打开"
     },
@@ -1422,6 +1442,38 @@
         "toggleLyrics": "显示 / 隐藏歌词",
         "toggleLike": "喜欢 / 取消喜欢"
       }
+    },
+    "offlineMode": {
+      "title": "离线模式",
+      "subtitle": "禁用 Last.fm、Deezer 和 LRCLIB,仅使用缓存数据。"
+    },
+    "profileIo": {
+      "title": "个人资料备份",
+      "subtitle": "将完整个人资料(播放列表、喜欢、统计、EQ、快捷键)导出或导入为单个 .waveflow 文件。",
+      "export": {
+        "action": "导出",
+        "dialogTitle": "导出 WaveFlow 个人资料",
+        "done": "个人资料导出成功。",
+        "failed": "导出失败。详情请查看日志。"
+      },
+      "import": {
+        "action": "导入",
+        "dialogTitle": "导入 WaveFlow 个人资料",
+        "done": "个人资料已导入 (ID {{id}})。请从个人资料菜单切换到它。",
+        "failed": "导入失败。文件可能已损坏或不兼容。"
+      }
+    },
+    "visualizer": {
+      "title": "音频可视化",
+      "subtitle": "在沉浸式视图中显示实时频谱(解码器线程上的轻量 FFT)"
+    },
+    "smartCrossfade": {
+      "title": "智能交叉淡化",
+      "subtitle": "自动跳过同一专辑内两首曲目间的淡化(适合概念专辑和现场录音)"
+    },
+    "showSpotify": {
+      "title": "显示 Spotify 入口",
+      "subtitle": "在侧边栏显示 Spotify 快捷方式"
     }
   },
   "scanProgress": {
@@ -1445,6 +1497,12 @@
     "searchPlaceholder": "搜索 Spotify",
     "tracks": "曲目",
     "playlists": "播放列表",
-    "emptyPlaylist": "此播放列表中没有可用的曲目(Spotify 可能不会公开本地文件或非你拥有的播放列表)。"
+    "emptyPlaylist": "此播放列表中没有可用的曲目(Spotify 可能不会公开本地文件或非你拥有的播放列表)。",
+    "notConfiguredTitle": "注册你的 Spotify 应用",
+    "notConfiguredMessage": "Spotify 要求每个第三方应用在播放前必须注册一个免费的 Client ID。请在 Spotify Developer dashboard 创建一个,然后粘贴到 WaveFlow 的「设置 → 集成」。",
+    "openDashboard": "打开 Spotify Developer dashboard",
+    "openSettings": "打开设置",
+    "notConnectedTitle": "Spotify 未连接",
+    "notConnectedMessage": "你的 Client ID 已配置。请到「设置」登录 Spotify Premium 账户,以加载播放列表并开始播放。"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -128,7 +128,7 @@
     "library": {
       "tracksCount_zero": "0 首曲目",
       "tracksCount_one": "{{count}} 曲目",
-      "tracksCount_other": "{{count}} 標題",
+      "tracksCount_other": "{{count}} 曲目",
       "createLibraryAria": "建立新音樂庫",
       "none": "尚無音樂庫",
       "popover": {
@@ -137,7 +137,7 @@
         "countLine": "{{tracks}} · {{albums}}",
         "tracks_zero": "0 首曲目",
         "tracks_one": "{{count}} 曲目",
-        "tracks_other": "{{count}} 標題",
+        "tracks_other": "{{count}} 曲目",
         "albums_zero": "0 張專輯",
         "albums_one": "{{count}} 專輯",
         "albums_other": "{{count}} 專輯",
@@ -160,7 +160,7 @@
       "recent": "最近播放的",
       "emptySubtext_zero": "0 首曲目",
       "emptySubtext_one": "{{count}} 曲目",
-      "emptySubtext_other": "{{count}} 標題",
+      "emptySubtext_other": "{{count}} 曲目",
       "createSmartAria": "建立智慧型播放清單"
     },
     "myMusic": {
@@ -178,7 +178,7 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 首曲目",
       "playlistSubtext_one": "{{count}} 曲目",
-      "playlistSubtext_other": "{{count}} 標題"
+      "playlistSubtext_other": "{{count}} 曲目"
     }
   },
   "topbar": {
@@ -380,12 +380,12 @@
     "albumGrid": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 標題"
+      "trackCount_other": "{{count}} 曲目"
     },
     "artistList": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 標題",
+      "trackCount_other": "{{count}} 曲目",
       "albumCount_zero": "0 張專輯",
       "albumCount_one": "{{count}} 張專輯",
       "albumCount_other": "{{count}} 張專輯"
@@ -393,12 +393,12 @@
     "genreList": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 標題"
+      "trackCount_other": "{{count}} 曲目"
     },
     "folderList": {
       "trackCount_zero": "0 首曲目",
       "trackCount_one": "{{count}} 曲目",
-      "trackCount_other": "{{count}} 標題",
+      "trackCount_other": "{{count}} 曲目",
       "lastScanned": "掃描來源：{{date}}",
       "neverScanned": "從未",
       "watched": "受監控",
@@ -418,7 +418,7 @@
     "title": "已喜歡的曲目",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
-    "count_other": "{{count}} 標題",
+    "count_other": "{{count}} 曲目",
     "emptyTitle": "沒有喜愛的曲目",
     "emptyDescription": "你喜歡的歌曲將顯示在這裡。瀏覽你的音樂庫,將喜歡的曲目加入收藏。",
     "playAll": "全部播放",
@@ -452,7 +452,7 @@
     "title": "最近播放的",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
-    "count_other": "{{count}} 標題",
+    "count_other": "{{count}} 曲目",
     "emptyTitle": "沒有最近播放的曲目",
     "emptyDescription": "您正在聆聽的歌曲將自動顯示於此處。"
   },
@@ -472,9 +472,9 @@
       "totalPlays": "播放次數",
       "totalTime": "收聽時間",
       "uniqueTracks": "獨立曲目",
-      "uniqueArtists_zero": "0 位藝術家",
-      "uniqueArtists_one": "{{count}} 藝術家",
-      "uniqueArtists_other": "{{count}} 藝術家",
+      "uniqueArtists_zero": "0 位藝人",
+      "uniqueArtists_one": "{{count}} 藝人",
+      "uniqueArtists_other": "{{count}} 藝人",
       "completionRate": "完整收聽率"
     },
     "byDay": {
@@ -763,7 +763,7 @@
     "badge": "播放清單",
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
-    "trackCount_other": "{{count}} 標題",
+    "trackCount_other": "{{count}} 曲目",
     "actions": {
       "play": "播放",
       "shuffle": "隨機播放",
@@ -868,7 +868,8 @@
       "genre": "類型",
       "genrePlaceholder": "流行、搖滾、爵士…"
     },
-    "changeCover": "更換封面"
+    "changeCover": "更換封面",
+    "properties": "屬性"
   },
   "selection": {
     "toolbarLabel": "選取操作",
@@ -888,7 +889,7 @@
     "shuffle": "隨機播放",
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
-    "trackCount_other": "{{count}} 標題",
+    "trackCount_other": "{{count}} 曲目",
     "discHeader": "第 {{number}} 張",
     "releaseDate": "發行日期",
     "emptyTitle": "找不到專輯",
@@ -904,13 +905,13 @@
     "allTracks": "所有曲目",
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
-    "trackCount_other": "{{count}} 標題",
+    "trackCount_other": "{{count}} 曲目",
     "albumCount_zero": "0 張專輯",
     "albumCount_one": "{{count}} 專輯",
     "albumCount_other": "{{count}} 專輯",
     "albumTrackCount_zero": "0 首曲目",
     "albumTrackCount_one": "{{count}} 曲目",
-    "albumTrackCount_other": "{{count}} 標題",
+    "albumTrackCount_other": "{{count}} 曲目",
     "emptyTitle": "找不到該藝人",
     "emptyDescription": "該藝人已不在目前的個人檔案中。",
     "bio": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -118,22 +118,22 @@
     },
     "sections": {
       "open": "開啟",
-      "library": "圖書館",
+      "library": "音樂庫",
       "playlists": "播放清單"
     },
     "open": {
       "file": "檔案",
-      "folder": "專題"
+      "folder": "資料夾"
     },
     "library": {
       "tracksCount_zero": "0 首曲目",
       "tracksCount_one": "{{count}} 曲目",
       "tracksCount_other": "{{count}} 標題",
-      "createLibraryAria": "建立新的資料庫",
-      "none": "沒有任何圖書館",
+      "createLibraryAria": "建立新音樂庫",
+      "none": "尚無音樂庫",
       "popover": {
-        "label": "圖書館選書",
-        "header": "圖書館",
+        "label": "選擇音樂庫",
+        "header": "音樂庫",
         "countLine": "{{tracks}} · {{albums}}",
         "tracks_zero": "0 首曲目",
         "tracks_one": "{{count}} 曲目",
@@ -142,12 +142,12 @@
         "albums_one": "{{count}} 專輯",
         "albums_other": "{{count}} 專輯",
         "see": "查看",
-        "new": "新聞"
+        "new": "新增"
       },
       "nav": {
         "tracks": "曲目",
         "albums": "專輯",
-        "artists": "藝術家",
+        "artists": "藝人",
         "genres": "類型",
         "explorer": "檔案總管"
       }
@@ -156,19 +156,19 @@
       "createPlaylistAria": "建立新的播放清單",
       "importM3uAria": "匯入 M3U 播放清單",
       "importDialogTitle": "匯入 M3U 播放清單",
-      "liked": "已按讚的貼文",
+      "liked": "已喜歡的曲目",
       "recent": "最近播放的",
       "emptySubtext_zero": "0 首曲目",
       "emptySubtext_one": "{{count}} 曲目",
       "emptySubtext_other": "{{count}} 標題",
-      "createSmartAria": "Create a smart playlist"
+      "createSmartAria": "建立智慧型播放清單"
     },
     "myMusic": {
       "title": "我的音樂",
       "addFolderAria": "匯入資料夾",
       "tracks": "曲目",
       "albums": "專輯",
-      "artists": "藝術家",
+      "artists": "藝人",
       "genres": "類型",
       "folders": "檔案"
     },
@@ -226,15 +226,15 @@
       "badge": "準備好聆聽了嗎",
       "subtitle": "發現您最喜愛的音樂，並探索嶄新的音韻。",
       "openFile": "開啟檔案",
-      "openFolder": "建立檔案",
+      "openFolder": "開啟資料夾",
       "importFiles": "匯入檔案",
-      "importFolder": "匯入檔案",
+      "importFolder": "匯入資料夾",
       "browseLibrary": "瀏覽我的音樂庫"
     },
     "stats": {
-      "library": "圖書館",
-      "liked": "已按讚的貼文",
-      "recent": "最近遊玩過的遊戲",
+      "library": "音樂庫",
+      "liked": "已喜歡的曲目",
+      "recent": "最近播放",
       "playlists": "播放清單"
     },
     "moodRadio": {
@@ -268,7 +268,7 @@
     "recentlyPlayed": {
       "title": "最近播放的",
       "emptyTitle": "尚未聆聽任何歌曲",
-      "emptyDescription": "輸入一首歌曲名稱，它就會顯示在此處。您的聆聽紀錄會隨著您的探索而逐漸建立。"
+      "emptyDescription": "播放一首歌曲後它會出現在這裡。隨著你不斷探索,聆聽紀錄會逐漸累積。"
     },
     "recentlyAdded": {
       "title": "最近新增"
@@ -301,27 +301,27 @@
         "albums_zero": "0 張專輯",
         "albums_one": "{{count}} 專輯",
         "albums_other": "{{count}} 專輯",
-        "artistes_zero": "0 位藝術家",
-        "artistes_one": "{{count}} 藝術家",
-        "artistes_other": "{{count}} 藝術家",
+        "artistes_zero": "0 位藝人",
+        "artistes_one": "{{count}} 位藝人",
+        "artistes_other": "{{count}} 位藝人",
         "genres_zero": "0 類型",
         "genres_one": "{{count}} 類型",
         "genres_other": "{{count}} 類型",
-        "dossiers_zero": "0 檔案",
-        "dossiers_one": "{{count}} 專題",
-        "dossiers_other": "{{count}} 檔案"
+        "dossiers_zero": "0 個資料夾",
+        "dossiers_one": "{{count}} 個資料夾",
+        "dossiers_other": "{{count}} 個資料夾"
       }
     },
     "tabs": {
       "morceaux": "曲目",
       "albums": "專輯",
-      "artistes": "藝術家",
+      "artistes": "藝人",
       "genres": "類型",
       "dossiers": "檔案"
     },
     "empty": {
       "morceaux": {
-        "title": "空的書庫",
+        "title": "音樂庫是空的",
         "description": "匯入音訊檔案或資料夾，以充實您的媒體庫。"
       },
       "albums": {
@@ -329,7 +329,7 @@
         "description": "匯入音訊檔案以自動建立專輯。"
       },
       "artistes": {
-        "title": "未找到任何藝術家",
+        "title": "找不到藝人",
         "description": "請先匯入音訊檔案。"
       },
       "genres": {
@@ -345,11 +345,11 @@
       "importFiles": "匯入檔案",
       "importFolder": "匯入資料夾",
       "share": "分享（即將推出）",
-      "rescan": "重新掃描書庫",
-      "rescanning": "正在重新掃描……",
+      "rescan": "重新掃描音樂庫",
+      "rescanning": "正在重新掃描音樂庫…",
       "changeArtwork": "更換圖片（即將推出）",
-      "edit": "編輯資料庫",
-      "delete": "刪除資料庫",
+      "edit": "編輯音樂庫",
+      "delete": "刪除音樂庫",
       "deleteConfirm": "請再次點擊以確認",
       "importing": "正在匯入…"
     },
@@ -364,12 +364,13 @@
     "table": {
       "number": "#",
       "title": "標題",
-      "artist": "藝術家",
+      "artist": "藝人",
       "album": "專輯",
       "duration": "時長",
-      "unknown": "—"
+      "unknown": "—",
+      "rating": "評分"
     },
-    "rating": "註",
+    "rating": "評分",
     "noRating": "無評分",
     "viewToggle": {
       "label": "顯示模式",
@@ -386,8 +387,8 @@
       "trackCount_one": "{{count}} 曲目",
       "trackCount_other": "{{count}} 標題",
       "albumCount_zero": "0 張專輯",
-      "albumCount_one": "{{count}} 專輯",
-      "albumCount_other": "{{count}} 專輯"
+      "albumCount_one": "{{count}} 張專輯",
+      "albumCount_other": "{{count}} 張專輯"
     },
     "genreList": {
       "trackCount_zero": "0 首曲目",
@@ -403,21 +404,26 @@
       "watched": "受監控",
       "watchOn": "自動監控變更",
       "watchOff": "停止監控",
-      "remove": "從資料庫中移除資料夾",
+      "remove": "從音樂庫中移除資料夾",
       "removeConfirm": "再次點擊確認"
+    },
+    "library": {
+      "nav": {
+        "artists": "藝人"
+      }
     }
   },
   "liked": {
-    "badge": "系列",
-    "title": "已按讚的貼文",
+    "badge": "收藏",
+    "title": "已喜歡的曲目",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
     "count_other": "{{count}} 標題",
     "emptyTitle": "沒有喜愛的曲目",
-    "emptyDescription": "您喜愛的歌曲將會顯示在此處。瀏覽您的音樂庫，並為喜愛的歌曲按讚。",
+    "emptyDescription": "你喜歡的歌曲將顯示在這裡。瀏覽你的音樂庫,將喜歡的曲目加入收藏。",
     "playAll": "全部播放",
-    "unlike": "取消按讚",
-    "like": "加入「喜歡」清單"
+    "unlike": "取消喜歡",
+    "like": "加入已喜歡"
   },
   "history": {
     "badge": "歷史",
@@ -442,7 +448,7 @@
     }
   },
   "recent": {
-    "badge": "沿革",
+    "badge": "歷史",
     "title": "最近播放的",
     "count_zero": "0 首曲目",
     "count_one": "{{count}} 曲目",
@@ -463,9 +469,9 @@
       "all": "全部"
     },
     "kpi": {
-      "totalPlays": "監聽",
+      "totalPlays": "播放次數",
       "totalTime": "收聽時間",
-      "uniqueTracks": "獨家標題",
+      "uniqueTracks": "獨立曲目",
       "uniqueArtists_zero": "0 位藝術家",
       "uniqueArtists_one": "{{count}} 藝術家",
       "uniqueArtists_other": "{{count}} 藝術家",
@@ -473,19 +479,19 @@
     },
     "byDay": {
       "title": "每日活動",
-      "empty": "此期間無監聽紀錄。"
+      "empty": "此期間無收聽紀錄。"
     },
     "byHour": {
       "title": "最喜歡的時間",
-      "empty": "此期間無監聽紀錄。",
-      "tooltip": "{{hour}} h — {{plays}} 次收聽"
+      "empty": "此期間無收聽紀錄。",
+      "tooltip": "{{hour}} 點 — {{plays}} 次播放"
     },
     "topTracks": {
-      "title": "熱門標題",
+      "title": "熱門曲目",
       "empty": "尚未播放任何歌曲。"
     },
     "topArtists": {
-      "title": "頂尖藝人",
+      "title": "熱門藝人",
       "empty": "沒有聆聽任何藝術家。"
     },
     "topAlbums": {
@@ -499,9 +505,9 @@
       "less": "較少",
       "more": "較多"
     },
-    "plays_zero": "0 次收聽",
-    "plays_one": "{{count}} 請聽",
-    "plays_other": "{{count}} 監聽",
+    "plays_zero": "0 次播放",
+    "plays_one": "{{count}} 次播放",
+    "plays_other": "{{count}} 次播放",
     "export": {
       "label": "匯出統計",
       "action": "匯出",
@@ -551,12 +557,12 @@
     },
     "activeDay": {
       "eyebrow": "你的巔峰日",
-      "subtitle": "{{duration}} 的聆聽,{{count}} 首曲目"
+      "subtitle": "聆聽 {{duration}} · {{count}} 首曲目"
     },
     "mood": {
-      "eyebrow": "你的平均 BPM",
+      "eyebrow": "你的平均節奏",
       "subtitle": "陪伴你一年的節奏",
-      "loudness": "平均響度:{{lufs}} LUFS",
+      "loudness": "平均響度: {{lufs}} LUFS",
       "energy": {
         "chill": "舒緩",
         "warm": "溫暖",
@@ -601,7 +607,7 @@
     "hero": {
       "subtitle": "跨平台高畫質音樂播放器",
       "checkUpdates": "檢查更新",
-      "developedBy": "由"
+      "developedBy": "開發者"
     },
     "sections": {
       "frameworkDesktop": "桌面框架",
@@ -609,13 +615,14 @@
       "backend": "後端（Rust）",
       "audio": "音訊",
       "shortcuts": "鍵盤快捷鍵",
-      "credits": "版權聲明"
+      "credits": "版權聲明",
+      "changelog": "更新記錄"
     },
     "shortcuts": {
       "playPause": "播放 / 暫停",
       "previousTrack": "上一首",
       "nextTrack": "下一首",
-      "volume": "卷",
+      "volume": "音量",
       "mute": "靜音",
       "keys": {
         "space": "空格"
@@ -624,6 +631,13 @@
     "credits": {
       "text": "以熱情設計與開發。採用開源技術打造。",
       "icons": "圖示由 Lucide、Phosphor、Mynaui 及 Iconify 提供。"
+    },
+    "changelog": {
+      "loading": "載入中…",
+      "empty": "暫無記錄",
+      "expand": "顯示其他 {{count}} 筆記錄",
+      "collapse": "收合",
+      "breaking": "重大變更"
     }
   },
   "feedback": {
@@ -643,8 +657,8 @@
     "controls": {
       "play": "播放",
       "pause": "暫停",
-      "previous": "上一頁",
-      "next": "下一頁",
+      "previous": "上一首",
+      "next": "下一首",
       "shuffleOn": "停用隨機播放",
       "shuffleOff": "啟用隨機播放",
       "repeatOff": "啟用重複播放",
@@ -652,7 +666,7 @@
       "repeatOne": "關閉重複播放"
     },
     "volume": {
-      "label": "卷",
+      "label": "音量",
       "mute": "靜音",
       "unmute": "開啟聲音"
     },
@@ -669,14 +683,14 @@
     "title": "播放佇列",
     "inactive": "已停用",
     "count_zero": "0 首曲目",
-    "count_one": "{{count}} 曲目",
-    "count_other": "{{count}} 片段",
+    "count_one": "{{count}} 首",
+    "count_other": "{{count}} 首",
     "emptyTitle": "沒什麼可聽的",
-    "emptyDescription": "從您的音樂庫中選取一首歌曲，以填滿播放清單。",
+    "emptyDescription": "從你的音樂庫中選取一首歌,加入播放佇列。",
     "nowPlaying": "進行中",
     "upNext_zero": "接下來",
-    "upNext_one": "接下來 · {{count}} track",
-    "upNext_other": "下一個 - {{count}} 曲目",
+    "upNext_one": "接下來 · {{count}} 首",
+    "upNext_other": "接下來 · {{count}} 首",
     "radio": {
       "label": "電台",
       "basedOn": "基於「{{title}}」"
@@ -712,15 +726,15 @@
     }
   },
   "libraryModal": {
-    "title": "建立資料庫",
-    "editTitle": "編輯圖庫",
-    "previewDefault": "建立資料庫",
+    "title": "建立音樂庫",
+    "editTitle": "編輯音樂庫",
+    "previewDefault": "建立音樂庫",
     "previewSubtitle": "0 首曲目 · 音樂庫",
-    "nameLabel": "圖書館名稱",
+    "nameLabel": "音樂庫名稱",
     "namePlaceholder": "例如：搖滾、爵士、古典……",
     "descriptionLabel": "說明",
     "descriptionPlaceholder": "簡短說明……",
-    "submit": "建立資料庫",
+    "submit": "建立音樂庫",
     "submitEdit": "儲存"
   },
   "playlistModal": {
@@ -728,7 +742,7 @@
     "editTitle": "編輯播放清單",
     "previewDefault": "新播放清單",
     "previewSubtitle": "0 首曲目 · 播放清單",
-    "nameLabel": "姓名",
+    "nameLabel": "名稱",
     "namePlaceholder": "例如：Chill Vibes、Workout Mix...",
     "descriptionLabel": "說明",
     "descriptionPlaceholder": "簡短說明……",
@@ -775,14 +789,14 @@
     "createPlaylist": "新播放清單",
     "playNext": "播放下一首",
     "addToQueue": "加入佇列",
-    "like": "加入「喜歡」的歌曲",
-    "unlike": "移除已按讚的貼文",
+    "like": "加入已喜歡",
+    "unlike": "從已喜歡中移除",
     "removeFromPlaylist": "從此播放清單中移除",
-    "goToAlbum": "前往相簿",
-    "goToArtist": "前往該藝術家",
+    "goToAlbum": "前往專輯",
+    "goToArtist": "前往藝人",
     "showInExplorer": "在檔案總管中顯示",
     "copyPath": "複製檔案路徑",
-    "properties": "特性",
+    "properties": "屬性",
     "startRadio": "開始電台",
     "rating": "評分",
     "ratingNone": "無評分",
@@ -821,9 +835,9 @@
       "file": "檔案"
     },
     "bpm": "BPM",
-    "loudness": "音量",
+    "loudness": "響度",
     "replayGain": "ReplayGain",
-    "peak": "Peak",
+    "peak": "峰值",
     "analyze": "分析",
     "reanalyze": "重新分析",
     "analyzing": "分析……",
@@ -831,12 +845,12 @@
     "trackNumber": "曲目編號",
     "duration": "時長",
     "codec": "編解碼器",
-    "bitDepth": "深度",
-    "sampleRate": "抽樣",
-    "channels": "頻道",
-    "bitrate": "流量",
+    "bitDepth": "位元深度",
+    "sampleRate": "取樣率",
+    "channels": "聲道",
+    "bitrate": "位元率",
     "key": "音調",
-    "fileSize": "尺寸",
+    "fileSize": "大小",
     "addedAt": "新增於",
     "filePath": "路徑",
     "showInExplorer": "在檔案總管中顯示",
@@ -847,7 +861,7 @@
     "saving": "儲存中…",
     "fields": {
       "title": "標題",
-      "artist": "藝術家",
+      "artist": "藝人",
       "album": "專輯",
       "trackNumber": "曲目號",
       "discNumber": "碟片號",
@@ -857,10 +871,10 @@
     "changeCover": "更換封面"
   },
   "selection": {
-    "toolbarLabel": "篩選條件",
-    "count_zero": "0 項已選中",
-    "count_one": "{{count}} 已選取",
-    "count_other": "{{count}} 入選",
+    "toolbarLabel": "選取操作",
+    "count_zero": "未選取項目",
+    "count_one": "已選取 {{count}} 項",
+    "count_other": "已選取 {{count}} 項",
     "play": "播放",
     "addToQueue": "加入佇列",
     "playNext": "播放下一首",
@@ -875,15 +889,15 @@
     "trackCount_zero": "0 首曲目",
     "trackCount_one": "{{count}} 曲目",
     "trackCount_other": "{{count}} 標題",
-    "discHeader": "{{number}} 硬碟",
-    "releaseDate": "發行",
+    "discHeader": "第 {{number}} 張",
+    "releaseDate": "發行日期",
     "emptyTitle": "找不到專輯",
-    "emptyDescription": "此相簿已不在活躍的個人檔案中。",
+    "emptyDescription": "此專輯已不在目前的個人檔案中。",
     "emptyTracksTitle": "沒有任何曲目",
     "emptyTracksDescription": "這張專輯中沒有任何可供聆聽的曲目。"
   },
   "artistDetail": {
-    "badge": "藝術家",
+    "badge": "藝人",
     "playAll": "全部播放",
     "shuffle": "隨機播放",
     "discography": "唱片目錄",
@@ -897,13 +911,13 @@
     "albumTrackCount_zero": "0 首曲目",
     "albumTrackCount_one": "{{count}} 曲目",
     "albumTrackCount_other": "{{count}} 標題",
-    "emptyTitle": "找不到該藝術家",
-    "emptyDescription": "該藝術家已不在活躍名單中。",
+    "emptyTitle": "找不到該藝人",
+    "emptyDescription": "該藝人已不在目前的個人檔案中。",
     "bio": {
       "title": "傳記"
     },
     "similar": {
-      "title": "相似藝術家",
+      "title": "相似藝人",
       "inLibrary": "在你的曲庫中",
       "notInLibrary": "不在你的曲庫中"
     }
@@ -912,7 +926,8 @@
     "title": "更改藝人圖片",
     "editAria": "更改藝人照片",
     "removeAction": "移除圖片",
-    "fansCount_other": "{{display}} 粉絲"
+    "fansCount_other": "{{display}} 位粉絲",
+    "fansCount_one": "{{display}} 位粉絲"
   },
   "genreDetail": {
     "badge": "曲風",
@@ -929,10 +944,10 @@
   "nowPlaying": {
     "title": "現在播放",
     "empty": "目前沒有正在播放的曲目",
-    "aboutArtist": "關於藝術家",
+    "aboutArtist": "關於藝人",
     "readMore": "閱讀更多",
-    "readLess": "縮小",
-    "noBio": "沒有傳記資料。請在設定中設定您的Last.fm金鑰。",
+    "readLess": "收合",
+    "noBio": "沒有傳記資料。請在設定中設定你的 Last.fm 金鑰。",
     "nextInQueue": "佇列中的下一首",
     "openQueue": "開啟佇列",
     "lyrics": {
@@ -957,7 +972,8 @@
     "next": "下一首",
     "devices": "輸出裝置",
     "moreActions": "更多動作",
-    "abLoop": "A-B 循環"
+    "abLoop": "A-B 循環",
+    "openFullscreen": "沉浸式檢視"
   },
   "miniPlayer": {
     "idle": "沒有播放中的曲目",
@@ -1007,16 +1023,16 @@
     }
   },
   "duplicates": {
-    "title": "Duplicates detected",
-    "summary": "{{groups}} groups · {{duplicates}} duplicates to remove",
-    "scanning": "Scanning…",
-    "empty": "No duplicates",
-    "emptyHint": "Your library is clean.",
-    "rescan": "Rescan",
-    "deleteOthers_zero": "Nothing to delete",
-    "deleteOthers_one": "Delete {{count}} duplicate",
-    "deleteOthers_other": "Delete {{count}} duplicates",
-    "keepAria": "Keep {{title}}"
+    "title": "偵測到重複檔案",
+    "summary": "{{groups}} 組 · {{duplicates}} 個重複檔案待移除",
+    "scanning": "掃描中…",
+    "empty": "沒有重複檔案",
+    "emptyHint": "你的音樂庫沒有重複檔案。",
+    "rescan": "重新掃描",
+    "deleteOthers_zero": "沒有可刪除的檔案",
+    "deleteOthers_one": "刪除 {{count}} 個重複檔案",
+    "deleteOthers_other": "刪除 {{count}} 個重複檔案",
+    "keepAria": "保留 {{title}}"
   },
   "dragDrop": {
     "dropHint": "放下以匯入",
@@ -1029,48 +1045,48 @@
     "armed": "A-B 循環已啟用：{{a}} → {{b}} (點擊清除)"
   },
   "smartPlaylistEditor": {
-    "createTitle": "New smart playlist",
-    "editTitle": "Edit smart playlist",
-    "create": "Create",
-    "preview": "Preview",
-    "previewCount": "{{count}} tracks match",
-    "nameRequired": "Name is required",
+    "createTitle": "新建智慧型播放清單",
+    "editTitle": "編輯智慧型播放清單",
+    "create": "建立",
+    "preview": "預覽",
+    "previewCount": "{{count}} 首符合",
+    "nameRequired": "名稱為必填",
     "fields": {
-      "name": "Name",
-      "description": "Description",
-      "title": "Title contains",
-      "artist": "Artist contains",
-      "album": "Album contains",
-      "year": "Year",
+      "name": "名稱",
+      "description": "說明",
+      "title": "標題包含",
+      "artist": "藝人包含",
+      "album": "專輯包含",
+      "year": "年份",
       "bpm": "BPM",
-      "durationMin": "Duration in minutes",
-      "hiRes": "Hi-Res only",
-      "liked": "Liked tracks only",
-      "formats": "Formats",
-      "genres": "Genres",
-      "sort": "Sort by",
-      "limit": "Max tracks",
+      "durationMin": "時長(分鐘)",
+      "hiRes": "僅 Hi-Res",
+      "liked": "僅已喜歡的曲目",
+      "formats": "格式",
+      "genres": "曲風",
+      "sort": "排序方式",
+      "limit": "曲目上限",
       "minRating": "最低評分"
     },
     "placeholders": {
-      "name": "My 2024 favourites",
-      "description": "Optional",
-      "noLimit": "Unlimited"
+      "name": "我的 2024 最愛",
+      "description": "選填",
+      "noLimit": "無上限"
     },
     "sections": {
-      "match": "Match",
-      "ranges": "Ranges",
-      "attributes": "Attributes",
-      "output": "Sort & limit"
+      "match": "符合",
+      "ranges": "範圍",
+      "attributes": "屬性",
+      "output": "排序與限制"
     },
     "sortOptions": {
-      "addedDesc": "Recently added",
-      "addedAsc": "Oldest added",
-      "yearDesc": "Year (descending)",
-      "yearAsc": "Year (ascending)",
-      "titleAsc": "Title (A → Z)",
-      "artistAsc": "Artist (A → Z)",
-      "random": "Random"
+      "addedDesc": "最近新增",
+      "addedAsc": "最早新增",
+      "yearDesc": "年份(由新到舊)",
+      "yearAsc": "年份(由舊到新)",
+      "titleAsc": "標題(A → Z)",
+      "artistAsc": "藝人(A → Z)",
+      "random": "隨機"
     },
     "tree": {
       "sectionTitle": "規則",
@@ -1119,13 +1135,13 @@
     "plainPlaceholder": "逐行輸入歌詞…",
     "linePlaceholder": "行文字",
     "capture": "擷取",
-    "captureHint": "開始播放後按空白鍵（或擷取）將目前行金定到目前時間",
+    "captureHint": "開始播放後按空白鍵(或擷取)將目前行錨定到播放點",
     "captureNow": "立即擷取",
-    "recapture": "重新金定到目前位置",
+    "recapture": "重新錨定到目前位置",
     "seekToLine": "跳到此行",
     "insertBelow": "在下方插入一行",
     "removeLine": "刪除行",
-    "lines": "行已金定",
+    "lines": "行已錨定",
     "writeToFile": "同時寫入音訊檔案 (USLT/LYRICS)",
     "offset": {
       "label": "整體偏移",
@@ -1142,18 +1158,21 @@
   },
   "sort": {
     "title": "標題",
-    "artist": "藝術家",
+    "artist": "藝人",
     "album": "專輯",
     "duration": "時長",
     "year": "年份",
     "addedAt": "最近新增",
-    "rating": "註",
-    "name": "姓名",
+    "rating": "評分",
+    "name": "名稱",
     "albumsCount": "專輯數量",
-    "tracksCount": "曲目數",
+    "tracksCount": "曲目數量",
     "ascending": "遞增",
     "descending": "遞減",
-    "filename": "檔案名稱"
+    "filename": "檔案名稱",
+    "customOrder": "自訂順序",
+    "recentlyAdded": "最近新增",
+    "menuTitle": "排序方式"
   },
   "settings": {
     "title": "設定",
@@ -1224,7 +1243,7 @@
       "subtitle": "將音量過大的片段調低，以保持整體音量一致"
     },
     "replayGain": {
-      "title": "申請 ReplayGain",
+      "title": "套用 ReplayGain",
       "subtitle": "使用每首曲目的分析增益值來平衡聽覺音量"
     },
     "exclusive": {
@@ -1265,17 +1284,17 @@
       "subtitle": "關閉後仍可從「…」選單存取 A-B 循環"
     },
     "duplicates": {
-      "title": "Detect duplicates",
-      "subtitle": "Find byte-identical files (same blake3) in your library",
-      "action": "Search"
+      "title": "偵測重複檔案",
+      "subtitle": "在音樂庫中尋找位元組相同的檔案(blake3 雜湊相同)",
+      "action": "搜尋"
     },
     "rescan": {
-      "title": "重新掃描書庫",
+      "title": "重新掃描音樂庫",
       "subtitle": "重新掃描所有資料夾並匯入新檔案",
       "action": "重新掃描"
     },
     "analyze": {
-      "title": "分析該書庫",
+      "title": "分析音樂庫",
       "subtitle": "計算未經分析曲目的BPM、音量及峰值",
       "action": "分析",
       "autoTitle": "自動分析",
@@ -1284,7 +1303,7 @@
       "failed_other": "{{count}} 失敗"
     },
     "artistImages": {
-      "title": "藝術家作品",
+      "title": "藝人圖片",
       "subtitle": "從 Deezer 下載藝人專輯封面",
       "action": "恢復",
       "progress": "已處理 {{current}}/{{total}}"
@@ -1296,7 +1315,7 @@
       "done": "已為 {{considered}} 位藝人中的 {{linked}} 位連結本地圖片"
     },
     "dataFolder": {
-      "title": "資料檔案",
+      "title": "資料資料夾",
       "subtitle": "開啟包含資料庫和封面圖檔的資料夾",
       "action": "開啟"
     },
@@ -1422,6 +1441,38 @@
         "toggleLyrics": "顯示 / 隱藏歌詞",
         "toggleLike": "喜歡 / 取消喜歡"
       }
+    },
+    "offlineMode": {
+      "title": "離線模式",
+      "subtitle": "停用 Last.fm、Deezer 和 LRCLIB,僅使用快取資料。"
+    },
+    "profileIo": {
+      "title": "個人檔案備份",
+      "subtitle": "將完整個人檔案(播放清單、喜歡、統計、EQ、快速鍵)匯出或匯入為單一 .waveflow 檔案。",
+      "export": {
+        "action": "匯出",
+        "dialogTitle": "匯出 WaveFlow 個人檔案",
+        "done": "個人檔案匯出成功。",
+        "failed": "匯出失敗。詳情請查看日誌。"
+      },
+      "import": {
+        "action": "匯入",
+        "dialogTitle": "匯入 WaveFlow 個人檔案",
+        "done": "個人檔案已匯入 (ID {{id}})。請從個人檔案選單切換到它。",
+        "failed": "匯入失敗。檔案可能損毀或不相容。"
+      }
+    },
+    "visualizer": {
+      "title": "音訊視覺化",
+      "subtitle": "在沉浸式檢視中顯示即時頻譜(解碼器執行緒上的輕量 FFT)"
+    },
+    "smartCrossfade": {
+      "title": "智慧交叉淡化",
+      "subtitle": "自動跳過同一張專輯內兩首曲目間的淡化(適合概念專輯和現場錄音)"
+    },
+    "showSpotify": {
+      "title": "顯示 Spotify 入口",
+      "subtitle": "在側邊欄中顯示 Spotify 快捷方式"
     }
   },
   "scanProgress": {
@@ -1445,6 +1496,12 @@
     "searchPlaceholder": "搜尋 Spotify",
     "tracks": "曲目",
     "playlists": "播放清單",
-    "emptyPlaylist": "此播放清單中沒有可用的曲目(Spotify 可能不會公開本機檔案或非你擁有的播放清單)。"
+    "emptyPlaylist": "此播放清單中沒有可用的曲目(Spotify 可能不會公開本機檔案或非你擁有的播放清單)。",
+    "notConfiguredTitle": "註冊你的 Spotify 應用程式",
+    "notConfiguredMessage": "Spotify 要求每個第三方應用程式在播放前必須註冊一個免費的 Client ID。請在 Spotify Developer dashboard 建立一個,然後貼到 WaveFlow 的「設定 → 整合」。",
+    "openDashboard": "開啟 Spotify Developer dashboard",
+    "openSettings": "開啟設定",
+    "notConnectedTitle": "Spotify 尚未連接",
+    "notConnectedMessage": "你的 Client ID 已設定。請至「設定」登入 Spotify Premium 帳號,以載入播放清單並開始播放。"
   }
 }


### PR DESCRIPTION
## Summary

Both Chinese locales had ~120 critical mistranslations + ~50 missing keys, mostly from unreviewed auto-translation that picked the wrong sense of polysemous words. This PR rewrites them.

### Critical sense fixes
- **Volume** (audio): 卷 *(book volume)* → 音量
- **Library**: 圖書館 / 图书馆 *(book library)* → 音樂庫 / 音乐库 — sidebar, popovers, modals, library actions, settings
- **Liked songs**: 已按讚的貼文 / 点赞的帖子 *(social media posts)* → 已喜歡的曲目 / 已喜欢的曲目
- **Queue** (zh-CN): 播放列表 *(playlist)* → 播放队列
- **Album** (after a track): 相簿 / 相册 *(photo album)* → 專輯 / 专辑 (also affects ``goToAlbum``)
- **Artist**: 藝術家 / 艺术家 *(painter)* → 藝人 / 艺人 across sidebar, library tabs, artistDetail, sort, nowPlaying, trackProperties
- **Apply ReplayGain**: 申請 / 申请 *(administrative request)* → 套用 / 应用
- **Statistics**: "wiretapping / monitoring" calques → 播放次數 / 播放次数 + 次播放 plural forms
- **Recently played**: 最近遊玩過的遊戲 *(games played)* → 最近播放
- **Properties**: 特性 *(characteristics)* → 屬性 / 属性
- **Collection badge**: 系列 *(TV series)* → 收藏
- **History badge** (zh-TW): 沿革 *(formal evolution)* → 歷史

### Audio engineering vocabulary
- 頻道 / 频道 → 聲道 / 声道 (channels)
- 流量 → 位元率 / 码率 (bitrate)
- 抽樣 / 采样 → 取樣率 / 采样率 (sample rate)
- 深度 → 位元深度 / 位深度 (bit depth)
- 尺寸 → 大小 (file size)
- 音量 → 響度 / 响度 for `loudness` (perceptual, not volume slider)
- Peak: ``Peak`` → 峰值

### Newly translated sections
- `duplicates.*` (was entirely English)
- `smartPlaylistEditor.*` (was 60% English)
- `settings.offlineMode.*`, `settings.profileIo.*`, `settings.visualizer.*`, `settings.smartCrossfade.*`, `settings.showSpotify.*`, `settings.duplicates.*` (were missing)
- `spotify.*` (notConfigured / notConnected / openDashboard / openSettings — were missing)
- `about.sections.changelog` + `about.changelog.*` (were missing)
- `sort.customOrder`, `sort.recentlyAdded`, `sort.menuTitle` (were missing)
- `artistImagePicker.fansCount_one`, `playerBar.openFullscreen` (were missing)

### Other corrections
- `playlistModal.nameLabel`: 姓名 *(person name)* → 名稱 / 名称
- `lyricsEditor`: 金定 (typo for 錨定) → 錨定 / 锚定
- `queue.upNext_one` (zh-TW): English ``track`` token left over → 首
- `albumDetail.discHeader`: ``{{number}} 硬碟`` (hard drive) → 第 {{number}} 張 (disc)
- ``nowPlaying.noBio``: Last.fm casing fixed

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [x] Manual smoke in the UI: switch language to 简体中文 / 繁體中文 and walk through Library / Liked / Statistics / Settings / Queue / Now Playing / Smart Playlist Editor / Duplicates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Mise à jour étendue des traductions chinois (zh-CN, zh-TW) : harmonisation de la terminologie et des libellés UI.
  * Ajustements visibles dans la navigation, la bibliothèque, playlists, vues d’album/artiste, file d’attente, barre de lecture et contrôles.
  * Révisions des modals/éditeurs (playlist, library, track actions, duplicates, smart playlist, lyrics), des textes de la page d’accueil/wrapped, des statistiques et des paramètres (dont nouvelles étiquettes).
  * Messages et états liés à l’intégration Spotify mis à jour.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->