### PR TITLE
feat(server-auth): waveflow-server account binding (Phase 1.f.desktop.1)

### DIFF
--- a/src-tauri/crates/app/src/commands/mod.rs
+++ b/src-tauri/crates/app/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod profile;
 pub mod profile_io;
 pub mod radio;
 pub mod scan;
+pub mod server_auth;
 pub mod share;
 pub mod similar;
 pub mod smart_playlists;

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -1220,9 +1220,7 @@ pub async fn player_set_eq_preset(
     preset_key: String,
 ) -> AppResult<()> {
     let Some(gains) = crate::audio::eq::preset_gains(&preset_key) else {
-        return Err(AppError::Other(format!(
-            "unknown EQ preset: {preset_key}"
-        )));
+        return Err(AppError::Other(format!("unknown EQ preset: {preset_key}")));
     };
     engine.shared().eq.set_all_bands_db(&gains);
     persist_eq(&state, engine.shared()).await;

--- a/src-tauri/crates/app/src/commands/server_auth.rs
+++ b/src-tauri/crates/app/src/commands/server_auth.rs
@@ -1,0 +1,81 @@
+//! Tauri commands for the `waveflow-server` account binding.
+//!
+//! Phase 1.f.desktop.1 — the foundational surface every later sub-PR
+//! builds on. Sync (`1.f.desktop.2`), repo swap (`1.f.desktop.3`), and
+//! WebSocket subscription (`1.f.desktop.4`) all read their config
+//! through [`crate::server_client`].
+//!
+//! Sign-in flow today: the user opens the server URL in their
+//! browser, signs into Better Auth, copies the JWT it issues, and
+//! pastes it into the Settings card. A polished local-loopback OAuth
+//! flow (mirroring `commands::spotify`) ships in `1.f.desktop.1b`
+//! once the matching `/desktop-login` route lands on `waveflow-web`.
+
+use crate::{
+    error::{AppError, AppResult},
+    server_client::{self, ServerStatus},
+    state::AppState,
+};
+
+/// Snapshot of the desktop's server binding for the Settings card.
+#[tauri::command]
+pub async fn server_get_status(state: tauri::State<'_, AppState>) -> AppResult<ServerStatus> {
+    server_client::status(&state).await
+}
+
+/// Persist the waveflow-server base URL. Validates the value parses
+/// as `http(s)://…`; empty input clears the row so the desktop falls
+/// back to local-only mode. App-wide (not per-profile) — see the
+/// module docstring on [`crate::server_client`].
+#[tauri::command]
+pub async fn server_set_url(
+    state: tauri::State<'_, AppState>,
+    url: String,
+) -> AppResult<ServerStatus> {
+    server_client::write_url(&state.app_db, &url).await?;
+    server_client::status(&state).await
+}
+
+/// Persist the Bearer JWT the user pasted in from the browser
+/// sign-in. Rejects empty / structurally-bad input — leaving a broken
+/// token in place would 401 every sync call. Per-profile.
+#[tauri::command]
+pub async fn server_set_token(
+    state: tauri::State<'_, AppState>,
+    token: String,
+) -> AppResult<ServerStatus> {
+    server_client::write_token(&state, &token).await?;
+    server_client::status(&state).await
+}
+
+/// Sign out the active profile from waveflow-server. Idempotent — no
+/// error when the user wasn't signed in to begin with. Server URL
+/// stays in place (so the user can re-paste a fresh token without
+/// re-entering the URL).
+#[tauri::command]
+pub async fn server_sign_out(state: tauri::State<'_, AppState>) -> AppResult<ServerStatus> {
+    server_client::clear_token(&state).await?;
+    server_client::status(&state).await
+}
+
+/// Open the persisted server URL in the user's default browser. The
+/// landing page itself is whatever `waveflow-web` serves at the root
+/// of the configured URL — typically the sign-in page when no
+/// session is present, the dashboard otherwise. We don't append a
+/// path because the post-1.f.desktop.1b flow will swap this for the
+/// loopback handshake; until then the user navigates by hand.
+///
+/// Returns 400-style errors (via [`AppError::Other`]) when the URL
+/// isn't configured yet, so the UI can pull the user back to the
+/// "set URL" step instead of opening a blank tab.
+#[tauri::command]
+pub async fn server_open_login_browser(state: tauri::State<'_, AppState>) -> AppResult<()> {
+    let url = server_client::read_url(&state.app_db)
+        .await?
+        .ok_or_else(|| {
+            AppError::Other("server URL is not configured; set it in Settings first".into())
+        })?;
+    tauri_plugin_opener::open_url(url, None::<&str>)
+        .map_err(|err| AppError::Other(format!("open server login: {err}")))?;
+    Ok(())
+}

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -20,6 +20,7 @@ mod offline;
 mod paths;
 mod queue;
 mod scrobbler;
+mod server_client;
 mod smart_playlists;
 mod spotify;
 mod state;
@@ -557,6 +558,11 @@ pub fn run() {
             commands::spotify::spotify_get_queue,
             commands::spotify::spotify_search,
             commands::spotify::spotify_pause_local,
+            commands::server_auth::server_get_status,
+            commands::server_auth::server_set_url,
+            commands::server_auth::server_set_token,
+            commands::server_auth::server_sign_out,
+            commands::server_auth::server_open_login_browser,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,
             commands::preferences::get_minimize_to_tray,

--- a/src-tauri/crates/app/src/server_client.rs
+++ b/src-tauri/crates/app/src/server_client.rs
@@ -1,0 +1,288 @@
+//! waveflow-server client wiring (Phase 1.f.desktop.1).
+//!
+//! Three responsibilities:
+//!
+//! 1. **Server URL persistence** — the base URL of the
+//!    `waveflow-server` deployment the active profile talks to. Stored
+//!    in `app_setting['app.waveflow_server_url']` (app-wide; most
+//!    users point one desktop install at one server, regardless of
+//!    profile). Empty value = not configured, the rest of the app
+//!    treats this as "local-only mode".
+//!
+//! 2. **JWT persistence** — Bearer JWT minted by Better Auth (via
+//!    `waveflow-web`'s `auth.api.getToken`). Stored per-profile in
+//!    `auth_credential` under the new `'waveflow_server'` provider,
+//!    matching the existing Last.fm / Spotify pattern. The blob holds
+//!    the raw JWT bytes today; a future hardening pass can move it to
+//!    the OS keyring without changing this module's surface.
+//!
+//! 3. **HTTP client builder** — `WaveflowServerClient::request(method,
+//!    path)` returns a [`reqwest::RequestBuilder`] pre-baked with the
+//!    server's base URL + the stored Bearer header. Hot path for every
+//!    future sync / CRUD call from the desktop.
+//!
+//! Out of scope (deferred to 1.f.desktop.1b / 1.f.desktop.4):
+//!
+//! - JWT refresh on 401 (needs the Better Auth refresh-token endpoint,
+//!   which we'll surface as a server-fn on `waveflow-web` first).
+//! - OS-keyring storage (the `keyring` crate ships fine on macOS /
+//!   Windows but the Linux story relies on libsecret + a running
+//!   secret service, which we want to validate against an AppImage
+//!   build before committing to it).
+//! - Local-loopback OAuth login flow — mirrors the existing
+//!   `commands::spotify` pattern, but the matching `/desktop-login`
+//!   route lives on `waveflow-web` and ships in its own PR.
+
+use chrono::Utc;
+use sqlx::SqlitePool;
+
+use crate::{
+    error::{AppError, AppResult},
+    state::AppState,
+};
+
+/// `app_setting` key for the base URL. App-wide on purpose — see the
+/// module docstring.
+pub const SERVER_URL_KEY: &str = "app.waveflow_server_url";
+
+/// `auth_credential.provider` value reserved for the waveflow-server
+/// JWT. Must match the CHECK constraint in the
+/// `20260601000000_waveflow_server_auth_provider` migration.
+pub const PROVIDER: &str = "waveflow_server";
+
+/// Snapshot returned to the frontend so a Settings card can render
+/// status without having to chain a `getUrl + isSignedIn` pair of
+/// invokes. Sent back from `server_get_status` and every mutating
+/// command.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ServerStatus {
+    /// Base URL the desktop talks to. `None` means the user hasn't
+    /// configured one; the rest of the app should treat that as
+    /// "local-only mode".
+    pub url: Option<String>,
+    /// `true` when a JWT row exists for the active profile under the
+    /// `'waveflow_server'` provider. Does NOT validate the token
+    /// against the server — that's an HTTP round-trip the caller can
+    /// do separately if they want a fresher signal.
+    pub signed_in: bool,
+}
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+/// Read the persisted server URL. Trim + filter-empty so an
+/// `app_setting` row that was cleared by the user (set to `""`)
+/// surfaces as `None` for the UI.
+pub async fn read_url(app_db: &SqlitePool) -> AppResult<Option<String>> {
+    let raw: Option<String> = sqlx::query_scalar("SELECT value FROM app_setting WHERE key = ?")
+        .bind(SERVER_URL_KEY)
+        .fetch_optional(app_db)
+        .await?;
+    Ok(raw.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()))
+}
+
+/// Upsert the server URL. Empty / whitespace-only input clears the
+/// row entirely — same convention as
+/// [`commands::integration::set_lastfm_api_key`].
+///
+/// Validates the URL is parseable + uses `http` / `https`; a typo'd
+/// value would otherwise stick around and break every subsequent
+/// `request()` build with a less helpful error.
+pub async fn write_url(app_db: &SqlitePool, url: &str) -> AppResult<()> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        sqlx::query("DELETE FROM app_setting WHERE key = ?")
+            .bind(SERVER_URL_KEY)
+            .execute(app_db)
+            .await?;
+        return Ok(());
+    }
+    let parsed = url::Url::parse(trimmed)
+        .map_err(|err| AppError::Other(format!("invalid server URL: {err}")))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(AppError::Other("server URL must use http or https".into()));
+    }
+    sqlx::query(
+        "INSERT INTO app_setting (key, value, value_type, updated_at)
+         VALUES (?, ?, 'string', ?)
+         ON CONFLICT(key) DO UPDATE
+            SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind(SERVER_URL_KEY)
+    .bind(trimmed)
+    .bind(now_ms())
+    .execute(app_db)
+    .await?;
+    Ok(())
+}
+
+/// Read the JWT for the active profile. Returns `None` when no row
+/// exists or the blob is empty — the UI treats both as "signed out".
+pub async fn read_token(state: &AppState) -> AppResult<Option<String>> {
+    let pool = match state.require_profile_pool().await {
+        Ok(p) => p,
+        Err(_) => return Ok(None),
+    };
+    let row: Option<Vec<u8>> =
+        sqlx::query_scalar("SELECT token_encrypted FROM auth_credential WHERE provider = ?")
+            .bind(PROVIDER)
+            .fetch_optional(&pool)
+            .await?;
+    let Some(bytes) = row else { return Ok(None) };
+    let token = String::from_utf8(bytes)
+        .map_err(|_| AppError::Other("waveflow_server JWT row is not valid UTF-8".into()))?;
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(trimmed.to_string()))
+    }
+}
+
+/// Upsert the JWT. Trims + rejects empty input (use [`clear_token`]
+/// for sign-out — leaving an empty blob would confuse the
+/// `connected` heuristic).
+pub async fn write_token(state: &AppState, token: &str) -> AppResult<()> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Other("token must not be empty".into()));
+    }
+    // Cheap structural sanity check — three base64url segments
+    // separated by dots. Doesn't validate the signature; that's the
+    // server's job on the first authenticated request.
+    if trimmed.split('.').count() != 3 {
+        return Err(AppError::Other(
+            "token does not look like a JWT (expected three dot-separated segments)".into(),
+        ));
+    }
+    let pool = state.require_profile_pool().await?;
+    let now = now_ms();
+    sqlx::query(
+        "INSERT INTO auth_credential
+            (provider, username, token_encrypted, refresh_token_encrypted,
+             expires_at, created_at, updated_at)
+         VALUES (?, NULL, ?, NULL, NULL, ?, ?)
+         ON CONFLICT(provider) DO UPDATE SET
+            token_encrypted = excluded.token_encrypted,
+            updated_at = excluded.updated_at",
+    )
+    .bind(PROVIDER)
+    .bind(trimmed.as_bytes())
+    .bind(now)
+    .bind(now)
+    .execute(&pool)
+    .await?;
+    Ok(())
+}
+
+/// Drop the JWT row for the active profile. Idempotent — no error if
+/// nothing was stored.
+pub async fn clear_token(state: &AppState) -> AppResult<()> {
+    let pool = match state.require_profile_pool().await {
+        Ok(p) => p,
+        Err(_) => return Ok(()),
+    };
+    sqlx::query("DELETE FROM auth_credential WHERE provider = ?")
+        .bind(PROVIDER)
+        .execute(&pool)
+        .await?;
+    Ok(())
+}
+
+/// Snapshot helper — single round-trip the Settings UI uses to render
+/// the "Compte serveur" card.
+pub async fn status(state: &AppState) -> AppResult<ServerStatus> {
+    let url = read_url(&state.app_db).await?;
+    let signed_in = read_token(state).await?.is_some();
+    Ok(ServerStatus { url, signed_in })
+}
+
+/// HTTP client wired against the persisted URL + JWT. Build once per
+/// caller — every method returns a fresh
+/// [`reqwest::RequestBuilder`] so the caller can layer query params /
+/// JSON body on top.
+///
+/// Errors map to [`AppError`] so handlers don't have to thread an
+/// extra error type — same convention as [`crate::spotify`].
+///
+/// Currently unused — the sync surface (`1.f.desktop.2`+) is the
+/// first consumer. Kept here so the foundational PR ships the
+/// complete shape and reviewers can audit the auth header attachment
+/// in one place.
+#[allow(dead_code)]
+pub struct WaveflowServerClient {
+    base_url: String,
+    token: String,
+    http: reqwest::Client,
+}
+
+#[allow(dead_code)]
+impl WaveflowServerClient {
+    /// Build a client against the active profile's stored config.
+    /// Returns `Err` when either the URL or the JWT is missing —
+    /// callers that want a "no-op when offline" semantic should use
+    /// [`try_build`] instead.
+    pub async fn build(state: &AppState) -> AppResult<Self> {
+        Self::try_build(state).await?.ok_or_else(|| {
+            AppError::Other(
+                "waveflow-server is not configured (set the URL and sign in first)".into(),
+            )
+        })
+    }
+
+    /// Build the client if both knobs are present, `Ok(None)`
+    /// otherwise. The sync / WS surface in 1.f.desktop.2+ uses this to
+    /// short-circuit cleanly when the user hasn't onboarded.
+    pub async fn try_build(state: &AppState) -> AppResult<Option<Self>> {
+        let Some(url) = read_url(&state.app_db).await? else {
+            return Ok(None);
+        };
+        let Some(token) = read_token(state).await? else {
+            return Ok(None);
+        };
+        // Strip the trailing slash so `format!("{base}/api/v1/…")`
+        // never produces a double slash. A double slash would still
+        // resolve on most servers but the OpenAPI spec rejects it,
+        // and matching the convention upfront keeps the request
+        // shape predictable in logs.
+        let base_url = url.trim_end_matches('/').to_string();
+        Ok(Some(Self {
+            base_url,
+            token,
+            http: reqwest::Client::builder()
+                // 30 s matches the server's tower-http timeout
+                // default + the legacy convention elsewhere in the
+                // desktop. A streaming download (1.f.desktop.4 +)
+                // will need to override this on a per-request basis.
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .map_err(|err| AppError::Other(format!("http client init: {err}")))?,
+        }))
+    }
+
+    /// Build a request against `path` (e.g. `"/api/v1/profiles"`).
+    /// Auto-prepends the persisted base URL and attaches the
+    /// `Authorization: Bearer …` header.
+    pub fn request(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {
+        let url = if path.starts_with('/') {
+            format!("{}{}", self.base_url, path)
+        } else {
+            format!("{}/{}", self.base_url, path)
+        };
+        self.http.request(method, url).bearer_auth(&self.token)
+    }
+
+    /// Direct accessor — useful when a caller needs to hand the JWT
+    /// off to another protocol (the WebSocket subscriber in
+    /// 1.f.desktop.4 has to attach it via the upgrade headers, not
+    /// the reqwest builder).
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// Base URL accessor — same use case as [`token`].
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}

--- a/src-tauri/crates/core/src/domain/profile.rs
+++ b/src-tauri/crates/core/src/domain/profile.rs
@@ -7,10 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Mirrors the `profile` table in `app.db`, plus a `data_dir` resolved to
 /// an absolute path so the frontend can display it if needed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(
-    any(feature = "sqlite", feature = "postgres"),
-    derive(sqlx::FromRow)
-)]
+#[cfg_attr(any(feature = "sqlite", feature = "postgres"), derive(sqlx::FromRow))]
 pub struct Profile {
     pub id: i64,
     /// Owning user id. `0` on single-tenant backends (desktop SQLite

--- a/src-tauri/crates/core/src/repository/postgres/profile.rs
+++ b/src-tauri/crates/core/src/repository/postgres/profile.rs
@@ -97,11 +97,7 @@ impl PostgresProfileRepository {
     /// The FK on `profile.user_id REFERENCES users(id)` makes a
     /// dangling user_id fail at the DB layer, so callers don't need
     /// a separate existence check.
-    pub async fn insert_for_user(
-        &self,
-        draft: &ProfileDraft,
-        user_id: i64,
-    ) -> CoreResult<i64> {
+    pub async fn insert_for_user(&self, draft: &ProfileDraft, user_id: i64) -> CoreResult<i64> {
         let id: i64 = sqlx::query_scalar(
             "INSERT INTO profile (user_id, name, color_id, avatar_hash, data_dir, created_at, last_used_at)
              VALUES ($1, $2, $3, $4, '', $5, $6)
@@ -193,25 +189,22 @@ impl PostgresProfileRepository {
             .fetch_all(&mut *tx)
             .await?;
 
-        let exists: Option<i64> = sqlx::query_scalar(
-            "SELECT id FROM profile WHERE id = $1 AND user_id = $2",
-        )
-        .bind(id)
-        .bind(user_id)
-        .fetch_optional(&mut *tx)
-        .await?;
+        let exists: Option<i64> =
+            sqlx::query_scalar("SELECT id FROM profile WHERE id = $1 AND user_id = $2")
+                .bind(id)
+                .bind(user_id)
+                .fetch_optional(&mut *tx)
+                .await?;
 
         if exists.is_none() {
             tx.commit().await?;
             return Ok(ProfileDeleteOutcome::NotFound);
         }
 
-        let count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM profile WHERE user_id = $1",
-        )
-        .bind(user_id)
-        .fetch_one(&mut *tx)
-        .await?;
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM profile WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(&mut *tx)
+            .await?;
 
         if count <= 1 {
             tx.commit().await?;
@@ -250,4 +243,3 @@ impl PostgresProfileRepository {
         Ok(updated.rows_affected() > 0)
     }
 }
-

--- a/src-tauri/migrations/profile/20260601000000_waveflow_server_auth_provider.sql
+++ b/src-tauri/migrations/profile/20260601000000_waveflow_server_auth_provider.sql
@@ -1,0 +1,39 @@
+-- Add `'waveflow_server'` as a per-profile auth credential provider.
+-- Phase 1.f.desktop.1 stores the JWT minted by Better Auth (via
+-- `waveflow-web`) so the desktop can call `waveflow-server`'s
+-- `/api/v1/*` endpoints with an `Authorization: Bearer …` header.
+--
+-- Per-profile, not app-wide: each desktop profile is meant to map to
+-- one Better Auth account, and switching profiles should switch the
+-- server identity along with the local library — same model the
+-- existing `lastfm` / `listenbrainz` / `deezer` / `spotify` rows follow.
+--
+-- SQLite cannot alter a CHECK constraint in place, so rebuild the
+-- table the same way `add_spotify_auth_provider` did. The
+-- `token_encrypted` BLOB stores the raw JWT bytes today (matching the
+-- existing `lastfm` row pattern — "encrypted" is aspirational, not
+-- enforced); a future hardening pass can wrap it in OS-keyring storage
+-- without changing the schema.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE auth_credential_new (
+    provider                TEXT PRIMARY KEY
+                            CHECK (provider IN ('lastfm','listenbrainz','deezer','spotify','waveflow_server')),
+    username                TEXT,
+    token_encrypted         BLOB NOT NULL,
+    refresh_token_encrypted BLOB,
+    expires_at              INTEGER,
+    created_at              INTEGER NOT NULL,
+    updated_at              INTEGER NOT NULL
+);
+
+INSERT INTO auth_credential_new
+    (provider, username, token_encrypted, refresh_token_encrypted, expires_at, created_at, updated_at)
+SELECT provider, username, token_encrypted, refresh_token_encrypted, expires_at, created_at, updated_at
+  FROM auth_credential;
+
+DROP TABLE auth_credential;
+ALTER TABLE auth_credential_new RENAME TO auth_credential;
+
+PRAGMA foreign_keys = ON;

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -42,6 +42,7 @@ import {
   Keyboard,
   Stethoscope,
 } from "lucide-react";
+import { ServerAccountCard } from "./settings/ServerAccountCard";
 import { useTheme } from "../../hooks/useTheme";
 import { THEME_PRESETS } from "../../lib/themes";
 import { getProfileSetting, setProfileSetting } from "../../lib/tauri/profile";
@@ -1927,6 +1928,13 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
                 label={t("settings.offlineMode.title")}
               />
             </div>
+
+            {/* WaveFlow server account binding (Phase 1.f.desktop.1).
+              Sits at the top of Intégrations because every later
+              sync surface (Settings → Mode serveur, the sync queue,
+              the WS subscriber) reads from the URL + JWT this card
+              configures. */}
+            <ServerAccountCard />
 
             <div className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
               <div className="flex items-start space-x-4">

--- a/src/components/views/settings/ServerAccountCard.tsx
+++ b/src/components/views/settings/ServerAccountCard.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CheckCircle2, ExternalLink, Server } from "lucide-react";
+import {
+  serverGetStatus,
+  serverOpenLoginBrowser,
+  serverSetToken,
+  serverSetUrl,
+  serverSignOut,
+  type ServerStatus,
+} from "../../../lib/tauri/serverAuth";
+
+/**
+ * Settings → Intégrations → "Compte serveur WaveFlow" card.
+ *
+ * Phase 1.f.desktop.1 — foundational binding to a `waveflow-server`
+ * deployment. The UI surfaces two state knobs:
+ *
+ * - **Server URL** (app-wide, persisted in `app_setting`): the base
+ *   URL the desktop will hit for `/api/v1/*` calls.
+ * - **JWT** (per-profile, persisted in `auth_credential`): pasted
+ *   from the browser sign-in. The polished local-loopback OAuth flow
+ *   ships in `1.f.desktop.1b`.
+ *
+ * The card is intentionally stateless beyond its own form fields —
+ * every action invokes a Tauri command and re-reads the snapshot, so
+ * a parallel change from another window (or a future profile-switch
+ * hook) stays in sync.
+ */
+export function ServerAccountCard() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<ServerStatus | null>(null);
+  const [urlDraft, setUrlDraft] = useState("");
+  const [tokenDraft, setTokenDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Initial load. The `cancelled` flag pattern keeps the lint
+  // rule (`react-hooks/set-state-in-effect`) happy — the setState
+  // calls live inside an async callback, not directly in the effect
+  // body, and the flag guards against a setState-after-unmount.
+  useEffect(() => {
+    let cancelled = false;
+    serverGetStatus()
+      .then((next) => {
+        if (cancelled) return;
+        setStatus(next);
+        setUrlDraft((current) => (current ? current : (next.url ?? "")));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSaveUrl = useCallback(async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const next = await serverSetUrl(urlDraft);
+      setStatus(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [urlDraft]);
+
+  const handleSaveToken = useCallback(async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const next = await serverSetToken(tokenDraft);
+      setStatus(next);
+      setTokenDraft("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [tokenDraft]);
+
+  const handleSignOut = useCallback(async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const next = await serverSignOut();
+      setStatus(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleOpenLogin = useCallback(async () => {
+    setError(null);
+    try {
+      await serverOpenLoginBrowser();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  const signedIn = status?.signed_in ?? false;
+  const urlConfigured = Boolean(status?.url);
+
+  return (
+    <section
+      aria-label={t("settings.serverAccount.title")}
+      className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors"
+    >
+      <div className="flex items-start space-x-4">
+        <Server size={20} className="text-zinc-400 mt-0.5" aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-sm font-medium text-zinc-900 dark:text-white">
+                {t("settings.serverAccount.title")}
+              </div>
+              <div className="text-xs text-zinc-400">
+                {t("settings.serverAccount.subtitle")}
+              </div>
+            </div>
+            {signedIn && (
+              <span
+                className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+                aria-live="polite"
+              >
+                <CheckCircle2 size={14} aria-hidden="true" />
+                {t("settings.serverAccount.signedIn")}
+              </span>
+            )}
+          </div>
+
+          {/* Server URL */}
+          <label className="block mt-4">
+            <span className="block text-xs font-medium text-zinc-600 dark:text-zinc-300 mb-1">
+              {t("settings.serverAccount.urlLabel")}
+            </span>
+            <div className="flex items-center space-x-2">
+              <input
+                type="url"
+                value={urlDraft}
+                onChange={(e) => {
+                  setUrlDraft(e.target.value);
+                }}
+                placeholder={t("settings.serverAccount.urlPlaceholder")}
+                spellCheck={false}
+                autoComplete="off"
+                disabled={busy}
+                className="flex-1 px-3 py-2 rounded-xl text-sm bg-white border border-zinc-200 text-zinc-800 placeholder-zinc-400 focus:outline-none focus:border-emerald-500 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100 dark:placeholder-zinc-500 disabled:opacity-60"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  void handleSaveUrl();
+                }}
+                disabled={busy}
+                className="px-3 py-2 rounded-xl text-sm font-medium bg-emerald-500 text-white hover:bg-emerald-600 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {t("settings.serverAccount.urlSave")}
+              </button>
+            </div>
+          </label>
+
+          {/* Browser sign-in shortcut + JWT paste */}
+          <div className="mt-4">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <span className="text-xs font-medium text-zinc-600 dark:text-zinc-300">
+                {t("settings.serverAccount.tokenLabel")}
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  void handleOpenLogin();
+                }}
+                disabled={!urlConfigured}
+                className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <ExternalLink size={12} aria-hidden="true" />
+                {t("settings.serverAccount.openLogin")}
+              </button>
+            </div>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-2">
+              {t("settings.serverAccount.tokenHint")}
+            </p>
+            <div className="flex items-start space-x-2">
+              <textarea
+                value={tokenDraft}
+                onChange={(e) => {
+                  setTokenDraft(e.target.value);
+                }}
+                placeholder={t("settings.serverAccount.tokenPlaceholder")}
+                spellCheck={false}
+                autoComplete="off"
+                rows={3}
+                disabled={busy}
+                className="flex-1 px-3 py-2 rounded-xl text-xs font-mono bg-white border border-zinc-200 text-zinc-800 placeholder-zinc-400 focus:outline-none focus:border-emerald-500 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100 dark:placeholder-zinc-500 disabled:opacity-60 resize-none"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  void handleSaveToken();
+                }}
+                disabled={busy || tokenDraft.trim().length === 0}
+                className="px-3 py-2 rounded-xl text-sm font-medium bg-emerald-500 text-white hover:bg-emerald-600 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {t("settings.serverAccount.tokenSave")}
+              </button>
+            </div>
+          </div>
+
+          {signedIn && (
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={() => {
+                  void handleSignOut();
+                }}
+                disabled={busy}
+                className="px-3 py-2 rounded-xl text-sm font-medium bg-zinc-200 text-zinc-800 hover:bg-zinc-300 transition-colors dark:bg-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-600 disabled:opacity-60"
+              >
+                {t("settings.serverAccount.signOut")}
+              </button>
+            </div>
+          )}
+
+          {error && (
+            <p
+              role="alert"
+              className="mt-3 text-xs text-red-600 dark:text-red-400"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/views/settings/ServerAccountCard.tsx
+++ b/src/components/views/settings/ServerAccountCard.tsx
@@ -60,8 +60,14 @@ export function ServerAccountCard() {
     setError(null);
     setBusy(true);
     try {
-      const next = await serverSetUrl(urlDraft);
+      // Normalise client-side so the input mirrors what got persisted
+      // (the backend trims too, but reflecting that here keeps the
+      // draft and the stored value in sync without a refresh
+      // round-trip).
+      const normalizedUrl = urlDraft.trim();
+      const next = await serverSetUrl(normalizedUrl);
       setStatus(next);
+      setUrlDraft(normalizedUrl);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -73,7 +79,12 @@ export function ServerAccountCard() {
     setError(null);
     setBusy(true);
     try {
-      const next = await serverSetToken(tokenDraft);
+      // Trim before send so a copy-paste that pulled a trailing
+      // newline (or `Bearer ` prefix-style padding the user might
+      // accidentally include) doesn't drag spurious bytes into the
+      // structural three-segment check.
+      const normalizedToken = tokenDraft.trim();
+      const next = await serverSetToken(normalizedToken);
       setStatus(next);
       setTokenDraft("");
     } catch (err) {

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1607,6 +1607,20 @@
     "hiResBadge": {
       "title": "شارة Hi-Res / DSD",
       "subtitle": "عرض ملصق «Hi-Res 24-bit» أو «DSD128» بجانب الأغاني المؤهلة وأسفل اسم الفنان في شريط المشغّل. مفعّل افتراضيًا."
+    },
+    "serverAccount": {
+      "title": "حساب خادم WaveFlow",
+      "subtitle": "اربط هذا الملف الشخصي بنسخة waveflow-server الخاصة بك لتفعيل المزامنة بين الأجهزة والتشغيل في المتصفح.",
+      "signedIn": "تم تسجيل الدخول",
+      "urlLabel": "عنوان الخادم",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "حفظ",
+      "tokenLabel": "رمز JWT",
+      "tokenHint": "سجّل الدخول إلى الخادم من متصفحك، انسخ رمز JWT الذي يصدره Better Auth ثم الصقه هنا.",
+      "tokenPlaceholder": "ألصق رمز JWT (ثلاثة مقاطع مفصولة بنقاط)",
+      "tokenSave": "حفظ",
+      "openLogin": "فتح تسجيل الدخول",
+      "signOut": "تسجيل الخروج"
     }
   },
   "spotify": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD-Badge",
       "subtitle": "Zeigt die Plakette „Hi-Res 24-bit“ oder „DSD128“ neben qualifizierenden Titeln und unter dem Künstlernamen in der Wiedergabeleiste. Standardmäßig aktiviert."
+    },
+    "serverAccount": {
+      "title": "WaveFlow-Server-Konto",
+      "subtitle": "Verknüpfe dieses Profil mit deiner waveflow-server-Instanz, um Multi-Gerät-Sync und Browser-Wiedergabe zu aktivieren.",
+      "signedIn": "Angemeldet",
+      "urlLabel": "Server-URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Speichern",
+      "tokenLabel": "JWT-Token",
+      "tokenHint": "Melde dich im Browser am Server an, kopiere das von Better Auth ausgestellte JWT und füge es hier ein.",
+      "tokenPlaceholder": "JWT einfügen (drei durch Punkte getrennte Segmente)",
+      "tokenSave": "Speichern",
+      "openLogin": "Anmeldung öffnen",
+      "signOut": "Abmelden"
     }
   },
   "spotify": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD badge",
       "subtitle": "Show the “Hi-Res 24-bit” or “DSD128” pill next to qualifying tracks and under the artist name in the player bar. On by default."
+    },
+    "serverAccount": {
+      "title": "WaveFlow server account",
+      "subtitle": "Link this profile to your waveflow-server instance to enable multi-device sync and browser playback.",
+      "signedIn": "Signed in",
+      "urlLabel": "Server URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Save",
+      "tokenLabel": "JWT token",
+      "tokenHint": "Sign in to the server in your browser, copy the JWT Better Auth issues, then paste it here.",
+      "tokenPlaceholder": "Paste the JWT (three dot-separated segments)",
+      "tokenSave": "Save",
+      "openLogin": "Open login",
+      "signOut": "Sign out"
     }
   },
   "spotify": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Insignia Hi-Res / DSD",
       "subtitle": "Muestra la etiqueta «Hi-Res 24-bit» o «DSD128» junto a las pistas compatibles y bajo el nombre del artista en la barra del reproductor. Activado por defecto."
+    },
+    "serverAccount": {
+      "title": "Cuenta del servidor WaveFlow",
+      "subtitle": "Conecta este perfil a tu instancia de waveflow-server para habilitar la sincronización multidispositivo y la reproducción en el navegador.",
+      "signedIn": "Sesión iniciada",
+      "urlLabel": "URL del servidor",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Guardar",
+      "tokenLabel": "Token JWT",
+      "tokenHint": "Inicia sesión en el servidor desde tu navegador, copia el JWT que Better Auth te entregue y pégalo aquí.",
+      "tokenPlaceholder": "Pega el JWT (tres segmentos separados por puntos)",
+      "tokenSave": "Guardar",
+      "openLogin": "Abrir inicio de sesión",
+      "signOut": "Cerrar sesión"
     }
   },
   "spotify": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Badge Hi-Res / DSD",
       "subtitle": "Affiche la pastille « Hi-Res 24-bit » ou « DSD128 » à côté des morceaux concernés et sous l'artiste dans la barre de lecture. Activé par défaut."
+    },
+    "serverAccount": {
+      "title": "Compte serveur WaveFlow",
+      "subtitle": "Reliez ce profil à votre instance waveflow-server pour activer la sync multi-appareils et la lecture sur navigateur.",
+      "signedIn": "Connecté",
+      "urlLabel": "URL du serveur",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Enregistrer",
+      "tokenLabel": "Jeton JWT",
+      "tokenHint": "Connectez-vous sur le serveur dans votre navigateur, copiez le JWT que Better Auth vous délivre puis collez-le ici.",
+      "tokenPlaceholder": "Collez le JWT (3 segments séparés par des points)",
+      "tokenSave": "Enregistrer",
+      "openLogin": "Ouvrir la connexion",
+      "signOut": "Se déconnecter"
     }
   },
   "spotify": {

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD बैज",
       "subtitle": "योग्य ट्रैक के बगल में और प्लेयर बार में कलाकार के नाम के नीचे «Hi-Res 24-bit» या «DSD128» पिल दिखाएँ। डिफ़ॉल्ट रूप से चालू।"
+    },
+    "serverAccount": {
+      "title": "WaveFlow सर्वर खाता",
+      "subtitle": "मल्टी-डिवाइस सिंक और ब्राउज़र प्लेबैक सक्षम करने के लिए इस प्रोफ़ाइल को अपने waveflow-server इंस्टेंस से लिंक करें।",
+      "signedIn": "साइन इन है",
+      "urlLabel": "सर्वर URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "सहेजें",
+      "tokenLabel": "JWT टोकन",
+      "tokenHint": "अपने ब्राउज़र में सर्वर पर साइन इन करें, Better Auth द्वारा जारी JWT कॉपी करें और यहाँ चिपकाएँ।",
+      "tokenPlaceholder": "JWT चिपकाएँ (बिंदु से अलग किए गए तीन खंड)",
+      "tokenSave": "सहेजें",
+      "openLogin": "लॉगिन खोलें",
+      "signOut": "साइन आउट"
     }
   },
   "spotify": {

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Lencana Hi-Res / DSD",
       "subtitle": "Tampilkan lencana «Hi-Res 24-bit» atau «DSD128» di samping lagu yang memenuhi syarat dan di bawah nama artis di bilah pemutar. Aktif secara default."
+    },
+    "serverAccount": {
+      "title": "Akun server WaveFlow",
+      "subtitle": "Hubungkan profil ini ke instans waveflow-server Anda untuk mengaktifkan sinkronisasi multi-perangkat dan pemutaran di peramban.",
+      "signedIn": "Masuk",
+      "urlLabel": "URL server",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Simpan",
+      "tokenLabel": "Token JWT",
+      "tokenHint": "Masuk ke server di peramban Anda, salin JWT yang dikeluarkan Better Auth, lalu tempel di sini.",
+      "tokenPlaceholder": "Tempel JWT (tiga segmen dipisahkan titik)",
+      "tokenSave": "Simpan",
+      "openLogin": "Buka login",
+      "signOut": "Keluar"
     }
   },
   "spotify": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Badge Hi-Res / DSD",
       "subtitle": "Mostra l'etichetta «Hi-Res 24-bit» o «DSD128» accanto ai brani idonei e sotto il nome dell'artista nella barra del riproduttore. Attivo di default."
+    },
+    "serverAccount": {
+      "title": "Account server WaveFlow",
+      "subtitle": "Collega questo profilo alla tua istanza waveflow-server per abilitare la sincronizzazione multi-dispositivo e la riproduzione nel browser.",
+      "signedIn": "Accesso effettuato",
+      "urlLabel": "URL del server",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Salva",
+      "tokenLabel": "Token JWT",
+      "tokenHint": "Accedi al server dal tuo browser, copia il JWT rilasciato da Better Auth e incollalo qui.",
+      "tokenPlaceholder": "Incolla il JWT (tre segmenti separati da punti)",
+      "tokenSave": "Salva",
+      "openLogin": "Apri accesso",
+      "signOut": "Esci"
     }
   },
   "spotify": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD バッジ",
       "subtitle": "対象トラックの横と、プレイヤーバーのアーティスト名の下に「Hi-Res 24-bit」または「DSD128」のラベルを表示します。デフォルトはオン。"
+    },
+    "serverAccount": {
+      "title": "WaveFlow サーバーアカウント",
+      "subtitle": "このプロファイルを waveflow-server インスタンスに紐付けて、マルチデバイス同期とブラウザ再生を有効にします。",
+      "signedIn": "サインイン中",
+      "urlLabel": "サーバー URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "保存",
+      "tokenLabel": "JWT トークン",
+      "tokenHint": "ブラウザでサーバーにサインインし、Better Auth が発行した JWT をコピーしてここに貼り付けてください。",
+      "tokenPlaceholder": "JWT を貼り付け（ドット区切りの3セグメント）",
+      "tokenSave": "保存",
+      "openLogin": "ログインを開く",
+      "signOut": "サインアウト"
     }
   },
   "scanProgress": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD 배지",
       "subtitle": "해당 트랙 옆과 플레이어 바의 아티스트 이름 아래에 «Hi-Res 24-bit» 또는 «DSD128» 배지를 표시합니다. 기본값은 켬."
+    },
+    "serverAccount": {
+      "title": "WaveFlow 서버 계정",
+      "subtitle": "이 프로필을 waveflow-server 인스턴스에 연결하여 멀티 디바이스 동기화와 브라우저 재생을 활성화합니다.",
+      "signedIn": "로그인됨",
+      "urlLabel": "서버 URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "저장",
+      "tokenLabel": "JWT 토큰",
+      "tokenHint": "브라우저에서 서버에 로그인한 뒤 Better Auth가 발급한 JWT를 복사해 여기에 붙여넣으세요.",
+      "tokenPlaceholder": "JWT 붙여넣기 (점으로 구분된 3개 세그먼트)",
+      "tokenSave": "저장",
+      "openLogin": "로그인 열기",
+      "signOut": "로그아웃"
     }
   },
   "spotify": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD-badge",
       "subtitle": "Toon de “Hi-Res 24-bit”- of “DSD128”-pil naast nummers die ervoor in aanmerking komen en onder de artiestennaam in de afspeelbalk. Standaard aan."
+    },
+    "serverAccount": {
+      "title": "WaveFlow-serveraccount",
+      "subtitle": "Koppel dit profiel aan je waveflow-server-instantie om multi-apparaatsync en weergave in de browser in te schakelen.",
+      "signedIn": "Aangemeld",
+      "urlLabel": "Server-URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Opslaan",
+      "tokenLabel": "JWT-token",
+      "tokenHint": "Meld je in de browser aan op de server, kopieer het JWT dat Better Auth uitgeeft en plak het hier.",
+      "tokenPlaceholder": "Plak het JWT (drie door punten gescheiden segmenten)",
+      "tokenSave": "Opslaan",
+      "openLogin": "Aanmelding openen",
+      "signOut": "Afmelden"
     }
   },
   "spotify": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Selo Hi-Res / DSD",
       "subtitle": "Mostra o selo \"Hi-Res 24-bit\" ou \"DSD128\" ao lado das faixas elegíveis e abaixo do nome do artista na barra do reprodutor. Ativado por padrão."
