### PR TITLE
fix(onboarding): re-trigger on freshly created profile

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -174,7 +174,11 @@ export function AppLayout() {
   // a memo recomputed on every render would briefly satisfy "show"
   // mid-boot before flipping back — that's the flash the modal
   // used to do.
-  const { libraries, isLoading: isLibraryLoading } = useLibrary();
+  const {
+    libraries,
+    isLoading: isLibraryLoading,
+    loadedProfileId: librariesLoadedFor,
+  } = useLibrary();
   const { activeProfile, isLoading: isProfileLoading } = useProfile();
   const [showOnboarding, setShowOnboarding] = useState(false);
   // Tracks the active profile id we've already evaluated against, so
@@ -187,6 +191,11 @@ export function AppLayout() {
   useEffect(() => {
     if (isProfileLoading || isLibraryLoading) return;
     if (!activeProfile) return;
+    // Defer until LibraryContext has refetched FOR this profile. Without
+    // this check the gate would evaluate with the previous profile's
+    // libraries during a switch — a fresh profile would silently skip
+    // onboarding if the previous one happened to have folders.
+    if (librariesLoadedFor !== activeProfile.id) return;
     if (evaluatedProfileId.current === activeProfile.id) return;
 
     const profileId = activeProfile.id;
@@ -216,7 +225,13 @@ export function AppLayout() {
     return () => {
       cancelled = true;
     };
-  }, [activeProfile, isProfileLoading, isLibraryLoading, libraries]);
+  }, [
+    activeProfile,
+    isProfileLoading,
+    isLibraryLoading,
+    librariesLoadedFor,
+    libraries,
+  ]);
 
   const dismissOnboarding = useCallback(() => {
     // Persist the choice so the modal doesn't reappear on next

--- a/src/contexts/LibraryContext.tsx
+++ b/src/contexts/LibraryContext.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -23,6 +24,14 @@ import {
 
 export function LibraryProvider({ children }: { children: ReactNode }) {
   const { activeProfile } = useProfile();
+  // Tracks the currently-active profile id so `refresh()` can detect when
+  // its in-flight `listLibraries` response belongs to a profile the user
+  // has since switched away from, and drop the stale write.
+  const activeProfileIdRef = useRef<number | null>(null);
+  useEffect(() => {
+    activeProfileIdRef.current = activeProfile?.id ?? null;
+  }, [activeProfile?.id]);
+
   const [libraries, setLibraries] = useState<Library[]>([]);
   const [loadedProfileId, setLoadedProfileId] = useState<number | null>(null);
   const [selectedLibraryId, setSelectedLibraryId] = useState<number | null>(
@@ -46,10 +55,15 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       setSelectedLibraryId(null);
       return;
     }
+    const profileIdAtStart = activeProfile.id;
     try {
       const list = await listLibraries();
+      // Drop the response if the user switched profile mid-flight — writing
+      // it would clobber the new profile's libraries with the old one's data
+      // and re-block the onboarding gate (see fix/onboarding-on-new-profile).
+      if (activeProfileIdRef.current !== profileIdAtStart) return;
       setLibraries(list);
-      setLoadedProfileId(activeProfile.id);
+      setLoadedProfileId(profileIdAtStart);
       setError(null);
       // Keep the current selection if it still exists, otherwise fall back to
       // the most-recently-updated library (which is the first one because of
@@ -59,6 +73,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
         return list[0]?.id ?? null;
       });
     } catch (err) {
+      if (activeProfileIdRef.current !== profileIdAtStart) return;
       const message = err instanceof Error ? err.message : String(err);
       setError(message);
       console.error("[LibraryContext] refresh failed", err);

--- a/src/contexts/LibraryContext.tsx
+++ b/src/contexts/LibraryContext.tsx
@@ -24,6 +24,7 @@ import {
 export function LibraryProvider({ children }: { children: ReactNode }) {
   const { activeProfile } = useProfile();
   const [libraries, setLibraries] = useState<Library[]>([]);
+  const [loadedProfileId, setLoadedProfileId] = useState<number | null>(null);
   const [selectedLibraryId, setSelectedLibraryId] = useState<number | null>(
     null,
   );
@@ -41,12 +42,14 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
   const refresh = useCallback(async () => {
     if (!activeProfile) {
       setLibraries([]);
+      setLoadedProfileId(null);
       setSelectedLibraryId(null);
       return;
     }
     try {
       const list = await listLibraries();
       setLibraries(list);
+      setLoadedProfileId(activeProfile.id);
       setError(null);
       // Keep the current selection if it still exists, otherwise fall back to
       // the most-recently-updated library (which is the first one because of
@@ -72,6 +75,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
         if (!activeProfile) {
           if (!cancelled) {
             setLibraries([]);
+            setLoadedProfileId(null);
             setSelectedLibraryId(null);
           }
           return;
@@ -79,6 +83,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
         const list = await listLibraries();
         if (cancelled) return;
         setLibraries(list);
+        setLoadedProfileId(activeProfile.id);
         setSelectedLibraryId((prev) => {
           if (prev != null && list.some((l) => l.id === prev)) return prev;
           return list[0]?.id ?? null;
@@ -191,6 +196,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
     <LibraryContext.Provider
       value={{
         libraries,
+        loadedProfileId,
         selectedLibraryId,
         selectedLibrary,
         isLoading,

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -11,6 +11,12 @@ interface LibraryContextValue {
   /** All libraries belonging to the currently active profile. */
   libraries: Library[];
   /**
+   * The profile id `libraries` was last fetched for. `null` until the first
+   * load completes. Lets consumers wait for a fresh fetch after a profile
+   * switch instead of acting on the previous profile's data.
+   */
+  loadedProfileId: number | null;
+  /**
    * Id of the library the user has currently "focused" in the sidebar.
    * `null` until libraries are loaded or when the profile has no libraries.
    */


### PR DESCRIPTION
## Bug

After creating a new profile from a populated one, the onboarding wizard never opens on the freshly switched-to profile, even though it has an empty library.

## Root cause

`AppLayout` latches the onboarding decision once per profile via the `evaluatedProfileId` ref. On profile switch, that latch fires on the **first** effect run after `activeProfile` changes — at which point `LibraryContext` has not yet finished refetching. The closure still holds the **previous** profile's `libraries`. If the prior profile had any folder-bearing library, the gate decides `isEmpty = false` for the new (actually empty) profile and never reopens.

## Fix

`LibraryContext` now exposes `loadedProfileId` (the profile id its `libraries` array was last fetched for). The onboarding gate in `AppLayout` defers its evaluation until `loadedProfileId === activeProfile.id`, so the decision always uses the new profile's data.

## Test plan

- [x] Open a populated profile with ≥1 library that has folders.
- [x] Create a new profile via the selector modal → onboarding modal opens on the new profile.
- [x] Dismiss → switch back to the original profile → onboarding does **not** reappear (latch + persisted setting both honored).
- [x] Switch back to the new (still empty) profile after dismissing → onboarding still does not reappear (dismissed setting persisted per-profile).
- [x] Cold start on the empty new profile → onboarding opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrigé un problème où le changement de profil affichait incorrectement les bibliothèques du profil précédent. L'application attend désormais le chargement complet des bibliothèques du profil actif avant de mettre à jour l'interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->