### PR TITLE
fix(ui): switch daily mix grid to flex-wrap with capped basis

### DIFF
--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -686,11 +686,11 @@ function HomeBannerSkeleton({ label }: HomeSkeletonProps) {
       aria-label={label}
       className="relative overflow-hidden min-h-32 rounded-3xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800/40 dark:shadow-none animate-pulse"
     >
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
+      <div className="flex flex-wrap gap-4 p-4">
         {Array.from({ length: 3 }).map((_, i) => (
           <div
             key={i}
-            className="aspect-16/7 rounded-2xl bg-zinc-200/70 dark:bg-zinc-700/40"
+            className="aspect-16/7 basis-70 grow max-w-100 rounded-2xl bg-zinc-200/70 dark:bg-zinc-700/40"
           />
         ))}
       </div>

--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -455,7 +455,7 @@ export function HomeView({
             />
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="flex flex-wrap gap-4">
             {smartPlaylists.map((pl) => {
               const cover = resolveRemoteImage(pl.cover_path, null);
               return (
@@ -463,7 +463,7 @@ export function HomeView({
                   key={`smart-${pl.id}`}
                   type="button"
                   onClick={() => onNavigateToPlaylist(pl.id)}
-                  className="group relative overflow-hidden rounded-2xl bg-zinc-100 dark:bg-zinc-800 aspect-16/7 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 transition-transform hover:-translate-y-0.5"
+                  className="group relative overflow-hidden rounded-2xl bg-zinc-100 dark:bg-zinc-800 aspect-16/7 basis-70 grow max-w-100 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 transition-transform hover:-translate-y-0.5"
                 >
                   {cover ? (
                     <img

--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -684,16 +684,14 @@ function HomeBannerSkeleton({ label }: HomeSkeletonProps) {
       role="status"
       aria-busy="true"
       aria-label={label}
-      className="relative overflow-hidden min-h-32 rounded-3xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800/40 dark:shadow-none animate-pulse"
+      className="flex flex-wrap gap-4 animate-pulse"
     >
-      <div className="flex flex-wrap gap-4 p-4">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div
-            key={i}
-            className="aspect-16/7 basis-70 grow max-w-100 rounded-2xl bg-zinc-200/70 dark:bg-zinc-700/40"
-          />
-        ))}
-      </div>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="aspect-16/7 basis-70 grow max-w-100 rounded-2xl bg-zinc-200/70 dark:bg-zinc-700/40"
+        />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `lg:grid-cols-3` capped the Daily Mix grid at three columns from 1024 px upwards, so on a 2K+ display each tile ballooned to ~750×330 with the fixed `aspect-16/7`. In a narrower (windowed) view a lone third card ended up half-row wide on its own line.
- Switch to `flex flex-wrap` with `basis-70 grow max-w-100` on each card so columns scale with viewport width, cards share leftover space up to a 400 px ceiling, and a solo trailing card no longer stretches across the full row.

## Before / after

| Viewport     | Before (`lg:grid-cols-3`)                       | After (`flex-wrap` + basis 280, max 400)           |
|--------------|-------------------------------------------------|----------------------------------------------------|
| ~2300 px FS  | 3 tiles × ~750 × 330                            | 5–6 tiles per row at 280–400 px wide               |
| ~1500 px win | 2 tiles row 1 + lone 3rd tile row 2 (half-row)  | 3 tiles per row at ~360 px, no orphan stretching   |
| ~700 px win  | 1 tile per row                                  | 2 tiles per row at 280 px (down to 1 below 560 px) |

## Test plan

- [x] `bun run typecheck` passes (verified locally).
- [x] `bun run lint` passes (verified locally).
- [x] Resize the window from very wide → narrow; tiles should resize/wrap without orphaned full-width cards.
- [x] Confirm an account with only one Daily Mix renders that single card at 400 px max, not the full row width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Améliorations**
  * Le carrousel "Daily Mix" passe d'une grille à un conteneur flexible (flex wrap) pour une meilleure réactivité et un espacement uniforme entre éléments.
  * Les boutons/cartes de playlist utilisent désormais des contraintes de dimensionnement (basis, grow, max‑width) pour un rendu cohérent sur différentes tailles d’écran.
  * Le squelette d’affichage (HomeBannerSkeleton) a été adapté pour conserver le ratio tout en respectant la nouvelle mise en page flexible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->