### PR TITLE
chore(release-please): point at post-workspace-split manifest paths

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,12 +11,17 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "src-tauri/tauri.conf.json",
+          "path": "src-tauri/crates/app/tauri.conf.json",
           "jsonpath": "$.version"
         },
         {
           "type": "toml",
-          "path": "src-tauri/Cargo.toml",
+          "path": "src-tauri/crates/app/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "src-tauri/crates/core/Cargo.toml",
           "jsonpath": "$.package.version"
         },
         {


### PR DESCRIPTION
## Summary

Phase 1.a moved the Tauri manifest + crate Cargo.toml under `src-tauri/crates/app/`, but `release-please-config.json` still referenced the pre-split paths in its `extra-files`. release-please silently skips missing extra-files, so PR #165 bumped only `package.json`, `CHANGELOG.md`, `README.md` and the manifest — leaving:

- `src-tauri/crates/app/tauri.conf.json` at `1.3.0`
- `src-tauri/crates/app/Cargo.toml` at `1.3.0`
- `src-tauri/crates/core/Cargo.toml` at `1.3.0`
- `src-tauri/Cargo.lock` stale (would fail CodeQL Rust build + downstream packaging)

This PR fixes the paths and adds the new `crates/core` entry. Once merged, release-please should re-run on the next push to `main` and regenerate PR #165 with all five manifests bumped + Cargo.lock refreshed.

## Test plan

- [x] Paths verified: all four target files exist at the new locations.
- [x] After merge: release-please workflow tick produces an updated #165 with `src-tauri/crates/app/tauri.conf.json`, both `crates/{app,core}/Cargo.toml`, and `Cargo.lock` in the diff.