### PR TITLE
chore(deps): bump sqlx from 0.8.6 to 0.9.0

### DIFF
--- a/docs/features/smart-playlists.md
+++ b/docs/features/smart-playlists.md
@@ -87,17 +87,17 @@ HAVING play_count > 0
 
 Differences vs Daily Mix:
 
-- **Lookback is 30 days** (not 90) so the playlist reflects the *current* rotation, not last quarter's binges. Matches Spotify's On Repeat cadence.
+- **Lookback is 30 days** (not 90) so the playlist reflects the _current_ rotation, not last quarter's binges. Matches Spotify's On Repeat cadence.
 - **No shuffle** — the playlist is the top-N tracks in straight play-count order, so the user's #1 most-played song lands at the top. Deterministic by construction, no seed needed.
 - **No tempo bucketing** — On Repeat is a single playlist, not a 3-way split.
-- **Minimum 8 distinct tracks** in the window before anything is materialised. Below that the playlist would be "the same handful of songs you already listened to a lot" and adds nothing over the History view. A previously-materialised row is *deleted* when this guard kicks in so a stale playlist doesn't linger after a quiet month.
+- **Minimum 8 distinct tracks** in the window before anything is materialised. Below that the playlist would be "the same handful of songs you already listened to a lot" and adds nothing over the History view. A previously-materialised row is _deleted_ when this guard kicks in so a stale playlist doesn't linger after a quiet month.
 - **Position is fixed at 0** so the row sorts ahead of every Daily Mix slot in the Home carousel and the sidebar.
 
 ### Brand cover
 
 On Repeat doesn't use the album-art composite — its identity is a fixed visual rendered deterministically by [`cover::build_on_repeat_cover`](../../src-tauri/src/smart_playlists/cover.rs): a 640×640 JPEG with a deep indigo → royal violet diagonal gradient overlaid with two intersecting pink rings forming an infinity loop. Same bytes every regen → same blake3 hash → the cache dedupes against the existing file instead of piling up orphans. No text is rasterised into the image (the playlist name and "On Repeat" eyebrow are rendered by React on top of the tile), so the canvas stays locale-agnostic.
 
-Future per-track-art families (Release Radar, Recently Added) will resolve the *first track's artist image* instead — that's why [`generator::first_track_artwork_paths`](../../src-tauri/src/smart_playlists/generator.rs) is `pub(super)` even though On Repeat doesn't use it.
+Future per-track-art families (Release Radar, Recently Added) will resolve the _first track's artist image_ instead — that's why [`generator::first_track_artwork_paths`](../../src-tauri/src/smart_playlists/generator.rs) is `pub(super)` even though On Repeat doesn't use it.
 
 ## Regen flow
 

