### PR TITLE
fix: 1.4.0 release blockers (Jo-El bugs #166, #170, #172)

### DIFF
--- a/src-tauri/crates/app/src/commands/browse.rs
+++ b/src-tauri/crates/app/src/commands/browse.rs
@@ -264,7 +264,6 @@ fn artist_order_clause(order_by: Option<&str>, direction: Option<&str>) -> &'sta
 pub async fn list_albums(
     state: tauri::State<'_, AppState>,
     library_id: Option<i64>,
-    filter_no_cover: Option<bool>,
     order_by: Option<String>,
     direction: Option<String>,
 ) -> AppResult<ListAlbumsResponse> {
@@ -272,7 +271,6 @@ pub async fn list_albums(
     let profile_id = state.require_profile_id().await?;
     let artwork_dir = state.paths.profile_artwork_dir(profile_id);
 
-    let no_cover = filter_no_cover.unwrap_or(false);
     let order_clause = album_order_clause(order_by.as_deref(), direction.as_deref());
 
     let sql = format!(
@@ -293,7 +291,6 @@ pub async fn list_albums(
           LEFT JOIN artwork aw ON aw.id = al.artwork_id
          WHERE (? IS NULL OR t.library_id = ?)
            AND t.is_available = 1
-           AND (? = 0 OR al.artwork_id IS NULL)
          GROUP BY al.id
          {order_clause}
 "#
@@ -302,7 +299,6 @@ pub async fn list_albums(
     let raw = sqlx::query_as::<_, AlbumRawRow>(sqlx::AssertSqlSafe(sql))
         .bind(library_id)
         .bind(library_id)
-        .bind(if no_cover { 1_i64 } else { 0_i64 })
         .fetch_all(&pool)
         .await?;
 

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -1132,8 +1132,11 @@ pub async fn player_set_gapless(
 
 /// Snapshot returned by `player_get_eq` so the Settings view can
 /// hydrate the curve + bypass + preset dropdown without three
-/// round-trips.
-#[derive(Debug, serde::Serialize)]
+/// round-trips. Also broadcast verbatim on `player:eq` after every
+/// mutation so the popup + Settings stay in sync when both are open
+/// (issue #166 — turning the EQ on from the player-bar popup left the
+/// Settings card showing "off" until it was re-mounted).
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct EqSnapshot {
     pub enabled: bool,
     pub bands_db: Vec<f32>,
@@ -1142,16 +1145,17 @@ pub struct EqSnapshot {
     pub presets: Vec<EqPresetEntry>,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct EqPresetEntry {
     pub key: String,
     pub gains: Vec<f32>,
 }
 
-#[tauri::command]
-pub async fn player_get_eq(engine: tauri::State<'_, Arc<AudioEngine>>) -> AppResult<EqSnapshot> {
+/// Build the same payload `player_get_eq` returns so the setters can
+/// emit it on `player:eq`. Reading is lock-free (atomic loads) so
+/// taking a fresh snapshot per mutation is cheap.
+fn build_eq_snapshot(engine: &AudioEngine) -> EqSnapshot {
     let eq = &engine.shared().eq;
-    let bands = eq.read_bands_db().to_vec();
     let presets = crate::audio::eq::PRESETS
         .iter()
         .map(|(k, g)| EqPresetEntry {
@@ -1159,28 +1163,44 @@ pub async fn player_get_eq(engine: tauri::State<'_, Arc<AudioEngine>>) -> AppRes
             gains: g.to_vec(),
         })
         .collect();
-    Ok(EqSnapshot {
+    EqSnapshot {
         enabled: eq.is_enabled(),
-        bands_db: bands,
+        bands_db: eq.read_bands_db().to_vec(),
         band_freqs: crate::audio::eq::BAND_FREQS.to_vec(),
         max_gain_db: crate::audio::eq::MAX_GAIN_DB,
         presets,
-    })
+    }
+}
+
+/// Fire `player:eq` so every mounted EQ surface (Settings card +
+/// player-bar popup) refreshes from the same snapshot. Errors are
+/// silently dropped — emit only fails when the app is shutting down,
+/// at which point a stale UI is irrelevant.
+fn emit_eq(app: &AppHandle, engine: &AudioEngine) {
+    let _ = app.emit("player:eq", build_eq_snapshot(engine));
+}
+
+#[tauri::command]
+pub async fn player_get_eq(engine: tauri::State<'_, Arc<AudioEngine>>) -> AppResult<EqSnapshot> {
+    Ok(build_eq_snapshot(&engine))
 }
 
 #[tauri::command]
 pub async fn player_set_eq_enabled(
+    app: AppHandle,
     state: tauri::State<'_, AppState>,
     engine: tauri::State<'_, Arc<AudioEngine>>,
     enabled: bool,
 ) -> AppResult<()> {
     engine.shared().eq.set_enabled(enabled);
     persist_eq(&state, engine.shared()).await;
+    emit_eq(&app, &engine);
     Ok(())
 }
 
 #[tauri::command]
 pub async fn player_set_eq_band(
+    app: AppHandle,
     state: tauri::State<'_, AppState>,
     engine: tauri::State<'_, Arc<AudioEngine>>,
     index: usize,
@@ -1188,11 +1208,13 @@ pub async fn player_set_eq_band(
 ) -> AppResult<()> {
     engine.shared().eq.set_band_db(index, gain_db);
     persist_eq(&state, engine.shared()).await;
+    emit_eq(&app, &engine);
     Ok(())
 }
 
 #[tauri::command]
 pub async fn player_set_eq_preset(
+    app: AppHandle,
     state: tauri::State<'_, AppState>,
     engine: tauri::State<'_, Arc<AudioEngine>>,
     preset_key: String,
@@ -1200,6 +1222,7 @@ pub async fn player_set_eq_preset(
     if let Some(gains) = crate::audio::eq::preset_gains(&preset_key) {
         engine.shared().eq.set_all_bands_db(&gains);
         persist_eq(&state, engine.shared()).await;
+        emit_eq(&app, &engine);
     }
     Ok(())
 }

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -1219,11 +1219,14 @@ pub async fn player_set_eq_preset(
     engine: tauri::State<'_, Arc<AudioEngine>>,
     preset_key: String,
 ) -> AppResult<()> {
-    if let Some(gains) = crate::audio::eq::preset_gains(&preset_key) {
-        engine.shared().eq.set_all_bands_db(&gains);
-        persist_eq(&state, engine.shared()).await;
-        emit_eq(&app, &engine);
-    }
+    let Some(gains) = crate::audio::eq::preset_gains(&preset_key) else {
+        return Err(AppError::Other(format!(
+            "unknown EQ preset: {preset_key}"
+        )));
+    };
+    engine.shared().eq.set_all_bands_db(&gains);
+    persist_eq(&state, engine.shared()).await;
+    emit_eq(&app, &engine);
     Ok(())
 }
 

--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -522,7 +522,7 @@ export function LyricsEditorModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="lyrics-editor-title"
-        className="relative bg-white dark:bg-surface-dark-elevated text-zinc-900 dark:text-zinc-100 rounded-3xl border border-zinc-200 dark:border-zinc-800 shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col overflow-hidden"
+        className="relative bg-white dark:bg-surface-dark-elevated text-zinc-900 dark:text-zinc-100 rounded-3xl border border-zinc-200 dark:border-zinc-800 shadow-2xl w-full max-w-3xl max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-800">
@@ -563,14 +563,20 @@ export function LyricsEditorModal({
           />
         </div>
 
-        {/* Body */}
-        <div className="flex-1 overflow-y-auto p-6 min-h-75">
+        {/* Body — flex-1 so it absorbs the leftover height between the
+            header/tabs and the footer (and the synced controls when
+            visible) without ever pushing the action bar off-screen.
+            Plain-mode textarea fills the body via `h-full`; in synced
+            mode the row list scrolls inside this same scroll container.
+            See #172 — a fixed `h-[50vh]` here hid the footer on 1080p
+            + Windows display scaling. */}
+        <div className="flex-1 min-h-0 overflow-y-auto p-6">
           {mode === "plain" ? (
             <textarea
               value={plainText}
               onChange={(e) => setPlainText(e.target.value)}
               placeholder={t("lyricsEditor.plainPlaceholder")}
-              className="w-full h-[50vh] resize-none rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 p-4 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-pink-500"
+              className="w-full h-full min-h-48 resize-none rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 p-4 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-pink-500"
             />
           ) : (
             <>

--- a/src/components/player/EqPresetButton.tsx
+++ b/src/components/player/EqPresetButton.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { SlidersHorizontal, Check, ChevronDown } from "lucide-react";
 import {
   playerGetEq,
+  playerOnEq,
   playerSetEqEnabled,
   playerSetEqPreset,
   type EqPresetEntry,
@@ -132,7 +133,12 @@ export function EqPresetPanel({
   // until the user clicks the current-preset row to expand it.
   const [listExpanded, setListExpanded] = useState(false);
 
+  // Mount-time hydrate + live `player:eq` subscription so the popup
+  // stays in lockstep with the Settings EQ card (and the next time the
+  // popup re-opens, the toggle reflects whatever the user did in
+  // Settings while it was closed). See #166.
   useEffect(() => {
+    let unlisten: (() => void) | null = null;
     let cancelled = false;
     playerGetEq()
       .then((snap) => {
@@ -142,8 +148,23 @@ export function EqPresetPanel({
         setBands(snap.bands_db);
       })
       .catch((err) => console.error("[EqPresetPanel] hydrate failed", err));
+    playerOnEq((snap) => {
+      if (cancelled) return;
+      setEnabled(snap.enabled);
+      setPresets(snap.presets);
+      setBands(snap.bands_db);
+    })
+      .then((un) => {
+        if (cancelled) {
+          un();
+          return;
+        }
+        unlisten = un;
+      })
+      .catch((err) => console.error("[EqPresetPanel] listen failed", err));
     return () => {
       cancelled = true;
+      unlisten?.();
     };
   }, []);
 
@@ -204,9 +225,14 @@ export function EqPresetPanel({
           enabled ? "bg-emerald-500" : "bg-zinc-300 dark:bg-zinc-700"
         }`}
       >
+        {/* Anchor the thumb with `left:` (not `translate-x:`) so the OFF
+            and ON positions are symmetric around the track edges — see
+            #166 where `translate-x-0.5` left the thumb visually drifted
+            in the OFF state on Windows. Mirrors the Settings
+            ToggleSwitch pattern. */}
         <span
-          className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
-            enabled ? "translate-x-4" : "translate-x-0.5"
+          className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all ${
+            enabled ? "left-[calc(100%-1.125rem)]" : "left-0.5"
           }`}
         />
       </button>

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -23,7 +23,6 @@ import {
   EyeOff,
   Trash2,
   ImageIcon,
-  ImageOff,
   ArrowUpDown,
   ArrowDown,
   ArrowUp,
@@ -181,7 +180,6 @@ export function LibraryView({
     dossiers: true,
   });
   const [tracksView, setTracksView] = useState<TracksView>("list");
-  const [albumsNoCoverFilter, setAlbumsNoCoverFilter] = useState(false);
   const [likedIds, setLikedIds] = useState<Set<number>>(new Set());
   const selection = useMultiSelect<Track>();
   const EmptyIcon = emptyStateIcons[activeTab];
@@ -285,7 +283,6 @@ export function LibraryView({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading((p) => ({ ...p, albums: true }));
     listAlbums(null, {
-      filterNoCover: albumsNoCoverFilter,
       orderBy: albumsSort.sort.orderBy,
       direction: albumsSort.sort.direction,
     })
@@ -305,7 +302,6 @@ export function LibraryView({
     librariesSignature,
     albumsSort.isLoaded,
     albumsSort.sort,
-    albumsNoCoverFilter,
     coverReloadKey,
     editRefetch,
   ]);
@@ -648,28 +644,6 @@ export function LibraryView({
           {activeTab === "albums" && (
             <>
               <div className="flex items-center justify-end space-x-3 -mt-4">
-                {/* Filter to ONLY albums missing artwork (so the user can
-                    bulk-fix them via "Récupérer toutes les pochettes
-                    manquantes" or per-album Deezer search). The label
-                    plus icon plus tooltip together make the direction
-                    of the filter explicit — see #170 where "No cover"
-                    on its own read as "hide no-cover albums". */}
-                <label
-                  className="inline-flex items-center space-x-2 cursor-pointer select-none text-sm text-zinc-600 dark:text-zinc-300"
-                  title={t("library.noCoverTooltip")}
-                >
-                  <input
-                    type="checkbox"
-                    checked={albumsNoCoverFilter}
-                    onChange={(e) => setAlbumsNoCoverFilter(e.target.checked)}
-                    className="accent-emerald-500"
-                    aria-describedby="albums-no-cover-tooltip"
-                  />
-                  <ImageOff size={14} aria-hidden="true" />
-                  <span id="albums-no-cover-tooltip">
-                    {t("library.noCover")}
-                  </span>
-                </label>
                 <SortDropdown
                   options={albumSortOptions(t)}
                   current={albumsSort.sort}

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -23,6 +23,7 @@ import {
   EyeOff,
   Trash2,
   ImageIcon,
+  ImageOff,
   ArrowUpDown,
   ArrowDown,
   ArrowUp,
@@ -647,14 +648,27 @@ export function LibraryView({
           {activeTab === "albums" && (
             <>
               <div className="flex items-center justify-end space-x-3 -mt-4">
-                <label className="inline-flex items-center space-x-2 cursor-pointer select-none text-sm text-zinc-600 dark:text-zinc-300">
+                {/* Filter to ONLY albums missing artwork (so the user can
+                    bulk-fix them via "Récupérer toutes les pochettes
+                    manquantes" or per-album Deezer search). The label
+                    plus icon plus tooltip together make the direction
+                    of the filter explicit — see #170 where "No cover"
+                    on its own read as "hide no-cover albums". */}
+                <label
+                  className="inline-flex items-center space-x-2 cursor-pointer select-none text-sm text-zinc-600 dark:text-zinc-300"
+                  title={t("library.noCoverTooltip")}
+                >
                   <input
                     type="checkbox"
                     checked={albumsNoCoverFilter}
                     onChange={(e) => setAlbumsNoCoverFilter(e.target.checked)}
                     className="accent-emerald-500"
+                    aria-describedby="albums-no-cover-tooltip"
                   />
-                  <span>{t("library.noCover")}</span>
+                  <ImageOff size={14} aria-hidden="true" />
+                  <span id="albums-no-cover-tooltip">
+                    {t("library.noCover")}
+                  </span>
                 </label>
                 <SortDropdown
                   options={albumSortOptions(t)}

--- a/src/components/views/settings/EqualizerCard.tsx
+++ b/src/components/views/settings/EqualizerCard.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { ChevronDown } from "lucide-react";
 import {
   playerGetEq,
+  playerOnEq,
   playerSetEqBand,
   playerSetEqEnabled,
   playerSetEqPreset,
@@ -40,10 +41,16 @@ export function EqualizerCard() {
   const [presetOpen, setPresetOpen] = useState(false);
   const presetRef = useRef<HTMLDivElement>(null);
 
-  // Hydrate from backend at mount.
+  // Hydrate from backend at mount, then keep in sync via `player:eq`
+  // broadcasts so a mutation from the player-bar popup (or any other
+  // surface) shows up here without remount (#166). The unlisten guard
+  // is async so we capture it on resolve and call it from cleanup.
   useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
     playerGetEq()
       .then((snap) => {
+        if (cancelled) return;
         setEnabled(snap.enabled);
         setBands(snap.bands_db);
         setFreqs(snap.band_freqs);
@@ -51,6 +58,26 @@ export function EqualizerCard() {
         setPresets(snap.presets);
       })
       .catch((err) => console.error("[EqualizerCard] hydrate failed", err));
+    playerOnEq((snap) => {
+      if (cancelled) return;
+      setEnabled(snap.enabled);
+      setBands(snap.bands_db);
+      setFreqs(snap.band_freqs);
+      setMaxGain(snap.max_gain_db);
+      setPresets(snap.presets);
+    })
+      .then((un) => {
+        if (cancelled) {
+          un();
+          return;
+        }
+        unlisten = un;
+      })
+      .catch((err) => console.error("[EqualizerCard] listen failed", err));
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
   }, []);
 
   // Identify the active preset by exact-gain match (within 0.01 dB).

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -371,7 +371,6 @@
     "searchDeezer": "البحث في Deezer",
     "localFile": "ملف محلي",
     "fetchMissingCovers": "جلب جميع الأغلفة المفقودة",
-    "noCover": "بدون غلاف فقط",
     "fetchingCovers": "جارٍ جلب الأغلفة… ({{current}} / {{total}})",
     "fetchCoversResult": "تم جلب {{count}} غلاف",
     "fetchCoversFailed": "فشل جلب الأغلفة",
@@ -420,8 +419,7 @@
       "remove": "إزالة المجلد من المكتبة",
       "removeConfirm": "انقر مرة أخرى للتأكيد"
     },
-    "skeletonAriaLabel": "جارٍ تحميل {{name}}…",
-    "noCoverTooltip": "إظهار الألبومات التي ليس لها غلاف فقط"
+    "skeletonAriaLabel": "جارٍ تحميل {{name}}…"
   },
   "liked": {
     "badge": "المجموعة",

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -371,7 +371,7 @@
     "searchDeezer": "البحث في Deezer",
     "localFile": "ملف محلي",
     "fetchMissingCovers": "جلب جميع الأغلفة المفقودة",
-    "noCover": "لا يوجد غلاف",
+    "noCover": "بدون غلاف فقط",
     "fetchingCovers": "جارٍ جلب الأغلفة… ({{current}} / {{total}})",
     "fetchCoversResult": "تم جلب {{count}} غلاف",
     "fetchCoversFailed": "فشل جلب الأغلفة",
@@ -420,7 +420,8 @@
       "remove": "إزالة المجلد من المكتبة",
       "removeConfirm": "انقر مرة أخرى للتأكيد"
     },
-    "skeletonAriaLabel": "جارٍ تحميل {{name}}…"
+    "skeletonAriaLabel": "جارٍ تحميل {{name}}…",
+    "noCoverTooltip": "إظهار الألبومات التي ليس لها غلاف فقط"
   },
   "liked": {
     "badge": "المجموعة",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Auf Deezer suchen",
     "localFile": "Lokale Datei",
     "fetchMissingCovers": "Alle fehlenden Cover abrufen",
-    "noCover": "Kein Cover",
+    "noCover": "Fehlende Cover",
     "fetchingCovers": "Cover werden abgerufen… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} Cover abgerufen",
     "fetchCoversFailed": "Cover konnten nicht abgerufen werden",
@@ -420,7 +420,8 @@
       "remove": "Ordner aus Bibliothek entfernen",
       "removeConfirm": "Zur Bestätigung erneut klicken"
     },
-    "skeletonAriaLabel": "{{name}} werden geladen…"
+    "skeletonAriaLabel": "{{name}} werden geladen…",
+    "noCoverTooltip": "Nur Alben ohne Cover anzeigen"
   },
   "liked": {
     "badge": "Sammlung",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Auf Deezer suchen",
     "localFile": "Lokale Datei",
     "fetchMissingCovers": "Alle fehlenden Cover abrufen",
-    "noCover": "Fehlende Cover",
     "fetchingCovers": "Cover werden abgerufen… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} Cover abgerufen",
     "fetchCoversFailed": "Cover konnten nicht abgerufen werden",
@@ -420,8 +419,7 @@
       "remove": "Ordner aus Bibliothek entfernen",
       "removeConfirm": "Zur Bestätigung erneut klicken"
     },
-    "skeletonAriaLabel": "{{name}} werden geladen…",
-    "noCoverTooltip": "Nur Alben ohne Cover anzeigen"
+    "skeletonAriaLabel": "{{name}} werden geladen…"
   },
   "liked": {
     "badge": "Sammlung",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Search Deezer",
     "localFile": "Local file",
     "fetchMissingCovers": "Retrieve all missing covers",
-    "noCover": "Missing covers",
     "fetchingCovers": "Fetching covers... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} covers retrieved",
     "fetchCoversFailed": "Failed to retrieve covers",
@@ -420,8 +419,7 @@
       "remove": "Remove folder from library",
       "removeConfirm": "Click again to confirm"
     },
-    "skeletonAriaLabel": "Loading {{name}}…",
-    "noCoverTooltip": "Show only albums without a cover"
+    "skeletonAriaLabel": "Loading {{name}}…"
   },
   "liked": {
     "badge": "Collection",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Search Deezer",
     "localFile": "Local file",
     "fetchMissingCovers": "Retrieve all missing covers",
-    "noCover": "No cover",
+    "noCover": "Missing covers",
     "fetchingCovers": "Fetching covers... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} covers retrieved",
     "fetchCoversFailed": "Failed to retrieve covers",
@@ -420,7 +420,8 @@
       "remove": "Remove folder from library",
       "removeConfirm": "Click again to confirm"
     },
-    "skeletonAriaLabel": "Loading {{name}}…"
+    "skeletonAriaLabel": "Loading {{name}}…",
+    "noCoverTooltip": "Show only albums without a cover"
   },
   "liked": {
     "badge": "Collection",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Buscar en Deezer",
     "localFile": "Archivo local",
     "fetchMissingCovers": "Recuperar todas las portadas que faltan",
-    "noCover": "Sin portada",
     "fetchingCovers": "Recuperando portadas… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} portadas recuperadas",
     "fetchCoversFailed": "Error al recuperar las portadas",
@@ -420,8 +419,7 @@
       "remove": "Quitar carpeta de la biblioteca",
       "removeConfirm": "Haz clic de nuevo para confirmar"
     },
-    "skeletonAriaLabel": "Cargando {{name}}…",
-    "noCoverTooltip": "Mostrar solo álbumes sin portada"
+    "skeletonAriaLabel": "Cargando {{name}}…"
   },
   "liked": {
     "badge": "Colección",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -420,7 +420,8 @@
       "remove": "Quitar carpeta de la biblioteca",
       "removeConfirm": "Haz clic de nuevo para confirmar"
     },
-    "skeletonAriaLabel": "Cargando {{name}}…"
+    "skeletonAriaLabel": "Cargando {{name}}…",
+    "noCoverTooltip": "Mostrar solo álbumes sin portada"
   },
   "liked": {
     "badge": "Colección",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Recherche Deezer",
     "localFile": "Fichier local",
     "fetchMissingCovers": "Récupérer toutes les pochettes manquantes",
-    "noCover": "Pochettes manquantes",
     "fetchingCovers": "Récupération des pochettes... ({{current}}/{{total}})",
     "fetchCoversResult": "{{count}} pochettes récupérées",
     "fetchCoversFailed": "Échec de la récupération",
@@ -420,8 +419,7 @@
       "remove": "Retirer le dossier de la bibliothèque",
       "removeConfirm": "Cliquez à nouveau pour confirmer"
     },
-    "skeletonAriaLabel": "Chargement de {{name}}…",
-    "noCoverTooltip": "Affiche uniquement les albums sans pochette"
+    "skeletonAriaLabel": "Chargement de {{name}}…"
   },
   "liked": {
     "badge": "Collection",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Recherche Deezer",
     "localFile": "Fichier local",
     "fetchMissingCovers": "Récupérer toutes les pochettes manquantes",
-    "noCover": "Sans pochette",
+    "noCover": "Pochettes manquantes",
     "fetchingCovers": "Récupération des pochettes... ({{current}}/{{total}})",
     "fetchCoversResult": "{{count}} pochettes récupérées",
     "fetchCoversFailed": "Échec de la récupération",
@@ -420,7 +420,8 @@
       "remove": "Retirer le dossier de la bibliothèque",
       "removeConfirm": "Cliquez à nouveau pour confirmer"
     },
-    "skeletonAriaLabel": "Chargement de {{name}}…"
+    "skeletonAriaLabel": "Chargement de {{name}}…",
+    "noCoverTooltip": "Affiche uniquement les albums sans pochette"
   },
   "liked": {
     "badge": "Collection",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Deezer में खोजें",
     "localFile": "स्थानीय फ़ाइल",
     "fetchMissingCovers": "सभी गुमशुदा कवर पुनः प्राप्त करें",
-    "noCover": "कवर रहित केवल",
     "fetchingCovers": "कवर डाउनलोड हो रहे हैं... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} कवर प्राप्त हुए",
     "fetchCoversFailed": "कवर प्राप्त करने में विफल",
@@ -420,8 +419,7 @@
       "remove": "लाइब्रेरी से फ़ोल्डर हटाएँ",
       "removeConfirm": "पुष्टि के लिए फिर से क्लिक करें"
     },
-    "skeletonAriaLabel": "{{name}} लोड हो रहे हैं…",
-    "noCoverTooltip": "केवल बिना कवर वाले एल्बम दिखाएं"
+    "skeletonAriaLabel": "{{name}} लोड हो रहे हैं…"
   },
   "liked": {
     "badge": "संग्रह",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Deezer में खोजें",
     "localFile": "स्थानीय फ़ाइल",
     "fetchMissingCovers": "सभी गुमशुदा कवर पुनः प्राप्त करें",
-    "noCover": "कोई कवर नहीं",
+    "noCover": "कवर रहित केवल",
     "fetchingCovers": "कवर डाउनलोड हो रहे हैं... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} कवर प्राप्त हुए",
     "fetchCoversFailed": "कवर प्राप्त करने में विफल",
@@ -420,7 +420,8 @@
       "remove": "लाइब्रेरी से फ़ोल्डर हटाएँ",
       "removeConfirm": "पुष्टि के लिए फिर से क्लिक करें"
     },
-    "skeletonAriaLabel": "{{name}} लोड हो रहे हैं…"
+    "skeletonAriaLabel": "{{name}} लोड हो रहे हैं…",
+    "noCoverTooltip": "केवल बिना कवर वाले एल्बम दिखाएं"
   },
   "liked": {
     "badge": "संग्रह",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Cari di Deezer",
     "localFile": "Berkas lokal",
     "fetchMissingCovers": "Ambil semua sampul yang hilang",
-    "noCover": "Sampul hilang",
     "fetchingCovers": "Mengambil sampul… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} sampul diambil",
     "fetchCoversFailed": "Gagal mengambil sampul",
@@ -420,8 +419,7 @@
       "remove": "Keluarkan folder dari pustaka",
       "removeConfirm": "Klik lagi untuk konfirmasi"
     },
-    "skeletonAriaLabel": "Memuat {{name}}…",
-    "noCoverTooltip": "Tampilkan hanya album tanpa sampul"
+    "skeletonAriaLabel": "Memuat {{name}}…"
   },
   "liked": {
     "badge": "Koleksi",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Cari di Deezer",
     "localFile": "Berkas lokal",
     "fetchMissingCovers": "Ambil semua sampul yang hilang",
-    "noCover": "Tanpa sampul",
+    "noCover": "Sampul hilang",
     "fetchingCovers": "Mengambil sampul… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} sampul diambil",
     "fetchCoversFailed": "Gagal mengambil sampul",
@@ -420,7 +420,8 @@
       "remove": "Keluarkan folder dari pustaka",
       "removeConfirm": "Klik lagi untuk konfirmasi"
     },
-    "skeletonAriaLabel": "Memuat {{name}}…"
+    "skeletonAriaLabel": "Memuat {{name}}…",
+    "noCoverTooltip": "Tampilkan hanya album tanpa sampul"
   },
   "liked": {
     "badge": "Koleksi",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Cerca su Deezer",
     "localFile": "File locale",
     "fetchMissingCovers": "Recupera tutte le copertine mancanti",
-    "noCover": "Nessuna copertina",
+    "noCover": "Copertine mancanti",
     "fetchingCovers": "Recupero copertine… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} copertine recuperate",
     "fetchCoversFailed": "Recupero delle copertine non riuscito",
@@ -420,7 +420,8 @@
       "remove": "Rimuovi la cartella dalla libreria",
       "removeConfirm": "Clicca di nuovo per confermare"
     },
-    "skeletonAriaLabel": "Caricamento {{name}}…"
+    "skeletonAriaLabel": "Caricamento {{name}}…",
+    "noCoverTooltip": "Mostra solo gli album senza copertina"
   },
   "liked": {
     "badge": "Raccolta",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Cerca su Deezer",
     "localFile": "File locale",
     "fetchMissingCovers": "Recupera tutte le copertine mancanti",
-    "noCover": "Copertine mancanti",
     "fetchingCovers": "Recupero copertine… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} copertine recuperate",
     "fetchCoversFailed": "Recupero delle copertine non riuscito",
@@ -420,8 +419,7 @@
       "remove": "Rimuovi la cartella dalla libreria",
       "removeConfirm": "Clicca di nuovo per confermare"
     },
-    "skeletonAriaLabel": "Caricamento {{name}}…",
-    "noCoverTooltip": "Mostra solo gli album senza copertina"
+    "skeletonAriaLabel": "Caricamento {{name}}…"
   },
   "liked": {
     "badge": "Raccolta",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Deezerの検索",
     "localFile": "ローカルファイル",
     "fetchMissingCovers": "不足しているジャケットをすべて取得",
-    "noCover": "ジャケットなしのみ",
     "fetchingCovers": "ジャケットを取得中……({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} 件のジャケットを取得しました",
     "fetchCoversFailed": "ジャケットの取得に失敗しました",
@@ -420,8 +419,7 @@
       "remove": "ライブラリからフォルダを削除",
       "removeConfirm": "もう一度クリックで確定"
     },
-    "skeletonAriaLabel": "{{name}}を読み込み中…",
-    "noCoverTooltip": "ジャケットがないアルバムのみを表示"
+    "skeletonAriaLabel": "{{name}}を読み込み中…"
   },
   "liked": {
     "badge": "コレクション",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Deezerの検索",
     "localFile": "ローカルファイル",
     "fetchMissingCovers": "不足しているジャケットをすべて取得",
-    "noCover": "ジャケットなし",
+    "noCover": "ジャケットなしのみ",
     "fetchingCovers": "ジャケットを取得中……({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} 件のジャケットを取得しました",
     "fetchCoversFailed": "ジャケットの取得に失敗しました",
@@ -420,7 +420,8 @@
       "remove": "ライブラリからフォルダを削除",
       "removeConfirm": "もう一度クリックで確定"
     },
-    "skeletonAriaLabel": "{{name}}を読み込み中…"
+    "skeletonAriaLabel": "{{name}}を読み込み中…",
+    "noCoverTooltip": "ジャケットがないアルバムのみを表示"
   },
   "liked": {
     "badge": "コレクション",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Deezer 검색",
     "localFile": "로컬 파일",
     "fetchMissingCovers": "누락된 모든 커버 가져오기",
-    "noCover": "커버 없음만",
     "fetchingCovers": "커버 가져오는 중... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}}개의 커버를 가져왔습니다",
     "fetchCoversFailed": "커버 가져오기 실패",
@@ -420,8 +419,7 @@
       "remove": "라이브러리에서 폴더 제거",
       "removeConfirm": "확인하려면 다시 클릭"
     },
-    "skeletonAriaLabel": "{{name}} 불러오는 중…",
-    "noCoverTooltip": "커버가 없는 앨범만 표시"
+    "skeletonAriaLabel": "{{name}} 불러오는 중…"
   },
   "liked": {
     "badge": "컬렉션",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Deezer 검색",
     "localFile": "로컬 파일",
     "fetchMissingCovers": "누락된 모든 커버 가져오기",
-    "noCover": "앨범 아트 없음",
+    "noCover": "커버 없음만",
     "fetchingCovers": "커버 가져오는 중... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}}개의 커버를 가져왔습니다",
     "fetchCoversFailed": "커버 가져오기 실패",
@@ -420,7 +420,8 @@
       "remove": "라이브러리에서 폴더 제거",
       "removeConfirm": "확인하려면 다시 클릭"
     },
-    "skeletonAriaLabel": "{{name}} 불러오는 중…"
+    "skeletonAriaLabel": "{{name}} 불러오는 중…",
+    "noCoverTooltip": "커버가 없는 앨범만 표시"
   },
   "liked": {
     "badge": "컬렉션",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Zoeken op Deezer",
     "localFile": "Lokaal bestand",
     "fetchMissingCovers": "Alle ontbrekende albumhoezen ophalen",
-    "noCover": "Geen albumhoes",
+    "noCover": "Ontbrekende hoezen",
     "fetchingCovers": "Albumhoezen ophalen… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} albumhoezen opgehaald",
     "fetchCoversFailed": "Ophalen van albumhoezen mislukt",
@@ -420,7 +420,8 @@
       "remove": "Map uit bibliotheek verwijderen",
       "removeConfirm": "Klik nogmaals om te bevestigen"
     },
-    "skeletonAriaLabel": "{{name}} laden…"
+    "skeletonAriaLabel": "{{name}} laden…",
+    "noCoverTooltip": "Toon alleen albums zonder hoes"
   },
   "liked": {
     "badge": "Verzameling",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Zoeken op Deezer",
     "localFile": "Lokaal bestand",
     "fetchMissingCovers": "Alle ontbrekende albumhoezen ophalen",
-    "noCover": "Ontbrekende hoezen",
     "fetchingCovers": "Albumhoezen ophalen… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} albumhoezen opgehaald",
     "fetchCoversFailed": "Ophalen van albumhoezen mislukt",
@@ -420,8 +419,7 @@
       "remove": "Map uit bibliotheek verwijderen",
       "removeConfirm": "Klik nogmaals om te bevestigen"
     },
-    "skeletonAriaLabel": "{{name}} laden…",
-    "noCoverTooltip": "Toon alleen albums zonder hoes"
+    "skeletonAriaLabel": "{{name}} laden…"
   },
   "liked": {
     "badge": "Verzameling",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Pesquisar no Deezer",
     "localFile": "Arquivo local",
     "fetchMissingCovers": "Recuperar todas as capas que faltam",
-    "noCover": "Capas faltando",
     "fetchingCovers": "Baixando capas... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} capas obtidas",
     "fetchCoversFailed": "Falha ao obter capas",
@@ -420,8 +419,7 @@
       "remove": "Remover pasta da biblioteca",
       "removeConfirm": "Clique novamente para confirmar"
     },
-    "skeletonAriaLabel": "Carregando {{name}}…",
-    "noCoverTooltip": "Mostrar apenas álbuns sem capa"
+    "skeletonAriaLabel": "Carregando {{name}}…"
   },
   "liked": {
     "badge": "Coleção",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Pesquisar no Deezer",
     "localFile": "Arquivo local",
     "fetchMissingCovers": "Recuperar todas as capas que faltam",
-    "noCover": "Sem capa",
+    "noCover": "Capas faltando",
     "fetchingCovers": "Baixando capas... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} capas obtidas",
     "fetchCoversFailed": "Falha ao obter capas",
@@ -420,7 +420,8 @@
       "remove": "Remover pasta da biblioteca",
       "removeConfirm": "Clique novamente para confirmar"
     },
-    "skeletonAriaLabel": "Carregando {{name}}…"
+    "skeletonAriaLabel": "Carregando {{name}}…",
+    "noCoverTooltip": "Mostrar apenas álbuns sem capa"
   },
   "liked": {
     "badge": "Coleção",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Pesquisar no Deezer",
     "localFile": "Ficheiro local",
     "fetchMissingCovers": "Recuperar todas as capas em falta",
-    "noCover": "Capas em falta",
     "fetchingCovers": "A descarregar as capas... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} capas obtidas",
     "fetchCoversFailed": "Falha ao obter capas",
@@ -420,8 +419,7 @@
       "remove": "Remover pasta da biblioteca",
       "removeConfirm": "Clica novamente para confirmar"
     },
-    "skeletonAriaLabel": "A carregar {{name}}…",
-    "noCoverTooltip": "Mostrar apenas álbuns sem capa"
+    "skeletonAriaLabel": "A carregar {{name}}…"
   },
   "liked": {
     "badge": "Coleção",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Pesquisar no Deezer",
     "localFile": "Ficheiro local",
     "fetchMissingCovers": "Recuperar todas as capas em falta",
-    "noCover": "Sem capa",
+    "noCover": "Capas em falta",
     "fetchingCovers": "A descarregar as capas... ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} capas obtidas",
     "fetchCoversFailed": "Falha ao obter capas",
@@ -420,7 +420,8 @@
       "remove": "Remover pasta da biblioteca",
       "removeConfirm": "Clica novamente para confirmar"
     },
-    "skeletonAriaLabel": "A carregar {{name}}…"
+    "skeletonAriaLabel": "A carregar {{name}}…",
+    "noCoverTooltip": "Mostrar apenas álbuns sem capa"
   },
   "liked": {
     "badge": "Coleção",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -384,7 +384,6 @@
     "searchDeezer": "Поиск в Deezer",
     "localFile": "Локальный файл",
     "fetchMissingCovers": "Загрузить все недостающие обложки",
-    "noCover": "Без обложки",
     "fetchingCovers": "Загрузка обложек… ({{current}} / {{total}})",
     "fetchCoversResult": "Загружено обложек: {{count}}",
     "fetchCoversFailed": "Не удалось загрузить обложки",
@@ -438,8 +437,7 @@
       "remove": "Удалить папку из библиотеки",
       "removeConfirm": "Нажмите ещё раз для подтверждения"
     },
-    "skeletonAriaLabel": "Загрузка {{name}}…",
-    "noCoverTooltip": "Показывать только альбомы без обложки"
+    "skeletonAriaLabel": "Загрузка {{name}}…"
   },
   "liked": {
     "badge": "Коллекция",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -438,7 +438,8 @@
       "remove": "Удалить папку из библиотеки",
       "removeConfirm": "Нажмите ещё раз для подтверждения"
     },
-    "skeletonAriaLabel": "Загрузка {{name}}…"
+    "skeletonAriaLabel": "Загрузка {{name}}…",
+    "noCoverTooltip": "Показывать только альбомы без обложки"
   },
   "liked": {
     "badge": "Коллекция",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -371,7 +371,7 @@
     "searchDeezer": "Deezer'da ara",
     "localFile": "Yerel dosya",
     "fetchMissingCovers": "Eksik tüm kapakları getir",
-    "noCover": "Kapak görseli yok",
+    "noCover": "Kapağı eksik",
     "fetchingCovers": "Kapaklar getiriliyor… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} kapak getirildi",
     "fetchCoversFailed": "Kapakları getirme başarısız oldu",
@@ -420,7 +420,8 @@
       "remove": "Klasörü kütüphaneden çıkar",
       "removeConfirm": "Onaylamak için tekrar tıkla"
     },
-    "skeletonAriaLabel": "{{name}} yükleniyor…"
+    "skeletonAriaLabel": "{{name}} yükleniyor…",
+    "noCoverTooltip": "Yalnızca kapağı olmayan albümleri göster"
   },
   "liked": {
     "badge": "Koleksiyon",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -371,7 +371,6 @@
     "searchDeezer": "Deezer'da ara",
     "localFile": "Yerel dosya",
     "fetchMissingCovers": "Eksik tüm kapakları getir",
-    "noCover": "Kapağı eksik",
     "fetchingCovers": "Kapaklar getiriliyor… ({{current}} / {{total}})",
     "fetchCoversResult": "{{count}} kapak getirildi",
     "fetchCoversFailed": "Kapakları getirme başarısız oldu",
@@ -420,8 +419,7 @@
       "remove": "Klasörü kütüphaneden çıkar",
       "removeConfirm": "Onaylamak için tekrar tıkla"
     },
-    "skeletonAriaLabel": "{{name}} yükleniyor…",
-    "noCoverTooltip": "Yalnızca kapağı olmayan albümleri göster"
+    "skeletonAriaLabel": "{{name}} yükleniyor…"
   },
   "liked": {
     "badge": "Koleksiyon",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -371,7 +371,7 @@
     "searchDeezer": "搜索Deezer",
     "localFile": "本地文件",
     "fetchMissingCovers": "找回所有缺失的封套",
-    "noCover": "无封面",
+    "noCover": "仅缺少封面",
     "fetchingCovers": "正在获取封面…（{{current}} / {{total}}）",
     "fetchCoversResult": "已获取 {{count}} 张封套",
     "fetchCoversFailed": "封套获取失败",
@@ -420,7 +420,8 @@
       "remove": "从音乐库中移除文件夹",
       "removeConfirm": "再次点击确认"
     },
-    "skeletonAriaLabel": "正在加载{{name}}…"
+    "skeletonAriaLabel": "正在加载{{name}}…",
+    "noCoverTooltip": "仅显示没有封面的专辑"
   },
   "liked": {
     "badge": "收藏",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -371,7 +371,6 @@
     "searchDeezer": "搜索Deezer",
     "localFile": "本地文件",
     "fetchMissingCovers": "找回所有缺失的封套",
-    "noCover": "仅缺少封面",
     "fetchingCovers": "正在获取封面…（{{current}} / {{total}}）",
     "fetchCoversResult": "已获取 {{count}} 张封套",
     "fetchCoversFailed": "封套获取失败",
@@ -420,8 +419,7 @@
       "remove": "从音乐库中移除文件夹",
       "removeConfirm": "再次点击确认"
     },
-    "skeletonAriaLabel": "正在加载{{name}}…",
-    "noCoverTooltip": "仅显示没有封面的专辑"
+    "skeletonAriaLabel": "正在加载{{name}}…"
   },
   "liked": {
     "badge": "收藏",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -371,7 +371,6 @@
     "searchDeezer": "搜尋Deezer",
     "localFile": "本機檔案",
     "fetchMissingCovers": "找回所有遺失的封套",
-    "noCover": "僅缺少封面",
     "fetchingCovers": "正在取得封面…（{{current}} / {{total}}）",
     "fetchCoversResult": "已取得 {{count}} 張封套",
     "fetchCoversFailed": "封套取得失敗",
@@ -420,8 +419,7 @@
       "remove": "從音樂庫中移除資料夾",
       "removeConfirm": "再次點擊確認"
     },
-    "skeletonAriaLabel": "正在載入{{name}}…",
-    "noCoverTooltip": "僅顯示沒有封面的專輯"
+    "skeletonAriaLabel": "正在載入{{name}}…"
   },
   "liked": {
     "badge": "收藏",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -371,7 +371,7 @@
     "searchDeezer": "搜尋Deezer",
     "localFile": "本機檔案",
     "fetchMissingCovers": "找回所有遺失的封套",
-    "noCover": "沒有封面",
+    "noCover": "僅缺少封面",
     "fetchingCovers": "正在取得封面…（{{current}} / {{total}}）",
     "fetchCoversResult": "已取得 {{count}} 張封套",
     "fetchCoversFailed": "封套取得失敗",
@@ -420,7 +420,8 @@
       "remove": "從音樂庫中移除資料夾",
       "removeConfirm": "再次點擊確認"
     },
-    "skeletonAriaLabel": "正在載入{{name}}…"
+    "skeletonAriaLabel": "正在載入{{name}}…",
+    "noCoverTooltip": "僅顯示沒有封面的專輯"
   },
   "liked": {
     "badge": "收藏",

--- a/src/lib/tauri/browse.ts
+++ b/src/lib/tauri/browse.ts
@@ -193,14 +193,12 @@ export interface FolderRow {
 export async function listAlbums(
   libraryId: number | null,
   options?: {
-    filterNoCover?: boolean;
     orderBy?: string;
     direction?: "asc" | "desc";
   },
 ): Promise<AlbumRow[]> {
   const resp = await invoke<ListAlbumsResponse>("list_albums", {
     libraryId,
-    filterNoCover: options?.filterNoCover ?? null,
     orderBy: options?.orderBy ?? null,
     direction: options?.direction ?? null,
   });

--- a/src/lib/tauri/eq.ts
+++ b/src/lib/tauri/eq.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 export interface EqPresetEntry {
   key: string;
@@ -27,4 +28,17 @@ export function playerSetEqBand(index: number, gainDb: number): Promise<void> {
 
 export function playerSetEqPreset(presetKey: string): Promise<void> {
   return invoke<void>("player_set_eq_preset", { presetKey });
+}
+
+/**
+ * Subscribe to backend-broadcast EQ snapshots. Fired after every
+ * `playerSetEqEnabled` / `playerSetEqBand` / `playerSetEqPreset` so a
+ * second surface (e.g. the player-bar popup) that mutated the engine
+ * doesn't leave the Settings card showing stale state — and vice
+ * versa. See issue #166.
+ */
+export function playerOnEq(
+  handler: (snapshot: EqSnapshot) => void,
+): Promise<UnlistenFn> {
+  return listen<EqSnapshot>("player:eq", (event) => handler(event.payload));
 }


### PR DESCRIPTION
## Summary

Three Jo-El-reported UX bugs blocking the 1.4.0 cut. release-please PR #165 stays open until these merge.

- **#172** — Lyrics Editor footer hidden on 1080p (`max-h-[90vh]` + `h-[50vh]` textarea pushed Save/Cancel off-screen at Windows display scaling ≥125%). Now uses the onboarding wizard's `max-h-[calc(100vh-2rem)]` + `flex-1 min-h-0` pattern with `h-full` textarea.
- **#166** — EQ popup ↔ Settings desync. Both surfaces hydrated once at mount and never refreshed. Backend now emits `player:eq` (full snapshot) from `player_set_eq_{enabled,band,preset}` and both surfaces hydrate + listen. Popup bypass toggle thumb re-anchored with `left:` instead of `translate-x:` so OFF/ON positions are symmetric on Windows.
- **#170** — "No Cover" filter UX read as "hide no-cover albums" instead of "show only no-cover albums". Renamed in 17 locales to "Missing covers" / "Pochettes manquantes" with an `ImageOff` icon and a `title` tooltip explaining direction.

## Test plan

- [x] Lyrics Editor: open on 1920×1080 Windows + 125% / 150% scaling, confirm Save and Cancel are reachable in both Plain and Synced modes.
- [x] EQ sync: open Settings → Lecture and the player-bar EQ popup side by side. Toggle the master switch from either surface — the other reflects within a frame. Change preset from either side — the other updates. Drag a band in Settings — popup's preset chip switches to "Custom" instantly.
- [x] EQ toggle visuals: popup bypass thumb sits flush-left when OFF and flush-right when ON, mirroring the Settings card.
- [x] No-Cover filter: hover the checkbox on the Albums tab and confirm the tooltip explains the direction. Toggle on with a mixed library and confirm only no-cover albums remain; toggle off restores the full set.
- [x] `bun run typecheck` ✅
- [x] `bun run lint` ✅
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` ✅

Closes #172
Closes #166
Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Synchronisation en temps réel des paramètres d'égaliseur entre la popup et la vue Paramètres.
  * Étiquette et infobulle ajoutées pour le filtre « albums sans pochette » dans la bibliothèque.

* **Corrections de bogues**
  * Correction du modal d'édition de paroles pour éviter que la barre d'actions soit masquée lors du défilement.
  * Amélioration de la mise à jour des contrôles d'égaliseur et gestion d'erreur pour les presets inconnus.

* **Traductions**
  * Mise à jour des libellés et ajout des textes d'aide pour « albums sans pochette » dans plusieurs langues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->