### PR TITLE
feat(core): rename_for_user returns the updated row

### DIFF
--- a/src-tauri/crates/core/src/repository/postgres/profile.rs
+++ b/src-tauri/crates/core/src/repository/postgres/profile.rs
@@ -118,22 +118,30 @@ impl PostgresProfileRepository {
         Ok(id)
     }
 
-    /// Rename a profile only if owned by `user_id`. `Ok(false)` covers
-    /// both "no such id" and "id belongs to another user".
+    /// Rename a profile only if owned by `user_id`. Returns the
+    /// updated row in one round-trip via `UPDATE ... RETURNING *`,
+    /// so the caller never has to follow up with a separate
+    /// `get_for_user` that could race a concurrent DELETE and flip
+    /// the response to a misleading 404. `Ok(None)` covers both "no
+    /// such id" and "id belongs to another user".
     pub async fn rename_for_user(
         &self,
         id: i64,
         new_name: &str,
         user_id: i64,
-    ) -> CoreResult<bool> {
-        let updated =
-            sqlx::query("UPDATE profile SET name = $1 WHERE id = $2 AND user_id = $3")
-                .bind(new_name)
-                .bind(id)
-                .bind(user_id)
-                .execute(&self.pool)
-                .await?;
-        Ok(updated.rows_affected() > 0)
+    ) -> CoreResult<Option<Profile>> {
+        let row = sqlx::query_as::<_, Profile>(
+            "UPDATE profile
+                SET name = $1
+              WHERE id = $2 AND user_id = $3
+          RETURNING id, user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at",
+        )
+        .bind(new_name)
+        .bind(id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
     }
 
     /// Stamp `last_used_at` only if owned by `user_id`. No-op when


### PR DESCRIPTION
## Summary

Follow-up on CodeRabbit's atomicity finding against [waveflow-server PR #6](https://github.com/InstaZDLL/waveflow-server/pull/6). The server's PATCH handler did \`rename_for_user\` (bool) → \`get_for_user\` (Option<Profile>), which can flip to a misleading 404 if a concurrent DELETE commits between the two calls.

## Change

\`PostgresProfileRepository::rename_for_user\` now returns \`Option<Profile>\` and runs the SQL as \`UPDATE … RETURNING …\`. The updated row comes back in one round-trip; the caller no longer needs a post-rename SELECT, which eliminates the race window entirely.

\`insert_for_user\` and \`touch_last_used_for_user\` have the same two-statement shape today; left as-is since neither has an active consumer racing the read-back. Worth revisiting if they grow one.

## Test plan

- [x] \`cargo check --workspace --all-targets\` ✅
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` ✅
- [x] \`cargo test --workspace\` ✅ (66 + 45 = 111 tests pass; the change is repository-internal, no callers in waveflow yet)
- [x] waveflow-server's PR #6 bumps the rev and simplifies the rename handler to consume the new shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Refactor**
  * Amélioration de la fiabilité du système de gestion des profils lors des opérations de renommage, avec une meilleure validation de la propriété des données.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InstaZDLL/WaveFlow/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->