+    },
+    "serverAccount": {
+      "title": "Conta do servidor WaveFlow",
+      "subtitle": "Vincule este perfil à sua instância do waveflow-server para habilitar a sincronização entre dispositivos e a reprodução no navegador.",
+      "signedIn": "Conectado",
+      "urlLabel": "URL do servidor",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Salvar",
+      "tokenLabel": "Token JWT",
+      "tokenHint": "Faça login no servidor pelo navegador, copie o JWT emitido pelo Better Auth e cole aqui.",
+      "tokenPlaceholder": "Cole o JWT (três segmentos separados por pontos)",
+      "tokenSave": "Salvar",
+      "openLogin": "Abrir login",
+      "signOut": "Sair"
     }
   },
   "spotify": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Distintivo Hi-Res / DSD",
       "subtitle": "Mostra o selo «Hi-Res 24-bit» ou «DSD128» ao lado das faixas elegíveis e sob o nome do artista na barra do reprodutor. Ativado por defeito."
+    },
+    "serverAccount": {
+      "title": "Conta do servidor WaveFlow",
+      "subtitle": "Associe este perfil à sua instância do waveflow-server para ativar a sincronização entre dispositivos e a reprodução no navegador.",
+      "signedIn": "Sessão iniciada",
+      "urlLabel": "URL do servidor",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Guardar",
+      "tokenLabel": "Token JWT",
+      "tokenHint": "Inicie sessão no servidor através do navegador, copie o JWT que o Better Auth emite e cole-o aqui.",
+      "tokenPlaceholder": "Cole o JWT (três segmentos separados por pontos)",
+      "tokenSave": "Guardar",
+      "openLogin": "Abrir início de sessão",
+      "signOut": "Terminar sessão"
     }
   },
   "spotify": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1648,6 +1648,20 @@
     "hiResBadge": {
       "title": "Бейдж Hi-Res / DSD",
       "subtitle": "Показывает значок «Hi-Res 24-bit» или «DSD128» рядом с подходящими треками и под именем исполнителя в панели плеера. Включено по умолчанию."
+    },
+    "serverAccount": {
+      "title": "Аккаунт сервера WaveFlow",
+      "subtitle": "Привяжите этот профиль к вашему экземпляру waveflow-server, чтобы включить синхронизацию между устройствами и воспроизведение в браузере.",
+      "signedIn": "Вход выполнен",
+      "urlLabel": "URL сервера",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Сохранить",
+      "tokenLabel": "JWT-токен",
+      "tokenHint": "Войдите на сервер в браузере, скопируйте JWT, выданный Better Auth, и вставьте его сюда.",
+      "tokenPlaceholder": "Вставьте JWT (три сегмента, разделённых точками)",
+      "tokenSave": "Сохранить",
+      "openLogin": "Открыть вход",
+      "signOut": "Выйти"
     }
   },
   "spotify": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD rozeti",
       "subtitle": "Uygun parçaların yanında ve oynatma çubuğunda sanatçı adının altında «Hi-Res 24-bit» veya «DSD128» rozetini gösterir. Varsayılan olarak açık."
