### PR TITLE
ci: skip rust job when no rust files are touched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - id: filter
+        # Detect whether the current change touches anything that can affect
+        # the Rust build. Locale-only / docs-only PRs skip the Rust matrix
+        # entirely to save Actions minutes (the windows matrix slot is 2× per
+        # minute). The workflow file itself is part of the filter so CI tweaks
+        # still re-run the job.
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            rust:
+              - 'src-tauri/**'
+              - '.github/workflows/ci.yml'
+
   rust:
     name: Rust (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
## Summary

Locale-only and docs-only PRs (recent overhauls of `ko.json`, `hi.json`, `pt.json`, `pt-BR.json`, `en.json`, etc.) were spending the full matrix on `ubuntu-latest` + `windows-latest` `cargo check` / `cargo test` for no reason — Windows minutes are billed 2× and the Rust job dominates the bill on this repo.

This PR introduces a tiny `changes` job that uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) to gate the Rust matrix on changes under `src-tauri/**` or to `.github/workflows/ci.yml` itself.

### Behaviour

| Files changed in PR | `changes` | `rust` (ubuntu + windows) | `frontend` |
|---|---|---|---|
| Locales only (`src/i18n/**`) | runs (~10s) | **skipped** | runs |
| Frontend (`src/**`, `package.json`, `tsconfig.json`, …) | runs | **skipped** | runs |
| Backend (`src-tauri/**`) | runs | runs | runs |
| CI workflow (`.github/workflows/ci.yml`) | runs | runs | runs |

`frontend` is left always-on because `bun run typecheck` already loads the locale JSON files via i18next and would catch a broken JSON there.

### Notes
- Action pinned to `dorny/paths-filter@de90cc6` (v3.0.2), matching the SHA-pin convention used by every other action in the workflow.
- Skipped jobs are reported as success by GitHub branch protection, so this does not relax any required-check rules.
- Concurrency cancellation is unchanged.

## Test plan
- [x] Merge this PR (a CI-touching change) → both jobs run.
- [x] Open a follow-up locale-only PR → `changes` runs, `rust` is skipped, `frontend` runs.