### PR TITLE
fix(locales): overhaul english source translations (en)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -10,15 +10,15 @@
     "viewArtwork": "View artwork"
   },
   "lastfmReauth": {
-    "title": "Last.fm's session has expired",
-    "message": "Your scrobbles are no longer being sent. Please log in again to resume.",
-    "action": "Open Settings"
+    "title": "Last.fm session expired",
+    "message": "Your scrobbles are no longer being sent. Sign in again to resume.",
+    "action": "Open settings"
   },
   "updater": {
     "available": {
-      "title": "Update available ({{version}})",
-      "message": "A new version of WaveFlow is ready to be installed.",
-      "action": "Install Now",
+      "title": "Update available (v{{version}})",
+      "message": "A new version of WaveFlow is ready to install.",
+      "action": "Install now",
       "later": "Later"
     },
     "downloading": {
@@ -98,7 +98,7 @@
       "getStarted": "Get started",
       "back": "Back",
       "continue": "Continue",
-      "understood": "I understand",
+      "understood": "Got it",
       "skipForNow": "Skip for now",
       "scanLater": "Scan later",
       "scanNow": "Scan now",
@@ -123,26 +123,26 @@
     },
     "open": {
       "file": "File",
-      "folder": "File"
+      "folder": "Folder"
     },
     "library": {
       "tracksCount_zero": "0 tracks",
       "tracksCount_one": "{{count}} track",
-      "tracksCount_other": "{{count}} titles",
+      "tracksCount_other": "{{count}} tracks",
       "createLibraryAria": "Create a new library",
       "none": "No libraries",
       "popover": {
-        "label": "Library Selection",
+        "label": "Library selection",
         "header": "Libraries",
         "countLine": "{{tracks}} · {{albums}}",
         "tracks_zero": "0 tracks",
         "tracks_one": "{{count}} track",
-        "tracks_other": "{{count}} titles",
+        "tracks_other": "{{count}} tracks",
         "albums_zero": "0 albums",
         "albums_one": "{{count}} album",
         "albums_other": "{{count}} albums",
         "see": "See",
-        "new": "News"
+        "new": "New"
       },
       "nav": {
         "tracks": "Songs",
@@ -156,11 +156,11 @@
       "createPlaylistAria": "Create a new playlist",
       "importM3uAria": "Import an M3U playlist",
       "importDialogTitle": "Import an M3U playlist",
-      "liked": "Liked posts",
+      "liked": "Liked tracks",
       "recent": "Recently played",
       "emptySubtext_zero": "0 tracks",
       "emptySubtext_one": "{{count}} track",
-      "emptySubtext_other": "{{count}} titles",
+      "emptySubtext_other": "{{count}} tracks",
       "createSmartAria": "Create a smart playlist"
     },
     "myMusic": {
@@ -170,7 +170,7 @@
       "albums": "Albums",
       "artists": "Artists",
       "genres": "Genres",
-      "folders": "Files"
+      "folders": "Folders"
     },
     "playlistSection": {
       "title": "Playlists"
@@ -178,7 +178,7 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 tracks",
       "playlistSubtext_one": "{{count}} track",
-      "playlistSubtext_other": "{{count}} titles"
+      "playlistSubtext_other": "{{count}} tracks"
     }
   },
   "topbar": {
@@ -203,8 +203,8 @@
       }
     },
     "theme": {
-      "enableLight": "Turn on light mode",
-      "enableDark": "Turn on dark mode"
+      "enableLight": "Switch to light mode",
+      "enableDark": "Switch to dark mode"
     },
     "profile": {
       "user": "User",
@@ -213,27 +213,27 @@
       "settings": "Settings",
       "feedback": "Feedback",
       "about": "About",
-      "quit": "Exit the app"
+      "quit": "Quit app"
     }
   },
   "home": {
     "greeting": {
-      "morning": "Hello",
+      "morning": "Good morning",
       "evening": "Good evening",
       "night": "Good night"
     },
     "banner": {
       "badge": "Ready to listen",
-      "subtitle": "Discover your favorite music and explore new sounds.",
+      "subtitle": "Discover your favourite music and explore new sounds.",
       "openFile": "Open a file",
-      "openFolder": "Open a file",
+      "openFolder": "Open a folder",
       "importFiles": "Import files",
       "importFolder": "Import folder",
       "browseLibrary": "Browse my library"
     },
     "stats": {
       "library": "Library",
-      "liked": "Liked posts",
+      "liked": "Liked tracks",
       "recent": "Recently played",
       "playlists": "Playlists"
     },
@@ -267,8 +267,8 @@
     },
     "recentlyPlayed": {
       "title": "Recently played",
-      "emptyTitle": "No tracks played",
-      "emptyDescription": "Play a song to have it appear here. Your listening history builds up as you discover new music."
+      "emptyTitle": "Nothing played yet",
+      "emptyDescription": "Play a track to have it appear here. Your listening history builds up as you discover new music."
     },
     "recentlyAdded": {
       "title": "Recently added"
@@ -295,29 +295,29 @@
     "header": {
       "addFolder": "Add a folder",
       "subtext": {
-        "morceaux_zero": "0 Track",
-        "morceaux_one": "{{count}} Track",
-        "morceaux_other": "{{count}} Songs",
-        "albums_zero": "0 Albums",
-        "albums_one": "{{count}} Album",
-        "albums_other": "{{count}} Albums",
-        "artistes_zero": "0 Artists",
-        "artistes_one": "{{count}} Artist",
-        "artistes_other": "{{count}} Artists",
-        "genres_zero": "0 Genre",
-        "genres_one": "{{count}} Genre",
-        "genres_other": "{{count}} Genres",
-        "dossiers_zero": "0 File",
-        "dossiers_one": "{{count}} File",
-        "dossiers_other": "{{count}} Files"
+        "morceaux_zero": "0 tracks",
+        "morceaux_one": "{{count}} track",
+        "morceaux_other": "{{count}} tracks",
+        "albums_zero": "0 albums",
+        "albums_one": "{{count}} album",
+        "albums_other": "{{count}} albums",
+        "artistes_zero": "0 artists",
+        "artistes_one": "{{count}} artist",
+        "artistes_other": "{{count}} artists",
+        "genres_zero": "0 genres",
+        "genres_one": "{{count}} genre",
+        "genres_other": "{{count}} genres",
+        "dossiers_zero": "0 folders",
+        "dossiers_one": "{{count}} folder",
+        "dossiers_other": "{{count}} folders"
       }
     },
     "tabs": {
-      "morceaux": "Songs",
+      "morceaux": "Tracks",
       "albums": "Albums",
       "artistes": "Artists",
       "genres": "Genres",
-      "dossiers": "Files"
+      "dossiers": "Folders"
     },
     "empty": {
       "morceaux": {
@@ -333,11 +333,11 @@
         "description": "Import some audio files to get started."
       },
       "genres": {
-        "title": "No genre found",
+        "title": "No genres found",
         "description": "Import audio files to explore different genres."
       },
       "dossiers": {
-        "title": "No files imported",
+        "title": "No folders imported",
         "description": "Import a folder from the action bar to browse it here."
       }
     },
@@ -353,14 +353,14 @@
       "deleteConfirm": "Click again to confirm",
       "importing": "Importing…"
     },