+    },
+    "serverAccount": {
+      "title": "WaveFlow sunucu hesabı",
+      "subtitle": "Çoklu cihaz senkronizasyonunu ve tarayıcı oynatmayı etkinleştirmek için bu profili waveflow-server örneğinize bağlayın.",
+      "signedIn": "Oturum açıldı",
+      "urlLabel": "Sunucu URL'si",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "Kaydet",
+      "tokenLabel": "JWT belirteci",
+      "tokenHint": "Tarayıcıdan sunucuya giriş yapın, Better Auth tarafından verilen JWT'yi kopyalayın ve buraya yapıştırın.",
+      "tokenPlaceholder": "JWT'yi yapıştırın (noktayla ayrılmış üç segment)",
+      "tokenSave": "Kaydet",
+      "openLogin": "Girişi aç",
+      "signOut": "Çıkış yap"
     }
   },
   "spotify": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD 标识",
       "subtitle": "在符合条件的曲目旁以及播放栏的艺人姓名下方显示「Hi-Res 24-bit」或「DSD128」标识。默认开启。"
+    },
+    "serverAccount": {
+      "title": "WaveFlow 服务器账户",
+      "subtitle": "将此配置文件关联到您的 waveflow-server 实例，以启用多设备同步和浏览器播放。",
+      "signedIn": "已登录",
+      "urlLabel": "服务器 URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "保存",
+      "tokenLabel": "JWT 令牌",
+      "tokenHint": "在浏览器中登录服务器，复制 Better Auth 颁发的 JWT，然后粘贴到此处。",
+      "tokenPlaceholder": "粘贴 JWT（点分隔的三段）",
+      "tokenSave": "保存",
+      "openLogin": "打开登录",
+      "signOut": "退出登录"
     }
   },
   "scanProgress": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1603,6 +1603,20 @@
     "hiResBadge": {
       "title": "Hi-Res / DSD 標籤",
       "subtitle": "在符合條件的曲目旁以及播放列的演出者名稱下方顯示「Hi-Res 24-bit」或「DSD128」標籤。預設開啟。"
+    },
+    "serverAccount": {
+      "title": "WaveFlow 伺服器帳號",
+      "subtitle": "將此設定檔關聯到您的 waveflow-server 執行個體，以啟用多裝置同步與瀏覽器播放。",
+      "signedIn": "已登入",
+      "urlLabel": "伺服器 URL",
+      "urlPlaceholder": "https://api.waveflow.app",
+      "urlSave": "儲存",
+      "tokenLabel": "JWT 權杖",
+      "tokenHint": "在瀏覽器登入伺服器，複製 Better Auth 發行的 JWT，再貼到這裡。",
+      "tokenPlaceholder": "貼上 JWT（以點分隔的三段）",
+      "tokenSave": "儲存",
+      "openLogin": "開啟登入",
+      "signOut": "登出"
     }
   },
   "scanProgress": {

--- a/src/lib/tauri/serverAuth.ts
+++ b/src/lib/tauri/serverAuth.ts
@@ -1,0 +1,53 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Snapshot of the desktop's binding to `waveflow-server` for the
+ * Settings card. `url` is the base URL the desktop will hit for
+ * `/api/v1/*` calls (app-wide). `signedIn` is `true` when the active
+ * profile has a JWT row under the `waveflow_server` provider — it
+ * does NOT validate the token against the server, which would cost an
+ * HTTP round-trip the UI rarely needs.
+ */
+export interface ServerStatus {
+  url: string | null;
+  signed_in: boolean;
+}
+
+/** Snapshot the server binding state. */
+export function serverGetStatus(): Promise<ServerStatus> {
+  return invoke<ServerStatus>("server_get_status");
+}
+
+/**
+ * Persist the waveflow-server base URL. Empty string clears the row
+ * (back to local-only mode). Validates parseability + http(s) scheme
+ * server-side, so a typo surfaces as an error rather than silently
+ * breaking future sync calls.
+ */
+export function serverSetUrl(url: string): Promise<ServerStatus> {
+  return invoke<ServerStatus>("server_set_url", { url });
+}
+
+/**
+ * Persist the Bearer JWT the user pasted in from the browser
+ * sign-in. Rejects empty / non-JWT-shaped input server-side.
+ */
+export function serverSetToken(token: string): Promise<ServerStatus> {
+  return invoke<ServerStatus>("server_set_token", { token });
+}
+
+/** Drop the per-profile JWT. URL stays so the user can re-paste. */
+export function serverSignOut(): Promise<ServerStatus> {
+  return invoke<ServerStatus>("server_sign_out");
+}
+
+/**
+ * Open the configured server URL in the user's default browser. The
+ * user is expected to sign in there (Better Auth handles the actual
+ * flow) and copy the JWT back into the Settings card. A future
+ * `1.f.desktop.1b` PR replaces this with a local-loopback OAuth flow
+ * mirroring the existing Spotify pattern.
+ */
+export function serverOpenLoginBrowser(): Promise<void> {
+  return invoke<void>("server_open_login_browser");
+}


### PR DESCRIPTION
Foundational desktop wiring for the [waveflow-server](https://github.com/InstaZDLL/waveflow-server) sync surface — Phase 1.f.desktop.1 of [#133](https://github.com/InstaZDLL/WaveFlow/issues/133). Closes the auth gap so the next three sub-PRs can land on top:
* `1.f.desktop.2` — Lamport clock + pending-ops queue
* `1.f.desktop.3` — Settings "Mode serveur" toggle + repo swap
* `1.f.desktop.4` — WebSocket subscribe + apply remote ops

This PR ships **only** the auth + HTTP-client foundation. No sync code paths consume `WaveflowServerClient` yet — it's marked `#[allow(dead_code)]` with a comment explaining the next consumer.

## Summary

- New `auth_credential` provider `'waveflow_server'` via a profile migration (rebuild-table pattern matching `add_spotify_auth_provider`).
- `src-tauri/crates/app/src/server_client.rs` — URL / JWT persistence + `WaveflowServerClient` (reqwest wrapper with Bearer auto-attach). Single source of truth for the server binding; documented surface for the upcoming sync sub-PRs.
- Five `#[tauri::command]` entries in `commands/server_auth.rs`: `server_get_status`, `server_set_url`, `server_set_token`, `server_sign_out`, `server_open_login_browser`. Every mutating command returns a fresh `ServerStatus` so the UI re-syncs on the same round-trip.
- New Settings → Intégrations card ([`ServerAccountCard.tsx`](src/components/views/settings/ServerAccountCard.tsx)) — URL input + JWT paste textarea + "Open login" button + emerald "Signed in" badge + Sign out. The cancelled-flag pattern on initial fetch keeps the React hooks v7 `set-state-in-effect` rule happy without lifting state.
- i18n: `settings.serverAccount.*` keys propagated to all 17 locales per the CLAUDE.md convention. Brand tokens (WaveFlow, JWT, URL, Better Auth) verbatim across locales.

## Sign-in flow

Today: **manual paste**. The user clicks "Ouvrir la connexion", their default browser opens the configured server URL, they sign in via Better Auth (`waveflow-web`), copy the issued JWT, and paste it back. Works against the current `waveflow-web` deploy without any web-side change.

Follow-up `1.f.desktop.1b`: replace the paste step with a local-loopback OAuth listener (mirroring `commands::spotify`'s `tiny_http` pattern). That requires a small companion PR on `waveflow-web` to add a `/desktop-login?cb=…` route that mints the JWT via `auth.api.getToken` and redirects to the localhost callback. Tracked separately so this PR stays focused.

## Out of scope (deferred, documented in module docstring)

- **OS-keyring storage** — the `keyring` crate ships fine on macOS / Windows; the Linux story relies on libsecret + a running secret service, which I want to validate against an AppImage build before committing to it. JWT lives in the per-profile `auth_credential.token_encrypted` blob today (same storage shape as Last.fm, ListenBrainz, Spotify).
- **JWT refresh on 401** — depends on a Better Auth refresh-token endpoint we haven't surfaced on `waveflow-web` yet. `1.f.desktop.4` adds this once the server-fn lands.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --workspace\` clean
- [x] \`cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings\` clean
- [x] Manual smoke against a local \`waveflow-server\`:
  - Open Settings → Intégrations → Compte serveur WaveFlow
  - Paste \`http://127.0.0.1:3000\` in URL, save → emerald badge stays hidden ("signed_in: false")
  - Click "Ouvrir la connexion" → system browser opens \`http://127.0.0.1:3000\`
  - Sign in there, copy JWT, paste into Token field, save → emerald "Signed in" badge appears
  - Switch profile → JWT is per-profile, badge disappears on the second profile
  - Click "Se déconnecter" → badge disappears, URL stays
  - Type a malformed URL (\`htp://x\`) → red error message via the validation path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration d’un compte serveur dans les Paramètres (carte dédiée) avec affichage du statut (connecté/non).
  * Sauvegarde et gestion de l’URL du serveur et du token JWT.
  * Ouverture du flux d’authentification dans le navigateur pour faciliter la connexion.
  * Déconnexion (sign out) depuis l’interface.

* **Chores**
  * Localisations ajoutées pour la gestion du compte serveur (plusieurs langues).
  * Migration de base de données pour supporter le fournisseur d’authentification serveur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->