### PR TITLE
feat(core): tenant-scoped methods on PostgresProfileRepository

### DIFF
--- a/src-tauri/crates/app/src/commands/profile.rs
+++ b/src-tauri/crates/app/src/commands/profile.rs
@@ -109,6 +109,12 @@ pub async fn create_profile(
 
     Ok(Profile {
         id: profile_id,
+        // Single-tenant: the desktop's `profile` table has no
+        // `user_id` column. The `0` sentinel is what
+        // `#[sqlx(default)]` would hand back from a `SELECT` that
+        // omits the column anyway, so writing it explicitly here
+        // keeps the round-trip consistent.
+        user_id: 0,
         name,
         color_id,
         avatar_hash: input.avatar_hash,

--- a/src-tauri/crates/core/src/domain/profile.rs
+++ b/src-tauri/crates/core/src/domain/profile.rs
@@ -13,6 +13,14 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct Profile {
     pub id: i64,
+    /// Owning user id. `0` on single-tenant backends (desktop SQLite
+    /// has no `user_id` column on its `profile` table); set to the
+    /// row's real owner on multi-tenant Postgres. Sqlx's `#[sqlx(default)]`
+    /// makes the field default to `0` when the column is absent from
+    /// the SELECT, so the same `Profile` struct round-trips on both
+    /// backends without a per-feature shape.
+    #[cfg_attr(any(feature = "sqlite", feature = "postgres"), sqlx(default))]
+    pub user_id: i64,
     pub name: String,
     pub color_id: String,
     pub avatar_hash: Option<String>,

--- a/src-tauri/crates/core/src/repository/postgres/profile.rs
+++ b/src-tauri/crates/core/src/repository/postgres/profile.rs
@@ -32,13 +32,202 @@ impl PostgresProfileRepository {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
     }
+
+    // ===== Tenant-scoped inherent methods =====
+    //
+    // The trait above is single-tenant: it acts on the `profile` table
+    // without filtering by owner. `waveflow-server` is multi-tenant, so
+    // it needs the same operations scoped to a `user_id`. These methods
+    // live as **inherent** impls (not on `ProfileRepository`) so the
+    // desktop's `SqliteProfileRepository` doesn't have to gain a fake
+    // user-id concept it'd never use — the desktop carries a single
+    // implicit user.
+    //
+    // Every query filters by `user_id` so a request from user A can
+    // never read, mutate or delete a profile belonging to user B —
+    // tenant isolation is enforced at the storage layer, not just at
+    // the handler.
+
+    /// Profiles owned by `user_id`, most-recently-used first.
+    pub async fn list_for_user(&self, user_id: i64) -> CoreResult<Vec<Profile>> {
+        let profiles = sqlx::query_as::<_, Profile>(
+            "SELECT id, user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
+               FROM profile
+              WHERE user_id = $1
+              ORDER BY last_used_at DESC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(profiles)
+    }
+
+    /// Fetch a profile only if it's owned by `user_id`. Returning
+    /// `Ok(None)` for an existing-but-foreign profile keeps the
+    /// not-found / not-owned cases indistinguishable to the caller —
+    /// a deliberate choice so the API doesn't leak the existence of
+    /// other users' rows.
+    pub async fn get_for_user(&self, id: i64, user_id: i64) -> CoreResult<Option<Profile>> {
+        let profile = sqlx::query_as::<_, Profile>(
+            "SELECT id, user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
+               FROM profile WHERE id = $1 AND user_id = $2",
+        )
+        .bind(id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(profile)
+    }
+
+    /// Insert a profile owned by `user_id`. Returns the new row id.
+    /// The FK on `profile.user_id REFERENCES users(id)` makes a
+    /// dangling user_id fail at the DB layer, so callers don't need
+    /// a separate existence check.
+    pub async fn insert_for_user(
+        &self,
+        draft: &ProfileDraft,
+        user_id: i64,
+    ) -> CoreResult<i64> {
+        let id: i64 = sqlx::query_scalar(
+            "INSERT INTO profile (user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at)
+             VALUES ($1, $2, $3, $4, '', $5, $6)
+             RETURNING id",
+        )
+        .bind(user_id)
+        .bind(&draft.name)
+        .bind(&draft.color_id)
+        .bind(draft.avatar_hash.as_deref())
+        .bind(draft.now_ms)
+        .bind(draft.now_ms)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(id)
+    }
+
+    /// Rename a profile only if owned by `user_id`. `Ok(false)` covers
+    /// both "no such id" and "id belongs to another user".
+    pub async fn rename_for_user(
+        &self,
+        id: i64,
+        new_name: &str,
+        user_id: i64,
+    ) -> CoreResult<bool> {
+        let updated =
+            sqlx::query("UPDATE profile SET name = $1 WHERE id = $2 AND user_id = $3")
+                .bind(new_name)
+                .bind(id)
+                .bind(user_id)
+                .execute(&self.pool)
+                .await?;
+        Ok(updated.rows_affected() > 0)
+    }
+
+    /// Stamp `last_used_at` only if owned by `user_id`. No-op when
+    /// the row doesn't match (no error — touch is best-effort).
+    pub async fn touch_last_used_for_user(
+        &self,
+        id: i64,
+        now_ms: i64,
+        user_id: i64,
+    ) -> CoreResult<()> {
+        sqlx::query("UPDATE profile SET last_used_at = $1 WHERE id = $2 AND user_id = $3")
+            .bind(now_ms)
+            .bind(id)
+            .bind(user_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Tenant-scoped delete. The "more than one profile must remain"
+    /// invariant is enforced **per-user** (the COUNT subquery filters
+    /// by `user_id`) so user A's delete is never blocked by user B's
+    /// row. Lock semantics mirror the single-tenant `delete_guarded`:
+    /// `LOCK TABLE profile IN SHARE ROW EXCLUSIVE MODE` inside a
+    /// transaction so a concurrent delete from the same user can't
+    /// race past the count check.
+    pub async fn delete_guarded_for_user(
+        &self,
+        id: i64,
+        user_id: i64,
+    ) -> CoreResult<ProfileDeleteOutcome> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("LOCK TABLE profile IN SHARE ROW EXCLUSIVE MODE")
+            .execute(&mut *tx)
+            .await?;
+
+        let exists: Option<i64> = sqlx::query_scalar(
+            "SELECT id FROM profile WHERE id = $1 AND user_id = $2",
+        )
+        .bind(id)
+        .bind(user_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        if exists.is_none() {
+            tx.commit().await?;
+            return Ok(ProfileDeleteOutcome::NotFound);
+        }
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM profile WHERE user_id = $1",
+        )
+        .bind(user_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if count <= 1 {
+            tx.commit().await?;
+            return Ok(ProfileDeleteOutcome::WasLast);
+        }
+
+        sqlx::query("DELETE FROM profile WHERE id = $1 AND user_id = $2")
+            .bind(id)
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(ProfileDeleteOutcome::Deleted)
+    }
+
+    /// Set the resolved `data_dir` for a freshly inserted profile,
+    /// scoped to the owning user. Mirrors `set_data_dir` from the
+    /// trait but with tenant isolation.
+    pub async fn set_data_dir_for_user(
+        &self,
+        id: i64,
+        data_dir: &str,
+        user_id: i64,
+    ) -> CoreResult<()> {
+        sqlx::query("UPDATE profile SET data_dir = $1 WHERE id = $2 AND user_id = $3")
+            .bind(data_dir)
+            .bind(id)
+            .bind(user_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
 impl ProfileRepository for PostgresProfileRepository {
+    // The trait surface is *single-tenant* (no `user_id` parameter),
+    // so these implementations are only safe in code paths that don't
+    // care about tenant isolation — admin scripts, migration tooling,
+    // tests. The HTTP handlers in `waveflow-server` use the inherent
+    // `*_for_user` methods above instead, which scope every query to
+    // the request's owning user.
+    //
+    // The SELECTs include `user_id` so the returned `Profile` carries
+    // the real owner (not the `0` sentinel `#[sqlx(default)]` would
+    // hand back), keeping a `list_all()` snapshot accurate for the
+    // admin / debug surfaces that consume it.
+
     async fn list_all(&self) -> CoreResult<Vec<Profile>> {
         let profiles = sqlx::query_as::<_, Profile>(
-            "SELECT id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
+            "SELECT id, user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
                FROM profile
               ORDER BY last_used_at DESC",
         )
@@ -49,7 +238,7 @@ impl ProfileRepository for PostgresProfileRepository {
 
     async fn get(&self, id: i64) -> CoreResult<Option<Profile>> {
         let profile = sqlx::query_as::<_, Profile>(
-            "SELECT id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
+            "SELECT id, user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
                FROM profile WHERE id = $1",
         )
         .bind(id)

--- a/src-tauri/crates/core/src/repository/postgres/profile.rs
+++ b/src-tauri/crates/core/src/repository/postgres/profile.rs
@@ -15,10 +15,15 @@
 //!
 //! - `$1`, `$2`, … placeholders instead of `?`
 //! - `RETURNING id` instead of `last_insert_rowid()`
-//! - `delete_guarded_for_user` wraps the check + DELETE in a
-//!   transaction with `LOCK TABLE profile IN SHARE ROW EXCLUSIVE
-//!   MODE`; READ COMMITTED isolation can't TOCTOU two concurrent
-//!   deletes the way SQLite's single-writer lock does.
+//! - `delete_guarded_for_user` opens a transaction, takes
+//!   `SELECT id FROM profile WHERE user_id = $1 ORDER BY id FOR
+//!   UPDATE` up-front (row-level locks on every profile the user
+//!   owns, in a deterministic order to avoid cross-transaction
+//!   deadlocks), then re-checks the per-user COUNT before the
+//!   DELETE. Concurrent deletes from the same user serialise on
+//!   those row locks so neither can race past the count check and
+//!   empty the user's profile set; deletes from a different user
+//!   touch disjoint rows and proceed in parallel.
 //!
 //! Schema (`profile.user_id BIGINT NOT NULL REFERENCES users(id)
 //! ON DELETE CASCADE`) lives in `waveflow-server/migrations/`
@@ -170,7 +175,12 @@ impl PostgresProfileRepository {
     ) -> CoreResult<ProfileDeleteOutcome> {
         let mut tx = self.pool.begin().await?;
 
-        sqlx::query("SELECT id FROM profile WHERE user_id = $1 FOR UPDATE")
+        // `ORDER BY id` so two transactions that both target the same
+        // user acquire their row locks in the same order — without it
+        // the lock-acquisition order depends on Postgres' chosen plan
+        // and a concurrent INSERT could push us toward an A→B / B→A
+        // deadlock loop.
+        sqlx::query("SELECT id FROM profile WHERE user_id = $1 ORDER BY id FOR UPDATE")
             .bind(user_id)
             .fetch_all(&mut *tx)
             .await?;

--- a/src-tauri/crates/core/src/repository/postgres/profile.rs
+++ b/src-tauri/crates/core/src/repository/postgres/profile.rs
@@ -1,26 +1,35 @@
-//! Postgres implementation of [`ProfileRepository`].
+//! Tenant-scoped Postgres profile repository for `waveflow-server`.
 //!
-//! Mirrors the SQLite implementation in
-//! [`crate::repository::sqlite::profile`] one-for-one — same semantics,
-//! same query shape, adjusted for Postgres conventions:
+//! Unlike [`crate::repository::sqlite::profile::SqliteProfileRepository`],
+//! this type deliberately **does not implement [`ProfileRepository`]**.
+//! The trait surface is single-tenant (no `user_id` parameter), and
+//! exposing it on a multi-tenant Postgres backend would let a careless
+//! caller bypass user isolation through `list_all() / get(id) /
+//! insert(draft)`. Server handlers consume the inherent `*_for_user`
+//! methods on this struct directly; if a future admin tool needs
+//! cross-tenant reads it'll get its own dedicated type (or a
+//! `PostgresAdminProfileRepository` newtype) rather than re-opening
+//! this footgun.
+//!
+//! Conventions vs. the SQLite sibling:
 //!
 //! - `$1`, `$2`, … placeholders instead of `?`
 //! - `RETURNING id` instead of `last_insert_rowid()`
-//! - The same atomic guarded-delete pattern: a single statement whose
-//!   `WHERE` clause references a subquery counting the surviving rows,
-//!   so a concurrent delete cannot leave the table empty (TOCTOU-free).
+//! - `delete_guarded_for_user` wraps the check + DELETE in a
+//!   transaction with `LOCK TABLE profile IN SHARE ROW EXCLUSIVE
+//!   MODE`; READ COMMITTED isolation can't TOCTOU two concurrent
+//!   deletes the way SQLite's single-writer lock does.
 //!
-//! The schema this targets ships in `waveflow-server/migrations/`
-//! (see RFC-001 §6.5). `id BIGSERIAL PRIMARY KEY`, the rest of the
-//! columns mirror the SQLite shape.
+//! Schema (`profile.user_id BIGINT NOT NULL REFERENCES users(id)
+//! ON DELETE CASCADE`) lives in `waveflow-server/migrations/`
+//! (see RFC-001 §6.5).
 
-use async_trait::async_trait;
 use sqlx::PgPool;
 
 use crate::{
     domain::profile::Profile,
     error::CoreResult,
-    repository::profile::{ProfileDeleteOutcome, ProfileDraft, ProfileRepository},
+    repository::profile::{ProfileDeleteOutcome, ProfileDraft},
 };
 
 #[derive(Debug, Clone)]
@@ -211,141 +220,3 @@ impl PostgresProfileRepository {
     }
 }
 
-#[async_trait]
-impl ProfileRepository for PostgresProfileRepository {
-    // The trait surface is *single-tenant* (no `user_id` parameter),
-    // so these implementations are only safe in code paths that don't
-    // care about tenant isolation — admin scripts, migration tooling,
-    // tests. The HTTP handlers in `waveflow-server` use the inherent
-    // `*_for_user` methods above instead, which scope every query to
-    // the request's owning user.
-    //
-    // The SELECTs include `user_id` so the returned `Profile` carries
-    // the real owner (not the `0` sentinel `#[sqlx(default)]` would
-    // hand back), keeping a `list_all()` snapshot accurate for the
-    // admin / debug surfaces that consume it.
-
-    async fn list_all(&self) -> CoreResult<Vec<Profile>> {
-        let profiles = sqlx::query_as::<_, Profile>(
-            "SELECT id, user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
-               FROM profile
-              ORDER BY last_used_at DESC",
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(profiles)
-    }
-
-    async fn get(&self, id: i64) -> CoreResult<Option<Profile>> {
-        let profile = sqlx::query_as::<_, Profile>(
-            "SELECT id, user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at
-               FROM profile WHERE id = $1",
-        )
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await?;
-        Ok(profile)
-    }
-
-    async fn insert(&self, draft: &ProfileDraft) -> CoreResult<i64> {
-        // `RETURNING id` is the Postgres equivalent of
-        // `last_insert_rowid()` — fetches the server-assigned BIGSERIAL
-        // in the same round-trip as the INSERT.
-        let id: i64 = sqlx::query_scalar(
-            "INSERT INTO profile (name, color_id, avatar_hash, data_dir, created_at, last_used_at)
-             VALUES ($1, $2, $3, '', $4, $5)
-             RETURNING id",
-        )
-        .bind(&draft.name)
-        .bind(&draft.color_id)
-        .bind(draft.avatar_hash.as_deref())
-        .bind(draft.now_ms)
-        .bind(draft.now_ms)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(id)
-    }
-
-    async fn set_data_dir(&self, id: i64, data_dir: &str) -> CoreResult<()> {
-        sqlx::query("UPDATE profile SET data_dir = $1 WHERE id = $2")
-            .bind(data_dir)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
-    async fn rename(&self, id: i64, new_name: &str) -> CoreResult<bool> {
-        let updated = sqlx::query("UPDATE profile SET name = $1 WHERE id = $2")
-            .bind(new_name)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(updated.rows_affected() > 0)
-    }
-
-    async fn touch_last_used(&self, id: i64, now_ms: i64) -> CoreResult<()> {
-        sqlx::query("UPDATE profile SET last_used_at = $1 WHERE id = $2")
-            .bind(now_ms)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
-    async fn delete_guarded(&self, id: i64) -> CoreResult<ProfileDeleteOutcome> {
-        // The SQLite sibling can rely on a single-statement
-        // `WHERE … AND (SELECT COUNT(*) … ) > 1` because SQLite
-        // serialises every writer at the file level. Postgres' READ
-        // COMMITTED isolation does not: two concurrent DELETEs against
-        // distinct rows can each read `COUNT = 2`, decide they're safe,
-        // lock their own row, and both commit — emptying the table.
-        //
-        // Take a `SHARE ROW EXCLUSIVE` lock on the table for the
-        // duration of the transaction: blocks concurrent writers
-        // (DELETE / UPDATE / INSERT) while letting SELECTs proceed.
-        // Inside that critical section the `COUNT(*)` re-check is
-        // guaranteed to observe the same row set the DELETE will see.
-        let mut tx = self.pool.begin().await?;
-
-        sqlx::query("LOCK TABLE profile IN SHARE ROW EXCLUSIVE MODE")
-            .execute(&mut *tx)
-            .await?;
-
-        let exists: Option<i64> = sqlx::query_scalar("SELECT id FROM profile WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&mut *tx)
-            .await?;
-
-        if exists.is_none() {
-            // Nothing to delete; release the lock cheaply.
-            tx.commit().await?;
-            return Ok(ProfileDeleteOutcome::NotFound);
-        }
-
-        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM profile")
-            .fetch_one(&mut *tx)
-            .await?;
-
-        if count <= 1 {
-            tx.commit().await?;
-            return Ok(ProfileDeleteOutcome::WasLast);
-        }
-
-        sqlx::query("DELETE FROM profile WHERE id = $1")
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
-        Ok(ProfileDeleteOutcome::Deleted)
-    }
-
-    async fn exists(&self, id: i64) -> CoreResult<bool> {
-        let row: Option<i64> = sqlx::query_scalar("SELECT id FROM profile WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(row.is_some())
-    }
-}

--- a/src-tauri/crates/core/src/repository/postgres/profile.rs
+++ b/src-tauri/crates/core/src/repository/postgres/profile.rs
@@ -151,10 +151,18 @@ impl PostgresProfileRepository {
     /// Tenant-scoped delete. The "more than one profile must remain"
     /// invariant is enforced **per-user** (the COUNT subquery filters
     /// by `user_id`) so user A's delete is never blocked by user B's
-    /// row. Lock semantics mirror the single-tenant `delete_guarded`:
-    /// `LOCK TABLE profile IN SHARE ROW EXCLUSIVE MODE` inside a
-    /// transaction so a concurrent delete from the same user can't
-    /// race past the count check.
+    /// row.
+    ///
+    /// Concurrency: open a transaction and acquire `FOR UPDATE` row
+    /// locks on *every* profile row owned by `user_id` up-front. Two
+    /// concurrent deletes from the same user serialise on those row
+    /// locks, so the COUNT(*) re-check below observes the same row
+    /// set the DELETE will see — without holding a table-level lock
+    /// that would block writes from other tenants. (A bare
+    /// `SELECT ... FOR UPDATE` on the target row alone wouldn't
+    /// suffice: two concurrent deletes targeting *different* rows of
+    /// the same user could each succeed and empty the set; locking
+    /// the whole tenant's row set is what closes that window.)
     pub async fn delete_guarded_for_user(
         &self,
         id: i64,
@@ -162,8 +170,9 @@ impl PostgresProfileRepository {
     ) -> CoreResult<ProfileDeleteOutcome> {
         let mut tx = self.pool.begin().await?;
 
-        sqlx::query("LOCK TABLE profile IN SHARE ROW EXCLUSIVE MODE")
-            .execute(&mut *tx)
+        sqlx::query("SELECT id FROM profile WHERE user_id = $1 FOR UPDATE")
+            .bind(user_id)
+            .fetch_all(&mut *tx)
             .await?;
 
         let exists: Option<i64> = sqlx::query_scalar(
@@ -202,21 +211,25 @@ impl PostgresProfileRepository {
     }
 
     /// Set the resolved `data_dir` for a freshly inserted profile,
-    /// scoped to the owning user. Mirrors `set_data_dir` from the
-    /// trait but with tenant isolation.
+    /// scoped to the owning user. `Ok(false)` covers both "no such
+    /// id" and "id belongs to another user" — same shape as
+    /// `rename_for_user` so callers can distinguish a no-op from a
+    /// successful write (a silently-discarded update would mask
+    /// `insert_for_user` + `set_data_dir_for_user` race bugs).
     pub async fn set_data_dir_for_user(
         &self,
         id: i64,
         data_dir: &str,
         user_id: i64,
-    ) -> CoreResult<()> {
-        sqlx::query("UPDATE profile SET data_dir = $1 WHERE id = $2 AND user_id = $3")
-            .bind(data_dir)
-            .bind(id)
-            .bind(user_id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+    ) -> CoreResult<bool> {
+        let updated =
+            sqlx::query("UPDATE profile SET data_dir = $1 WHERE id = $2 AND user_id = $3")
+                .bind(data_dir)
+                .bind(id)
+                .bind(user_id)
+                .execute(&self.pool)
+                .await?;
+        Ok(updated.rows_affected() > 0)
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 1.b.4a — give \`waveflow-server\` the multi-tenant API surface it needs for the upcoming \`/api/v1/profiles\` CRUD endpoints, without forcing the desktop's single-tenant \`SqliteProfileRepository\` to adopt a \`user_id\` concept it would never use.

## Strategy

### \`Profile\` struct gains \`user_id: i64\`

\`#[sqlx(default)]\` makes the field default to \`0\` when a SELECT doesn't include it — that's the desktop's behaviour today (no \`user_id\` column on the SQLite \`profile\` table) and also any Postgres admin probe that omits the column. Multi-tenant SELECTs carry the real owner.

The desktop's \`commands::profile::create_profile\` builds the struct directly; it now sets \`user_id: 0\` explicitly to match the sentinel \`sqlx(default)\` would hand back.

### Tenant-scoped inherent methods (NOT on the trait)

\`PostgresProfileRepository\` grows a parallel API:

| Method                      | Scope                                                                          |
| --------------------------- | ------------------------------------------------------------------------------ |
| \`list_for_user(user_id)\`  | profiles owned by \`user_id\`, MRU-first                                       |
| \`get_for_user(id, uid)\`   | one profile, only if owned by \`uid\` (None hides existence of other users')   |
| \`insert_for_user\`         | creates with the right \`user_id\`; FK on \`profile.user_id\` catches mismatch |
| \`rename_for_user\`         | id+user_id WHERE                                                               |
| \`touch_last_used_for_user\`| id+user_id WHERE                                                               |
| \`set_data_dir_for_user\`   | id+user_id WHERE                                                               |
| \`delete_guarded_for_user\` | LOCK TABLE + per-user COUNT > 1 invariant (user A unaffected by user B)        |

The trait \`ProfileRepository\` stays unchanged, so \`SqliteProfileRepository\` doesn't gain a sham \`user_id\` parameter. The server will call \`*_for_user\` methods exclusively.

### Trait SELECTs updated

\`list_all\`, \`get\` on the Postgres impl now include \`user_id\` in the SELECT so an admin / debug caller sees the real owner instead of the \`0\` sentinel. The trait \`insert\` keeps its previous shape — it'll fail at runtime once the schema migration in 1.b.4b adds the NOT NULL \`user_id\` column. That's a deliberate footgun documented inline, since server handlers must call \`insert_for_user\`.

## Out of scope

- The actual \`users\` + \`profile.user_id\` migrations — they live on \`waveflow-server/migrations/\` (next PR, 1.b.4b).
- Library / Track / Playlist tenant-scoping — 1.b.5+.

## Test plan

- [x] \`cargo check --workspace --all-targets\` ✅
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` ✅
- [x] \`cargo test --workspace\` ✅ (66 + 45 = 111 tests pass, zero regression)
- [x] waveflow-server's 1.b.4b PR consumes this via git rev and exercises every \`*_for_user\` method through the \`/api/v1/profiles\` CRUD endpoints + a Postgres service container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Refactor**
  * Gestion des profils remaniée pour supporter single-tenant et multi-tenant.
  * Les opérations sur les profils sont désormais toujours isolées par utilisateur (scoping des lectures/écritures).
  * Ajout d’un champ propriétaire explicite (user_id) aux profils ; valeur sentinelle 0 pour compatibilité single-tenant.
  * Suppression/renommage/mise à jour et suppression « protégée » adaptées au périmètre par utilisateur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->