### PR TITLE
fix(playlist): stop freezing edit modal after cover upload (#105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        # Resolving `bun-version: latest` hits the GitHub API to list
+        # `oven-sh/bun` tags. The action reads GITHUB_TOKEN from env to
+        # authenticate; without it the request returns 401 ("Bad
+        # credentials") on GitHub-hosted runners. The action has no
+        # `github-token` input, so we plumb the token through env.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           bun-version: latest
 

--- a/docs/features/playlists.md
+++ b/docs/features/playlists.md
@@ -45,7 +45,7 @@ User playlists support custom covers, managed alongside the existing `cover_hash
 
 Smart playlists (`is_smart = 1`) are excluded from every code path here — they're owned by the smart-playlist regen flow. The post-mutation hook (`playlist_cover::maybe_regen_auto_cover`) checks both flags before running and logs a warning on failure (never blocks the mutation it was triggered by).
 
-The frontend exposes the controls in the **edit modal** ([`CreatePlaylistModal.tsx`](../../src/components/common/CreatePlaylistModal.tsx)) Spotify-style: large preview tile on the left, hover overlay with a pencil icon ("Choose photo"), and a `...` menu top-right with "Change photo" / "Remove photo". The remove option is conditional on `cover_hash != null`.
+The frontend exposes the controls in the **edit modal** ([`CreatePlaylistModal.tsx`](../../src/components/common/CreatePlaylistModal.tsx)) Spotify-style: large preview tile on the left, hover overlay with a pencil icon ("Choose photo"), and a `...` menu top-right with "Change photo" / "Remove photo". The remove option is conditional on `cover_hash != null`. After every cover mutation the modal calls `onCoverChanged`, which the parent ([`PlaylistView`](../../src/components/views/PlaylistView.tsx)) implements by re-fetching the current playlist *and* invoking [`PlaylistContext.refresh()`](../../src/contexts/PlaylistContext.tsx) — that second call is what makes the sidebar tile re-render (the sidebar reads from the context, not from `PlaylistView`'s local state).
 
 ## Recently played
 

--- a/src/components/views/PlaylistView.tsx
+++ b/src/components/views/PlaylistView.tsx
@@ -138,6 +138,7 @@ export function PlaylistView({
     playlists,
     removeTrackFromPlaylist,
     createPlaylist,
+    refresh: refreshPlaylists,
   } = usePlaylist();
   const [isCreatePlaylistModalOpen, setIsCreatePlaylistModalOpen] =
     useState(false);
@@ -721,10 +722,15 @@ export function PlaylistView({
         onCoverChanged={async () => {
           // Cover backend command already wrote the new hash; pull the
           // fresh row so `cover_path` updates without waiting for the
-          // next user navigation.
+          // next user navigation, AND refresh PlaylistContext so the
+          // sidebar tile re-renders (it reads from the context, not
+          // from this view's local state).
           if (playlistId == null) return;
           try {
-            const fresh = await getPlaylist(playlistId);
+            const [fresh] = await Promise.all([
+              getPlaylist(playlistId),
+              refreshPlaylists(),
+            ]);
             setPlaylist(fresh);
           } catch (err) {
             console.error("[PlaylistView] refresh after cover change", err);

--- a/src/components/views/PlaylistView.tsx
+++ b/src/components/views/PlaylistView.tsx
@@ -725,12 +725,15 @@ export function PlaylistView({
           // next user navigation, AND refresh PlaylistContext so the
           // sidebar tile re-renders (it reads from the context, not
           // from this view's local state).
+          //
+          // Decoupled on purpose: a context-refresh failure must not
+          // block the local-state update. `PlaylistContext.refresh`
+          // swallows its own errors (logs to console), so the bare
+          // fire-and-forget is safe.
           if (playlistId == null) return;
+          void refreshPlaylists();
           try {
-            const [fresh] = await Promise.all([
-              getPlaylist(playlistId),
-              refreshPlaylists(),
-            ]);
+            const fresh = await getPlaylist(playlistId);
             setPlaylist(fresh);
           } catch (err) {
             console.error("[PlaylistView] refresh after cover change", err);

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 /**
  * Modal accessibility helper. Wires up the three behaviours every
@@ -24,6 +24,15 @@ export function useModalA11y<T extends HTMLElement>(
 ) {
   const containerRef = useRef<T | null>(null);
   const lastFocusedRef = useRef<HTMLElement | null>(null);
+  // Latest-onClose ref so the effect below depends ONLY on `isOpen`.
+  // Callers typically pass an inline lambda (`onClose={() =>
+  // setOpen(false)}`), which would otherwise re-run the focus-trap
+  // setup on every parent re-render — yanking focus back to the first
+  // input mid-typing (the playlist edit modal symptom).
+  const onCloseRef = useRef(onClose);
+  useLayoutEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   useEffect(() => {
     if (!isOpen) return;
@@ -43,7 +52,7 @@ export function useModalA11y<T extends HTMLElement>(
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (e.key !== "Tab" || !containerRef.current) return;
@@ -75,7 +84,7 @@ export function useModalA11y<T extends HTMLElement>(
       const prev = lastFocusedRef.current;
       if (prev && document.contains(prev)) prev.focus();
     };
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   return containerRef;
 }


### PR DESCRIPTION
Closes #105.

## Summary

- **Modal "freeze"**: [`useModalA11y`](src/hooks/useModalA11y.ts) listed `onClose` in its effect deps. Every parent re-render created a fresh inline `onClose` lambda, re-ran the focus-trap setup, and yanked focus back to the first focusable element. After uploading a custom cover, `setPlaylist(fresh)` re-rendered `PlaylistView`, the name input kept losing focus to itself, and the modal felt locked. Fix: capture `onClose` in a ref updated via `useLayoutEffect` and drop it from deps. Same latent bug existed across the 15 other modals using this hook — they're all fixed at the root.
- **Sidebar tile stale**: `onCoverChanged` only refreshed `PlaylistView`'s local state, so the sidebar (which reads from `PlaylistContext`) stayed on the old hash until something else triggered a context refresh. Now calls `refreshPlaylists()` alongside the local `getPlaylist`.
- **Docs**: noted in `docs/features/playlists.md` why `onCoverChanged` must refresh both the view *and* the playlist context.

## Test plan

- [x] Open an existing playlist → click ⋯ → Edit details
- [x] Click the cover → "Change photo" → pick a JPG / PNG / WEBP
- [x] Modal stays interactive — the name input doesn't flash or steal focus, you can immediately type to rename
- [x] New cover appears in the edit preview, in the playlist header, **and** in the sidebar tile (no need to navigate away and back)
- [x] Click ⋯ on the cover → "Remove photo" → returns to the auto-generated 2×2 composite, sidebar updates too
- [x] Esc still closes the modal (focus-trap cleanup verified)
- [x] Smoke-test other modals (`CreateLibraryModal`, `SmartPlaylistEditorModal`, `BatchTagEditModal`, `TrackPropertiesModal`) — focus restoration on close still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Harmonisation du rafraîchissement après modification de la couverture : la sidebar et la vue playlist se mettent à jour de façon cohérente.
  * Fiabilisation du comportement des modales (touche Échap et callbacks) pour éviter fermetures manquantes et effets indésirables.

* **Documentation**
  * Mise à jour de la doc "Playlists" précisant le comportement d'édition des couvertures et le rafraîchissement associé.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->