### PR TITLE
fix(queue): manual additions stack in user queue, not at absolute end

### DIFF
--- a/docs/features/playback.md
+++ b/docs/features/playback.md
@@ -108,3 +108,11 @@ UI is a tri-state click cycle in [`AbLoopButton`](../../src/components/player/Ab
 ## Queue
 
 [`queue.rs`](../../src-tauri/src/queue.rs) — persistent SQLite-backed queue with shuffle (Fisher-Yates with seeded xorshift), repeat (off/all/one), auto-advance and drag-and-drop reorder. The frontend operates on a virtualised list so a 6000-track shuffle doesn't lock the UI.
+
+**User queue vs context tail.** Every `queue_item` carries a `source_type` (`'album'`, `'playlist'`, `'smart'`, `'manual'`, …). The Spotify-style split flows out of that flag:
+
+- `fill_queue` (Play album / Play playlist / Play smart) populates the queue with `source_type = 'album' | 'playlist' | …` from the current view.
+- `insert_after_current` (Play next, context-menu action) drops the picks at `current_index + 1` with `source_type = 'manual'` — pushes the rest of the queue down by N.
+- `append_to_user_queue` (Add to queue, context-menu action) finds the boundary `MIN(position) WHERE position > current AND source_type != 'manual'` — i.e. the first context-tail item — and inserts the new picks right before it with `source_type = 'manual'`. Falls back to `append` when the entire post-cursor tail is already manual (or there's nothing past the cursor), and to `fill_queue` when the queue is empty.
+
+Net effect matches Spotify's behaviour: the manual block stacks between Now Playing and the album / playlist tail. "Play next" pushes to the top of that block, "Add to queue" stacks at the bottom, and the album resumes once the user queue drains. No tracks get banished to the very end past the rest of the album any more.

--- a/src-tauri/src/commands/player.rs
+++ b/src-tauri/src/commands/player.rs
@@ -1555,9 +1555,12 @@ pub async fn player_reorder_queue(
     Ok(())
 }
 
-/// Append a list of tracks to the end of the playback queue without
-/// disturbing the current cursor. Used by the context menu's
-/// "Add to queue" action.
+/// Append a list of tracks to the **user queue** (the contiguous
+/// 'manual' block sitting between the current track and the context
+/// tail), without disturbing the current cursor. Mirrors Spotify's
+/// "Add to queue" — manual picks fire after Now Playing and before
+/// the album / playlist tail resumes, rather than being banished to
+/// the very end of the list.
 #[tauri::command]
 pub async fn player_add_to_queue(
     app: AppHandle,
@@ -1565,7 +1568,7 @@ pub async fn player_add_to_queue(
     track_ids: Vec<i64>,
 ) -> AppResult<()> {
     let pool = state.require_profile_pool().await?;
-    queue::append(&pool, &track_ids, "manual", None).await?;
+    queue::append_to_user_queue(&pool, &track_ids, None).await?;
     emit_queue_changed(&app);
     Ok(())
 }

--- a/src-tauri/src/queue.rs
+++ b/src-tauri/src/queue.rs
@@ -335,12 +335,59 @@ pub async fn append_to_user_queue(
     if track_ids.is_empty() {
         return Ok(());
     }
-    let len = queue_length(pool).await?;
+
+    // Single transaction wraps the boundary lookup AND the insert so the
+    // decision can't be invalidated between reads and writes by a
+    // concurrent advance / fill_queue / shuffle (SQLite WAL allows
+    // many readers but only one writer, and our reads were happening
+    // outside that single-writer envelope before this commit). Every
+    // SQL inside the function now runs against `&mut *tx`.
+    let mut tx = pool.begin().await?;
+    let now = Utc::now().timestamp_millis();
+
+    let len: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM queue_item")
+        .fetch_one(&mut *tx)
+        .await?;
+
+    // Empty queue — replicate `fill_queue` inline so it stays in the
+    // same tx. Same shape, just bound to "manual" since we know the
+    // origin.
     if len == 0 {
-        return fill_queue(pool, "manual", source_id, track_ids, 0).await;
+        for (pos, id) in track_ids.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO queue_item (track_id, position, source_type, source_id, added_at)
+                 VALUES (?, ?, 'manual', ?, ?)",
+            )
+            .bind(id)
+            .bind(pos as i64)
+            .bind(source_id)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+        }
+        sqlx::query(
+            "UPDATE profile_setting
+                SET value = ?, updated_at = ?
+              WHERE key = 'queue.current_index'",
+        )
+        .bind("0")
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM profile_setting WHERE key = 'queue.preshuffle'")
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        return Ok(());
     }
-    let current = read_setting_i64(pool, "queue.current_index")
-        .await?
+
+    let current_raw: Option<String> = sqlx::query_scalar(
+        "SELECT value FROM profile_setting WHERE key = 'queue.current_index'",
+    )
+    .fetch_optional(&mut *tx)
+    .await?;
+    let current = current_raw
+        .and_then(|s| s.parse::<i64>().ok())
         .unwrap_or(0)
         .clamp(0, len - 1);
 
@@ -350,47 +397,71 @@ pub async fn append_to_user_queue(
             AND source_type != 'manual'",
     )
     .bind(current)
-    .fetch_one(pool)
+    .fetch_one(&mut *tx)
     .await?;
 
+    // NULL boundary = no context tail past the cursor (entire tail is
+    // already manual, or current is at the very end). Same end shape as
+    // `append`: drop the new rows at MAX(position) + 1.
     let insert_at = match boundary {
         Some(p) => p,
-        None => return append(pool, track_ids, "manual", source_id).await,
+        None => {
+            let max_pos: Option<i64> = sqlx::query_scalar("SELECT MAX(position) FROM queue_item")
+                .fetch_one(&mut *tx)
+                .await?;
+            max_pos.map(|p| p + 1).unwrap_or(0)
+        }
     };
+    let needs_shift = boundary.is_some();
 
     let count = track_ids.len() as i64;
-    let mut tx = pool.begin().await?;
 
-    // Park-shift detour — same trick as `insert_after_current`. SQLite
-    // checks UNIQUE(position) per row so a direct `position + N`
-    // collides mid-update; bump the affected rows to a high range, then
-    // bring them back down past the freshly inserted block.
-    const OFFSET: i64 = 10_000_000;
-    sqlx::query("UPDATE queue_item SET position = position + ? WHERE position >= ?")
-        .bind(OFFSET)
-        .bind(insert_at)
-        .execute(&mut *tx)
-        .await?;
+    if needs_shift {
+        // Park-shift detour — same trick as `insert_after_current`.
+        // SQLite checks UNIQUE(position) per row so a direct
+        // `position + N` collides mid-update; bump the affected rows
+        // to a high range, then bring them back down past the freshly
+        // inserted block.
+        const OFFSET: i64 = 10_000_000;
+        sqlx::query("UPDATE queue_item SET position = position + ? WHERE position >= ?")
+            .bind(OFFSET)
+            .bind(insert_at)
+            .execute(&mut *tx)
+            .await?;
 
-    let now = Utc::now().timestamp_millis();
-    for (offset, id) in track_ids.iter().enumerate() {
-        sqlx::query(
-            "INSERT INTO queue_item (track_id, position, source_type, source_id, added_at)
-             VALUES (?, ?, 'manual', ?, ?)",
-        )
-        .bind(id)
-        .bind(insert_at + offset as i64)
-        .bind(source_id)
-        .bind(now)
-        .execute(&mut *tx)
-        .await?;
+        for (offset, id) in track_ids.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO queue_item (track_id, position, source_type, source_id, added_at)
+                 VALUES (?, ?, 'manual', ?, ?)",
+            )
+            .bind(id)
+            .bind(insert_at + offset as i64)
+            .bind(source_id)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+        }
+        sqlx::query("UPDATE queue_item SET position = position - ? + ? WHERE position >= ?")
+            .bind(OFFSET)
+            .bind(count)
+            .bind(insert_at + OFFSET)
+            .execute(&mut *tx)
+            .await?;
+    } else {
+        // No shift needed — append directly past the last row.
+        for (offset, id) in track_ids.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO queue_item (track_id, position, source_type, source_id, added_at)
+                 VALUES (?, ?, 'manual', ?, ?)",
+            )
+            .bind(id)
+            .bind(insert_at + offset as i64)
+            .bind(source_id)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+        }
     }
