### PR TITLE
fix(library): drop violet halo around artist tiles on dark portraits (#106)

### DIFF
--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1985,7 +1985,12 @@ function ArtistList({
             <FadeInImage
               src={artistPictureSrc}
               alt={artist.name}
-              wrapperClassName="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 border border-violet-200/60 dark:border-violet-800/40 shadow-sm group-hover:shadow-md transition-shadow"
+              // No violet border here on purpose — `rounded-full` + a
+              // 1 px violet border draws around the image clip, which
+              // reads as a visible halo on dark portraits (#106).
+              // The placeholder bg gradient is fine because `object-cover`
+              // fully covers it once the image decodes.
+              wrapperClassName="w-full aspect-square rounded-full bg-linear-to-br from-violet-100 to-violet-200 dark:from-violet-900/40 dark:to-violet-800/30 shadow-sm group-hover:shadow-md transition-shadow"
               placeholder={
                 <span className="text-5xl font-bold text-violet-500/70 dark:text-violet-400/60">
                   {artist.name.trim().charAt(0).toUpperCase() || "?"}


### PR DESCRIPTION
Closes #106.

## Summary

The Artists main grid wraps each image in a [`FadeInImage`](src/components/common/FadeInImage.tsx) whose wrapper carried `border border-violet-200/60 dark:border-violet-800/40`. On a \`rounded-full\` clip, that 1 px violet border is drawn along the outer perimeter of the circular mask — invisible on bright portraits, very visible as a colored halo on dark ones (A-ha, Gary Moore in the issue screenshots).

Fix: remove the violet border from the image branch only. The placeholder gradient stays (it's fully covered by \`object-cover\` once the image decodes, and provides backdrop during the brief loading flash). The no-image fallback branch is untouched — its border is intentional decoration around the initial-letter placeholder.

The Artist detail view ([\`ArtistDetailView.tsx\`](src/components/views/ArtistDetailView.tsx)) was already clean because its \`<img>\` renders without a wrapper border (only \`shadow-lg\`), which matches the new behavior on the grid.

## Test plan

- [x] Open the Library → Artists tab in **dark mode**
- [x] Locate dark artist portraits (e.g. A-ha, Gary Moore, anything with a black background)
- [x] No colored ring around the round avatar — image edges are clean
- [x] Bright portraits (ABBA, Blondie, Ella Langley) look the same as before
- [x] Artists without an image still show the violet circle + initial letter placeholder (border intact on this branch)
- [x] Same check in **light mode** — no halo regression on either dark or bright portraits
- [x] Artist detail page (\`ArtistDetailView\`) still renders the large round portrait identically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppression de la bordure violette involontaire autour des avatars d'artistes dans la vue de la bibliothèque.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->