-    "changeCover": "Change the cover",
+    "changeCover": "Change cover",
     "searchDeezer": "Search Deezer",
     "localFile": "Local file",
-    "fetchMissingCovers": "Retrieve all missing sleeves",
-    "noCover": "Without a sleeve",
-    "fetchingCovers": "Download the covers... ({{current}} / {{total}})",
-    "fetchCoversResult": "{{count}} sleeves retrieved",
-    "fetchCoversFailed": "Failed to retrieve sleeves",
+    "fetchMissingCovers": "Retrieve all missing covers",
+    "noCover": "No cover",
+    "fetchingCovers": "Fetching covers... ({{current}} / {{total}})",
+    "fetchCoversResult": "{{count}} covers retrieved",
+    "fetchCoversFailed": "Failed to retrieve covers",
     "table": {
       "number": "#",
       "title": "Title",
@@ -369,7 +369,7 @@
       "duration": "Duration",
       "unknown": "—"
     },
-    "rating": "Note",
+    "rating": "Rating",
     "noRating": "No rating",
     "viewToggle": {
       "label": "Display mode",
@@ -379,12 +379,12 @@
     "albumGrid": {
       "trackCount_zero": "0 tracks",
       "trackCount_one": "{{count}} track",
-      "trackCount_other": "{{count}} titles"
+      "trackCount_other": "{{count}} tracks"
     },
     "artistList": {
       "trackCount_zero": "0 tracks",
       "trackCount_one": "{{count}} track",
-      "trackCount_other": "{{count}} titles",
+      "trackCount_other": "{{count}} tracks",
       "albumCount_zero": "0 albums",
       "albumCount_one": "{{count}} album",
       "albumCount_other": "{{count}} albums"
@@ -392,32 +392,32 @@
     "genreList": {
       "trackCount_zero": "0 tracks",
       "trackCount_one": "{{count}} track",
-      "trackCount_other": "{{count}} titles"
+      "trackCount_other": "{{count}} tracks"
     },
     "folderList": {
       "trackCount_zero": "0 tracks",
       "trackCount_one": "{{count}} track",
-      "trackCount_other": "{{count}} titles",
-      "lastScanned": "Scanned from: {{date}}",
+      "trackCount_other": "{{count}} tracks",
+      "lastScanned": "Scanned: {{date}}",
       "neverScanned": "never",
       "watched": "Monitored",
       "watchOn": "Automatically monitor changes",
-      "watchOff": "Stop surveillance",
+      "watchOff": "Stop monitoring",
       "remove": "Remove folder from library",
       "removeConfirm": "Click again to confirm"
     }
   },
   "liked": {
     "badge": "Collection",
-    "title": "Liked posts",
+    "title": "Liked tracks",
     "count_zero": "0 tracks",
     "count_one": "{{count}} track",
-    "count_other": "{{count}} titles",
+    "count_other": "{{count}} tracks",
     "emptyTitle": "No liked tracks",
-    "emptyDescription": "The songs you like will appear here. Browse your library and like your favorite tracks.",
+    "emptyDescription": "Tracks you like will appear here. Browse your library and like your favourite tracks.",
     "playAll": "Play all",
-    "unlike": "Unfollow",
-    "like": "Add to Favorites"
+    "unlike": "Remove from Liked",
+    "like": "Add to Liked"
   },
   "history": {
     "badge": "History",
@@ -434,7 +434,7 @@
     "plays_one": "{{count}} play",
     "plays_other": "{{count}} plays",
     "range": {
-      "all": "All time",
+      "all": "All",
       "7d": "7 days",
       "30d": "30 days",
       "90d": "90 days",
@@ -446,9 +446,9 @@
     "title": "Recently played",
     "count_zero": "0 tracks",
     "count_one": "{{count}} track",
-    "count_other": "{{count}} titles",
+    "count_other": "{{count}} tracks",
     "emptyTitle": "No recent tracks",
-    "emptyDescription": "The songs you're listening to will appear here automatically."
+    "emptyDescription": "Tracks you listen to will appear here automatically."
   },
   "statistics": {
     "title": "Statistics",
@@ -460,36 +460,36 @@
       "30d": "30 days",
       "90d": "90 days",
       "1y": "1 year",
-      "all": "Everything"
+      "all": "All time"
     },
     "kpi": {
-      "totalPlays": "Wiretapping",
+      "totalPlays": "Plays",
       "totalTime": "Listening time",
-      "uniqueTracks": "Unique titles",
+      "uniqueTracks": "Unique tracks",
       "uniqueArtists_zero": "0 artists",
       "uniqueArtists_one": "{{count}} artist",
       "uniqueArtists_other": "{{count}} artists",
-      "completionRate": "Full-listening rate"
+      "completionRate": "Full-listen rate"
     },
     "byDay": {
-      "title": "Daily Activity",
-      "empty": "No monitoring during this period."
+      "title": "Daily activity",
+      "empty": "No listening during this period."
     },
     "byHour": {
-      "title": "Favorite times",
-      "empty": "No monitoring during this period.",
-      "tooltip": "{{hour}} h — {{plays}} plays"
+      "title": "Peak hours",
+      "empty": "No listening during this period.",
+      "tooltip": "{{hour}}h — {{plays}} plays"
     },
     "topTracks": {
-      "title": "Top Stories",
+      "title": "Top tracks",
       "empty": "No tracks played."
     },
     "topArtists": {
-      "title": "Top Artists",
-      "empty": "No artists were played."
+      "title": "Top artists",
+      "empty": "No artists played."
     },
     "topAlbums": {
-      "title": "Top Albums",
+      "title": "Top albums",
       "empty": "No albums played."
     },
     "heatmap": {
@@ -500,8 +500,8 @@
       "more": "More"
     },
     "plays_zero": "0 plays",
-    "plays_one": "{{count}} listen",
-    "plays_other": "{{count}} wiretaps",
+    "plays_one": "{{count}} play",
+    "plays_other": "{{count}} plays",
     "export": {
       "label": "Export statistics",
       "action": "Export",
@@ -517,7 +517,7 @@
     "prev": "Previous slide",
     "next": "Next slide",
     "yearPicker": "Pick a year",
-    "backToHome": "Back to Home",
+    "backToHome": "Back to home",
     "playsShort_zero": "0 plays",
     "playsShort_one": "{{count}} play",
     "playsShort_other": "{{count}} plays",
@@ -566,7 +566,7 @@
       }
     },
     "clock": {
-      "eyebrow": "Your listening hour",
+      "eyebrow": "Your peak listening hour",
       "subtitle": "The peak of your day"
     },
     "streak": {
@@ -593,7 +593,7 @@
     "outro": {
       "title": "Thanks for listening with WaveFlow",
       "subtitle": "Keep exploring — your Wrapped updates in real time.",
-      "cta": "Back to Home"
+      "cta": "Back to home"
     }
   },
   "about": {
@@ -604,7 +604,7 @@
       "developedBy": "Developed by"
     },
     "sections": {
-      "frameworkDesktop": "Desktop Framework",
+      "frameworkDesktop": "Desktop framework",
       "frontend": "Frontend",
       "backend": "Backend (Rust)",
       "audio": "Audio",
@@ -617,7 +617,7 @@
       "previousTrack": "Previous track",
       "nextTrack": "Next track",
       "volume": "Volume",
-      "mute": "Mute the sound",
+      "mute": "Mute",
       "keys": {
         "space": "Space"
       }
@@ -626,7 +626,7 @@
       "loading": "Loading…",
       "empty": "No entries available",
       "expand": "Show {{count}} more entries",
-      "collapse": "Show fewer",
+      "collapse": "Show less",
       "breaking": "Breaking"
     },
     "credits": {
@@ -638,11 +638,11 @@
     "title": "Feedback",
     "hero": {
       "title": "Help us improve WaveFlow",
-      "description": "Have you found a bug, have an idea for improvement, or just want to give us some feedback? We read every message and take your suggestions into account."
+      "description": "Spotted a bug, have an idea for improvement, or just want to share feedback? We read every message and take your suggestions into account."
     },
     "contact": {
-      "section": "Contact Us",
-      "subtitle": "Whether it's a bug, a suggestion, or a question—we read every message"
+      "section": "Contact us",
+      "subtitle": "Bug, suggestion or question — we read every message"
     }
   },
   "player": {
@@ -656,20 +656,20 @@
       "shuffleOn": "Disable shuffle",
       "shuffleOff": "Enable shuffle",
       "repeatOff": "Enable repeat",
-      "repeatAll": "Repeat once",
-      "repeatOne": "Turn off repeat"
+      "repeatAll": "Repeat one",
+      "repeatOne": "Disable repeat"
     },
     "volume": {
       "label": "Volume",
       "mute": "Mute",
-      "unmute": "Turn on the sound"
+      "unmute": "Unmute"
     },
     "speed": {
       "label": "Playback speed ({{value}})",
       "title": "Playback speed",
       "slider": "Speed slider",
       "custom": "Custom speed",
-      "pitchHint": "Pitch tracks speed (no time-stretching)."
+      "pitchHint": "Pitch follows speed (no time-stretching)."
     },
     "seek": "Seek"
   },
