### PR TITLE
fix(queue-panel): let Up Next fill the available height

### DIFF
--- a/src/components/layout/QueuePanel.tsx
+++ b/src/components/layout/QueuePanel.tsx
@@ -212,9 +212,9 @@ export function QueuePanel() {
             </p>
           </div>
         ) : (
-          <div className="flex-1 overflow-y-auto -mx-2 px-2 space-y-5 scrollbar-hide">
+          <div className="flex-1 flex flex-col min-h-0 -mx-2 px-2 space-y-5">
             {snapshot?.source_type === "radio" && items[0] && (
-              <div className="flex items-center gap-3 p-3 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-100 dark:border-emerald-900/40">
+              <div className="shrink-0 flex items-center gap-3 p-3 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-100 dark:border-emerald-900/40">
                 <div className="shrink-0 w-9 h-9 rounded-full bg-emerald-500/15 flex items-center justify-center text-emerald-600 dark:text-emerald-400">
                   <Radio size={18} />
                 </div>
@@ -229,7 +229,7 @@ export function QueuePanel() {
               </div>
             )}
             {nowPlaying && (
-              <section>
+              <section className="shrink-0">
                 <div className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase mb-2 px-1">
                   {t("queue.nowPlaying")}
                 </div>
@@ -237,7 +237,7 @@ export function QueuePanel() {
               </section>
             )}
             {upNext.length > 0 && (
-              <section>
+              <section className="flex-1 flex flex-col min-h-0">
                 <div className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase mb-2 px-1">
                   {t("queue.upNext", { count: upNext.length })}
                 </div>
@@ -394,7 +394,7 @@ function SortableUpNext({
       <SortableContext items={ids} strategy={verticalListSortingStrategy}>
         <div
           ref={scrollRef}
-          className="max-h-[55vh] overflow-y-auto scrollbar-hide"
+          className="flex-1 min-h-0 overflow-y-auto scrollbar-hide"
         >
           <div
             style={{


### PR DESCRIPTION
## Summary

User flagged the play queue panel showing a wide empty band between the last visible row and the volume strip — most visible on 1080p+ displays. Root cause: the virtualized Up Next scroll container at [QueuePanel.tsx:397](src/components/layout/QueuePanel.tsx#L397) carried a `max-h-[55vh]` cap that truncated the list to ~55 % of the viewport regardless of how much vertical room the panel actually had.

Compounding issue: the parent content wrapper at line 215 also had `overflow-y-auto`, so the nested cap was producing **two independent scrollers** — the inner one maxed at 55vh, then continued scrolling engaged the outer one, with no visual cue that the user had crossed from one to the other.

## Fix

Restructured the inner column as a proper flex stack:
- Content wrapper switches from `overflow-y-auto` to `flex flex-col min-h-0` so its children flow as flex items.
- Radio banner + Now Playing section pin to their natural height via `shrink-0`.
- Up Next section becomes `flex-1 flex flex-col min-h-0`, and its inner virtualizer scroll element trades the `max-h-[55vh]` cap for `flex-1 min-h-0 overflow-y-auto` so it consumes everything left over after the eyebrow.

One scroller, fills the panel down to the volume strip, no truncation regardless of viewport size.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Manual smoke: open the queue panel on a 1080p+ display with a 100+ track queue → list should now extend to just above the volume strip; scrolling stays in a single scroller without crossing into a parent scroll context.
- [x] Manual smoke: shorter queue (~5 tracks) → list still hugs its content, no awkward expand.
- [x] DnD reorder still works (virtualization unchanged, only the scroll container sizing moved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations de l'interface**
  * Optimisation de la disposition et du défilement du panneau de file d'attente pour une meilleure utilisation de l'espace disponible.
  * Meilleure organisation visuelle des sections "En cours de lecture" et "À venir" pour une navigation plus fluide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->