### PR TITLE
fix(lint): ignore secrets/ in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default tseslint.config(
       "waveflow-landing/**",
       "vscode-discord-rich-presence/**",
       "scripts/**",
+      "secrets/**",
       "**/*.config.ts",
       "**/*.config.js",
       "**/.commitlintrc.cjs",


### PR DESCRIPTION
## Summary

`secrets/` is gitignored (release keys + the OpenRouter `validate-translations.mjs` helper live there) but eslint was still scanning it, producing 14 `no-undef` errors on Node globals (`console`, `fetch`, `setTimeout`) every time `bun run lint` was run on a checkout where the script is present. Adding `secrets/**` to the ignore list mirrors how `scripts/` is already excluded.

## Test plan

- [x] `bun run lint` exits cleanly on a checkout that contains `secrets/validate-translations.mjs`.
- [x] `bun run lint` still flags real issues in `src/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Chores**
  * Mise à jour de la configuration ESLint pour ignorer les fichiers de secrets lors du linting du code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->