@@ -678,10 +678,10 @@
     "inactive": "INACTIVE",
     "count_zero": "0 tracks",
     "count_one": "{{count}} track",
-    "count_other": "{{count}} songs",
+    "count_other": "{{count}} tracks",
     "emptyTitle": "Nothing to listen to",
-    "emptyDescription": "Play a song from your library to fill the queue.",
-    "nowPlaying": "In progress",
+    "emptyDescription": "Play a track from your library to fill the queue.",
+    "nowPlaying": "Now playing",
     "upNext_zero": "Up next",
     "upNext_one": "Up next · {{count}} track",
     "upNext_other": "Up next · {{count}} tracks",
@@ -698,7 +698,7 @@
     "activeLabel": "Active output",
     "loading": "Searching for devices…",
     "empty": "No output device available",
-    "systemDefault": "By default"
+    "systemDefault": "System default"
   },
   "profiles": {
     "select": {
@@ -707,28 +707,28 @@
       "add": "Add",
       "edit": "Edit",
       "active": "Active profile",
-      "switchTo": "Toggle"
+      "switchTo": "Switch"
     },
     "create": {
       "title": "New profile",
-      "subtitle": "Create a profile to personalize your experience",
-      "nameLabel": "Profile Name",
+      "subtitle": "Create a profile to personalise your experience",
+      "nameLabel": "Profile name",
       "namePlaceholder": "Enter a name...",
-      "colorLabel": "Profile color",
-      "colorAria": "Color{{color}}",
+      "colorLabel": "Profile colour",
+      "colorAria": "Colour {{color}}",
       "submit": "Create profile"
     }
   },
   "libraryModal": {
-    "title": "Create a Library",
-    "editTitle": "Edit the Library",
-    "previewDefault": "Create a Library",
+    "title": "Create a library",
+    "editTitle": "Edit the library",
+    "previewDefault": "Create a library",
     "previewSubtitle": "0 tracks · Library",
-    "nameLabel": "Library Name",
-    "namePlaceholder": "e.g., Rock, Jazz, Classical...",
+    "nameLabel": "Library name",
+    "namePlaceholder": "e.g. Rock, Jazz, Classical...",
     "descriptionLabel": "Description",
-    "descriptionPlaceholder": "A brief description...",
-    "submit": "Create a Library",
+    "descriptionPlaceholder": "A short description...",
+    "submit": "Create a library",
     "submitEdit": "Save"
   },
   "playlistModal": {
@@ -736,12 +736,12 @@
     "editTitle": "Edit the playlist",
     "previewDefault": "New playlist",
     "previewSubtitle": "0 tracks · Playlist",
-    "nameLabel": "Last Name",
-    "namePlaceholder": "Examples: Chill Vibes, Workout Mix...",
+    "nameLabel": "Name",
+    "namePlaceholder": "e.g. Chill Vibes, Workout Mix...",
     "descriptionLabel": "Description",
-    "descriptionPlaceholder": "A brief description...",
-    "colorLabel": "Color",
-    "colorAria": "Color{{color}}",
+    "descriptionPlaceholder": "A short description...",
+    "colorLabel": "Colour",
+    "colorAria": "Colour {{color}}",
     "iconLabel": "Icon",
     "iconAria": "{{icon}} icon",
     "submit": "Create",
@@ -757,7 +757,7 @@
     "badge": "Playlist",
     "trackCount_zero": "0 tracks",
     "trackCount_one": "{{count}} track",
-    "trackCount_other": "{{count}} titles",
+    "trackCount_other": "{{count}} tracks",
     "actions": {
       "play": "Play",
       "shuffle": "Shuffle",
@@ -767,7 +767,7 @@
       "deleteConfirm": "Click again to confirm"
     },
     "export": {
-      "dialogTitle": "Export the playlist as an M3U file"
+      "dialogTitle": "Export the playlist as M3U"
     },
     "emptyTitle": "This playlist is empty",
     "emptyDescription": "Add tracks from your libraries using the + button on each row.",
@@ -783,13 +783,13 @@
     "createPlaylist": "New playlist",
     "playNext": "Play next",
     "addToQueue": "Add to queue",
-    "like": "Add to Liked Titles",
-    "unlike": "Remove liked posts",
+    "like": "Add to Liked",
+    "unlike": "Remove from Liked",
     "removeFromPlaylist": "Remove from this playlist",
-    "goToAlbum": "Go to the album",
-    "goToArtist": "Go to the artist",
-    "showInExplorer": "View in Explorer",
-    "copyPath": "Copy the file path",
+    "goToAlbum": "Go to album",
+    "goToArtist": "Go to artist",
+    "showInExplorer": "Show in Explorer",
+    "copyPath": "Copy file path",
     "properties": "Properties",
     "startRadio": "Start radio",
     "rating": "Rating",
@@ -829,25 +829,25 @@
       "file": "File"
     },
     "bpm": "BPM",
