### PR TITLE
docs(ui): note the symmetric Immersive button in FullscreenLyrics header

### DIFF
--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -35,7 +35,7 @@ The right panel is **a flex sibling** of the center column, not an overlay — o
 
 [`FullscreenNowPlaying`](../../src/components/player/FullscreenNowPlaying.tsx) is an Apple-Music-style overlay (`fixed inset-0 z-100`) that turns the current track into the focal point: huge centred cover, large title + clickable artist + album, the same `PlaybackControls` / `ProgressBar` / `VolumeControl` the bottom bar uses, and a like toggle. Background is a blurred copy of the artwork (with a 55% black wash over it) so the view stays visually anchored to the track without any extra theming work.
 
-Two entry points in the [`PlayerBar`](../../src/components/player/PlayerBar.tsx): clicking the cover in the bottom bar (mirrors Spotify) or the dedicated Maximize2 icon next to the lyrics toggle. Closes on Escape or the X button. State is local to the bar — no `PlayerContext` involvement because nothing else needs to know about the overlay.
+Two entry points in the [`PlayerBar`](../../src/components/player/PlayerBar.tsx): clicking the cover in the bottom bar (mirrors Spotify) or the dedicated Maximize2 icon next to the lyrics toggle. The header of [`FullscreenLyrics`](../../src/components/player/FullscreenLyrics.tsx) also carries a Maximize2 button (symmetric to the Mic2 "open lyrics" button in `FullscreenNowPlaying`) so the user can round-trip Immersive ↔ Lyrics without leaving fullscreen — the parent flips the fullscreen mutex so only one overlay is ever mounted. Closes on Escape or the X button. State is local to the bar — no `PlayerContext` involvement because nothing else needs to know about the overlay.
 
 ## Mini-player
 


### PR DESCRIPTION
## Summary
- One-line docs fix: the Immersive Now Playing section in [`docs/features/ui.md`](docs/features/ui.md) listed the PlayerBar entry points but never mentioned the new Maximize2 button in the FullscreenLyrics header that closes the round-trip Lyrics → Immersive (added in PR #124 / issue #109).
- Caught while doing a post-release audit of docs vs. code.

## Test plan
- [ ] Render the docs / read the diff — wording reads naturally next to the existing PlayerBar entry-points sentence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Mise à jour de la documentation UI/UX pour Immersive Now Playing : clarification des points d'accès depuis la barre (clic cover et icône Maximize), navigation entre les vues Immersive et Lyrics fullscreen, et gestes de fermeture disponibles (Escape ou bouton X).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->