### PR TITLE
fix(ui): apply backdrop blur to modal scrims for better separation

### DIFF
--- a/src/components/common/ArtistImagePickerModal.tsx
+++ b/src/components/common/ArtistImagePickerModal.tsx
@@ -171,7 +171,7 @@ export function ArtistImagePickerModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div

--- a/src/components/common/BatchTagEditModal.tsx
+++ b/src/components/common/BatchTagEditModal.tsx
@@ -120,7 +120,7 @@ export function BatchTagEditModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={handleClose}
     >
       <div

--- a/src/components/common/CoverPickerModal.tsx
+++ b/src/components/common/CoverPickerModal.tsx
@@ -117,7 +117,7 @@ export function CoverPickerModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div

--- a/src/components/common/CreateLibraryModal.tsx
+++ b/src/components/common/CreateLibraryModal.tsx
@@ -76,7 +76,7 @@ export function CreateLibraryModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div

--- a/src/components/common/CreatePlaylistModal.tsx
+++ b/src/components/common/CreatePlaylistModal.tsx
@@ -165,7 +165,7 @@ export function CreatePlaylistModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div

--- a/src/components/common/DuplicatesModal.tsx
+++ b/src/components/common/DuplicatesModal.tsx
@@ -99,7 +99,7 @@ export function DuplicatesModal({ isOpen, onClose }: DuplicatesModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div

--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -518,7 +518,7 @@ export function LyricsEditorModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div

--- a/src/components/common/ProfileSelectorModal.tsx
+++ b/src/components/common/ProfileSelectorModal.tsx
@@ -141,7 +141,7 @@ export function ProfileSelectorModal({
       role="dialog"
       aria-modal="true"
       aria-label={t("profiles.select.title")}
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       {view === "select" && (

--- a/src/components/common/SmartPlaylistEditorModal.tsx
+++ b/src/components/common/SmartPlaylistEditorModal.tsx
@@ -141,7 +141,7 @@ export function SmartPlaylistEditorModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div

--- a/src/components/common/TrackPropertiesModal.tsx
+++ b/src/components/common/TrackPropertiesModal.tsx
@@ -266,7 +266,7 @@ export function TrackPropertiesModal({
 
   return (
     <div
-      className="fixed inset-0 z-100 bg-black/80 flex items-center justify-center animate-fade-in p-4"
+      className="fixed inset-0 z-100 bg-black/80 backdrop-blur-md flex items-center justify-center animate-fade-in p-4"
       onClick={onClose}
     >
       <div


### PR DESCRIPTION
## Summary
- Adds `backdrop-blur-md` to the 10 modal backdrops that were rendering as a flat `bg-black/80` scrim, matching the existing `OnboardingModal` pattern.
- Underlying library / playlist / settings content stops bleeding through behind wizards and forms, so the dialog reads as a distinct surface rather than mixing with the page underneath (issue #108).
- `Lightbox` is intentionally untouched: image viewing keeps the dark `bg-black/90` canvas with no blur.

Closes #108

## Test plan
- [x] Open Settings → create / rename / delete a profile — backdrop is clearly blurred behind the wizard.
- [x] Trigger Create Playlist, Create Library, Cover Picker, Artist Image Picker, Smart Playlist Editor, Track Properties, Batch Tag Edit, Duplicates, Lyrics Editor — all show the same blurred scrim.
- [x] Open the Lightbox (cover full-screen) — still flat dark, no blur (regression check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Amélioration visuelle des modales : application d'un effet de flou d'arrière-plan pour une meilleure présentation lors de l'affichage des modales de l'application, offrant une expérience utilisateur plus polished.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->