-    "loudness": "Volume",
+    "loudness": "Loudness",
     "replayGain": "ReplayGain",
     "peak": "Peak",
-    "analyze": "Analyze",
-    "reanalyze": "Re-analyze",
-    "analyzing": "Analysis…",
+    "analyze": "Analyse",
+    "reanalyze": "Re-analyse",
+    "analyzing": "Analysing…",
     "year": "Year",
     "trackNumber": "Track number",
     "duration": "Duration",
     "codec": "Codec",
-    "bitDepth": "Depth",
-    "sampleRate": "Sampling",
+    "bitDepth": "Bit depth",
+    "sampleRate": "Sample rate",
     "channels": "Channels",
-    "bitrate": "Flow rate",
+    "bitrate": "Bitrate",
     "key": "Key",
     "fileSize": "Size",
     "addedAt": "Added on",
     "filePath": "Path",
-    "showInExplorer": "View in Explorer",
+    "showInExplorer": "Show in Explorer",
     "mono": "Mono",
     "stereo": "Stereo",
     "edit": "Edit",
@@ -865,7 +865,7 @@
     "changeCover": "Change cover"
   },
   "selection": {
-    "toolbarLabel": "Selection activities",
+    "toolbarLabel": "Selection actions",
     "count_zero": "0 selected",
     "count_one": "{{count}} selected",
     "count_other": "{{count}} selected",
@@ -882,9 +882,9 @@
     "shuffle": "Shuffle",
     "trackCount_zero": "0 tracks",
     "trackCount_one": "{{count}} track",
-    "trackCount_other": "{{count}} titles",
-    "discHeader": "{{number}} Album",
-    "releaseDate": "Exit",
+    "trackCount_other": "{{count}} tracks",
+    "discHeader": "Disc {{number}}",
+    "releaseDate": "Release date",
     "emptyTitle": "Album not found",
     "emptyDescription": "This album is no longer available in the active profile.",
     "emptyTracksTitle": "No tracks",
@@ -895,16 +895,16 @@
     "playAll": "Play all",
     "shuffle": "Shuffle",
     "discography": "Discography",
-    "allTracks": "All titles",
+    "allTracks": "All tracks",
     "trackCount_zero": "0 tracks",
     "trackCount_one": "{{count}} track",
-    "trackCount_other": "{{count}} titles",
+    "trackCount_other": "{{count}} tracks",
     "albumCount_zero": "0 albums",
     "albumCount_one": "{{count}} album",
     "albumCount_other": "{{count}} albums",
     "albumTrackCount_zero": "0 tracks",
     "albumTrackCount_one": "{{count}} track",
-    "albumTrackCount_other": "{{count}} titles",
+    "albumTrackCount_other": "{{count}} tracks",
     "emptyTitle": "Artist not found",
     "emptyDescription": "This artist is no longer listed in the active profile.",
     "bio": {
@@ -940,8 +940,8 @@
     "empty": "No track playing",
     "aboutArtist": "About the artist",
     "readMore": "Read more",
-    "readLess": "Minimize",
-    "noBio": "No biography available. Set your \"Last.fm\" key in the settings.",
+    "readLess": "Show less",
+    "noBio": "No biography available. Set your Last.fm key in the settings.",
     "nextInQueue": "Next in queue",
     "openQueue": "Open queue",
     "lyrics": {
@@ -967,7 +967,7 @@
     "openFullscreen": "Immersive view",
     "devices": "Output devices",
     "moreActions": "More actions",
-    "abLoop": "A-B Loop"
+    "abLoop": "A-B loop"
   },
   "miniPlayer": {
     "idle": "No track playing",
@@ -995,22 +995,22 @@
     "importTitle": "Import an .lrc file",
     "actions": {
       "import": "Import an .lrc file",
-      "refetch": "Resume the search",
+      "refetch": "Search again",
       "clear": "Clear lyrics",
       "fullscreen": "Fullscreen",
       "edit": "Edit lyrics"
     },
     "source": {
-      "embedded": "Lyrics included in the file",
+      "embedded": "Lyrics embedded in file",
       "lrc_file": "Imported .lrc file",
       "api": "LRCLIB",
       "manual": "Manual entry"
     },
     "format": {
-      "lrc": "Synchronized",
-      "enhanced_lrc": "Word-by-word synchronized",
+      "lrc": "Synchronised",
+      "enhanced_lrc": "Word-by-word synchronised",
       "ttml": "TTML word-by-word",
-      "plain": "Unsynchronized"
+      "plain": "Unsynchronised"
     },
     "toast": {
       "tagWriteSkipped": "TTML kept in cache only (not written to the audio tag)"
@@ -1157,11 +1157,11 @@
     "duration": "Duration",
     "year": "Year",
     "addedAt": "Recently added",
-    "rating": "Note",
+    "rating": "Rating",
     "customOrder": "Custom order",
     "recentlyAdded": "Recently added",
     "menuTitle": "Sort by",
-    "name": "Last Name",
+    "name": "Name",
     "albumsCount": "Number of albums",
     "tracksCount": "Number of tracks",
     "ascending": "Ascending",
@@ -1176,7 +1176,7 @@
       "playback": "Playback",
       "integrations": "Integrations",
       "appearance": "Appearance",
-      "storage": "Storage & Data",
+      "storage": "Storage & data",
       "data": "Data",
       "shortcuts": "Keyboard shortcuts",
       "diagnostics": "Diagnostics"
@@ -1211,18 +1211,18 @@
         "title": "Last.fm",
         "subtitle": "Artist bios and scrobbling. Create a key at last.fm/api/account/create",
         "placeholder": "API key",
-        "secretPlaceholder": "A shared secret",
+        "secretPlaceholder": "Shared secret",
         "save": "Save",
         "saved": "Saved ✓",
-        "show": "View",
+        "show": "Show",
         "hide": "Hide",
-        "connectedAs": "Logged in as",
-        "disconnect": "Log out",
+        "connectedAs": "Signed in as",
+        "disconnect": "Sign out",
         "loginPrompt": "Sign in to scrobble your listening history:",
         "usernamePlaceholder": "Username",
         "passwordPlaceholder": "Password",
         "connect": "Sign in",
-        "connecting": "Logging in…"
+        "connecting": "Signing in…"
       },
       "discord": {
         "title": "Discord Rich Presence",
@@ -1254,15 +1254,15 @@
       "subtitle": "Seamless transitions between tracks (coming soon)"
     },
     "normalize": {
-      "title": "Adjust the volume",
-      "subtitle": "Lower the volume of tracks that are too loud to ensure a consistent volume level"
+      "title": "Normalise volume",
+      "subtitle": "Lower the volume of tracks that are too loud to keep a consistent level"
     },
     "replayGain": {
       "title": "Apply ReplayGain",
-      "subtitle": "Use each track's analyzed gain to balance perceived volume"
+      "subtitle": "Use each track's analysed gain to balance perceived volume"
     },
     "exclusive": {
-      "title": "WASAPI Exclusive Mode (Windows)",
+      "title": "WASAPI exclusive mode (Windows)",
       "subtitle": "Bit-perfect: bypass the Windows mixer for interference-free output. Falls back to shared mode if the device rejects exclusive access.",
       "fallback": "The device doesn't accept exclusive mode. Falling back to shared mode."
     },
@@ -1279,8 +1279,8 @@
       "subtitle": "Automatically launch WaveFlow when the system starts up"
     },
     "minimizeToTray": {
-      "title": "Minimize to the system tray",
-      "subtitle": "Closing the window minimizes the application to the system tray"
+      "title": "Minimise to the system tray",
+      "subtitle": "Closing the window minimises the application to the system tray"
     },
     "scanOnStart": {
       "title": "Scan at startup",
@@ -1309,13 +1309,13 @@
     },
     "rescan": {
       "title": "Rescan the library",
-      "subtitle": "Review all folders and import the new files",
+      "subtitle": "Review all folders and import new files",
       "action": "Rescan"
     },
     "analyze": {
-      "title": "Analyze the library",
-      "subtitle": "Calculate BPM, volume and peak for non-analyzed tracks",
-      "action": "Analyze",
+      "title": "Analyse the library",
+      "subtitle": "Compute BPM, loudness and peak for non-analysed tracks",
+      "action": "Analyse",
       "autoTitle": "Automatic analysis",
       "autoSubtitle": "Run analysis in the background after each scan that adds new tracks",
       "failed_one": "{{count}} failure",
@@ -1323,8 +1323,8 @@
     },
     "artistImages": {
       "title": "Artist images",
-      "subtitle": "Download the album covers from Deezer",
-      "action": "Recover",
+      "subtitle": "Download the artist images from Deezer",
+      "action": "Retrieve",
       "progress": "{{current}}/{{total}} processed"
     },
     "localArtistImages": {
@@ -1350,7 +1350,7 @@
       }
     },
     "dataFolder": {
-      "title": "Data file",
+      "title": "Data folder",
       "subtitle": "Open the folder containing the database and the covers",
       "action": "Open"
     },
@@ -1364,10 +1364,10 @@
       "action": "Prefetch",
       "progress": "{{current}}/{{total}} processed · {{hits}} found"
     },