-    sqlx::query("UPDATE queue_item SET position = position - ? + ? WHERE position >= ?")
-        .bind(OFFSET)
-        .bind(count)
-        .bind(insert_at + OFFSET)
-        .execute(&mut *tx)
-        .await?;
 
     sqlx::query("DELETE FROM profile_setting WHERE key = 'queue.preshuffle'")
         .execute(&mut *tx)

--- a/src-tauri/src/queue.rs
+++ b/src-tauri/src/queue.rs
@@ -312,6 +312,93 @@ pub async fn append(
     Ok(())
 }
 
+/// Append `track_ids` to the **user queue** — the contiguous block of
+/// `source_type = 'manual'` items sitting between the current track
+/// and the context tail (whatever album / playlist / smart-playlist
+/// fill seeded the queue). Matches Spotify semantics: "Add to queue"
+/// stacks tracks at the *bottom* of the user queue, not at the
+/// absolute end past every remaining album track, so the user can
+/// keep playing the album they started while their manual picks fire
+/// one by one in between.
+///
+/// Boundary = `MIN(position)` among items past the current cursor
+/// whose `source_type != 'manual'`. NULL boundary means the entire
+/// tail is already manual (or there's nothing past the cursor) — that
+/// degenerates into [`append`]. Empty queue still degenerates into
+/// [`fill_queue`] so the first "Add to queue" click on a fresh
+/// session starts playback.
+pub async fn append_to_user_queue(
+    pool: &SqlitePool,
+    track_ids: &[i64],
+    source_id: Option<i64>,
+) -> AppResult<()> {
+    if track_ids.is_empty() {
+        return Ok(());
+    }
+    let len = queue_length(pool).await?;
+    if len == 0 {
+        return fill_queue(pool, "manual", source_id, track_ids, 0).await;
+    }
+    let current = read_setting_i64(pool, "queue.current_index")
+        .await?
+        .unwrap_or(0)
+        .clamp(0, len - 1);
+
+    let boundary: Option<i64> = sqlx::query_scalar(
+        "SELECT MIN(position) FROM queue_item
+          WHERE position > ?
+            AND source_type != 'manual'",
+    )
+    .bind(current)
+    .fetch_one(pool)
+    .await?;
+
+    let insert_at = match boundary {
+        Some(p) => p,
+        None => return append(pool, track_ids, "manual", source_id).await,
+    };
+
+    let count = track_ids.len() as i64;
+    let mut tx = pool.begin().await?;
+
+    // Park-shift detour — same trick as `insert_after_current`. SQLite
+    // checks UNIQUE(position) per row so a direct `position + N`
+    // collides mid-update; bump the affected rows to a high range, then
+    // bring them back down past the freshly inserted block.
+    const OFFSET: i64 = 10_000_000;
+    sqlx::query("UPDATE queue_item SET position = position + ? WHERE position >= ?")
+        .bind(OFFSET)
+        .bind(insert_at)
+        .execute(&mut *tx)
+        .await?;
+
+    let now = Utc::now().timestamp_millis();
+    for (offset, id) in track_ids.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO queue_item (track_id, position, source_type, source_id, added_at)
+             VALUES (?, ?, 'manual', ?, ?)",
+        )
+        .bind(id)
+        .bind(insert_at + offset as i64)
+        .bind(source_id)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+    }
+    sqlx::query("UPDATE queue_item SET position = position - ? + ? WHERE position >= ?")
+        .bind(OFFSET)
+        .bind(count)
+        .bind(insert_at + OFFSET)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("DELETE FROM profile_setting WHERE key = 'queue.preshuffle'")
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
 /// Insert `track_ids` immediately after the current cursor position.
 /// Existing items past the cursor are pushed down to keep the queue
 /// dense. Returns nothing — the cursor itself doesn't move so the


