### PR TITLE
perf(views): skeleton + lazy-chunk prefetch across all views

### DIFF
--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -24,6 +24,12 @@ Three-column flex row:
 
 The right panel is **a flex sibling** of the center column, not an overlay — opening it shrinks the content area Spotify-style. The center column has `min-w-0` so wide tables collapse instead of pushing the panel off-screen. Only one of the three right-panels is mounted at a time (mutex via `PlayerContext`).
 
+### View loading & code-splitting
+
+Every full-page view (Home, Library, Liked, History, Playlist, Album/Artist/Genre detail, Statistics, Wrapped, Settings) is `React.lazy()`-loaded. The Suspense fallback in [`AppLayout`](../../src/components/layout/AppLayout.tsx) is [`ViewSuspenseFallback`](../../src/components/common/ViewSuspenseFallback.tsx) — a layout-shaped skeleton (`role="status"` / `aria-busy="true"`) instead of a spinner that read as a blank screen. To make the fallback rarely fire at all, AppLayout schedules a `requestIdleCallback` after first mount that warm-imports every lazy view module; once those imports resolve they're cached in the module registry, so a sidebar click usually skips Suspense entirely.
+
+Per-view data fetches initialise their `isLoading` state to `true` (not `false`) so the first render paints a skeleton matching the view's shape rather than flashing the empty-state for the frame between mount and the first effect tick. Detail pages (Album/Artist/Genre) share [`DetailViewSkeleton`](../../src/components/common/DetailViewSkeleton.tsx); list-shaped pages use inline `<…Skeleton>` components colocated with their view file.
+
 ## Panels
 
 - [`NowPlayingPanel`](../../src/components/layout/NowPlayingPanel.tsx) — large artwork, clickable artists, "About the artist" section populated from the Deezer + Last.fm caches, and a "Next in queue" teaser with an "Open queue" link that hands the right slot off to `QueuePanel`. Lightbox on cover click.