-    "regenerateThumbnails": "Reload thumbnails",
-    "regenerateThumbnailsSubtitle": "Reconstruct the missing 1x/2x variants for all sleeves",
+    "regenerateThumbnails": "Regenerate thumbnails",
+    "regenerateThumbnailsSubtitle": "Rebuild the missing 1x/2x variants for all covers",
     "regenerateThumbnailsAction": "Regenerate",
-    "regenerateThumbnailsDone": "{{count}} regenerated thumbnails",
+    "regenerateThumbnailsDone": "{{count}} thumbnails regenerated",
     "reset": {
       "title": "Reset the app",
       "subtitle": "Delete all data and restore to factory settings",
@@ -1378,7 +1378,7 @@
       "subtitle": "To report a bug, open the logs folder or copy recent logs and paste them into a ticket.",
       "openFolder": "Open folder",
       "copyLogs": "Copy logs",
-      "copied": "Copied logs",
+      "copied": "Logs copied",
       "copyFailed": "Unable to copy logs"
     },
     "visualizer": {


### PR DESCRIPTION
## Summary

Complete rewrite of `en.json`. The file had been auto-translated from `fr.json` by a tool that lost domain context, producing embarrassing contresens that propagated to every downstream locale that copied from it.

### Critical mistranslations fixed

| Key | Before (❌) | After (✅) |
|---|---|---|
| `statistics.kpi.totalPlays` | Wiretapping | Plays |
| `statistics.plays_other` | {{count}} wiretaps | {{count}} plays |
| `albumDetail.releaseDate` | Exit | Release date |
| `trackProperties.bitrate` | Flow rate | Bitrate |
| `trackProperties.bitDepth` | Depth | Bit depth |
| `trackProperties.sampleRate` | Sampling | Sample rate |
| `trackProperties.loudness` | Volume | Loudness |
| `sidebar.playlists.liked` / `home.stats.liked` / `liked.title` | Liked posts | Liked tracks |
| `liked.unlike` | Unfollow | Remove from Liked |
| `liked.like` | Add to Favorites | Add to Liked |
| `trackActions.like` | Add to Liked Titles | Add to Liked |
| `trackActions.unlike` | Remove liked posts | Remove from Liked |
| `playlistModal.nameLabel` / `sort.name` | Last Name | Name |
| `library.rating` / `sort.rating` | Note | Rating |
| `selection.toolbarLabel` | Selection activities | Selection actions |
| `folderList.watchOff` | Stop surveillance | Stop monitoring |
| `statistics.byDay/byHour.empty` | No monitoring during this period | No listening during this period |
| `statistics.topTracks.title` | Top Stories | Top tracks |
| `statistics.range.all` | Everything | All time |
| `albumDetail.discHeader` | {{number}} Album | Disc {{number}} |
| `queue.count_other` | {{count}} songs | {{count}} tracks |
| `nowPlaying.readLess` | Minimize | Show less |
| `about.shortcuts.mute` | Mute the sound | Mute |
| `player.volume.unmute` | Turn on the sound | Unmute |
| `home.banner.openFolder` | Open a file | Open a folder |
| `wrapped.clock.eyebrow` | Your listening hour | Your peak listening hour |
| `library.{fetchCoversFailed,fetchMissingCovers,fetchCoversResult,noCover}` | sleeves | covers |
| `settings.normalize.title` | Adjust the volume | Normalise volume |
| `settings.dataFolder.title` | Data file | Data folder |
| `settings.regenerateThumbnails` | Reload thumbnails | Regenerate thumbnails |
| `profiles.create.colorAria` | Color{{color}} | Colour {{color}} |
| `topbar.profile.quit` | Exit the app | Quit app |

### Other improvements
- libraryModal / playlistModal: title-case → sentence-case for headings
- `playlistModal.namePlaceholder`: "Examples: ..." → "e.g. ..." (consistency with libraryModal)
- `lyrics.actions.refetch`: "Resume the search" → "Search again"
- `lyrics.source.embedded`: "Lyrics included in the file" → "Lyrics embedded in file"
- `home.greeting.morning`: "Hello" → "Good morning"
- `folderList.lastScanned`: "Scanned from:" → "Scanned:"
- `library.empty.genres.title`: "No genre found" → "No genres found"
- `library.empty.dossiers.title`: "No files imported" → "No folders imported"
- `library.tabs.dossiers` + `sidebar.myMusic.folders` + `library.header.subtext.dossiers_*`: Files/File → Folders/folder
- `library.tabs.morceaux`: Songs → Tracks (consistency with sidebar nav)
- `settings.integrations.lastfm`: Logged in / Log out → Signed in / Sign out (consistency with Sign in / Signing in)
- Many minor idiomatic cleanups

### Not changed (out of scope)
- Keys `library.header.subtext.morceaux_*` / `artistes_*` / `dossiers_*`, `library.tabs.morceaux/artistes/dossiers` and `library.empty.morceaux/artistes/dossiers` are kept in French — they're used as tab identifiers in [LibraryView.tsx](src/components/views/LibraryView.tsx). Renaming would require code changes orthogonal to this translation cleanup.

### Validation
- [x] JSON valid
- [x] Key parity with fr.json (0 missing / 0 extra)
- [x] Visual QA of English UI

### Downstream impact
This change fixes the **fallback** language. Other locales (ko, hi, pt, zh, ja…) that already addressed the same contresens locally remain correct. Locales that still mirror the broken English (es, de, it, nl, ru, tr, id, ar, pt-BR) would benefit from similar cleanups in follow-up PRs — but their current values render fine on their own; this PR only changes en.json values.