### PR TITLE
ci(release): point at post-workspace-split tauri.conf.json paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
             exit 1
           }
 
-          $configPath = "src-tauri/tauri.conf.json"
+          $configPath = "src-tauri/crates/app/tauri.conf.json"
           $config = Get-Content $configPath -Raw | ConvertFrom-Json
           $signCommandObj = [pscustomobject]@{
             cmd = $signtoolPath
@@ -211,10 +211,16 @@ jobs:
           BUNDLES: ${{ matrix.tauri_bundles }}
           TARGET: ${{ matrix.tauri_target }}
         run: |
+          # `bun run tauri` routes through `scripts/tauri.mjs`, the
+          # wrapper that injects `--config src-tauri/crates/app/tauri.conf.json`
+          # after the subcommand. The Tauri CLI can't auto-discover the
+          # config from the repo root since Phase 1.a moved it under
+          # the workspace's `crates/app/` member — bypassing the
+          # wrapper here would fail with "tauri.conf.json not found".
           if [ -n "$TARGET" ]; then
-            bun x tauri build --target "$TARGET" --bundles "$BUNDLES"
+            bun run tauri build --target "$TARGET" --bundles "$BUNDLES"
           else
-            bun x tauri build --bundles "$BUNDLES"
+            bun run tauri build --bundles "$BUNDLES"
           fi
 
       - name: Scrub Authenticode secrets (Windows)
@@ -229,7 +235,7 @@ jobs:
             Remove-Item -LiteralPath $pfx -Force
             Write-Host "[sign] Removed $pfx"
           }
-          $config = "src-tauri/tauri.conf.json"
+          $config = "src-tauri/crates/app/tauri.conf.json"
           if (Test-Path $config) {
             git checkout -- $config
             Write-Host "[sign] Reverted $config to HEAD"


### PR DESCRIPTION
## Summary

Same root cause as #177 but for `release.yml` — Phase 1.a moved `src-tauri/tauri.conf.json` under `crates/app/` but the release workflow still hardcoded the pre-split path. The v1.4.0 Windows build failed with `Cannot find path 'src-tauri/tauri.conf.json'` during the Authenticode signCommand injection step.

- Two PowerShell blocks now point at `src-tauri/crates/app/tauri.conf.json`
- `bun x tauri build` → `bun run tauri build` so the [`scripts/tauri.mjs`](scripts/tauri.mjs) wrapper injects `--config` correctly

## Test plan

- [ ] After merge, re-dispatch `release.yml --ref main -f tag_name=v1.4.0` and verify Windows/macOS/Linux builds all complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimisation du processus de construction et de publication du workflow de sortie pour améliorer la cohérence des chemins de configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->