--- a/src/components/common/DetailViewSkeleton.tsx
+++ b/src/components/common/DetailViewSkeleton.tsx
@@ -1,0 +1,56 @@
+/**
+ * Detail-page skeleton shared by AlbumDetailView, ArtistDetailView and
+ * GenreDetailView. Mimics the "big cover / artist photo + header on the
+ * left, track list below" layout so the swap to live data is a content
+ * change instead of a blank → populated jump.
+ *
+ * `ariaLabel` is announced by screen readers via `role="status"` while
+ * the page chunk + SQL fetch resolve.
+ */
+export function DetailViewSkeleton({
+  ariaLabel,
+  shape = "square",
+}: {
+  ariaLabel: string;
+  /** Cover shape — `square` for albums/genres, `circle` for artists. */
+  shape?: "square" | "circle";
+}) {
+  const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
+  const shapeClass = shape === "circle" ? "rounded-full" : "rounded-2xl";
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={ariaLabel}
+      className="space-y-8 animate-pulse pb-12"
+    >
+      <div className="flex items-end space-x-6">
+        <div className={`w-44 h-44 ${shapeClass} ${tile}`} />
+        <div className="flex-1 space-y-3 pb-4">
+          <div className={`h-3 w-16 rounded ${tile}`} />
+          <div className={`h-10 w-2/3 rounded ${tile}`} />
+          <div className={`h-3 w-1/3 rounded ${tile}`} />
+          <div className="flex space-x-3 pt-2">
+            <div className={`h-10 w-28 rounded-xl ${tile}`} />
+            <div className={`h-10 w-10 rounded-xl ${tile}`} />
+            <div className={`h-10 w-10 rounded-xl ${tile}`} />
+          </div>
+        </div>
+      </div>
+      <div className="rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-800/40 overflow-hidden">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[3rem_2.75rem_1fr_1fr_5rem] gap-4 px-5 py-2 h-14 items-center border-b border-zinc-100 dark:border-zinc-800/60"
+          >
+            <div className={`h-3 w-4 rounded ${tile} justify-self-end`} />
+            <div className={`w-10 h-10 rounded-md ${tile}`} />
+            <div className={`h-3 rounded ${tile}`} />
+            <div className={`h-3 rounded ${tile}`} />
+            <div className={`h-3 w-10 rounded ${tile} justify-self-end`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/ViewSuspenseFallback.tsx
+++ b/src/components/common/ViewSuspenseFallback.tsx
@@ -1,0 +1,39 @@
+/**
+ * Generic skeleton shown while a lazily-loaded view's JS chunk
+ * downloads. Replaces the tiny centered spinner that previously
+ * looked like an unhandled blank screen on first navigation to a
+ * route. Most navigations skip this entirely because [`AppLayout`]
+ * pre-warms every view chunk at idle time after first mount.
+ */
+export function ViewSuspenseFallback() {
+  const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading"
+      className="space-y-8 animate-pulse pb-12"
+    >
+      <div className="flex items-start space-x-5">
+        <div className={`w-20 h-20 rounded-2xl ${tile}`} />
+        <div className="flex-1 space-y-3 pt-2">
+          <div className={`h-7 w-1/3 rounded ${tile}`} />
+          <div className={`h-3 w-1/4 rounded ${tile}`} />
+        </div>
+      </div>
+      <div className="space-y-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[2.75rem_1fr_1fr_5rem] gap-4 items-center"
+          >
+            <div className={`w-10 h-10 rounded-md ${tile}`} />
+            <div className={`h-3 rounded ${tile}`} />
+            <div className={`h-3 rounded ${tile}`} />
+            <div className={`h-3 w-10 rounded ${tile} justify-self-end`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/ViewSuspenseFallback.tsx
+++ b/src/components/common/ViewSuspenseFallback.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 /**
  * Generic skeleton shown while a lazily-loaded view's JS chunk
  * downloads. Replaces the tiny centered spinner that previously
@@ -6,12 +8,13 @@
  * pre-warms every view chunk at idle time after first mount.
  */
 export function ViewSuspenseFallback() {
+  const { t } = useTranslation();
   const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
   return (
     <div
       role="status"
       aria-busy="true"
-      aria-label="Loading"
+      aria-label={t("common.loading")}
       className="space-y-8 animate-pulse pb-12"
     >
       <div className="flex items-start space-x-5">

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -204,6 +204,9 @@ export function AppLayout() {
       void import("../views/StatisticsView");
       void import("../views/WrappedView");
       void import("../views/SettingsView");
+      void import("../views/SpotifyView");
+      void import("../views/AboutView");
+      void import("../views/FeedbackView");
     };
     type IdleWindow = Window & {
       requestIdleCallback?: (

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -30,6 +30,7 @@ import { LastfmReauthBanner } from "../common/LastfmReauthBanner";
 import { UpdateBanner } from "../common/UpdateBanner";
 import { ScanProgressToast } from "../common/ScanProgressToast";
 import { OnboardingModal } from "../common/OnboardingModal";
+import { ViewSuspenseFallback } from "../common/ViewSuspenseFallback";
 import { PageScrollContext } from "../../contexts/PageScrollContext";
 
 const HomeView = lazy(() =>
@@ -186,6 +187,39 @@ export function AppLayout() {
   // Ref handed down to virtualized tables so they share the page-level
   // scroller instead of nesting their own.
   const pageScrollRef = useRef<HTMLDivElement>(null);
+
+  // Idle-time chunk warm-up for every lazily-loaded view. Once these
+  // imports resolve they're cached in the module registry, so a later
+  // navigation hits the Suspense fallback for zero ms instead of
+  // pausing for the network round-trip on the first click.
+  useEffect(() => {
+    const warmup = () => {
+      void import("../views/LibraryView");
+      void import("../views/LikedView");
+      void import("../views/HistoryView");
+      void import("../views/PlaylistView");
+      void import("../views/AlbumDetailView");
+      void import("../views/ArtistDetailView");
+      void import("../views/GenreDetailView");
+      void import("../views/StatisticsView");
+      void import("../views/WrappedView");
+      void import("../views/SettingsView");
+    };
+    type IdleWindow = Window & {
+      requestIdleCallback?: (
+        cb: () => void,
+        opts?: { timeout?: number },
+      ) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+    const w = window as IdleWindow;
+    if (typeof w.requestIdleCallback === "function") {
+      const handle = w.requestIdleCallback(warmup, { timeout: 2000 });
+      return () => w.cancelIdleCallback?.(handle);
+    }
+    const timer = setTimeout(warmup, 300);
+    return () => clearTimeout(timer);
+  }, []);
 
   useEffect(() => {
     if (isProfileLoading || isLibraryLoading) return;
@@ -500,13 +534,7 @@ export function AppLayout() {
               className="flex-1 overflow-y-auto p-8 relative"
             >
               <PageScrollContext.Provider value={pageScrollRef}>
-                <Suspense
-                  fallback={
-                    <div className="flex min-h-64 items-center justify-center text-zinc-500 dark:text-zinc-400">
-                      <Loader2 size={22} className="animate-spin" />
-                    </div>
-                  }
-                >
+                <Suspense fallback={<ViewSuspenseFallback />}>
                   {/* Crossfade + slight slide between views. Keyed on
                       the structural view id (album/artist/genre/playlist
                       keep a single key so the inner view handles its own

--- a/src/components/views/AlbumDetailView.tsx
+++ b/src/components/views/AlbumDetailView.tsx
@@ -4,6 +4,7 @@ import { Play, Shuffle, Clock, Music2, Heart, ImageIcon } from "lucide-react";
 import { Artwork } from "../common/Artwork";
 import { ArtistLink } from "../common/ArtistLink";
 import { EmptyState } from "../common/EmptyState";
+import { DetailViewSkeleton } from "../common/DetailViewSkeleton";
 import { CreatePlaylistModal } from "../common/CreatePlaylistModal";
 import { CoverPickerModal } from "../common/CoverPickerModal";
 import { HiResBadge } from "../common/HiResBadge";
@@ -44,7 +45,10 @@ export function AlbumDetailView({
   const { createPlaylist } = usePlaylist();
 
   const [album, setAlbum] = useState<AlbumDetail | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  // Init true so the skeleton paints on first render — paired with the
+  // `!album && !isLoading` early-return below, this also prevents a
+  // one-frame "album not found" flash before the fetch schedules.
+  const [isLoading, setIsLoading] = useState(true);
   const [likedIds, setLikedIds] = useState<Set<number>>(new Set());
   const [isCreatePlaylistModalOpen, setIsCreatePlaylistModalOpen] =
     useState(false);
@@ -153,7 +157,7 @@ export function AlbumDetailView({
     );
   }
 
-  if (!album) return null; // loading
+  if (!album) return <DetailViewSkeleton ariaLabel={t("albumDetail.badge")} />; // loading
 
   // Build playable Track[] from AlbumTrack[] for the player
   const playableTracks = album.tracks.map((at) => ({

--- a/src/components/views/ArtistDetailView.tsx
+++ b/src/components/views/ArtistDetailView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Play, Shuffle, Music2, Clock, Heart, Pencil } from "lucide-react";
 import { Artwork } from "../common/Artwork";
 import { EmptyState } from "../common/EmptyState";
+import { DetailViewSkeleton } from "../common/DetailViewSkeleton";
 import { CreatePlaylistModal } from "../common/CreatePlaylistModal";
 import { ArtistImagePickerModal } from "../common/ArtistImagePickerModal";
 import { HiResBadge } from "../common/HiResBadge";
@@ -48,7 +49,10 @@ export function ArtistDetailView({
 
   const [artist, setArtist] = useState<ArtistDetail | null>(null);
   const [tracks, setTracks] = useState<Track[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Init true so the skeleton paints on first render (paired with the
+  // `!artist && !isLoading` early-return below to avoid a one-frame
+  // "artist not found" flash before the fetch effect schedules).
+  const [isLoading, setIsLoading] = useState(true);
   const [likedIds, setLikedIds] = useState<Set<number>>(new Set());
   const [isCreatePlaylistModalOpen, setIsCreatePlaylistModalOpen] =
     useState(false);
@@ -223,7 +227,11 @@ export function ArtistDetailView({
     );
   }
 
-  if (!artist) return null;
+  if (!artist) {
+    return (
+      <DetailViewSkeleton ariaLabel={t("artistDetail.badge")} shape="circle" />
+    );
+  }
 
   const handlePlayAll = async () => {
     if (tracks.length === 0) return;

--- a/src/components/views/GenreDetailView.tsx
+++ b/src/components/views/GenreDetailView.tsx
@@ -4,6 +4,7 @@ import { Play, Shuffle, Clock, Music2, Heart, Tags } from "lucide-react";
 import { Artwork } from "../common/Artwork";
 import { ArtistLink } from "../common/ArtistLink";
 import { EmptyState } from "../common/EmptyState";
+import { DetailViewSkeleton } from "../common/DetailViewSkeleton";
 import { CreatePlaylistModal } from "../common/CreatePlaylistModal";
 import { HiResBadge } from "../common/HiResBadge";
 import { PlayingIndicator } from "../common/PlayingIndicator";
@@ -36,7 +37,10 @@ export function GenreDetailView({
   const { createPlaylist } = usePlaylist();
 
   const [genre, setGenre] = useState<GenreDetail | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  // Init true so the skeleton paints on first render (paired with the
+  // `!genre && !isLoading` early-return below to avoid a one-frame
+  // "genre not found" flash before the fetch effect schedules).
+  const [isLoading, setIsLoading] = useState(true);
   const [likedIds, setLikedIds] = useState<Set<number>>(new Set());
   const [isCreatePlaylistModalOpen, setIsCreatePlaylistModalOpen] =
     useState(false);
@@ -109,7 +113,7 @@ export function GenreDetailView({
     );
   }
 
-  if (!genre) return null;
+  if (!genre) return <DetailViewSkeleton ariaLabel={t("genreDetail.badge")} />;
 
   const tracks = genre.tracks;
 

--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -113,7 +113,11 @@ export function HomeView({
     importFolder,
   } = useLibrary();
   const { playTracks, playbackState, currentTrack } = usePlayer();
-  const { playlists, refresh: refreshPlaylists } = usePlaylist();
+  const {
+    playlists,
+    isLoading: playlistsLoading,
+    refresh: refreshPlaylists,
+  } = usePlaylist();
   const [isRegenerating, setIsRegenerating] = useState(false);
 
   // Smart playlists are stored in the same `playlist` table as user
@@ -148,6 +152,11 @@ export function HomeView({
   const [recentAlbums, setRecentAlbums] = useState<AlbumRow[]>([]);
   const [isImporting, setIsImporting] = useState(false);
   const [wrappedYears, setWrappedYears] = useState<number[]>([]);
+  // Per-section loading flags — start true so each carousel paints a
+  // skeleton on first render rather than flashing its (large) empty
+  // state for the duration of the first SQL fetch.
+  const [recentPlaysLoading, setRecentPlaysLoading] = useState(true);
+  const [recentAlbumsLoading, setRecentAlbumsLoading] = useState(true);
 
   const greetingName = activeProfile?.name ?? "";
   const totalTracks = useMemo(
@@ -195,7 +204,10 @@ export function HomeView({
       .then((rows) => {
         if (!cancelled) setRecentPlays(rows);
       })
-      .catch((err) => console.error("[HomeView] list recent plays", err));
+      .catch((err) => console.error("[HomeView] list recent plays", err))
+      .finally(() => {
+        if (!cancelled) setRecentPlaysLoading(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -216,7 +228,10 @@ export function HomeView({
       .then((rows) => {
         if (!cancelled) setRecentAlbums(rows.slice(0, ALBUMS_LIMIT));
       })
-      .catch((err) => console.error("[HomeView] list albums", err));
+      .catch((err) => console.error("[HomeView] list albums", err))
+      .finally(() => {
+        if (!cancelled) setRecentAlbumsLoading(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -406,7 +421,9 @@ export function HomeView({
               : t("home.dailyMix.regenerate", "Régénérer")}
           </button>
         </div>
-        {smartPlaylists.length === 0 ? (
+        {smartPlaylists.length === 0 && playlistsLoading ? (
+          <HomeBannerSkeleton label={t("home.dailyMix.title", "Pour vous")} />
+        ) : smartPlaylists.length === 0 ? (
           <div className="relative overflow-hidden min-h-32 rounded-3xl border flex items-center justify-center p-8 border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800/40 dark:shadow-none">
             <EmptyState
               icon={<Sparkles size={32} />}
@@ -477,7 +494,9 @@ export function HomeView({
             </button>
           )}
         </div>
-        {recentPlays.length === 0 ? (
+        {recentPlays.length === 0 && recentPlaysLoading ? (
+          <HomeCarouselSkeleton label={t("home.recentlyPlayed.title")} />
+        ) : recentPlays.length === 0 ? (
           <div className="relative overflow-hidden min-h-80 rounded-3xl border flex items-center justify-center p-8 border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800/40 dark:shadow-none">
             <EmptyState
               icon={<Clock size={32} />}
@@ -590,6 +609,9 @@ export function HomeView({
               {t("home.seeAll")}
             </button>
           </div>
+          {recentAlbums.length === 0 && recentAlbumsLoading ? (
+            <HomeCarouselSkeleton label={t("home.recentlyAdded.title")} />
+          ) : (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4">
             {recentAlbums.map((album) => (
               <button
@@ -623,8 +645,49 @@ export function HomeView({
               </button>
             ))}
           </div>
+          )}
         </section>
       )}
+    </div>
+  );
+}
+
+function HomeBannerSkeleton({ label }: { label: string }) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={label}
+      className="relative overflow-hidden min-h-32 rounded-3xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800/40 dark:shadow-none animate-pulse"
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="aspect-16/7 rounded-2xl bg-zinc-200/70 dark:bg-zinc-700/40"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HomeCarouselSkeleton({ label }: { label: string }) {
+  const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={label}
+      className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4 animate-pulse"
+    >
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="p-3 space-y-3">
+          <div className={`w-full aspect-square rounded-2xl ${tile}`} />
+          <div className={`h-3 w-3/4 rounded ${tile}`} />
+          <div className={`h-3 w-1/2 rounded ${tile}`} />
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -594,8 +594,11 @@ export function HomeView({
         )}
       </section>
 
-      {/* Récemment ajoutés — only render when we have albums to show. */}
-      {hasLibrary && recentAlbums.length > 0 && (
+      {/* Récemment ajoutés — render while loading (skeleton) or once
+          we have data; only suppress when the library is empty AND
+          nothing is loading, which is the "no library yet" state where
+          the welcome banner handles the empty case on its own. */}
+      {hasLibrary && (recentAlbumsLoading || recentAlbums.length > 0) && (
         <section>
           <div className="flex items-end justify-between mb-6">
             <h2 className="text-2xl font-bold inline-block border-b-4 border-emerald-500 pb-1 text-zinc-900 dark:text-white">
@@ -652,7 +655,11 @@ export function HomeView({
   );
 }
 
-function HomeBannerSkeleton({ label }: { label: string }) {
+interface HomeSkeletonProps {
+  label: string;
+}
+
+function HomeBannerSkeleton({ label }: HomeSkeletonProps) {
   return (
     <div
       role="status"
@@ -672,7 +679,7 @@ function HomeBannerSkeleton({ label }: { label: string }) {
   );
 }
 
-function HomeCarouselSkeleton({ label }: { label: string }) {
+function HomeCarouselSkeleton({ label }: HomeSkeletonProps) {
   const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
   return (
     <div

--- a/src/components/views/LikedView.tsx
+++ b/src/components/views/LikedView.tsx
@@ -30,7 +30,9 @@ export function LikedView({
   const { playTracks, currentTrack, playbackState } = usePlayer();
   const { createPlaylist } = usePlaylist();
   const [tracks, setTracks] = useState<Track[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Init to `true` so the skeleton paints on first render — otherwise
+  // we'd flash the empty-state for one frame before the effect schedules.
+  const [isLoading, setIsLoading] = useState(true);
   const [isCreatePlaylistModalOpen, setIsCreatePlaylistModalOpen] =
     useState(false);
   // Local liked-set built from `tracks`: every loaded row is liked by
@@ -124,7 +126,9 @@ export function LikedView({
       </div>
 
       {/* Tracks */}
-      {tracks.length > 0 ? (
+      {tracks.length === 0 && isLoading ? (
+        <LikedSkeleton t={t} />
+      ) : tracks.length > 0 ? (
         <div className="rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-800/40 overflow-hidden">
           <div className="grid grid-cols-[3rem_2.75rem_1fr_1fr_1fr_5rem_2.5rem] gap-4 px-5 py-3 text-[10px] font-bold tracking-widest text-zinc-400 uppercase border-b border-zinc-100 dark:border-zinc-800">
             <span className="text-right">{t("library.table.number")}</span>
@@ -270,6 +274,37 @@ export function LikedView({
       />
 
       {trackContextMenu.render()}
+    </div>
+  );
+}
+
+function LikedSkeleton({
+  t,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={t("liked.title")}
+      className="rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-800/40 overflow-hidden animate-pulse"
+    >
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div
+          key={i}
+          className="grid grid-cols-[3rem_2.75rem_1fr_1fr_1fr_5rem_2.5rem] gap-4 px-5 py-2 h-14 items-center border-b border-zinc-100 dark:border-zinc-800/60"
+        >
+          <div className={`h-3 w-4 rounded ${tile} justify-self-end`} />
+          <div className={`w-10 h-10 rounded-md ${tile}`} />
+          <div className={`h-3 rounded ${tile}`} />
+          <div className={`h-3 rounded ${tile}`} />
+          <div className={`h-3 rounded ${tile}`} />
+          <div className={`h-3 w-10 rounded ${tile} justify-self-end`} />
+          <div className={`h-3 w-3 rounded ${tile} justify-self-center`} />
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/views/LikedView.tsx
+++ b/src/components/views/LikedView.tsx
@@ -278,11 +278,11 @@ export function LikedView({
   );
 }
 
-function LikedSkeleton({
-  t,
-}: {
+interface LikedSkeletonProps {
   t: (key: string, options?: Record<string, unknown>) => string;
-}) {
+}
+
+function LikedSkeleton({ t }: LikedSkeletonProps) {
   const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
   return (
     <div

--- a/src/components/views/PlaylistView.tsx
+++ b/src/components/views/PlaylistView.tsx
@@ -145,7 +145,12 @@ export function PlaylistView({
 
   const [playlist, setPlaylist] = useState<Playlist | null>(null);
   const [tracks, setTracks] = useState<Track[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Init `true` so the skeleton paints on first render — the
+  // not-found EmptyState (`playlist == null && !isLoading` early return
+  // a few lines down) is also predicated on this flag, so leaving it
+  // `false` here would flash "playlist not found" for one frame
+  // before the fetch effect schedules.
+  const [isLoading, setIsLoading] = useState(true);
   // Per-playlist sort mode, persisted in `profile_setting['sort.playlist:<id>']`
   // via `useSortMemory`. The hook keeps a `direction` field for API
   // symmetry with the library view, but the playlist UI only exposes
@@ -684,7 +689,9 @@ export function PlaylistView({
       )}
 
       {/* Tracks list */}
-      {tracks.length > 0 ? (
+      {tracks.length === 0 && isLoading ? (
+        <PlaylistSkeleton t={t} />
+      ) : tracks.length > 0 ? (
         <PlaylistTrackTable
           tracks={displayTracks}
           isLoading={isLoading}
@@ -1326,6 +1333,36 @@ function PlaylistSortMenu({ current, onChange, t }: PlaylistSortMenuProps) {
           })}
         </ul>
       )}
+    </div>
+  );
+}
+
+function PlaylistSkeleton({
+  t,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  const tile = "bg-zinc-200/70 dark:bg-zinc-700/40";
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={t("playlistView.emptyTitle")}
+      className="rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-800/40 overflow-hidden animate-pulse"
+    >
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div
+          key={i}
+          className="grid grid-cols-[3rem_2.75rem_1fr_1fr_1fr_5rem] gap-4 px-5 py-2 h-14 items-center border-b border-zinc-100 dark:border-zinc-800/60"
+        >
+          <div className={`h-3 w-4 rounded ${tile} justify-self-end`} />
+          <div className={`w-10 h-10 rounded-md ${tile}`} />
+          <div className={`h-3 rounded ${tile}`} />
+          <div className={`h-3 rounded ${tile}`} />
+          <div className={`h-3 rounded ${tile}`} />
+          <div className={`h-3 w-10 rounded ${tile} justify-self-end`} />
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -7,7 +7,8 @@
     "confirm": "تأكيد",
     "open": "فتح",
     "optional": "(اختياري)",
-    "viewArtwork": "عرض الغلاف"
+    "viewArtwork": "عرض الغلاف",
+    "loading": "جارٍ التحميل…"
   },
   "lastfmReauth": {
     "title": "انتهت جلسة Last.fm",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -7,7 +7,8 @@
     "confirm": "Bestätigen",
     "open": "Öffnen",
     "optional": "(optional)",
-    "viewArtwork": "Cover anzeigen"
+    "viewArtwork": "Cover anzeigen",
+    "loading": "Wird geladen…"
   },
   "lastfmReauth": {
     "title": "Last.fm-Sitzung abgelaufen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -7,7 +7,8 @@
     "confirm": "Confirm",
     "open": "Open",
     "optional": "(optional)",
-    "viewArtwork": "View artwork"
+    "viewArtwork": "View artwork",
+    "loading": "Loading…"
   },
   "lastfmReauth": {
     "title": "Last.fm session expired",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -7,7 +7,8 @@
     "confirm": "Confirmar",
     "open": "Abrir",
     "optional": "(opcional)",
-    "viewArtwork": "Ver portada"
+    "viewArtwork": "Ver portada",
+    "loading": "Cargando…"
   },
   "lastfmReauth": {
     "title": "Sesión de Last.fm caducada",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -7,7 +7,8 @@
     "confirm": "Confirmer",
     "open": "Ouvrir",
     "optional": "(optionnel)",
-    "viewArtwork": "Voir l'illustration"
+    "viewArtwork": "Voir l'illustration",
+    "loading": "Chargement…"
   },
   "lastfmReauth": {
     "title": "Session Last.fm expirée",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -7,7 +7,8 @@
     "confirm": "पुष्टि करें",
     "open": "खोलें",
     "optional": "(वैकल्पिक)",
-    "viewArtwork": "आर्टवर्क देखें"
+    "viewArtwork": "आर्टवर्क देखें",
+    "loading": "लोड हो रहा है…"
   },
   "lastfmReauth": {
     "title": "Last.fm का सत्र समाप्त हो गया है",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -7,7 +7,8 @@
     "confirm": "Konfirmasi",
     "open": "Buka",
     "optional": "(opsional)",
-    "viewArtwork": "Lihat sampul"
+    "viewArtwork": "Lihat sampul",
+    "loading": "Memuat…"
   },
   "lastfmReauth": {
     "title": "Sesi Last.fm kedaluwarsa",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -7,7 +7,8 @@
     "confirm": "Conferma",
     "open": "Apri",
     "optional": "(opzionale)",
-    "viewArtwork": "Mostra copertina"
+    "viewArtwork": "Mostra copertina",
+    "loading": "Caricamento…"
   },
   "lastfmReauth": {
     "title": "Sessione Last.fm scaduta",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -7,7 +7,8 @@
     "confirm": "確認する",
     "open": "開く",
     "optional": "（任意）",
-    "viewArtwork": "アートワークを表示"
+    "viewArtwork": "アートワークを表示",
+    "loading": "読み込み中…"
   },
   "lastfmReauth": {
     "title": "Last.fmのセッションが期限切れになりました",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -7,7 +7,8 @@
     "confirm": "확인",
     "open": "열기",
     "optional": "(선택 사항)",
-    "viewArtwork": "아트워크 보기"
+    "viewArtwork": "아트워크 보기",
+    "loading": "불러오는 중…"
   },
   "lastfmReauth": {
     "title": "Last.fm 세션이 만료되었습니다",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -7,7 +7,8 @@
     "confirm": "Bevestigen",
     "open": "Openen",
     "optional": "(optioneel)",
-    "viewArtwork": "Albumhoes bekijken"
+    "viewArtwork": "Albumhoes bekijken",
+    "loading": "Laden…"
   },
   "lastfmReauth": {
     "title": "Last.fm-sessie verlopen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -7,7 +7,8 @@
     "confirm": "Confirmar",
     "open": "Abrir",
     "optional": "(opcional)",
-    "viewArtwork": "Ver capa"
+    "viewArtwork": "Ver capa",
+    "loading": "Carregando…"
   },
   "lastfmReauth": {
     "title": "A sessão do Last.fm expirou",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -7,7 +7,8 @@
     "confirm": "Confirmar",
     "open": "Abrir",
     "optional": "(opcional)",
-    "viewArtwork": "Ver capa"
+    "viewArtwork": "Ver capa",
+    "loading": "A carregar…"
   },
   "lastfmReauth": {
     "title": "A sessão do Last.fm expirou",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -7,7 +7,8 @@
     "confirm": "Подтвердить",
     "open": "Открыть",
     "optional": "(необязательно)",
-    "viewArtwork": "Посмотреть обложку"
+    "viewArtwork": "Посмотреть обложку",
+    "loading": "Загрузка…"
   },
   "lastfmReauth": {
     "title": "Сессия Last.fm истекла",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -7,7 +7,8 @@
     "confirm": "Onayla",
     "open": "Aç",
     "optional": "(isteğe bağlı)",
-    "viewArtwork": "Kapağı görüntüle"
+    "viewArtwork": "Kapağı görüntüle",
+    "loading": "Yükleniyor…"
   },
   "lastfmReauth": {
     "title": "Last.fm oturumu sona erdi",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -7,7 +7,8 @@
     "confirm": "确认",
     "open": "打开",
     "optional": "（可选）",
-    "viewArtwork": "查看封面"
+    "viewArtwork": "查看封面",
+    "loading": "加载中…"
   },
   "lastfmReauth": {
     "title": "Last.fm会话已过期",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -7,7 +7,8 @@
     "confirm": "確認",
     "open": "開啟",
     "optional": "（可選）",
-    "viewArtwork": "查看封面"
+    "viewArtwork": "查看封面",
+    "loading": "載入中…"
   },
   "lastfmReauth": {
     "title": "Last.fm的連線已過期",


### PR DESCRIPTION
## Summary
- Replaces the bare Suspense spinner with a layout-shaped skeleton (`ViewSuspenseFallback`, `role=status`) and warm-imports every `React.lazy` view chunk at idle time so a sidebar click rarely hits Suspense at all
- LikedView, HomeView, PlaylistView, AlbumDetailView, ArtistDetailView, GenreDetailView all init `isLoading=true` and paint a tailored skeleton on first render instead of flashing EmptyState (or, for the detail pages, returning `null` for a fully blank page)
- HomeView gains per-section loading flags so the Daily Mix banner, "Recently played" carousel and "Recently added" grid each swap independently from skeleton to data

## Context
The previous PR (#135) eliminated the loading flash for the **Library** tabs. This PR extends the same treatment to every other full-page view. The root causes were two layered loading patterns:

1. **Lazy-chunk download** — every view is `React.lazy()`-loaded, and the Suspense fallback was a tiny centered spinner that read as a blank page during the chunk download. Fixed by:
   - Replacing the fallback with a generic layout-shaped skeleton
   - Idle-time `requestIdleCallback` warm-import in AppLayout so the chunks are already cached when the user clicks a sidebar entry
2. **Data fetch flash** — each view initialized `isLoading=false`, so for one render frame `data.length === 0 && !isLoading` was true → EmptyState (or `return null`) flashed before the effect tick fired. Fixed by initializing `isLoading=true` and rendering a tailored skeleton during the first load.

## Test plan
- [x] Cold boot the app → no white-with-spinner screen, immediate skeleton paint
- [x] Click each sidebar item (Liked Songs, Home, Library, History, Stats, Wrapped, Settings) → no Suspense fallback after the first idle warmup completes
- [x] Navigate into an album / artist / genre detail page → full-page detail skeleton instead of blank page
- [x] Empty library: skeletons still appear briefly, then proper EmptyState renders
- [x] Screen reader announces "Loading <section>" via `role=status` on each skeleton
- [x] `bun run typecheck`, `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’écrans de chargement « skeleton » cohérents pour vues et listes afin d’éviter les flashes d’état vide lors du rendu initial.

* **Améliorations**
  * Pré‑chargement en arrière‑plan des vues pour des navigations ultérieures plus rapides.

* **Internationalisation**
  * Nouvelle clé de libellé "loading" ajoutée à de nombreuses traductions.

* **Documentation**
  * Nouvelle section décrivant le chargement paresseux des vues et le comportement des fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->