### PR TITLE
feat(player): scroll wheel on volume slider to adjust volume (#118)

### DIFF
--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -122,6 +122,8 @@ Right side of [`PlayerBar`](../../src/components/player/PlayerBar.tsx) is the hi
 
 When adding a new player-bar action: default it into the overflow menu first — promote to primary only when usage data or user feedback warrants it. If both placements make sense, expose a pin toggle. The "⋯" trigger auto-hides when its menu would be empty.
 
+**Volume control** ([`VolumeControl`](../../src/components/player/VolumeControl.tsx)) supports three input modalities: pointer drag on the track, keyboard arrows / Home / End when the slider has focus (5 % step, 0 / 100 jumps), and **mouse-wheel scroll** anywhere over the icon + track area (5 % step, wheel up raises). The wheel handler is bound through `addEventListener('wheel', ..., { passive: false })` so it can `preventDefault` the underlying page scroll — React 17+'s JSX `onWheel` is passive and would let the track list behind the player bar scroll at the same time. Horizontal-only scrolls (`deltaY === 0`, e.g. trackpad sideways swipes) are ignored so they don't get treated as a volume-down tick.
+
 **Playback speed** lives inside [`MoreActionsMenu`](../../src/components/player/MoreActionsMenu.tsx) (range slider + five presets) rather than a dedicated bar button — it's used too rarely to deserve a permanent slot. When speed ≠ 1×, the "⋯" trigger surfaces a compact `1.25×` badge in emerald (same corner as the sleep-timer countdown — the countdown wins when both are active). See [playback / Playback speed](playback.md#playback-speed-05--2) for the backend side.
 
 ### Pin toggles

--- a/src/components/player/VolumeControl.tsx
+++ b/src/components/player/VolumeControl.tsx
@@ -26,6 +26,11 @@ export function VolumeControl() {
     const el = wheelHostRef.current;
     if (!el) return;
     const handler = (e: WheelEvent) => {
+      // Ignore horizontal-only scrolls (trackpad swipes deliver
+      // `deltaY === 0` with non-zero `deltaX`) — without this guard
+      // the `< 0 ? up : down` ternary would treat them as a
+      // volume-down tick.
+      if (e.deltaY === 0) return;
       e.preventDefault();
       // Negative deltaY = wheel up = volume up. The `setVolume`
       // setter in `PlayerContext` clamps to [0, 100].

--- a/src/components/player/VolumeControl.tsx
+++ b/src/components/player/VolumeControl.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useRef,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
@@ -7,10 +8,32 @@ import { useTranslation } from "react-i18next";
 import { Volume1, Volume2, VolumeX } from "lucide-react";
 import { usePlayer } from "../../hooks/usePlayer";
 
+/** Scroll-wheel step in percent, matched to the keyboard arrow step
+ *  below so wheel + keyboard feel identical. */
+const WHEEL_STEP = 5;
+
 export function VolumeControl() {
   const { t } = useTranslation();
   const { volume, setVolume, toggleMute } = usePlayer();
   const trackRef = useRef<HTMLDivElement>(null);
+  const wheelHostRef = useRef<HTMLDivElement>(null);
+
+  // Scroll-wheel volume control. React 17+ attaches `wheel` listeners
+  // as passive at the root, so an `onWheel={...}` JSX handler can't
+  // `preventDefault` to suppress the page scroll behind the player
+  // bar. Bind directly with `{ passive: false }` instead.
+  useEffect(() => {
+    const el = wheelHostRef.current;
+    if (!el) return;
+    const handler = (e: WheelEvent) => {
+      e.preventDefault();
+      // Negative deltaY = wheel up = volume up. The `setVolume`
+      // setter in `PlayerContext` clamps to [0, 100].
+      setVolume(volume + (e.deltaY < 0 ? WHEEL_STEP : -WHEEL_STEP));
+    };
+    el.addEventListener("wheel", handler, { passive: false });
+    return () => el.removeEventListener("wheel", handler);
+  }, [volume, setVolume]);
 
   const updateFromClientX = (clientX: number) => {
     const track = trackRef.current;
@@ -70,7 +93,7 @@ export function VolumeControl() {
 
   return (
     <>
-      <div className="flex items-center space-x-2 w-32">
+      <div ref={wheelHostRef} className="flex items-center space-x-2 w-32">
         <button
           type="button"
           onClick={toggleMute}


### PR DESCRIPTION
Closes #118.

## Summary

Hovering the volume control in the player bar and scrolling the wheel now nudges the volume by **5 %** per tick — wheel up raises, wheel down lowers. The step matches the keyboard arrow step that's already wired up below in the same component.

## Why \`addEventListener\` instead of \`onWheel\`

React 17+ attaches root \`wheel\` listeners as **passive**, so a JSX \`onWheel\` handler can't \`preventDefault\` the underlying page scroll. Without that, scrolling over the slider would also scroll the track list behind the player bar. Binding directly with \`addEventListener('wheel', handler, { passive: false })\` suppresses the page scroll cleanly. No other wheel handlers in the codebase, so no precedent to follow.

The listener is attached to the first inner \`<div>\` that already wraps the volume icon + slider track — scrolling anywhere over the visible control area works, including over the mute icon button.

## Test plan

- [x] Hover the volume slider in the player bar → scroll up → volume rises by 5 %
- [x] Scroll down → volume lowers by 5 %
- [x] Scroll past 0 / 100 → clamps (no negative or > 100 values)
- [x] Scroll over the mute icon at the left of the slider → also works
- [x] Page behind the player bar (e.g. a long track list scrolled to bottom) does NOT scroll while wheeling over the slider
- [x] Existing pointer drag + click + keyboard arrows still work identically
- [x] \`bun run lint\` ✅
- [x] \`bun run typecheck\` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Contrôle du volume par molette sur l’élément de volume : ajustement par pas de 5%, sensible uniquement au mouvement vertical, avec blocage du défilement de la page pendant l’usage pour une interaction fluide.

* **Documentation**
  * Mise à jour de la documentation UI pour décrire les modalités d’entrée (molette, glisser, raccourcis), la granularité et les comportements aux limites (0%/100%).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->