### PR DESCRIPTION
## Summary

User flagged that "Add to queue" was dropping tracks at the **bottom of the entire queue** — behind every remaining album / playlist track. Watching what you actually queued meant scrolling past 100+ context tracks, and the picks fired in the wrong order relative to "Play next" (which already inserts at current+1).

Carve out a real "user queue" block, Spotify-style: the contiguous `source_type = 'manual'` rows sitting between the current track and the context tail.

## How

The `queue_item` table already carries a `source_type` column populated by every queue-building path (`'album'` from Play album, `'playlist'` from Play playlist, `'manual'` from the two context-menu actions). New helper [`queue::append_to_user_queue`](src-tauri/src/queue.rs) walks that flag:

```sql
SELECT MIN(position) FROM queue_item
 WHERE position > :current
   AND source_type != 'manual'
```

Result = start of the context tail. Insert the picks immediately before it (push the tail down by N, park-shift detour for SQLite's `UNIQUE(position)`). When the query returns NULL — entire tail is already manual, or current is at the last slot — degenerate into `append`. When the queue is empty, degenerate into `fill_queue` so the first "Add to queue" on a fresh session still starts playback.

`player_add_to_queue` switched to the new helper. "Play next" semantics unchanged — `insert_after_current` already pushes to current+1, i.e. the top of the user queue.

## End state

```
[…ctx_played, ctx_current (NOW PLAYING),
   manual_play_next_N, manual_play_next_N-1, …, manual_play_next_1,  ← user queue: Play-next stacked on top
   manual_add_1, manual_add_2, …, manual_add_M,                       ← user queue: Add-to-queue stacked at bottom
 ctx_next, ctx_after, …]                                              ← context tail resumes after user queue drains
```

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo test --lib queue` → 2/2 passed (only pure-fn coverage exists for queue.rs, matches the rest of the codebase's no-SQL-integration-tests convention)
- [x] Manual smoke (golden path):
  1. Play an album (12 tracks, on track 3)
  2. "Add to queue" track X → X lands at position 4 (right after track 3), context shifts to 5+
  3. "Add to queue" track Y → Y lands at position 5 (after X), context shifts to 6+
  4. "Play next" track Z → Z lands at position 4 (between current and X), X/Y shift to 5/6, context to 7+
  5. Let auto-advance run → playback order is `track 3 → Z → X → Y → track 4 → track 5 → …`
- [x] Manual smoke (edge cases):
  - Empty queue + "Add to queue" → fills queue and starts playback at track 0
  - All-manual queue + "Add to queue" → appends at end (no context tail to insert before)
  - Current at last position + "Add to queue" → appends at end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * L’action d’« ajouter à la file » place désormais les morceaux dans une zone dédiée entre la piste en cours et le contenu de l’album/playlist (comportement aligné sur Spotify), sans perturber la position de lecture actuelle.
* **Documentation**
  * Ajout d’une documentation détaillée expliquant la logique de la file d’attente utilisateur, le marquage des entrées et les cas de placement/recouvrement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->