### PR TITLE
feat(lyrics): add immersive button to fullscreen lyrics header

### DIFF
--- a/src/components/player/FullscreenLyrics.tsx
+++ b/src/components/player/FullscreenLyrics.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { X, Music2 } from "lucide-react";
+import { X, Music2, Maximize2 } from "lucide-react";
 import { Artwork } from "../common/Artwork";
 import type { Track } from "../../lib/tauri/track";
 import {
@@ -140,14 +140,25 @@ export function FullscreenLyrics({
               </div>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label={t("common.close")}
-            className="p-2.5 rounded-full bg-white/10 hover:bg-white/20 transition-colors shrink-0"
-          >
-            <X size={22} />
-          </button>
+          <div className="flex items-center gap-3 shrink-0">
+            <button
+              type="button"
+              onClick={onOpenNowPlaying}
+              aria-label={t("playerBar.openFullscreen")}
+              title={t("playerBar.openFullscreen")}
+              className="p-2.5 rounded-full bg-white/10 hover:bg-white/20 transition-colors"
+            >
+              <Maximize2 size={22} />
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={t("common.close")}
+              className="p-2.5 rounded-full bg-white/10 hover:bg-white/20 transition-colors"
+            >
+              <X size={22} />
+            </button>
+          </div>
         </div>
 
         {/* Lyrics body */}


### PR DESCRIPTION
## Summary
- Adds a `Maximize2` button next to the close X in `FullscreenLyrics`, symmetric to the `Mic2` "switch to lyrics" button already present in `FullscreenNowPlaying`.
- One-click round-trip Immersive ↔ Lyrics without leaving fullscreen, which closes the asymmetry called out in issue #109.
- Reuses the existing `onOpenNowPlaying` callback (parent already flips the fullscreen mutex) and the existing `playerBar.openFullscreen` i18n key — no new strings, no plumbing changes.

The pre-existing cover-thumbnail click on the header keeps working for users who already learned that gesture.

Closes #109

## Test plan
- [x] Open Fullscreen Lyrics from the player bar — header shows a Maximize2 button between the cover thumbnail and the X.
- [x] Click Maximize2 → switches to Fullscreen Now Playing.
- [x] In Fullscreen Now Playing, click Mic2 → returns to Fullscreen Lyrics (existing path, sanity check).
- [x] Click the cover thumbnail in Fullscreen Lyrics — still works (legacy switch path).
- [x] Hover the new button — shows "Vue immersive" tooltip (French) / "Immersive view" (English).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de boutons de contrôle pour agrandir et fermer l'affichage des paroles en plein écran.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->