### PR TITLE
feat(sync): lamport clock + pending-ops queue infrastructure (Phase 1.f.desktop.2)

### DIFF
--- a/src-tauri/crates/app/src/commands/mod.rs
+++ b/src-tauri/crates/app/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod similar;
 pub mod smart_playlists;
 pub mod spotify;
 pub mod stats;
+pub mod sync;
 pub mod track;
 pub mod tray;
 pub mod wrapped;

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -46,10 +46,20 @@ pub async fn sync_get_queue_state(state: tauri::State<'_, AppState>) -> AppResul
             lamport::read(&pool).await?,
             queue::count_pending(&pool).await?,
         ),
-        // No active profile — return defaults so the UI can render
-        // without a hard error. Should be unreachable post-bootstrap
-        // but covered defensively.
-        Err(_) => (0, 0),
+        Err(err) => {
+            // No active profile is the only legitimate path here
+            // post-bootstrap (we render defaults so the Settings card
+            // can still mount). Anything else — a pool init failure,
+            // a closed RwLock, etc. — should at minimum land in the
+            // tracing sink so an operator can correlate the "0 / 0"
+            // surface with the actual cause instead of staring at a
+            // silently-empty card.
+            tracing::warn!(
+                error = %err,
+                "sync_get_queue_state: require_profile_pool failed, returning defaults",
+            );
+            (0, 0)
+        }
     };
 
     Ok(SyncQueueState {

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -1,0 +1,70 @@
+//! Diagnostic Tauri commands for the sync infrastructure shipped in
+//! Phase 1.f.desktop.2. The Settings → Diagnostics panel will use
+//! [`sync_get_queue_state`] to show the user how many ops are
+//! waiting to be sent and what the local Lamport floor + device id
+//! are; [`sync_clear_pending`] is the nuclear option for when the
+//! queue is wedged.
+//!
+//! No CRUD enqueue hooks are wired in this PR — see the
+//! [`crate::sync`] module docstring for the scope split.
+
+use serde::Serialize;
+
+use crate::{
+    error::AppResult,
+    state::AppState,
+    sync::{device, lamport, queue},
+};
+
+#[derive(Debug, Serialize)]
+pub struct SyncQueueState {
+    /// Stable per-install device id the server pins its UNIQUEs
+    /// against. `None` only on a fresh install before the first call
+    /// — production code always goes through [`device::ensure`] so
+    /// the diagnostic value mirrors what the future drain task will
+    /// send.
+    pub device_id: Option<String>,
+    /// Per-profile Lamport floor. `0` on a fresh profile, otherwise
+    /// the value the next outbound op would slot at (= last issued
+    /// `+ 1`).
+    pub lamport_local_max: i64,
+    /// Number of rows currently in the local queue.
+    pub pending_count: i64,
+}
+
+/// Snapshot of the desktop's sync infrastructure for the Settings
+/// panel. Does NOT generate a device id if the row hasn't been
+/// planted yet — reading-without-side-effects is safer for a
+/// diagnostic surface, and the CRUD enqueue hook (1.f.desktop.2b)
+/// is the right place to lazy-create on first write.
+#[tauri::command]
+pub async fn sync_get_queue_state(state: tauri::State<'_, AppState>) -> AppResult<SyncQueueState> {
+    let device_id = device::read(&state.app_db).await?;
+
+    let (lamport_local_max, pending_count) = match state.require_profile_pool().await {
+        Ok(pool) => (
+            lamport::read(&pool).await?,
+            queue::count_pending(&pool).await?,
+        ),
+        // No active profile — return defaults so the UI can render
+        // without a hard error. Should be unreachable post-bootstrap
+        // but covered defensively.
+        Err(_) => (0, 0),
+    };
+
+    Ok(SyncQueueState {
+        device_id,
+        lamport_local_max,
+        pending_count,
+    })
+}
+
+/// Drop every queued op. Used by the Settings diagnostic panel when
+/// the user wants a clean slate (e.g. after switching servers).
+/// Returns the number of rows that were removed so the UI can
+/// surface a confirmation toast.
+#[tauri::command]
+pub async fn sync_clear_pending(state: tauri::State<'_, AppState>) -> AppResult<u64> {
+    let pool = state.require_profile_pool().await?;
+    queue::clear(&pool).await
+}

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -24,6 +24,7 @@ mod server_client;
 mod smart_playlists;
 mod spotify;
 mod state;
+mod sync;
 mod thumbnails;
 mod watcher;
 
@@ -565,6 +566,8 @@ pub fn run() {
             commands::server_auth::server_sign_out,
             commands::server_auth::server_open_login_browser,
             commands::server_auth::server_begin_loopback_login,
+            commands::sync::sync_get_queue_state,
+            commands::sync::sync_clear_pending,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,
             commands::preferences::get_minimize_to_tray,

--- a/src-tauri/crates/app/src/sync/device.rs
+++ b/src-tauri/crates/app/src/sync/device.rs
@@ -1,0 +1,122 @@
+// Every helper here is part of the public surface for the future
+// CRUD enqueue hooks (1.f.desktop.2b) and the drain task
+// (1.f.desktop.4). Only `read` is consumed by the diagnostic
+// commands this PR ships — keeping `ensure` behind a module-scoped
+// allow lets the follow-up review against the final shape.
+#![allow(dead_code)]
+
+//! Stable per-install device id. The server pins
+//! `(user_id, device_id, operation_id)` + `(user_id, device_id,
+//! lamport_ts)` UNIQUEs against this value, so a fresh UUID would
+//! break the idempotency + monotonicity invariants the queue's drain
+//! pass relies on. We generate one lazily on first read and never
+//! rotate it — a reinstall produces a new device id, which the server
+//! treats as a brand-new device (correct behaviour, since the
+//! previous install's Lamport history isn't recoverable anyway).
+//!
+//! Lives in `app_setting` (app-wide) rather than `profile_setting`
+//! because the same physical desktop is the same device regardless of
+//! which Better Auth account the active profile maps to. Two profiles
+//! sharing a desktop should send ops under the same `device_id` — the
+//! server keys on `(user_id, device_id, lamport_ts)`, so different
+//! `user_id`s already give each profile its own Lamport space.
+
+use chrono::Utc;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::AppResult;
+
+/// `app_setting` key holding the persisted device id.
+pub const KEY: &str = "sync.device_id";
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+/// Return the stable device id, generating + persisting a fresh
+/// UUIDv4 on first call. Subsequent calls (across reboots) hit the
+/// cached row — no entropy drawn.
+///
+/// Uses `INSERT … ON CONFLICT(key) DO NOTHING RETURNING value` so a
+/// race between two concurrent first-callers collapses to a single
+/// row: the loser's INSERT is a no-op and the SELECT below picks up
+/// the winner's id.
+pub async fn ensure(app_db: &SqlitePool) -> AppResult<String> {
+    if let Some(existing) = read(app_db).await? {
+        return Ok(existing);
+    }
+    let new_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO app_setting (key, value, value_type, updated_at)
+         VALUES (?, ?, 'string', ?)
+         ON CONFLICT(key) DO NOTHING",
+    )
+    .bind(KEY)
+    .bind(&new_id)
+    .bind(now_ms())
+    .execute(app_db)
+    .await?;
+    // Re-read to settle the race — the row above may have come from
+    // a concurrent caller's INSERT that won the ON CONFLICT race.
+    Ok(read(app_db).await?.unwrap_or(new_id))
+}
+
+/// Read the persisted device id without generating one. Returns
+/// `None` only on a fresh install before [`ensure`] has been called.
+pub async fn read(app_db: &SqlitePool) -> AppResult<Option<String>> {
+    let raw: Option<String> = sqlx::query_scalar("SELECT value FROM app_setting WHERE key = ?")
+        .bind(KEY)
+        .fetch_optional(app_db)
+        .await?;
+    Ok(raw.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    /// Stand up an in-memory sqlite pool with the minimal
+    /// `app_setting` schema the device helpers need. Using a stripped
+    /// schema (rather than running the real migrator) keeps the test
+    /// fast and avoids dragging the entire `app.db` initial-state
+    /// fixture into the unit suite.
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE app_setting (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                value_type TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn ensure_persists_uuid_and_is_idempotent() {
+        let pool = pool().await;
+        let first = ensure(&pool).await.unwrap();
+        // The returned id must parse as a valid UUID.
+        Uuid::parse_str(&first).expect("device id parses as UUID");
+        // Subsequent calls return the same id — no entropy redraw,
+        // no row replacement.
+        let second = ensure(&pool).await.unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn read_returns_none_on_fresh_db() {
+        let pool = pool().await;
+        assert!(read(&pool).await.unwrap().is_none());
+    }
+}

--- a/src-tauri/crates/app/src/sync/lamport.rs
+++ b/src-tauri/crates/app/src/sync/lamport.rs
@@ -1,0 +1,194 @@
+// See the matching note in `device.rs` — `next` / `observe_remote`
+// are the public surface the CRUD hooks + WS subscriber consume in
+// follow-up sub-PRs. Diagnostic commands here use only `read`.
+#![allow(dead_code)]
+
+//! Per-profile Lamport clock. The server's
+//! `(user_id, device_id, lamport_ts)` UNIQUE rejects regressions with
+//! SQLSTATE 23505, so the only way for the desktop to keep its
+//! batches accepted is to draw a strictly-increasing value for every
+//! local op AND bump past every remote op the WS subscriber forwards.
+//!
+//! Persistence lives in `profile_setting['sync.lamport_local_max']`
+//! (per-profile because each profile maps to a distinct Better Auth
+//! user, and the server keys its UNIQUE on `(user_id, device_id,
+//! lamport_ts)` — different users get their own Lamport spaces even
+//! on the same device).
+//!
+//! Both writes are atomic via a single SQLite UPSERT + RETURNING.
+//! No `SELECT … then UPDATE` race window between concurrent
+//! enqueue calls.
+
+use chrono::Utc;
+use sqlx::SqlitePool;
+
+use crate::error::AppResult;
+
+/// `profile_setting` key holding the per-profile Lamport floor.
+pub const KEY: &str = "sync.lamport_local_max";
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+/// Atomically increment the Lamport clock and return the new value.
+///
+/// Implemented as a single UPSERT with `RETURNING`:
+///
+/// - Fresh profile (no row yet) → INSERT with `value = '1'`, return
+///   `1`.
+/// - Existing row → DO UPDATE bumps the value by 1, return the new
+///   value.
+///
+/// The CAST chains keep the column as TEXT (which is what the
+/// `profile_setting` schema requires for compat with every other
+/// setting type) while operating arithmetically.
+pub async fn next(profile_pool: &SqlitePool) -> AppResult<i64> {
+    let row: (i64,) = sqlx::query_as(
+        "INSERT INTO profile_setting (key, value, value_type, updated_at)
+         VALUES (?, '1', 'int', ?)
+         ON CONFLICT(key) DO UPDATE
+            SET value = CAST(CAST(profile_setting.value AS INTEGER) + 1 AS TEXT),
+                updated_at = excluded.updated_at
+         RETURNING CAST(value AS INTEGER)",
+    )
+    .bind(KEY)
+    .bind(now_ms())
+    .fetch_one(profile_pool)
+    .await?;
+    Ok(row.0)
+}
+
+/// Bump the local clock to at least `remote` so the next [`next`]
+/// call returns `remote + 1`. No-op when the local value is already
+/// at or above `remote`.
+///
+/// Used by the future WS subscriber (1.f.desktop.4): every inbound
+/// `sync_op` carries the originating device's `lamport_ts`; observing
+/// it locally keeps the Lamport ordering coherent across devices so
+/// the next local op the user fires can't slot below a remote op the
+/// server has already committed.
+pub async fn observe_remote(profile_pool: &SqlitePool, remote: i64) -> AppResult<()> {
+    if remote <= 0 {
+        return Ok(());
+    }
+    // SQLite's scalar `max(a, b, …)` returns the greatest argument
+    // (distinct from the `max(col)` aggregate). On INSERT (no existing
+    // row) the value is just `remote`; on UPDATE we take the
+    // pairwise max so a stale remote can't lower the local floor.
+    //
+    // Both sides MUST be cast to INTEGER before the `max()` call —
+    // SQLite's type-affinity rules make TEXT > INTEGER in a mixed
+    // comparison, so `max(10, "3")` would return `"3"` and silently
+    // lower the local floor. The explicit double cast is what keeps
+    // the monotonicity invariant intact.
+    sqlx::query(
+        "INSERT INTO profile_setting (key, value, value_type, updated_at)
+         VALUES (?, CAST(? AS TEXT), 'int', ?)
+         ON CONFLICT(key) DO UPDATE
+            SET value = CAST(
+                    max(
+                        CAST(profile_setting.value AS INTEGER),
+                        CAST(excluded.value AS INTEGER)
+                    ) AS TEXT
+                ),
+                updated_at = excluded.updated_at",
+    )
+    .bind(KEY)
+    .bind(remote)
+    .bind(now_ms())
+    .execute(profile_pool)
+    .await?;
+    Ok(())
+}
+
+/// Read the current Lamport floor without bumping it. Returns `0`
+/// when the row hasn't been created yet (= no local op has ever
+/// fired, the clock is at its natural origin). Diagnostic only —
+/// production code should always go through [`next`] /
+/// [`observe_remote`] so the increments stay atomic.
+pub async fn read(profile_pool: &SqlitePool) -> AppResult<i64> {
+    let raw: Option<i64> =
+        sqlx::query_scalar("SELECT CAST(value AS INTEGER) FROM profile_setting WHERE key = ?")
+            .bind(KEY)
+            .fetch_optional(profile_pool)
+            .await?;
+    Ok(raw.unwrap_or(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE profile_setting (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                value_type TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn next_starts_at_one_and_is_monotonic() {
+        let pool = pool().await;
+        assert_eq!(next(&pool).await.unwrap(), 1);
+        assert_eq!(next(&pool).await.unwrap(), 2);
+        assert_eq!(next(&pool).await.unwrap(), 3);
+        assert_eq!(read(&pool).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn observe_remote_bumps_past_local() {
+        let pool = pool().await;
+        assert_eq!(next(&pool).await.unwrap(), 1);
+        observe_remote(&pool, 42).await.unwrap();
+        // Local is now 42 — next() must return 43, not 2.
+        assert_eq!(next(&pool).await.unwrap(), 43);
+    }
+
+    #[tokio::test]
+    async fn observe_remote_never_lowers_local() {
+        let pool = pool().await;
+        for _ in 0..10 {
+            next(&pool).await.unwrap();
+        }
+        observe_remote(&pool, 3).await.unwrap();
+        // Local stays at 10 (the latest next() return) — a stale
+        // remote can't drag the clock backwards.
+        assert_eq!(read(&pool).await.unwrap(), 10);
+        assert_eq!(next(&pool).await.unwrap(), 11);
+    }
+
+    #[tokio::test]
+    async fn observe_remote_handles_zero_and_negative() {
+        let pool = pool().await;
+        observe_remote(&pool, 0).await.unwrap();
+        observe_remote(&pool, -5).await.unwrap();
+        // Neither call should have planted a row.
+        assert_eq!(read(&pool).await.unwrap(), 0);
+        assert_eq!(next(&pool).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn observe_remote_seeds_clock_on_fresh_profile() {
+        let pool = pool().await;
+        // No prior `next()` — observing a remote should still plant
+        // the row so the next local op slots above it.
+        observe_remote(&pool, 7).await.unwrap();
+        assert_eq!(read(&pool).await.unwrap(), 7);
+        assert_eq!(next(&pool).await.unwrap(), 8);
+    }
+}

--- a/src-tauri/crates/app/src/sync/mod.rs
+++ b/src-tauri/crates/app/src/sync/mod.rs
@@ -1,0 +1,37 @@
+//! Multi-device sync infrastructure for the desktop side of
+//! [RFC-001 §6.6](https://github.com/InstaZDLL/WaveFlow/blob/main/docs/rfcs/RFC-001-waveflow-server.md#66-sync).
+//!
+//! Phase 1.f.desktop.2 ships the foundational helpers every later
+//! sub-PR builds on:
+//!
+//! - [`device`] — the stable per-install UUID the server pins the
+//!   `(user_id, device_id, …)` UNIQUEs against. Lazily generated on
+//!   first read, persisted app-wide in `app_setting['sync.device_id']`.
+//!
+//! - [`lamport`] — per-profile monotonic clock. [`lamport::next`]
+//!   atomically increments and returns the new value; the desktop's
+//!   CRUD commands will pair it with [`queue::enqueue`] to stamp
+//!   every outgoing op. [`lamport::observe_remote`] is the rejoin
+//!   path — when a future WS subscriber (1.f.desktop.4) sees a higher
+//!   remote `lamport_ts`, it bumps the local clock past it so the
+//!   next local op stays globally monotonic.
+//!
+//! - [`queue`] — the local write-ahead log. Rows here are ops the
+//!   user produced while signed into a `waveflow-server`; a future
+//!   drain task (1.f.desktop.4) posts them to
+//!   `/api/v1/sync/ops` and removes the rows the server accepts.
+//!
+//! ## What this PR does NOT ship
+//!
+//! - **CRUD enqueue hooks** in `commands/playlist`, `commands/library`,
+//!   `commands/edit`. Wiring each command site is a 1.f.desktop.2b
+//!   concern so the infrastructure here can be validated in isolation
+//!   and the CRUD changes review separately.
+//! - **Canonical-id mapping** for cross-device entity identity (see
+//!   [`queue`] docstring for the open design question).
+//! - **The drain task itself** — that's 1.f.desktop.4 alongside the
+//!   WebSocket subscriber.
+
+pub mod device;
+pub mod lamport;
+pub mod queue;

--- a/src-tauri/crates/app/src/sync/queue.rs
+++ b/src-tauri/crates/app/src/sync/queue.rs
@@ -144,7 +144,18 @@ struct PendingOpRow {
 /// Return the next `limit` pending rows in FIFO order. The drain
 /// task calls this in a loop with a small `limit` so a flaky server
 /// doesn't pin the whole queue in memory.
+///
+/// `limit <= 0` short-circuits to an empty `Vec` rather than going
+/// through to SQLite. SQLite treats a negative `LIMIT` as "no limit"
+/// (returns every row), so a caller that miscomputes the page size
+/// would otherwise pull the entire queue into memory. `limit == 0`
+/// is technically a valid no-op against SQLite but the guard keeps
+/// the contract uniform: every non-positive input maps to "nothing
+/// requested".
 pub async fn list_pending(profile_pool: &SqlitePool, limit: i64) -> AppResult<Vec<PendingOp>> {
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
     let rows: Vec<PendingOpRow> = sqlx::query_as(
         "SELECT id, operation_id, lamport_ts, entity, entity_id, field, op,
                 payload, created_at, last_attempt_at, attempt_count, last_error
@@ -263,7 +274,7 @@ mod tests {
             .unwrap();
         sqlx::query(
             "CREATE TABLE sync_pending_op (
-                id INTEGER PRIMARY KEY,
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
                 operation_id TEXT NOT NULL UNIQUE,
                 lamport_ts INTEGER NOT NULL UNIQUE CHECK (lamport_ts > 0),
                 entity TEXT NOT NULL,
@@ -397,6 +408,42 @@ mod tests {
         };
         let err = enqueue(&pool, &draft, 1).await.unwrap_err();
         assert!(format!("{err}").to_lowercase().contains("check"));
+    }
+
+    #[tokio::test]
+    async fn list_pending_guards_against_non_positive_limit() {
+        let pool = pool().await;
+        for lamport in 1..=3 {
+            enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+                .await
+                .unwrap();
+        }
+        // `LIMIT 0` is a no-op against SQLite anyway, but the guard
+        // turns it into an explicit early return that doesn't pay
+        // the round-trip.
+        assert!(list_pending(&pool, 0).await.unwrap().is_empty());
+        // `LIMIT -1` would otherwise be treated as "no limit" by
+        // SQLite — the dangerous case the guard exists to catch.
+        assert!(list_pending(&pool, -1).await.unwrap().is_empty());
+        // Positive limit still works.
+        assert_eq!(list_pending(&pool, 10).await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn ids_stay_monotonic_after_clear() {
+        // Without `INTEGER PRIMARY KEY AUTOINCREMENT` SQLite would
+        // restart the id counter at 1 after a full drain. A future
+        // high-water-mark drain task that tracks `last_processed_id`
+        // would silently miss ops appended after the reset; pin the
+        // AUTOINCREMENT behaviour with a regression test.
+        let pool = pool().await;
+        let (id_a, _) = enqueue(&pool, &draft("1", None), 1).await.unwrap();
+        clear(&pool).await.unwrap();
+        let (id_b, _) = enqueue(&pool, &draft("2", None), 2).await.unwrap();
+        assert!(
+            id_b > id_a,
+            "AUTOINCREMENT must keep ids monotonic across clears: id_a={id_a}, id_b={id_b}",
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/sync/queue.rs
+++ b/src-tauri/crates/app/src/sync/queue.rs
@@ -1,0 +1,415 @@
+// `enqueue`, `list_pending`, `drop_acked`, `mark_failed` are the
+// drain-task surface (1.f.desktop.4). Diagnostic commands here use
+// only `count_pending` + `clear`.
+#![allow(dead_code)]
+
+//! Local pending-ops queue. Rows here are ops the user produced
+//! while signed into a `waveflow-server`; a future drain task
+//! (1.f.desktop.4) posts them to `/api/v1/sync/ops` and removes the
+//! rows the server accepts.
+//!
+//! The queue is intentionally dumb storage — every write is a single
+//! INSERT, every read a single SELECT. The orchestration (when to
+//! drain, what to retry, how to back off) belongs to the drain task,
+//! not the queue.
+//!
+//! ## Open design question — canonical entity ids
+//!
+//! Today the desktop stores `entity_id` as the TEXT-coerced local
+//! `i64` from the SQLite tables (`playlist.id`, `library.id`, …).
+//! This is fine for ops produced by THIS device — the server's
+//! UNIQUE keys on `(user_id, device_id, entity, entity_id)` will
+//! pick the right row.
+//!
+//! It does NOT cross devices cleanly: device A's playlist#42 and
+//! device B's playlist#42 are not the same playlist. A future PR
+//! introduces a stable `canonical_id UUID` on every syncable entity
+//! and routes ops through that instead. Until then, the WS subscriber
+//! has to translate incoming `entity_id`s through a `local_id ↔
+//! canonical_id` mapping table that 1.f.desktop.4 introduces.
+//!
+//! Documenting the gap here so a reader of `enqueue` doesn't assume
+//! the current shape is the final wire format.
+
+use chrono::Utc;
+use serde::Serialize;
+use sqlx::{QueryBuilder, Sqlite, SqlitePool};
+use uuid::Uuid;
+
+use crate::error::AppResult;
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+/// Draft of an op the caller wants to enqueue. The CRUD command site
+/// builds this from its own context and hands it off to [`enqueue`];
+/// the queue assigns the `operation_id`, the `id`, and the
+/// `created_at` itself so nothing leaks across layers.
+#[derive(Debug, Clone)]
+pub struct PendingOpDraft {
+    /// `"playlist" | "library" | "track" | …`. Free-form so the
+    /// protocol can grow without a desktop release.
+    pub entity: String,
+    /// String-coerced entity id (see the module docstring on the
+    /// canonical-id question).
+    pub entity_id: String,
+    /// `None` for whole-entity ops (insert / delete), `Some` for
+    /// partial updates ("set name", "set color").
+    pub field: Option<String>,
+    /// `"set" | "delete" | "insert" | "noop"` — must match the
+    /// migration's CHECK constraint.
+    pub op: String,
+    /// Op-specific JSON payload. Serialised to text at the SQL layer.
+    pub payload: Option<serde_json::Value>,
+}
+
+/// A row read back from the queue. The drain task hydrates this and
+/// hands it to the server; `id` is the local SQLite rowid the drain
+/// later passes to [`drop_acked`].
+#[derive(Debug, Clone, Serialize)]
+pub struct PendingOp {
+    pub id: i64,
+    pub operation_id: String,
+    pub lamport_ts: i64,
+    pub entity: String,
+    pub entity_id: String,
+    pub field: Option<String>,
+    pub op: String,
+    pub payload: Option<serde_json::Value>,
+    pub created_at: i64,
+    pub last_attempt_at: Option<i64>,
+    pub attempt_count: i64,
+    pub last_error: Option<String>,
+}
+
+/// Append a draft to the queue under the caller-supplied
+/// `lamport_ts`. The caller is responsible for drawing the lamport
+/// value via [`crate::sync::lamport::next`] — splitting the two
+/// responsibilities means the queue stays a pure-storage layer.
+///
+/// Returns the assigned `(id, operation_id)` so the caller can
+/// correlate logs without an extra SELECT.
+pub async fn enqueue(
+    profile_pool: &SqlitePool,
+    draft: &PendingOpDraft,
+    lamport_ts: i64,
+) -> AppResult<(i64, String)> {
+    let operation_id = Uuid::new_v4().to_string();
+    let payload_json = match draft.payload.as_ref() {
+        Some(v) => Some(serde_json::to_string(v).map_err(|e| {
+            crate::error::AppError::Other(format!("sync queue payload serialise: {e}"))
+        })?),
+        None => None,
+    };
+    let now = now_ms();
+    let row: (i64,) = sqlx::query_as(
+        "INSERT INTO sync_pending_op
+            (operation_id, lamport_ts, entity, entity_id, field, op, payload, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         RETURNING id",
+    )
+    .bind(&operation_id)
+    .bind(lamport_ts)
+    .bind(&draft.entity)
+    .bind(&draft.entity_id)
+    .bind(draft.field.as_deref())
+    .bind(&draft.op)
+    .bind(payload_json.as_deref())
+    .bind(now)
+    .fetch_one(profile_pool)
+    .await?;
+    Ok((row.0, operation_id))
+}
+
+/// Raw row shape from `sync_pending_op`. Hydrated into [`PendingOp`]
+/// (which carries the parsed JSON payload) by [`list_pending`]. Kept
+/// private so callers see the cleaner public type.
+#[derive(sqlx::FromRow)]
+struct PendingOpRow {
+    id: i64,
+    operation_id: String,
+    lamport_ts: i64,
+    entity: String,
+    entity_id: String,
+    field: Option<String>,
+    op: String,
+    payload: Option<String>,
+    created_at: i64,
+    last_attempt_at: Option<i64>,
+    attempt_count: i64,
+    last_error: Option<String>,
+}
+
+/// Return the next `limit` pending rows in FIFO order. The drain
+/// task calls this in a loop with a small `limit` so a flaky server
+/// doesn't pin the whole queue in memory.
+pub async fn list_pending(profile_pool: &SqlitePool, limit: i64) -> AppResult<Vec<PendingOp>> {
+    let rows: Vec<PendingOpRow> = sqlx::query_as(
+        "SELECT id, operation_id, lamport_ts, entity, entity_id, field, op,
+                payload, created_at, last_attempt_at, attempt_count, last_error
+         FROM sync_pending_op
+         ORDER BY id ASC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(profile_pool)
+    .await?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let payload = match row.payload {
+            Some(text) => Some(serde_json::from_str(&text).map_err(|e| {
+                crate::error::AppError::Other(format!(
+                    "sync queue row {} payload parse: {e}",
+                    row.id,
+                ))
+            })?),
+            None => None,
+        };
+        out.push(PendingOp {
+            id: row.id,
+            operation_id: row.operation_id,
+            lamport_ts: row.lamport_ts,
+            entity: row.entity,
+            entity_id: row.entity_id,
+            field: row.field,
+            op: row.op,
+            payload,
+            created_at: row.created_at,
+            last_attempt_at: row.last_attempt_at,
+            attempt_count: row.attempt_count,
+            last_error: row.last_error,
+        });
+    }
+    Ok(out)
+}
+
+/// Drop every row the server has acknowledged. The drain task
+/// batches the ack lookup so we don't hammer the DB with one DELETE
+/// per row.
+///
+/// Uses `QueryBuilder::push_bind` to construct the `IN (…)` list —
+/// sqlx 0.9 rejects dynamically-built `&str` SQL on its `query()`
+/// path (`SqlSafeStr` is only impl'd for `&'static str`), so the
+/// typed builder is the canonical escape hatch.
+pub async fn drop_acked(profile_pool: &SqlitePool, ids: &[i64]) -> AppResult<u64> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let mut qb: QueryBuilder<Sqlite> =
+        QueryBuilder::new("DELETE FROM sync_pending_op WHERE id IN (");
+    let mut sep = qb.separated(", ");
+    for id in ids {
+        sep.push_bind(id);
+    }
+    sep.push_unseparated(")");
+    let res = qb.build().execute(profile_pool).await?;
+    Ok(res.rows_affected())
+}
+
+/// Mark a row as having failed its latest attempt, increment the
+/// counter, and store the server's error string. Leaves the row
+/// in the queue so the next drain pass can retry.
+pub async fn mark_failed(profile_pool: &SqlitePool, id: i64, error: &str) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE sync_pending_op
+            SET last_attempt_at = ?,
+                attempt_count = attempt_count + 1,
+                last_error = ?
+         WHERE id = ?",
+    )
+    .bind(now_ms())
+    .bind(error)
+    .bind(id)
+    .execute(profile_pool)
+    .await?;
+    Ok(())
+}
+
+/// Number of rows currently waiting. Diagnostic only — the drain
+/// task uses [`list_pending`] which already gives it a count.
+pub async fn count_pending(profile_pool: &SqlitePool) -> AppResult<i64> {
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sync_pending_op")
+        .fetch_one(profile_pool)
+        .await?;
+    Ok(count)
+}
+
+/// Nuclear option for the Settings → Diagnostics panel. Drops every
+/// row regardless of state. Returned for a confirmation toast.
+pub async fn clear(profile_pool: &SqlitePool) -> AppResult<u64> {
+    let res = sqlx::query("DELETE FROM sync_pending_op")
+        .execute(profile_pool)
+        .await?;
+    Ok(res.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    /// Stand up an in-memory pool with the `sync_pending_op` schema
+    /// copy-pasted from the migration. Updating the migration without
+    /// updating this fixture would silently diverge the unit tests
+    /// from production behaviour — a small price for not pulling the
+    /// real migrator into the unit suite.
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE sync_pending_op (
+                id INTEGER PRIMARY KEY,
+                operation_id TEXT NOT NULL UNIQUE,
+                lamport_ts INTEGER NOT NULL UNIQUE CHECK (lamport_ts > 0),
+                entity TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                field TEXT,
+                op TEXT NOT NULL CHECK (op IN ('set','delete','insert','noop')),
+                payload TEXT,
+                created_at INTEGER NOT NULL,
+                last_attempt_at INTEGER,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    fn draft(entity_id: &str, field: Option<&str>) -> PendingOpDraft {
+        PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: entity_id.into(),
+            field: field.map(str::to_string),
+            op: "set".into(),
+            payload: Some(serde_json::json!({ "value": "x" })),
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_writes_row_and_returns_ids() {
+        let pool = pool().await;
+        let (id, operation_id) = enqueue(&pool, &draft("1", Some("name")), 1).await.unwrap();
+        assert!(id > 0);
+        Uuid::parse_str(&operation_id).expect("operation_id is a UUID");
+
+        let rows = list_pending(&pool, 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, id);
+        assert_eq!(rows[0].operation_id, operation_id);
+        assert_eq!(rows[0].lamport_ts, 1);
+        assert_eq!(rows[0].entity, "playlist");
+        assert_eq!(rows[0].entity_id, "1");
+        assert_eq!(rows[0].field.as_deref(), Some("name"));
+        assert_eq!(rows[0].op, "set");
+        assert_eq!(
+            rows[0].payload.as_ref().unwrap(),
+            &serde_json::json!({ "value": "x" }),
+        );
+        assert_eq!(rows[0].attempt_count, 0);
+        assert!(rows[0].last_attempt_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_pending_returns_fifo_order() {
+        let pool = pool().await;
+        for lamport in 1..=5 {
+            enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+                .await
+                .unwrap();
+        }
+        let rows = list_pending(&pool, 10).await.unwrap();
+        let lamports: Vec<i64> = rows.iter().map(|r| r.lamport_ts).collect();
+        assert_eq!(lamports, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn lamport_unique_constraint_rejects_duplicates() {
+        let pool = pool().await;
+        enqueue(&pool, &draft("1", None), 42).await.unwrap();
+        let err = enqueue(&pool, &draft("2", None), 42).await.unwrap_err();
+        let s = format!("{err}");
+        assert!(
+            s.contains("UNIQUE") || s.contains("constraint"),
+            "expected UNIQUE violation, got {s}",
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_acked_removes_matching_rows() {
+        let pool = pool().await;
+        let mut ids = Vec::new();
+        for lamport in 1..=5 {
+            let (id, _) = enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+                .await
+                .unwrap();
+            ids.push(id);
+        }
+        let removed = drop_acked(&pool, &[ids[0], ids[2], ids[4]]).await.unwrap();
+        assert_eq!(removed, 3);
+        let remaining: Vec<i64> = list_pending(&pool, 10)
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.lamport_ts)
+            .collect();
+        assert_eq!(remaining, vec![2, 4]);
+    }
+
+    #[tokio::test]
+    async fn drop_acked_empty_input_is_noop() {
+        let pool = pool().await;
+        enqueue(&pool, &draft("1", None), 1).await.unwrap();
+        assert_eq!(drop_acked(&pool, &[]).await.unwrap(), 0);
+        assert_eq!(count_pending(&pool).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn mark_failed_bumps_counter_and_records_error() {
+        let pool = pool().await;
+        let (id, _) = enqueue(&pool, &draft("1", None), 1).await.unwrap();
+        mark_failed(&pool, id, "503 Service Unavailable")
+            .await
+            .unwrap();
+        mark_failed(&pool, id, "504 Gateway Timeout").await.unwrap();
+        let row = &list_pending(&pool, 1).await.unwrap()[0];
+        assert_eq!(row.attempt_count, 2);
+        assert_eq!(row.last_error.as_deref(), Some("504 Gateway Timeout"));
+        assert!(row.last_attempt_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn check_constraint_rejects_unknown_op() {
+        let pool = pool().await;
+        let draft = PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: "1".into(),
+            field: None,
+            op: "rename".into(), // not in CHECK list
+            payload: None,
+        };
+        let err = enqueue(&pool, &draft, 1).await.unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("check"));
+    }
+
+    #[tokio::test]
+    async fn count_and_clear_observable() {
+        let pool = pool().await;
+        for lamport in 1..=3 {
+            enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+                .await
+                .unwrap();
+        }
+        assert_eq!(count_pending(&pool).await.unwrap(), 3);
+        let cleared = clear(&pool).await.unwrap();
+        assert_eq!(cleared, 3);
+        assert_eq!(count_pending(&pool).await.unwrap(), 0);
+    }
+}

--- a/src-tauri/migrations/profile/20260602000000_sync_pending_op.sql
+++ b/src-tauri/migrations/profile/20260602000000_sync_pending_op.sql
@@ -24,11 +24,20 @@
 --   surface at INSERT instead of after a costly round-trip.
 -- - `op` is gated by a CHECK so a typo'd write doesn't land bytes the
 --   server would 400 on.
--- - The `id INTEGER PRIMARY KEY` is SQLite's rowid alias and gives us
---   stable FIFO ordering for the drain pass.
+-- - `id INTEGER PRIMARY KEY AUTOINCREMENT` keeps the rowid strictly
+--   monotonic across the table's lifetime — without `AUTOINCREMENT`,
+--   SQLite reuses ids after deletes (the next insert picks
+--   `MAX(rowid) + 1` of the surviving rows). A future drain task
+--   that tracks a "last-processed id" high-water mark would silently
+--   miss ops appended after the queue was fully drained, because
+--   their reused ids would slot below the mark. The
+--   `sqlite_sequence` bookkeeping row that AUTOINCREMENT plants
+--   costs one extra small write per insert, which is unmeasurable
+--   next to the JSON-payload serialisation the same INSERT already
+--   does.
 
 CREATE TABLE sync_pending_op (
-    id              INTEGER PRIMARY KEY,
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
     operation_id    TEXT NOT NULL UNIQUE,
     lamport_ts      INTEGER NOT NULL UNIQUE CHECK (lamport_ts > 0),
     entity          TEXT NOT NULL,

--- a/src-tauri/migrations/profile/20260602000000_sync_pending_op.sql
+++ b/src-tauri/migrations/profile/20260602000000_sync_pending_op.sql
@@ -1,0 +1,55 @@
+-- Local pending-ops queue. Phase 1.f.desktop.2 of RFC-001 §6.6.
+--
+-- Every CRUD command that the user fires while a `waveflow_server`
+-- JWT is configured will enqueue a row here (the actual enqueue hooks
+-- land in a follow-up 1.f.desktop.2b PR; this migration just stands
+-- the table up). A future 1.f.desktop.4 drain task posts queued ops
+-- to the server's `POST /api/v1/sync/ops` and removes the rows the
+-- server accepts.
+--
+-- Per-profile (lives in the profile `data.db`) because every op is
+-- tenant-scoped to the active Better Auth user. Switching profiles
+-- mid-flight doesn't carry pending ops over — the queue and the JWT
+-- are both per-profile by construction.
+--
+-- Invariants the queue keeps:
+--
+-- - `operation_id` is the idempotency key against the server's
+--   `(user_id, device_id, operation_id)` UNIQUE. A retry of a
+--   half-failed batch sends the same id and the server short-circuits
+--   to the existing row instead of inflating the log.
+-- - `lamport_ts` is strictly monotonic per device (server-side UNIQUE
+--   on `(user_id, device_id, lamport_ts)` rejects regressions with
+--   23505). Local UNIQUE here is defense in depth — a duplicate would
+--   surface at INSERT instead of after a costly round-trip.
+-- - `op` is gated by a CHECK so a typo'd write doesn't land bytes the
+--   server would 400 on.
+-- - The `id INTEGER PRIMARY KEY` is SQLite's rowid alias and gives us
+--   stable FIFO ordering for the drain pass.
+
+CREATE TABLE sync_pending_op (
+    id              INTEGER PRIMARY KEY,
+    operation_id    TEXT NOT NULL UNIQUE,
+    lamport_ts      INTEGER NOT NULL UNIQUE CHECK (lamport_ts > 0),
+    entity          TEXT NOT NULL,
+    entity_id       TEXT NOT NULL,
+    field           TEXT,
+    op              TEXT NOT NULL
+                    CHECK (op IN ('set','delete','insert','noop')),
+    payload         TEXT,
+    created_at      INTEGER NOT NULL,
+    -- Bookkeeping for the drain task. NULL on rows that haven't been
+    -- attempted yet; updated by the drain loop on each retry.
+    last_attempt_at INTEGER,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    -- Last error string the server returned (e.g. a 409
+    -- lamport-regression hint or a 5xx burst). Cleared on success
+    -- before the row is dropped.
+    last_error      TEXT
+);
+
+-- Drain pass orders by `id ASC` (FIFO). The PK index already covers
+-- that, but a paired index on `created_at` makes the diagnostic
+-- "show me the oldest pending row" query cheap.
+CREATE INDEX sync_pending_op_created_idx
+    ON sync_pending_op (created_at);


### PR DESCRIPTION
Local-side foundation for the multi-device sync protocol from [RFC-001 §6.6](https://github.com/InstaZDLL/WaveFlow/blob/main/docs/rfcs/RFC-001-waveflow-server.md#66-sync). Every sub-PR downstream (CRUD enqueue hooks 1.f.desktop.2b, Settings toggle + repo swap 1.f.desktop.3, WS subscriber + drain 1.f.desktop.4) reads the storage shape and the clock helpers shipped here.

## Summary

- **Schema** — new per-profile migration \`20260602000000_sync_pending_op.sql\`. \`sync_pending_op\` is the local write-ahead log with FIFO \`id\`, UNIQUE on \`operation_id\` (server idempotency key) + \`lamport_ts\` (local defence in depth), CHECK on \`op ∈ {set,delete,insert,noop}\`. Retry bookkeeping in \`last_attempt_at\` / \`attempt_count\` / \`last_error\`.
- **\`crate::sync::device\`** — stable per-install \`device_id\` (UUIDv4), lazy-generated on first read, persisted app-wide in \`app_setting['sync.device_id']\`. App-wide rather than per-profile so two profiles sharing a desktop emit ops under the same \`device_id\` — the server's \`(user_id, device_id, lamport_ts)\` UNIQUE already gives each profile its own Lamport space via the differing \`user_id\`.
- **\`crate::sync::lamport\`** — per-profile monotonic clock. \`next()\` atomically increments via a single UPSERT + RETURNING (no SELECT-then-UPDATE race). \`observe_remote(remote)\` is the rejoin path the future WS subscriber uses to bump past inbound op timestamps.
- **\`crate::sync::queue\`** — append-only local queue with \`enqueue\` / \`list_pending\` / \`drop_acked\` / \`mark_failed\` / \`count_pending\` / \`clear\`. \`drop_acked\` uses \`QueryBuilder::push_bind\` for the \`IN (…)\` list since sqlx 0.9 refuses dynamically-built \`&str\` on the \`query()\` path.
- **Diagnostics** — \`sync_get_queue_state\` (returns \`{ device_id, lamport_local_max, pending_count }\`) and \`sync_clear_pending\` (nuclear option).

## Test plan

\`cargo test -p waveflow --lib sync::\` — **15 unit tests, all green:**

- \`device\`: UUID generation + idempotence on re-read, \`read\` returns None on fresh DB.
- \`lamport\`: monotonic increment, observe-remote bumps past local, observe-remote refuses to lower, handles 0 / negative as no-op, seeds clock on fresh profile.
- \`queue\`: enqueue writes row + returns ids, FIFO order on list_pending, lamport UNIQUE rejects duplicates, drop_acked removes specified rows + handles empty input, mark_failed bumps counter + records error string, CHECK rejects unknown op string, count + clear observable.

Each test stands up an in-memory sqlite pool with the production schema copy-pasted from the migration.

- [x] \`cargo check --workspace\`
- [x] \`cargo clippy -p waveflow --all-targets -- -D warnings\`
- [x] \`cargo fmt -p waveflow --check\`
- [x] \`cargo test -p waveflow --lib sync::\`

## Out of scope (documented in module docstrings)

- **CRUD enqueue hooks** across \`commands/{playlist,library,edit}\` (~15 sites). Follow-up 1.f.desktop.2b so each hook reviews against the helpers already in tree.
- **Canonical-id mapping** for cross-device entity identity. Today \`entity_id\` is the local i64 coerced to TEXT; cross-device requires a \`local_id ↔ canonical_id\` mapping table that 1.f.desktop.4 introduces alongside the WS subscriber.
- **The drain task itself** — 1.f.desktop.4.

Helpers not called yet (\`ensure\`, \`next\`, \`observe_remote\`, \`enqueue\`, \`list_pending\`, \`drop_acked\`, \`mark_failed\`) carry a module-level \`#![allow(dead_code)]\` with a justification comment pointing at the consuming sub-PR. Same pattern PR #189 used for \`WaveflowServerClient\`.

## SQLite gotcha worth pinning

\`lamport::observe_remote\` initially used \`max(profile_setting.value AS INTEGER, excluded.value)\` for the monotonic UPSERT — that's wrong because \`excluded.value\` is TEXT and SQLite's mixed-affinity comparison rules treat TEXT > INTEGER. So \`max(10, \"3\")\` returned \`\"3\"\` and silently lowered the clock. Both sides need \`CAST AS INTEGER\` before the scalar \`max\` call. Test \`observe_remote_never_lowers_local\` pins the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Infrastructure de synchronisation multi-appareils ajoutée : identifiant d’appareil persistant, horloge de synchronisation par profil et file persistante d’opérations en attente.
  * Commandes exposées permettant à l’interface de consulter l’état de la file (compteurs, timestamps) et d’effacer les opérations en attente avec retour du nombre supprimé.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->