### PR TITLE
fix(lyrics): restore spacing between word-synced lyric tokens

### DIFF
--- a/src/components/layout/LyricsPanel.tsx
+++ b/src/components/layout/LyricsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
@@ -274,27 +274,38 @@ export function LyricsPanel() {
                       {hasWords ? (
                         <span>
                           {line.words!.map((word, wi) => (
-                            <span
-                              key={wi}
-                              className={
-                                wi === activeWordIndex
-                                  ? "text-pink-500 dark:text-pink-400"
-                                  : wi < activeWordIndex
-                                    ? ""
-                                    : "opacity-60"
-                              }
-                              style={{
-                                display: "inline-block",
-                                transform:
+                            // See FullscreenLyrics for the rationale:
+                            // `inline-block` strips the JSX whitespace
+                            // that would normally separate inline
+                            // siblings, and many Enhanced LRC sources
+                            // omit spaces between word stamps. A literal
+                            // `" "` text node restores the gap; if the
+                            // source did carry trailing whitespace in
+                            // `word.text`, `white-space: normal`
+                            // collapses the pair to one.
+                            <Fragment key={wi}>
+                              <span
+                                className={
                                   wi === activeWordIndex
-                                    ? "scale(1.04)"
-                                    : "scale(1)",
-                                transition:
-                                  "color 150ms ease, opacity 150ms ease, transform 150ms ease",
-                              }}
-                            >
-                              {word.text}
-                            </span>
+                                    ? "text-pink-500 dark:text-pink-400"
+                                    : wi < activeWordIndex
+                                      ? ""
+                                      : "opacity-60"
+                                }
+                                style={{
+                                  display: "inline-block",
+                                  transform:
+                                    wi === activeWordIndex
+                                      ? "scale(1.04)"
+                                      : "scale(1)",
+                                  transition:
+                                    "color 150ms ease, opacity 150ms ease, transform 150ms ease",
+                                }}
+                              >
+                                {word.text}
+                              </span>
+                              {wi < line.words!.length - 1 && " "}
+                            </Fragment>
                           ))}
                         </span>
                       ) : (

--- a/src/components/player/FullscreenLyrics.tsx
+++ b/src/components/player/FullscreenLyrics.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { Fragment, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { X, Music2, Maximize2 } from "lucide-react";
 import { Artwork } from "../common/Artwork";
@@ -217,27 +217,40 @@ export function FullscreenLyrics({
                                   : wi < activeWordIndex
                                     ? "past"
                                     : "future";
+                              // Render a literal space between adjacent
+                              // word boxes. `display: inline-block` strips
+                              // the JSX whitespace that would normally
+                              // separate inline siblings, and many
+                              // Enhanced LRC sources omit spaces between
+                              // word stamps (`<wt>Meet<wt>me<wt>in…`),
+                              // so without this the active line collapses
+                              // to "Meetmeinthecrowd". If the source did
+                              // include trailing space inside `word.text`,
+                              // `white-space: normal` collapses the pair
+                              // back to one.
                               return (
-                                <span
-                                  key={wi}
-                                  style={{
-                                    opacity:
-                                      wState === "active"
-                                        ? 1
-                                        : wState === "past"
-                                          ? 0.8
-                                          : 0.45,
-                                    transform:
-                                      wState === "active"
-                                        ? "scale(1.04)"
-                                        : "scale(1)",
-                                    display: "inline-block",
-                                    transition:
-                                      "opacity 150ms ease, transform 150ms ease",
-                                  }}
-                                >
-                                  {word.text}
-                                </span>
+                                <Fragment key={wi}>
+                                  <span
+                                    style={{
+                                      opacity:
+                                        wState === "active"
+                                          ? 1
+                                          : wState === "past"
+                                            ? 0.8
+                                            : 0.45,
+                                      transform:
+                                        wState === "active"
+                                          ? "scale(1.04)"
+                                          : "scale(1)",
+                                      display: "inline-block",
+                                      transition:
+                                        "opacity 150ms ease, transform 150ms ease",
+                                    }}
+                                  >
+                                    {word.text}
+                                  </span>
+                                  {wi < line.words!.length - 1 && " "}
+                                </Fragment>
                               );
                             })}
                           </span>


### PR DESCRIPTION
## Bug

On a track with Enhanced LRC word-level timestamps, the **active** line collapsed into a single run with no spaces between words:

> "Meet me in the crowd, people, people" → \`Meetmeinthecrowd,people,people\`

Other lines on the same track render correctly because they only paint when not active.

## Cause

Two ingredients combined:

1. Each word in the active line is rendered as its own \`display: inline-block\` \`<span>\` so the per-word karaoke highlight can independently animate scale + opacity. Inline-block siblings don't carry JSX-level whitespace — \`<span>a</span><span>b</span>\` renders as \`ab\`.
2. Many Enhanced LRC sources omit spaces between word stamps (\`<00:01>Meet<00:02>me<00:03>in…\`), so the parser's \`body.slice(start, end)\` yields word texts with no inner whitespace either.

Non-active lines escape both because they fall through to \`line.text\` (already space-joined by the parser).

## Fix

Wrap each word \`<span>\` in a \`Fragment\` with a literal \`" "\` text node when it isn't the last. The text node provides the inter-box gap; if the source DID carry trailing whitespace in \`word.text\`, \`white-space: normal\` collapses the pair back to one space. Same idiom applied identically in [FullscreenLyrics](src/components/player/FullscreenLyrics.tsx) and [LyricsPanel](src/components/layout/LyricsPanel.tsx).

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun run lint\`
- [x] Play a track with Enhanced LRC: active line shows spaces between words
- [x] Same track in side LyricsPanel: same result
- [x] Plain LRC track still renders unchanged (no word stamps → same code path as before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Corrections de bogues**
  * Correction de l'espacement entre les mots dans l'affichage des paroles synchronisées et en mode karaoké. Les mots sont maintenant correctement espacés pour une meilleure lisibilité. Cette amélioration concerne aussi bien les paroles en temps réel que le mode karaoké, offrant une expérience visuelle plus claire et plus agréable à la lecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->