### PR TITLE
fix(ui): portal fullscreen lyrics so opacity tween doesn't bleed through

### DIFF
--- a/src/components/layout/LyricsPanel.tsx
+++ b/src/components/layout/LyricsPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import {
@@ -321,25 +322,31 @@ export function LyricsPanel() {
           onSaved={(next) => setPayload(next)}
         />
 
-        {/* Fullscreen overlay — rendered as a sibling so it covers
-            the whole app, not just the panel. Toggled via PlayerContext
-            so the immersive Now Playing view can switch into karaoke
-            mode without unmounting the panel that owns the lyrics
-            state. */}
-        {isFullscreenLyricsOpen && currentTrack && (
-          <FullscreenLyrics
-            track={currentTrack}
-            payload={payload}
-            lrcLines={lrcLines}
-            isSynced={isSynced}
-            activeIndex={activeIndex}
-            isFetching={isFetching}
-            error={error}
-            onClose={closeFullscreenLyrics}
-            onOpenNowPlaying={openFullscreenNowPlaying}
-            onSeek={handleSeekToLine}
-          />
-        )}
+        {/* Fullscreen overlay — portalled to `document.body` so it
+            escapes the `motion.aside`'s opacity/width animation; without
+            the portal the overlay inherits the parent's `opacity: 0`
+            tween at mount and the app background flashes through during
+            the immersive→lyrics transition (the reverse direction is
+            unaffected because LyricsPanel is already fully opaque by
+            then). Mounted as a portal sibling at the document root keeps
+            the panel as the owner of the lyrics fetch / parse state. */}
+        {isFullscreenLyricsOpen &&
+          currentTrack &&
+          createPortal(
+            <FullscreenLyrics
+              track={currentTrack}
+              payload={payload}
+              lrcLines={lrcLines}
+              isSynced={isSynced}
+              activeIndex={activeIndex}
+              isFetching={isFetching}
+              error={error}
+              onClose={closeFullscreenLyrics}
+              onOpenNowPlaying={openFullscreenNowPlaying}
+              onSeek={handleSeekToLine}
+            />,
+            document.body,
+          )}
 
         {/* Footer actions */}
         {currentTrack != null && (

--- a/src/components/player/FullscreenLyrics.tsx
+++ b/src/components/player/FullscreenLyrics.tsx
@@ -83,11 +83,15 @@ export function FullscreenLyrics({
       role="dialog"
       aria-modal="true"
       aria-labelledby="fullscreen-lyrics-title"
-      className="fixed inset-0 z-[100] animate-fade-in"
+      className="fixed inset-0 z-[100] bg-zinc-950"
     >
       {/* Blurred artwork background — falls back to a flat dark
-          gradient when the track has no cover. */}
-      <div className="absolute inset-0 overflow-hidden">
+          gradient when the track has no cover.
+          The `animate-fade-in` lives here (not on the outer wrapper)
+          so the opaque `bg-zinc-950` above paints solid from frame 1
+          — without that base the wrapper's own opacity tween would
+          let the home view bleed through during the 300 ms ramp. */}
+      <div className="absolute inset-0 overflow-hidden animate-fade-in">
         {track.artwork_path ? (
           <Artwork
             path={track.artwork_path}
@@ -99,13 +103,13 @@ export function FullscreenLyrics({
             rounded="md"
           />
         ) : (
-          <div className="w-full h-full bg-gradient-to-br from-zinc-800 to-zinc-950" />
+          <div className="w-full h-full bg-linear-to-br from-zinc-800 to-zinc-950" />
         )}
         <div className="absolute inset-0 bg-black/65" />
       </div>
 
       {/* Foreground */}
-      <div className="relative h-full flex flex-col text-white">
+      <div className="relative h-full flex flex-col text-white animate-fade-in">
         {/* Header */}
         <div className="flex items-center justify-between px-8 py-6 shrink-0">
           <div className="flex items-center gap-4 min-w-0">

--- a/src/components/player/FullscreenNowPlaying.tsx
+++ b/src/components/player/FullscreenNowPlaying.tsx
@@ -128,12 +128,16 @@ export function FullscreenNowPlaying({
       role="dialog"
       aria-modal="true"
       aria-label={t("playerBar.openFullscreen")}
-      className="fixed inset-0 z-100 animate-fade-in"
+      className="fixed inset-0 z-100 bg-zinc-950"
     >
       {/* Blurred artwork background — falls back to a flat dark
           gradient when the track has no cover. Same recipe as the
-          fullscreen lyrics overlay so they feel like siblings. */}
-      <div className="absolute inset-0 overflow-hidden">
+          fullscreen lyrics overlay so they feel like siblings.
+          The `animate-fade-in` lives here (not on the outer wrapper)
+          so the opaque `bg-zinc-950` above paints solid from frame 1
+          — without that base the wrapper's own opacity tween would
+          let the home view bleed through during the 300 ms ramp. */}
+      <div className="absolute inset-0 overflow-hidden animate-fade-in">
         {currentTrack?.artwork_path ? (
           <Artwork
             path={currentTrack.artwork_path}
@@ -151,7 +155,7 @@ export function FullscreenNowPlaying({
       </div>
 
       {/* Foreground */}
-      <div className="relative h-full flex flex-col text-white">
+      <div className="relative h-full flex flex-col text-white animate-fade-in">
         {/* Top bar — lyrics switcher + share + close. Controls live at
             the bottom so the cover gets the visual centre. */}
         <div className="flex items-center justify-end gap-3 px-8 py-6 shrink-0">


### PR DESCRIPTION
## Bug

Switching from the immersive Now Playing view (\`FullscreenNowPlaying\`) to the fullscreen lyrics view via the lyrics button caused a ~500 ms glitch where the regular app UI (search bar, sidebar, top bar) was visible through the new overlay. The reverse direction (lyrics → immersive) was unaffected.

## Root cause

\`LyricsPanel\` is a \`motion.aside\` with \`initial={{ width: 0, opacity: 0 }}\` ([LyricsPanel.tsx#L180-L186](src/components/layout/LyricsPanel.tsx#L180-L186)), animating to full opacity over a spring tween (~500 ms). \`FullscreenLyrics\` was rendered as a **descendant** of that motion subtree ([LyricsPanel.tsx#L329](src/components/layout/LyricsPanel.tsx#L329)), so:

- **Immersive → Lyrics**: \`activeRightPanel\` flips to \`"lyrics"\`, \`LyricsPanel\` mounts and starts its opacity-from-0 tween, dragging \`FullscreenLyrics\` along with it. The overlay is transparent at first paint; the app UI shows through. \`FullscreenNowPlaying\` (sibling under the always-mounted \`PlayerBar\`) unmounts instantly without an exit tween.
- **Lyrics → Immersive**: \`LyricsPanel\` is already at opacity 1; only \`fullscreenOverlay\` changes. \`FullscreenLyrics\` unmounts, \`FullscreenNowPlaying\` mounts and runs its own 300 ms \`animate-fade-in\` against a stable parent. No bleed-through.

## Fix

Portal \`FullscreenLyrics\` to \`document.body\` via \`react-dom/createPortal\`, so the rendered subtree sits next to \`<App>\` instead of inside the animated \`motion.aside\`. The panel still owns the lyrics fetch / parse state — only the visual subtree moves. Same pattern already used in \`QueuePanel.tsx\` for the dnd-kit drag overlay.

## Test plan

- [x] \`bun run typecheck\` passes.
- [x] \`bun run lint\` passes.
- [x] Click the cover thumbnail in the player bar → immersive Now Playing opens.
- [x] From immersive, click the Lyrics button → fullscreen lyrics overlay appears **without** any flash of the app UI behind it.
- [x] From fullscreen lyrics, click the cover thumbnail (or Maximize2 icon) → immersive Now Playing returns smoothly.
- [x] Open the lyrics side panel (via the player-bar Lyrics button while the lyrics overlay isn't open), then click Maximize2 → fullscreen lyrics still mounts cleanly (panel already opaque).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Amélioration de l'affichage des écrans plein écran (paroles et lecture) : meilleure isolation visuelle et stabilité, fond flouté ou dégradé avec voile sombre, base opaque pour éviter les artefacts, et transitions d'apparition réajustées pour des animations plus cohérentes. L'overlay est désormais monté à la racine du document pour un rendu plus stable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->