### PR TITLE
docs(readme): cap Wrapped screenshot via height attribute (GitHub strips style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ WaveFlow is a local music player desktop app with a Spotify-inspired 3-panel UI.
   </tr>
   <tr>
     <td width="50%"><img src="docs/screenshots/karaoke-lyrics.png" alt="Apple Music style fullscreen karaoke lyrics" /></td>
-    <td width="50%" align="center"><img src="docs/screenshots/wrapped.png" alt="WaveFlow Wrapped year-in-review with top tracks, average tempo and longest streak" style="max-height: 520px; width: auto;" /></td>
+    <td width="50%" align="center"><img src="docs/screenshots/wrapped.png" alt="WaveFlow Wrapped year-in-review with top tracks, average tempo and longest streak" height="380" /></td>
   </tr>
   <tr>
     <td align="center"><sub><b>Karaoke lyrics</b> · Apple-Music-style word-level highlight with click-to-seek</sub></td>


### PR DESCRIPTION
Follow-up to #161.

GitHub's markdown sanitizer drops inline `style` attributes (`max-height: 520px; width: auto;` from the merged version), so the portrait Wrapped capture rendered at its natural massive size next to the landscape Karaoke-lyrics tile.

Switching to the HTML `height` attribute (allowlisted by GitHub) — `height="380"` — gives the browser one fixed dimension, which it pairs with the natural aspect ratio to bring the Wrapped tile in line with its row partner.

## Test plan

- [ ] Refresh the README on the PR's Files tab — Wrapped tile should render at roughly the same height as the Karaoke-lyrics tile, centered in its cell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Documentation**
  * Amélioration de la présentation des images dans la documentation pour une meilleure lisibilité.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->