### PR TITLE
feat(ui): surface the resampling arrow in the audio quality footer

### DIFF
--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -181,7 +181,7 @@ Hovering (or keyboard-focusing) the footer opens [`AudioPipelinePopover`](../../
 #### Sections displayed
 
 - **Source** — codec, sample rate, bit depth, bitrate, channel layout (`Mono` / `Stereo` / `3.0` / `4.0` / `5.0` / `5.1` / `6.1` / `7.1`).
-- **Processing** — chips lighting up for every active stage: `DSD → PCM`, `Resample`, `Downmix`, `EQ`, `ReplayGain`, `Normalize`, `Mono` mixdown, `Speed ≠ 1×`. No chip → "Aucun traitement appliqué".
+- **Processing** — chips lighting up for every active stage. The two conversion chips inline the actual delta so they match the footer's arrow notation: `Rééchantillonnage 48 → 44.1 kHz`, `Downmix 5.1 → Stereo`. The other chips stay as bare labels: `DSD → PCM`, `EQ`, `ReplayGain`, `Normalize`, `Mono` mixdown, `Speed ≠ 1×`. No chip → "Aucun traitement appliqué".
 - **Output** — device sample rate + channel layout read from the live engine snapshot (`PlayerStateSnapshot.sample_rate` / `channels`), not the track row, so resampling and downmix are reflected correctly.
 
 #### Bit-perfect conditions

--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -174,7 +174,7 @@ The overflow popover itself is capped at `max-h-[calc(100dvh-7rem)]` with `overf
 
 ### Audio-quality footer + pipeline popover
 
-The opt-in audio-quality footer ([`AudioQualityFooter`](../../src/components/player/AudioQualityFooter.tsx), pinned via Settings → Appearance → Player bar layout) is a thin strip below the player bar that surfaces the source file specs in compact form (`48 kHz · 256 kb/s · 6 Mo` on the left, `AAC · 24bit · 48kHz` on the right; bitrates ≥ 1000 kbps render as `Mb/s`). The Hi-Res pill surfaces when [`isHiRes`](../../src/lib/hiRes.ts) accepts the source bit depth / sample rate combination.
+The opt-in audio-quality footer ([`AudioQualityFooter`](../../src/components/player/AudioQualityFooter.tsx), pinned via Settings → Appearance → Player bar layout) is a thin strip below the player bar that surfaces the source file specs in compact form (`48 kHz · 256 kb/s · 6 Mo` on the left, `AAC · 24bit · 48kHz` on the right; bitrates ≥ 1000 kbps render as `Mb/s`). When the engine is resampling — source rate ≠ output device rate — the left chunk renders an arrow instead: `48 kHz → 44.1 kHz · …`, so the user can spot the conversion at a glance without opening the popover. The arrow is gated on the device rate being known (the engine reports `0` before the first stream opens); otherwise we fall back to the source rate alone rather than printing a misleading `48 kHz → null`. The Hi-Res pill surfaces when [`isHiRes`](../../src/lib/hiRes.ts) accepts the source bit depth / sample rate combination.
 
 Hovering (or keyboard-focusing) the footer opens [`AudioPipelinePopover`](../../src/components/player/AudioPipelinePopover.tsx) — an audiophile-grade breakdown of what the engine is actually doing.
 

--- a/src/components/player/AudioPipelinePopover.tsx
+++ b/src/components/player/AudioPipelinePopover.tsx
@@ -170,13 +170,19 @@ export function AudioPipelinePopover({ track }: AudioPipelinePopoverProps) {
   if (isResampling)
     chips.push({
       key: "resample",
-      label: t("playerBar.pipeline.chip.resample"),
+      // Surface the actual from→to rates so the chip mirrors the
+      // footer's `48 kHz → 44.1 kHz` arrow. Stripped of the unit on
+      // the left side since the `kHz` suffix on the right reads for
+      // both (matches the way audio devices are usually labelled).
+      label: `${t("playerBar.pipeline.chip.resample")} ${(track.sample_rate! / 1000)
+        .toFixed(1)
+        .replace(/\.0$/, "")} → ${formatSampleRate(snap!.outputSampleRate)}`,
       tone: "convert",
     });
   if (isDownmixing)
     chips.push({
       key: "downmix",
-      label: t("playerBar.pipeline.chip.downmix"),
+      label: `${t("playerBar.pipeline.chip.downmix")} ${formatChannelLayout(track.channels)} → ${formatChannelLayout(snap!.outputChannels)}`,
       tone: "convert",
     });
   if (isEq)

--- a/src/components/player/AudioQualityFooter.tsx
+++ b/src/components/player/AudioQualityFooter.tsx
@@ -2,7 +2,14 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { QueueTrackPayload } from "../../lib/tauri/player";
 import { isHiRes } from "../../lib/hiRes";
+import { usePlayer } from "../../hooks/usePlayer";
 import { AudioPipelinePopover } from "./AudioPipelinePopover";
+
+/** Format an Hz value as a compact "44.1 kHz" / "48 kHz" label. */
+function formatRateKHz(hz: number | null | undefined): string | null {
+  if (hz == null || hz <= 0) return null;
+  return (hz / 1000).toFixed(1).replace(/\.0$/, "");
+}
 
 interface AudioQualityFooterProps {
   track: QueueTrackPayload | null;
@@ -16,10 +23,10 @@ const HOVER_CLOSE_DELAY_MS = 200;
 
 /**
  * Thin status strip below the PlayerBar that surfaces the source
- * file's audio specs — sample rate, bitrate, file size on the left
- * and codec / bit depth / sample rate again on the right (the
- * compact "FLAC · 24bit · 44kHz" pill that audiophiles recognise
- * from RustMusic and similar players).
+ * file's audio specs — sample rate (with an arrow when the engine
+ * is resampling to a different device rate), bitrate, file size on
+ * the left and codec / bit depth / sample rate again on the right
+ * (the compact "FLAC · 24bit · 44kHz" pill audiophiles expect).
  *
  * On hover (or keyboard focus) opens [`AudioPipelinePopover`] above
  * the strip with the full Source → DSP chips → Output breakdown so
@@ -34,6 +41,7 @@ const HOVER_CLOSE_DELAY_MS = 200;
  */
 export function AudioQualityFooter({ track }: AudioQualityFooterProps) {
   const { t } = useTranslation();
+  const { deviceSampleRate } = usePlayer();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const openTimerRef = useRef<number | null>(null);
   const closeTimerRef = useRef<number | null>(null);
@@ -100,17 +108,29 @@ export function AudioQualityFooter({ track }: AudioQualityFooterProps) {
     );
   }
 
-  const sampleRateKHz = track.sample_rate
-    ? (track.sample_rate / 1000).toFixed(1).replace(/\.0$/, "")
-    : null;
+  const sampleRateKHz = formatRateKHz(track.sample_rate);
+  const deviceRateKHz = formatRateKHz(deviceSampleRate);
+  // Resampling is the source rate ≠ output rate case. Both have to
+  // be known for the arrow to mean anything — if the device rate
+  // hasn't been hydrated yet we just show the source rate alone
+  // rather than printing a misleading "48 kHz → null".
+  const isResampling =
+    sampleRateKHz != null &&
+    deviceRateKHz != null &&
+    sampleRateKHz !== deviceRateKHz;
+  const sampleRateLabel = isResampling
+    ? `${sampleRateKHz} kHz → ${deviceRateKHz} kHz`
+    : sampleRateKHz != null
+      ? `${sampleRateKHz} kHz`
+      : null;
   const sizeMB =
     track.file_size > 0 ? Math.round(track.file_size / (1024 * 1024)) : null;
 
   const leftBits: string[] = [];
-  if (sampleRateKHz) leftBits.push(`${sampleRateKHz} kHz`);
+  if (sampleRateLabel) leftBits.push(sampleRateLabel);
   if (track.bitrate) {
-    // RustMusic convention — show Mb/s when ≥ 1000 kbps so 24-bit
-    // 192 kHz lossless reads "9.2 Mb/s" rather than a wall of digits.
+    // Show Mb/s when ≥ 1000 kbps so 24-bit 192 kHz lossless reads
+    // "9.2 Mb/s" rather than a wall of digits.
     leftBits.push(
       track.bitrate >= 1000
         ? `${(track.bitrate / 1000).toFixed(track.bitrate >= 10000 ? 1 : 2).replace(/\.?0+$/, "")} Mb/s`

--- a/src/components/player/AudioQualityFooter.tsx
+++ b/src/components/player/AudioQualityFooter.tsx
@@ -108,16 +108,19 @@ export function AudioQualityFooter({ track }: AudioQualityFooterProps) {
     );
   }
 
+  // Resampling check works on raw Hz, not the formatted kHz strings.
+  // Otherwise a source like 44 056 Hz (rare non-standard CD rip) on a
+  // 44 100 Hz device would silently round to "44.1" on both sides and
+  // hide the resampling. `track.sample_rate` and `deviceSampleRate`
+  // are both already integers from the engine.
+  const isResampling =
+    track.sample_rate != null &&
+    track.sample_rate > 0 &&
+    deviceSampleRate != null &&
+    deviceSampleRate > 0 &&
+    track.sample_rate !== deviceSampleRate;
   const sampleRateKHz = formatRateKHz(track.sample_rate);
   const deviceRateKHz = formatRateKHz(deviceSampleRate);
-  // Resampling is the source rate ≠ output rate case. Both have to
-  // be known for the arrow to mean anything — if the device rate
-  // hasn't been hydrated yet we just show the source rate alone
-  // rather than printing a misleading "48 kHz → null".
-  const isResampling =
-    sampleRateKHz != null &&
-    deviceRateKHz != null &&
-    sampleRateKHz !== deviceRateKHz;
   const sampleRateLabel = isResampling
     ? `${sampleRateKHz} kHz → ${deviceRateKHz} kHz`
     : sampleRateKHz != null

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -170,6 +170,15 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   // each rebuild costs ~one rubato chunk of audio (negligible).
   const [playbackSpeed, setPlaybackSpeedState] = useState(1.0);
 
+  // Live output-device sample rate (Hz) and channel count, as
+  // reported by the engine snapshot. Used by the AudioQualityFooter
+  // resampling arrow and by other UI bits that want to surface the
+  // bit-perfect vs. resampled distinction. Refreshed on profile load
+  // and on every `player:track-changed` because WASAPI exclusive
+  // mode can re-open the device at the new track's native rate.
+  const [deviceSampleRate, setDeviceSampleRate] = useState<number | null>(null);
+  const [deviceChannels, setDeviceChannels] = useState<number | null>(null);
+
   // Suppress incoming position events while the user drags the
   // progress bar, so the thumb doesn't fight the mouse.
   const isSeekingRef = useRef(false);
@@ -200,6 +209,11 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         previousVolumeRef.current = Math.round(snap.volume * 100);
         setIsShuffled(snap.shuffle);
         setRepeatMode(snap.repeat_mode);
+        // Device-side audio fields are unset (0) before the first
+        // stream opens; null'ing them out keeps the type honest so
+        // downstream UI can skip the "0 kHz" display.
+        setDeviceSampleRate(snap.sample_rate > 0 ? snap.sample_rate : null);
+        setDeviceChannels(snap.channels > 0 ? snap.channels : null);
         if (snap.current_track) {
           setCurrentTrack(queuePayloadToTrack(snap.current_track));
           setDurationMs(snap.current_track.duration_ms);
@@ -257,6 +271,23 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
             setCurrentTrack(queuePayloadToTrack(e.payload));
             setDurationMs(e.payload.duration_ms);
             setPositionMs(0);
+            // Refresh the device-side fields from the engine: WASAPI
+            // exclusive mode may have reopened the stream at the new
+            // track's native rate, and we want the AudioQualityFooter
+            // resampling arrow to reflect that without polling.
+            playerGetState()
+              .then((snap) => {
+                setDeviceSampleRate(
+                  snap.sample_rate > 0 ? snap.sample_rate : null,
+                );
+                setDeviceChannels(snap.channels > 0 ? snap.channels : null);
+              })
+              .catch((err) =>
+                console.error(
+                  "[PlayerContext] refresh device rate failed",
+                  err,
+                ),
+              );
           }),
         );
         unlisten.push(
@@ -643,6 +674,8 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         toggleMute,
         playbackSpeed,
         setPlaybackSpeed,
+        deviceSampleRate,
+        deviceChannels,
         isShuffled,
         toggleShuffle,
         repeatMode,

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -178,6 +178,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   // mode can re-open the device at the new track's native rate.
   const [deviceSampleRate, setDeviceSampleRate] = useState<number | null>(null);
   const [deviceChannels, setDeviceChannels] = useState<number | null>(null);
+  // Monotonic token for in-flight `playerGetState` refreshes triggered
+  // by `player:track-changed`. If the user fires three skips in a row,
+  // three snapshot fetches race; without the token an older snapshot
+  // resolving second would overwrite the newer one and stick a stale
+  // device rate into the UI until the next track change.
+  const deviceRefreshTokenRef = useRef(0);
 
   // Suppress incoming position events while the user drags the
   // progress bar, so the thumb doesn't fight the mouse.
@@ -274,20 +280,25 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
             // Refresh the device-side fields from the engine: WASAPI
             // exclusive mode may have reopened the stream at the new
             // track's native rate, and we want the AudioQualityFooter
-            // resampling arrow to reflect that without polling.
-            playerGetState()
-              .then((snap) => {
+            // resampling arrow to reflect that without polling. Token-
+            // guarded so a slow earlier snapshot can't overwrite a
+            // faster later one when the user rage-clicks `next`.
+            const reqToken = ++deviceRefreshTokenRef.current;
+            void (async () => {
+              try {
+                const snap = await playerGetState();
+                if (reqToken !== deviceRefreshTokenRef.current) return;
                 setDeviceSampleRate(
                   snap.sample_rate > 0 ? snap.sample_rate : null,
                 );
                 setDeviceChannels(snap.channels > 0 ? snap.channels : null);
-              })
-              .catch((err) =>
+              } catch (err) {
                 console.error(
                   "[PlayerContext] refresh device rate failed",
                   err,
-                ),
-              );
+                );
+              }
+            })();
           }),
         );
         unlisten.push(

--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -59,6 +59,12 @@ interface PlayerContextValue {
   playbackSpeed: number;
   setPlaybackSpeed: (value: number) => void;
 
+  // Live output-device fields, refreshed on every `player:track-changed`
+  // so WASAPI exclusive re-opens are reflected. Both are `null` before
+  // the first stream has opened; UI must skip the "0 kHz" display.
+  deviceSampleRate: number | null;
+  deviceChannels: number | null;
+
   // Shuffle / repeat are backend-synced via player_toggle_shuffle /
   // player_cycle_repeat. The UI flips optimistically and rolls back
   // on backend error.


### PR DESCRIPTION
## Why

The audio-quality footer below the player bar was showing only the source file's sample rate (`48 kHz · 256 kb/s · 6 Mo`). When the engine resampled to a different device rate the user had to hover the footer to discover it (via \`AudioPipelinePopover\`). Surfacing the conversion inline removes that round-trip — audiophiles can spot a non-bit-perfect chain at a glance.

## What's new

When source rate ≠ device rate the left chunk of the footer now renders an arrow:

| Situation                          | Left chunk                       |
|------------------------------------|----------------------------------|
| Bit-perfect (rates match)          | \`48 kHz · 256 kb/s · 6 Mo\`     |
| Resampling 48 → 44.1               | \`48 kHz → 44.1 kHz · 256 kb/s · 6 Mo\` |
| Resampling 96 → 48 (hi-res down)   | \`96 kHz → 48 kHz · 9.2 Mb/s · 95 Mo\`  |
| Device rate not yet known          | \`48 kHz · …\` (source only)     |

The arrow only renders when **both** rates are known and differ. The engine reports a sample rate of 0 before the first stream has opened (very brief window at app launch); during that window the footer falls back to the source rate alone rather than printing a misleading \`48 kHz → null\`.

## Wiring

- **PlayerContext** now tracks \`deviceSampleRate\` + \`deviceChannels\` (both \`number | null\`). Hydrated from \`player_get_state\` at provider mount, refreshed on every \`player:track-changed\` so WASAPI exclusive re-opens that match the new track's native rate are reflected within a frame.
- **\`usePlayer()\`** interface bumped with the two new fields, both nullable.
- **AudioQualityFooter** reads \`deviceSampleRate\` from \`usePlayer\` and composes the arrow when needed.

## Out of scope

\`AudioPipelinePopover\` already shows the full Source / Output breakdown on hover, so it doesn't need to change here — the popover continues to fetch a fresh engine snapshot on open.

## Test plan

- [x] \`bun run typecheck\` passes.
- [x] \`bun run lint\` passes for the touched files (pre-existing errors in \`secrets/validate-translations.mjs\` are unrelated).
- [x] Enable the audio-quality footer in Settings → Appearance → Player bar layout.
- [x] Play a 48 kHz track on a 44.1 kHz output → \`48 kHz → 44.1 kHz\` arrow appears.
- [x] Play a 44.1 kHz track on a 44.1 kHz output → no arrow, just \`44.1 kHz\`.
- [x] (Windows) Enable WASAPI exclusive mode, play a 96 kHz file → arrow shows \`96 kHz\` if the device re-opens at 96 kHz; otherwise shows the resampled target.
- [x] Open the popover on hover → Source + Output sections show consistent values with the arrow on the footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Mise à jour de la doc sur l’affichage de qualité audio pour décrire le rendu lors de resampling (comportement selon connaissance du taux de l’appareil).

* **Nouvelles fonctionnalités**
  * L’info-bandeau affiche “source → appareil” quand le taux de l’appareil est connu ; sinon, affiche la valeur source seule.
  * Les puces de traitement montrent désormais les conversions « de → vers » (taux et format/canaux) dans leurs libellés.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->