--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -180,11 +180,11 @@ The opt-in audio-quality footer ([`AudioQualityFooter`](../../src/components/pla
 
 [`HiResBadge`](../../src/components/common/HiResBadge.tsx) is the green pill that decorates track rows, album grid tiles, and the player-bar metadata when the source qualifies as Hi-Res (`isHiRes` — ≥ 24-bit, ≥ 44.1 kHz) or as DSD (`dsdLabel` returns `DSD64` / `DSD128` / …). Three variants:
 
-| Variant   | Used in                                                              | Style                                                                                                  |
-| --------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `overlay` | Album / artist grid covers (default).                                | Absolute-positioned pill in the cover's top-left corner with a drop shadow.                            |
-| `inline`  | TrackTable rows, sidebar lists.                                      | Inline rounded pill next to the title.                                                                 |
-| `text`    | Player bar — under the artist name.                                  | Spotify-style minimal green uppercase text, no pill background, blends into the metadata stack.        |
+| Variant   | Used in                               | Style                                                                                           |
+| --------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `overlay` | Album / artist grid covers (default). | Absolute-positioned pill in the cover's top-left corner with a drop shadow.                     |
+| `inline`  | TrackTable rows, sidebar lists.       | Inline rounded pill next to the title.                                                          |
+| `text`    | Player bar — under the artist name.   | Spotify-style minimal green uppercase text, no pill background, blends into the metadata stack. |
 
 All variants are gated by [`useHiResBadgeVisibility`](../../src/hooks/useHiResBadgeVisibility.ts), which reads `profile_setting['ui.show_hi_res_badge']` (default `true`) and re-reads on the `waveflow:hi-res-badge-visibility` window event. Settings → Appearance ships [`HiResBadgeCard`](../../src/components/views/settings/HiResBadgeCard.tsx) to flip the flag — when off, every mounted `HiResBadge` returns `null` in one render, including the player-bar text label. Per-profile so a kid's profile can hide the audiophile chrome while the audiophile profile keeps it.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -386,12 +386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +655,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +684,12 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cocoa"
@@ -734,12 +745,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -1012,6 +1017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,17 +1092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,9 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1149,8 +1150,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1427,13 +1429,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1535,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1878,6 +1879,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2061,9 +2063,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2074,11 +2085,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2107,29 +2118,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2717,9 +2719,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -2777,21 +2776,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2935,16 +2925,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "md-5"
@@ -3146,22 +3126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,24 +3161,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3618,7 +3570,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3634,15 +3586,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -3721,37 +3664,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -4035,33 +3951,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4076,21 +3982,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-window-handle"
@@ -4112,15 +4015,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4315,26 +4209,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4797,13 +4671,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4857,16 +4731,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4937,7 +4801,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4998,20 +4862,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5022,12 +4876,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -5037,12 +4892,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -5057,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5070,15 +4924,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck 0.5.0",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -5089,58 +4943,43 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5 0.10.6",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
  "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -5156,16 +4995,14 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "home",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5176,13 +5013,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -5192,7 +5030,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -6742,12 +6579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6872,7 +6703,7 @@ dependencies = [
  "libc",
  "lofty",
  "mac_address",
- "md-5 0.11.0",
+ "md-5",
  "notify",
  "quick-xml 0.40.1",
  "realfft",
@@ -7051,13 +6882,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -7315,15 +7142,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7371,21 +7189,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7456,12 +7259,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7480,12 +7277,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7501,12 +7292,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7540,12 +7325,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7561,12 +7340,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7588,12 +7361,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7609,12 +7376,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,7 +65,7 @@ tokio = { version = "1", features = ["full"] }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 
 # Database
-sqlx = { version = "0.8", features = [
+sqlx = { version = "0.9", features = [
     "runtime-tokio",
     "sqlite",
     "migrate",

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -299,7 +299,7 @@ pub async fn list_albums(
 "#
     );
 
-    let raw = sqlx::query_as::<_, AlbumRawRow>(&sql)
+    let raw = sqlx::query_as::<_, AlbumRawRow>(sqlx::AssertSqlSafe(sql))
         .bind(library_id)
         .bind(library_id)
         .bind(if no_cover { 1_i64 } else { 0_i64 })
@@ -383,7 +383,7 @@ pub async fn list_artists(
         "#
     );
 
-    let raw = sqlx::query_as::<_, ArtistRowRaw>(&sql)
+    let raw = sqlx::query_as::<_, ArtistRowRaw>(sqlx::AssertSqlSafe(sql))
         .bind(library_id)
         .bind(library_id)
         .fetch_all(&pool)

--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -427,7 +427,7 @@ async fn sync_db(pool: &SqlitePool, track_id: i64, edit: &TrackEdit) -> AppResul
 
     if !sets.is_empty() {
         let sql = format!("UPDATE track SET {} WHERE id = ?", sets.join(", "));
-        let mut q = sqlx::query(&sql);
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(sql));
         if let Some(t) = edit.title.as_ref() {
             q = q.bind(t.trim());
         }

--- a/src-tauri/src/commands/integration.rs
+++ b/src-tauri/src/commands/integration.rs
@@ -277,9 +277,7 @@ pub async fn set_discord_rpc_enabled(
 /// to `false` (off) when never configured — toast notifications are
 /// intrusive and we want explicit opt-in rather than silent spam.
 #[tauri::command]
-pub async fn get_notifications_track_change(
-    state: tauri::State<'_, AppState>,
-) -> AppResult<bool> {
+pub async fn get_notifications_track_change(state: tauri::State<'_, AppState>) -> AppResult<bool> {
     Ok(crate::notifications::read_enabled(&state.app_db).await)
 }
 

--- a/src-tauri/src/commands/radio.rs
+++ b/src-tauri/src/commands/radio.rs
@@ -222,7 +222,7 @@ async fn pick_candidate_tracks(
          LIMIT 200
         "#
     );
-    let mut q = sqlx::query_as::<_, TrackCandidate>(&sql);
+    let mut q = sqlx::query_as::<_, TrackCandidate>(sqlx::AssertSqlSafe(sql));
     for id in artist_ids {
         q = q.bind(*id);
     }
@@ -288,7 +288,7 @@ async fn cached_similar_library_ids(pool: &SqlitePool, seed_artist_id: i64) -> A
     let placeholders = canonicals.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let sql =
         format!("SELECT id, canonical_name FROM artist WHERE canonical_name IN ({placeholders})");
-    let mut q = sqlx::query_as::<_, (i64, String)>(&sql);
+    let mut q = sqlx::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(sql));
     for c in &canonicals {
         q = q.bind(c);
     }

--- a/src-tauri/src/commands/similar.rs
+++ b/src-tauri/src/commands/similar.rs
@@ -146,7 +146,7 @@ pub async fn get_similar_artists(
                LEFT JOIN app.metadata_artist ma ON ma.deezer_id = a.deezer_id
               WHERE a.canonical_name IN ({placeholders})"
         );
-        let mut q = sqlx::query_as::<_, (i64, String, Option<String>)>(&sql);
+        let mut q = sqlx::query_as::<_, (i64, String, Option<String>)>(sqlx::AssertSqlSafe(sql));
         for c in &canonicals {
             q = q.bind(c);
         }

--- a/src-tauri/src/commands/track.rs
+++ b/src-tauri/src/commands/track.rs
@@ -266,7 +266,7 @@ pub async fn list_tracks(
         "#
     );
 
-    let rows = sqlx::query_as::<_, TrackRow>(&sql)
+    let rows = sqlx::query_as::<_, TrackRow>(sqlx::AssertSqlSafe(sql))
         .bind(library_id)
         .bind(library_id)
         .fetch_all(&pool)
@@ -688,7 +688,7 @@ pub async fn search_tracks_advanced(
     }
     sql.push_str("LIMIT 200");
 
-    let mut q = sqlx::query_as::<_, TrackRow>(&sql);
+    let mut q = sqlx::query_as::<_, TrackRow>(sqlx::AssertSqlSafe(sql));
     for b in binds {
         q = match b {
             Bind::Str(s) => q.bind(s),

--- a/src-tauri/src/db/migration_heal.rs
+++ b/src-tauri/src/db/migration_heal.rs
@@ -83,7 +83,7 @@ pub async fn heal_line_ending_drift(pool: &SqlitePool, migrator: &Migrator) -> A
             continue;
         }
 
-        let sql_bytes = migration.sql.as_bytes();
+        let sql_bytes = migration.sql.as_str().as_bytes();
         let lf = normalize_to_lf(sql_bytes);
         let crlf = lf_to_crlf(&lf);
 

--- a/src-tauri/src/db/profile_db.rs
+++ b/src-tauri/src/db/profile_db.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
-    Executor, SqlitePool,
+    SqlitePool,
 };
 
 use crate::error::AppResult;
@@ -47,7 +47,7 @@ pub async fn open(path: &Path, app_db_path: &Path) -> AppResult<SqlitePool> {
                 let path_str = app_db_path_owned.to_string_lossy().into_owned();
                 let escaped = path_str.replace('\'', "''");
                 let stmt = format!("ATTACH DATABASE '{escaped}' AS app");
-                conn.execute(stmt.as_str()).await?;
+                sqlx::query(sqlx::AssertSqlSafe(stmt)).execute(&mut *conn).await?;
                 Ok(())
             })
         })

--- a/src-tauri/src/db/profile_db.rs
+++ b/src-tauri/src/db/profile_db.rs
@@ -47,7 +47,9 @@ pub async fn open(path: &Path, app_db_path: &Path) -> AppResult<SqlitePool> {
                 let path_str = app_db_path_owned.to_string_lossy().into_owned();
                 let escaped = path_str.replace('\'', "''");
                 let stmt = format!("ATTACH DATABASE '{escaped}' AS app");
-                sqlx::query(sqlx::AssertSqlSafe(stmt)).execute(&mut *conn).await?;
+                sqlx::query(sqlx::AssertSqlSafe(stmt))
+                    .execute(&mut *conn)
+                    .await?;
                 Ok(())
             })
         })

--- a/src-tauri/src/smart_playlists/cover.rs
+++ b/src-tauri/src/smart_playlists/cover.rs
@@ -130,8 +130,11 @@ fn render_on_repeat_canvas() -> RgbImage {
     const RING: [u8; 3] = [236, 72, 153]; // tailwind pink-500
     const RING_HIGHLIGHT: [u8; 3] = [244, 114, 182]; // tailwind pink-400
 
-    let mut canvas: RgbImage =
-        ImageBuffer::from_pixel(CANVAS_PX, CANVAS_PX, Rgb([TOP_LEFT[0] as u8, TOP_LEFT[1] as u8, TOP_LEFT[2] as u8]));
+    let mut canvas: RgbImage = ImageBuffer::from_pixel(
+        CANVAS_PX,
+        CANVAS_PX,
+        Rgb([TOP_LEFT[0] as u8, TOP_LEFT[1] as u8, TOP_LEFT[2] as u8]),
+    );
 
     // Diagonal background gradient — top-left → bottom-right.
     let max_d = ((CANVAS_PX - 1) as f32) * 2.0;

--- a/src-tauri/src/smart_playlists/custom.rs
+++ b/src-tauri/src/smart_playlists/custom.rs
@@ -489,7 +489,7 @@ pub async fn run_query(pool: &SqlitePool, rules: &CustomRules) -> AppResult<Vec<
     sql.push_str(" LIMIT ?");
     binds.push(BindValue::Int(limit));
 
-    let mut q = sqlx::query_scalar::<_, i64>(&sql);
+    let mut q = sqlx::query_scalar::<_, i64>(sqlx::AssertSqlSafe(sql));
     for b in binds {
         q = match b {
             BindValue::Int(v) => q.bind(v),

--- a/src-tauri/src/smart_playlists/generator.rs
+++ b/src-tauri/src/smart_playlists/generator.rs
@@ -344,7 +344,7 @@ async fn top_artists_with_bpm(
                 picture_hash: String,
             }
             let rows: Vec<PRow> = {
-                let mut q = sqlx::query_as::<_, PRow>(&sql);
+                let mut q = sqlx::query_as::<_, PRow>(sqlx::AssertSqlSafe(sql));
                 for id in &ids {
                     q = q.bind(*id);
                 }
@@ -413,7 +413,7 @@ pub(super) async fn first_track_artwork_paths(
         hash: String,
         format: String,
     }
-    let mut q = sqlx::query_as::<_, Row>(&sql);
+    let mut q = sqlx::query_as::<_, Row>(sqlx::AssertSqlSafe(sql));
     for id in track_ids {
         q = q.bind(*id);
     }
@@ -472,7 +472,7 @@ async fn pick_tracks_for_artists(
          LIMIT 200
         "#,
     );
-    let mut q = sqlx::query_as::<_, TrackPickRow>(&sql);
+    let mut q = sqlx::query_as::<_, TrackPickRow>(sqlx::AssertSqlSafe(sql));
     for id in artist_ids {
         q = q.bind(*id);
     }

--- a/src-tauri/src/smart_playlists/on_repeat.rs
+++ b/src-tauri/src/smart_playlists/on_repeat.rs
@@ -56,10 +56,7 @@ struct TrackPlayRow {
 /// profile id is not required here; future per-track-art families
 /// (Release Radar, Recently Added) will take a `profile_id` to resolve
 /// the active library's artwork cache.
-pub async fn regenerate_on_repeat(
-    pool: &SqlitePool,
-    paths: &AppPaths,
-) -> AppResult<Option<i64>> {
+pub async fn regenerate_on_repeat(pool: &SqlitePool, paths: &AppPaths) -> AppResult<Option<i64>> {
     let cutoff_ms = Utc::now().timestamp_millis() - (LOOKBACK_DAYS * 86_400_000);
     let tracks = top_played_tracks(pool, cutoff_ms).await?;
 

--- a/src/components/player/AudioPipelinePopover.tsx
+++ b/src/components/player/AudioPipelinePopover.tsx
@@ -2,10 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FileAudio, Cpu, Speaker, Sparkles } from "lucide-react";
 import type { QueueTrackPayload } from "../../lib/tauri/player";
-import {
-  playerGetAudioSettings,
-  playerGetState,
-} from "../../lib/tauri/player";
+import { playerGetAudioSettings, playerGetState } from "../../lib/tauri/player";
 import { playerGetEq } from "../../lib/tauri/eq";
 import { usePlayer } from "../../hooks/usePlayer";
 
@@ -174,7 +171,9 @@ export function AudioPipelinePopover({ track }: AudioPipelinePopoverProps) {
       // footer's `48 kHz → 44.1 kHz` arrow. Stripped of the unit on
       // the left side since the `kHz` suffix on the right reads for
       // both (matches the way audio devices are usually labelled).
-      label: `${t("playerBar.pipeline.chip.resample")} ${(track.sample_rate! / 1000)
+      label: `${t("playerBar.pipeline.chip.resample")} ${(
+        track.sample_rate! / 1000
+      )
         .toFixed(1)
         .replace(/\.0$/, "")} → ${formatSampleRate(snap!.outputSampleRate)}`,
       tone: "convert",
@@ -323,11 +322,7 @@ export function AudioPipelinePopover({ track }: AudioPipelinePopoverProps) {
           last thing the audiophile reads. */}
       {isBitPerfect && (
         <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 flex items-center gap-2">
-          <Sparkles
-            size={14}
-            className="text-emerald-500"
-            aria-hidden="true"
-          />
+          <Sparkles size={14} className="text-emerald-500" aria-hidden="true" />
           <span className="text-xs font-semibold text-emerald-600 dark:text-emerald-400">
             {t("playerBar.pipeline.bitPerfect")}
           </span>

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -2276,11 +2276,7 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
                 Not Disturb on every platform, opt-in only). */}
             <div className="flex items-center justify-between py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
               <div className="flex items-center space-x-4">
-                <Bell
-                  size={20}
-                  className="text-zinc-400"
-                  aria-hidden="true"
-                />
+                <Bell size={20} className="text-zinc-400" aria-hidden="true" />
                 <div>
                   <div className="text-sm font-medium text-zinc-900 dark:text-white">
                     {t("settings.integrations.notifications.title")}

--- a/src/components/views/settings/HiResBadgeCard.tsx
+++ b/src/components/views/settings/HiResBadgeCard.tsx
@@ -14,10 +14,7 @@ export function HiResBadgeCard() {
   const { visible, setVisible } = useHiResBadgeVisibility();
 
   return (
-    <section
-      aria-label={t("settings.hiResBadge.title")}
-      className="px-4 py-3"
-    >
+    <section aria-label={t("settings.hiResBadge.title")} className="px-4 py-3">
       <label className="flex items-start justify-between gap-3 cursor-pointer">
         <span className="flex items-start gap-3 min-w-0">
           <Sparkles

--- a/src/lib/tauri/playlist.ts
+++ b/src/lib/tauri/playlist.ts
@@ -58,7 +58,10 @@ export type SmartPlaylistKind =
 export function smartPlaylistKind(p: Playlist): SmartPlaylistKind {
   if (p.is_smart !== 1 || !p.smart_rules) return null;
   try {
-    const parsed = JSON.parse(p.smart_rules) as { kind?: string; slot?: number };
+    const parsed = JSON.parse(p.smart_rules) as {
+      kind?: string;
+      slot?: number;
+    };
     if (parsed.kind === "daily_mix" && typeof parsed.slot === "number") {
       return { kind: "daily_mix", slot: parsed.slot };
     }


### PR DESCRIPTION
## Summary
- Bumps `sqlx` from 0.8.6 → 0.9.0 in `src-tauri`.
- Migrates 12 dynamic-SQL call sites through `sqlx::AssertSqlSafe(...)` — sqlx 0.9 narrowed `query*()` to `impl SqlSafeStr` (only `&'static str` or `AssertSqlSafe`-wrapped owned strings) as a guard rail against `format!()`-built queries. All migrated sites build SQL from internal templates (whitelisted ORDER BY clauses, `?,?,?` placeholders), never from user input — `bind()` carries every dynamic value.
- Adapts `Migration::sql` (now `SqlStr`) in [`db::migration_heal`](src-tauri/src/db/migration_heal.rs) and the per-connection `ATTACH DATABASE` in [`db::profile_db`](src-tauri/src/db/profile_db.rs) which lost its `&str` leniency to the new `'static + Execute<'q>` bound.

Replaces #151 (Dependabot PR that did the version bump only, leaving 14 compile errors).

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` → 110 passed
- [x] CI green (Rust ubuntu + windows)
- [x] Manual smoke: launch app, switch profile, scan library, regenerate smart playlists (exercises every migrated query path + the ATTACH hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Mise à jour de la dépendance sqlx vers 0.9
  * Renforcement de la validation/sûreté des requêtes SQL côté application

* **Documentation**
  * Ajustements de mise en forme dans la doc des smart‑playlists et de l’UI

* **Style**
  * Plusieurs retouches de formatage et mise en forme du code sans changement fonctionnel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->