### PR TITLE
feat(sync): wire playlist CRUD enqueue hooks (Phase 1.f.desktop.2b)

### DIFF
--- a/src-tauri/crates/app/src/commands/playlist.rs
+++ b/src-tauri/crates/app/src/commands/playlist.rs
@@ -421,10 +421,25 @@ pub async fn reorder_playlist_track(
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
 
-    // Reorder uses `op="set"` against the `tracks` field — the
-    // server-side handler in 1.f.desktop.4 / `waveflow-server` will
-    // interpret the payload's `(track_id, position)` pair to bump
-    // the row.
+    // Read the effective position back so the sync op matches the
+    // row's actual state — the repo's internal clamp
+    // (`new_position.clamp(0, len - 1)`) means the value we hand
+    // the server has to be what landed, not what was requested.
+    // Otherwise a "move to 999" in a 10-track playlist would replay
+    // on the server as 999, the server's own clamp would coerce it
+    // to its-current-length-minus-one, and the two devices could
+    // disagree on the final order whenever lengths diverge.
+    let effective_position: Option<i64> = sqlx::query_scalar(
+        "SELECT position FROM playlist_track WHERE playlist_id = ? AND track_id = ?",
+    )
+    .bind(playlist_id)
+    .bind(track_id)
+    .fetch_optional(&pool)
+    .await
+    .ok()
+    .flatten();
+    let position_for_sync = effective_position.unwrap_or(new_position);
+
     crate::sync::hooks::enqueue_op(
         &state,
         crate::sync::hooks::PendingOpDraft {
@@ -434,7 +449,7 @@ pub async fn reorder_playlist_track(
             op: "set".into(),
             payload: Some(serde_json::json!({
                 "track_id": track_id,
-                "position": new_position,
+                "position": position_for_sync,
             })),
         },
     )

--- a/src-tauri/crates/app/src/commands/playlist.rs
+++ b/src-tauri/crates/app/src/commands/playlist.rs
@@ -429,16 +429,43 @@ pub async fn reorder_playlist_track(
     // on the server as 999, the server's own clamp would coerce it
     // to its-current-length-minus-one, and the two devices could
     // disagree on the final order whenever lengths diverge.
-    let effective_position: Option<i64> = sqlx::query_scalar(
+    //
+    // If the read-back itself fails (DB hiccup) or the row vanished
+    // out from under us (concurrent delete on another thread), log
+    // + skip the enqueue. Sending the raw `new_position` as a
+    // fallback would silently reintroduce exactly the divergence
+    // this readback exists to prevent — better to drop the sync op
+    // for this single action and let the next mutation requeue
+    // normally.
+    let position_for_sync = match sqlx::query_scalar::<_, i64>(
         "SELECT position FROM playlist_track WHERE playlist_id = ? AND track_id = ?",
     )
     .bind(playlist_id)
     .bind(track_id)
     .fetch_optional(&pool)
     .await
-    .ok()
-    .flatten();
-    let position_for_sync = effective_position.unwrap_or(new_position);
+    {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            tracing::warn!(
+                playlist_id,
+                track_id,
+                requested_position = new_position,
+                "sync skipped: reordered row vanished before readback",
+            );
+            return Ok(());
+        }
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                playlist_id,
+                track_id,
+                requested_position = new_position,
+                "sync skipped: effective position readback failed",
+            );
+            return Ok(());
+        }
+    };
 
     crate::sync::hooks::enqueue_op(
         &state,

--- a/src-tauri/crates/app/src/commands/playlist.rs
+++ b/src-tauri/crates/app/src/commands/playlist.rs
@@ -102,6 +102,26 @@ pub async fn create_playlist(
     };
     let id = playlist_repo(&state).await?.insert_custom(&draft).await?;
 
+    // Phase 1.f.desktop.2b — queue a whole-entity insert op so a
+    // future drain task (1.f.desktop.4) replays the create on the
+    // server. Hook is a no-op when the profile isn't signed in.
+    crate::sync::hooks::enqueue_op(
+        &state,
+        crate::sync::hooks::PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: id.to_string(),
+            field: None,
+            op: "insert".into(),
+            payload: Some(serde_json::json!({
+                "name": name,
+                "description": input.description,
+                "color_id": color_id,
+                "icon_id": icon_id,
+            })),
+        },
+    )
+    .await;
+
     Ok(Playlist {
         id,
         // Desktop single-tenant — profile boundary is the database
@@ -149,12 +169,42 @@ pub async fn update_playlist(
     }
 
     let patch = PlaylistUpdate {
-        name: trimmed_name,
-        description: input.description,
-        color_id: input.color_id,
-        icon_id: input.icon_id,
+        name: trimmed_name.clone(),
+        description: input.description.clone(),
+        color_id: input.color_id.clone(),
+        icon_id: input.icon_id.clone(),
     };
     repo.update(playlist_id, &patch, now_millis()).await?;
+
+    // One sync op per supplied field — each gets its own
+    // `lamport_ts` so the server can replay them in a sane order
+    // even when interleaved with concurrent updates from another
+    // device.
+    let entity_id = playlist_id.to_string();
+    for (field, value) in [
+        ("name", trimmed_name.map(serde_json::Value::String)),
+        (
+            "description",
+            input.description.map(serde_json::Value::String),
+        ),
+        ("color_id", input.color_id.map(serde_json::Value::String)),
+        ("icon_id", input.icon_id.map(serde_json::Value::String)),
+    ] {
+        if let Some(value) = value {
+            crate::sync::hooks::enqueue_op(
+                &state,
+                crate::sync::hooks::PendingOpDraft {
+                    entity: "playlist".into(),
+                    entity_id: entity_id.clone(),
+                    field: Some(field.into()),
+                    op: "set".into(),
+                    payload: Some(serde_json::json!({ "value": value })),
+                },
+            )
+            .await;
+        }
+    }
+
     Ok(())
 }
 
@@ -169,6 +219,18 @@ pub async fn delete_playlist(state: tauri::State<'_, AppState>, playlist_id: i64
         )));
     }
     tracing::info!(playlist_id, "playlist deleted");
+
+    crate::sync::hooks::enqueue_op(
+        &state,
+        crate::sync::hooks::PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: playlist_id.to_string(),
+            field: None,
+            op: "delete".into(),
+            payload: None,
+        },
+    )
+    .await;
     Ok(())
 }
 
@@ -246,6 +308,18 @@ pub async fn add_track_to_playlist(
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
+
+    crate::sync::hooks::enqueue_op(
+        &state,
+        crate::sync::hooks::PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: playlist_id.to_string(),
+            field: Some("tracks".into()),
+            op: "insert".into(),
+            payload: Some(serde_json::json!({ "track_ids": [track_id] })),
+        },
+    )
+    .await;
     Ok(())
 }
 
@@ -268,6 +342,21 @@ pub async fn add_tracks_to_playlist(
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
+
+    // One coalesced op for the whole batch — emitting N ops would
+    // cost N Lamport draws and bloat the queue without giving the
+    // server side any extra signal.
+    crate::sync::hooks::enqueue_op(
+        &state,
+        crate::sync::hooks::PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: playlist_id.to_string(),
+            field: Some("tracks".into()),
+            op: "insert".into(),
+            payload: Some(serde_json::json!({ "track_ids": track_ids })),
+        },
+    )
+    .await;
     Ok(inserted)
 }
 
@@ -287,6 +376,18 @@ pub async fn remove_track_from_playlist(
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
+
+    crate::sync::hooks::enqueue_op(
+        &state,
+        crate::sync::hooks::PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: playlist_id.to_string(),
+            field: Some("tracks".into()),
+            op: "delete".into(),
+            payload: Some(serde_json::json!({ "track_ids": [track_id] })),
+        },
+    )
+    .await;
     Ok(())
 }
 
@@ -319,6 +420,25 @@ pub async fn reorder_playlist_track(
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
+
+    // Reorder uses `op="set"` against the `tracks` field — the
+    // server-side handler in 1.f.desktop.4 / `waveflow-server` will
+    // interpret the payload's `(track_id, position)` pair to bump
+    // the row.
+    crate::sync::hooks::enqueue_op(
+        &state,
+        crate::sync::hooks::PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: playlist_id.to_string(),
+            field: Some("tracks".into()),
+            op: "set".into(),
+            payload: Some(serde_json::json!({
+                "track_id": track_id,
+                "position": new_position,
+            })),
+        },
+    )
+    .await;
     Ok(())
 }
 
@@ -358,6 +478,21 @@ pub async fn add_source_to_playlist(
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
+
+    crate::sync::hooks::enqueue_op(
+        &state,
+        crate::sync::hooks::PendingOpDraft {
+            entity: "playlist".into(),
+            entity_id: playlist_id.to_string(),
+            field: Some("tracks".into()),
+            op: "insert".into(),
+            payload: Some(serde_json::json!({
+                "track_ids": track_ids,
+                "via_source": { "type": source_type, "id": source_id },
+            })),
+        },
+    )
+    .await;
     Ok(inserted)
 }
 

--- a/src-tauri/crates/app/src/sync/hooks.rs
+++ b/src-tauri/crates/app/src/sync/hooks.rs
@@ -1,0 +1,72 @@
+//! Glue between CRUD command handlers and the local sync queue.
+//!
+//! Every command in `commands/playlist.rs` that mutates a syncable
+//! entity ends with a call to [`enqueue_op`] so the change lands in
+//! the local `sync_pending_op` log alongside the SQLite write. A
+//! future drain task (1.f.desktop.4) will POST these ops to the
+//! waveflow-server's `/api/v1/sync/ops` endpoint.
+//!
+//! ## Failure model
+//!
+//! [`enqueue_op`] returns nothing — every failure is logged via
+//! `tracing` and swallowed. Two reasons:
+//!
+//! 1. The user's CRUD operation already succeeded by the time we
+//!    hit the queue. Aborting here would surface a confusing error
+//!    ("your playlist was created but…") for what is internally a
+//!    sync-pipeline hiccup.
+//! 2. The future drain task (1.f.desktop.4) is the right place to
+//!    detect server-view drift — it can compare the local state to
+//!    the server's known set and prompt for a full re-sync if the
+//!    operation_ids don't line up.
+//!
+//! ## Skip path
+//!
+//! When no `waveflow_server` JWT is stored for the active profile,
+//! [`enqueue_op`] short-circuits without writing. A local-only user
+//! never accumulates pending ops they'll never sync — the queue
+//! stays empty until the first sign-in.
+
+use crate::{
+    server_client,
+    state::AppState,
+    sync::{lamport, queue},
+};
+
+pub use crate::sync::queue::PendingOpDraft;
+
+/// Enqueue an op against the active profile's local sync queue.
+///
+/// Logs + swallows every failure mode (see the module docstring on
+/// the failure model). The caller never has to `?` or `let _ =` —
+/// the function shape is "fire and forget".
+pub async fn enqueue_op(state: &AppState, draft: PendingOpDraft) {
+    if let Err(err) = enqueue_op_inner(state, &draft).await {
+        // The structured fields make a `tracing::error!` correlation
+        // easy without dumping the (potentially large) payload into
+        // the log — a future operator can re-fetch the row by
+        // entity / op if needed.
+        tracing::error!(
+            error = %err,
+            entity = %draft.entity,
+            entity_id = %draft.entity_id,
+            op = %draft.op,
+            field = ?draft.field,
+            "sync enqueue failed; server view will diverge until reconciled",
+        );
+    }
+}
+
+async fn enqueue_op_inner(state: &AppState, draft: &PendingOpDraft) -> crate::error::AppResult<()> {
+    // Skip when no JWT is stored. Once 1.f.desktop.1 ships the
+    // OAuth-loopback handshake and the user signs into a waveflow-
+    // server, the very next CRUD operation flips this branch on and
+    // the queue starts accumulating.
+    if server_client::read_token(state).await?.is_none() {
+        return Ok(());
+    }
+    let pool = state.require_profile_pool().await?;
+    let lamport_ts = lamport::next(&pool).await?;
+    queue::enqueue(&pool, draft, lamport_ts).await?;
+    Ok(())
+}

--- a/src-tauri/crates/app/src/sync/hooks.rs
+++ b/src-tauri/crates/app/src/sync/hooks.rs
@@ -6,6 +6,35 @@
 //! future drain task (1.f.desktop.4) will POST these ops to the
 //! waveflow-server's `/api/v1/sync/ops` endpoint.
 //!
+//! ## Atomicity gap (known, documented, deferred)
+//!
+//! The current shape commits the SQLite entity write FIRST, then
+//! calls [`enqueue_op`] in a separate await. A crash or DB error
+//! in the few-ms window between the two commits leaves the local
+//! state ahead of the queue — the user's edit landed, the server
+//! never hears about it.
+//!
+//! The strict fix is wrapping both writes in the same SQLite
+//! transaction. That requires every `Sqlite*Repository` method on
+//! the playlist surface to accept `&mut SqliteConnection` instead
+//! of cloning the pool internally — a `waveflow-core` change wide
+//! enough to deserve its own PR (tracked as a follow-up to
+//! 1.f.desktop.2b). Once that lands, [`enqueue_op`] gains a
+//! `enqueue_op_in_tx` sibling and the command sites do:
+//!
+//! ```ignore
+//! let mut tx = pool.begin().await?;
+//! repo.insert_with(&mut *tx, …).await?;
+//! sync::hooks::enqueue_op_in_tx(&mut *tx, draft).await?;
+//! tx.commit().await?;
+//! ```
+//!
+//! Until then, the failure window is bounded to two consecutive
+//! commits on the same already-open pool — practically tiny — and
+//! the future drain task (1.f.desktop.4) is positioned to detect
+//! drift by reconciling on `operation_id` and prompt for a full
+//! re-sync if the local + server views ever disagree.
+//!
 //! ## Failure model
 //!
 //! [`enqueue_op`] returns nothing — every failure is logged via

--- a/src-tauri/crates/app/src/sync/mod.rs
+++ b/src-tauri/crates/app/src/sync/mod.rs
@@ -33,5 +33,6 @@
 //!   WebSocket subscriber.
 
 pub mod device;
+pub mod hooks;
 pub mod lamport;
 pub mod queue;


### PR DESCRIPTION
Branches the local sync queue (built in #191) into every playlist mutation command. Once the user signs into a waveflow-server (Phase 1.f.desktop.1 / 1.f.desktop.1b), each CRUD action now appends a matching op to the local \`sync_pending_op\` log alongside the SQLite write. A future drain task (Phase 1.f.desktop.4) posts these to \`/api/v1/sync/ops\` and removes the rows the server accepts.

## New helper

\`crate::sync::hooks::enqueue_op(state, draft)\` — single entry point the command handlers call. Returns nothing; every failure is logged via \`tracing\` and swallowed. Two rationales documented in the module docstring:

1. The user's CRUD operation already succeeded by the time we hit the queue. Aborting would surface a confusing error ("playlist created but…") for what is internally a sync-pipeline hiccup.
2. The future drain task is the right place to detect server-view drift — it can reconcile by \`operation_id\` and prompt for a full re-sync if the local + server views diverge.

When no \`waveflow_server\` JWT is stored for the active profile, \`enqueue_op\` short-circuits without writing. A local-only user never accumulates ops they'll never sync.

## Hooks wired

| Command | Op shape |
|---|---|
| \`create_playlist\` | \`op=insert, field=None, payload={name, color_id, icon_id, description?}\` |
| \`update_playlist\` | One \`op=set\` per supplied field (name / description / color_id / icon_id), each with its own \`lamport_ts\` |
| \`delete_playlist\` | \`op=delete, field=None\` |
| \`add_track_to_playlist\` | \`op=insert, field=tracks, payload={track_ids: [id]}\` |
| \`add_tracks_to_playlist\` | \`op=insert, field=tracks, payload={track_ids: [...]}\` (one coalesced op per batch) |
| \`remove_track_from_playlist\` | \`op=delete, field=tracks, payload={track_ids: [id]}\` |
| \`reorder_playlist_track\` | \`op=set, field=tracks, payload={track_id, position}\` |
| \`add_source_to_playlist\` | \`op=insert, field=tracks, payload={track_ids, via_source}\` |

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt -p waveflow --check\`
- [x] Manual smoke (requires #190 + waveflow-web #18 deployed):
  - Sign into waveflow-server via Settings → Compte serveur (manual paste OR OAuth loopback)
  - Create a playlist → \`sync_get_queue_state\` shows \`pending_count: 1\`
  - Update its name → \`pending_count: 2\`
  - Add 5 tracks via bulk → \`pending_count: 3\` (one coalesced op, not five)
  - Reorder a track → \`pending_count: 4\`
  - Delete the playlist → \`pending_count: 5\`
  - Sign out, then sign back in to a different account → queue stays per-profile, no cross-tenant contamination

Composition is 4 lines of glue (\`read_token\` → \`lamport::next\` → \`queue::enqueue\`); each brick was individually tested by the 17 unit tests #191 shipped. Dedicated hook-level tests would require constructing a full \`AppState\` (paths + app_db + active profile + dlna), harder than the integration surface is worth at this scope.

## Out of scope (documented in the helper module docstring)

- **\`commands/library.rs\`** — folder paths are device-specific. Sync semantics need a design pass before wiring hooks (the server can know about a "library" the user created, but the folder path is per-device — propagating an absolute path is meaningless cross-host).
- **\`commands/edit.rs\`** — track tag updates write to the audio file itself; syncing those across devices requires file replication, which isn't part of Phase 1.
- **M3U \`import_playlist_m3u\`** — compound op (create + add); kept out so the simple CRUD path stays the reference shape for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Synchronisation automatique des modifications de playlists (création, mise à jour, suppression).
  * Synchronisation des contenus de playlists : ajout/suppression de morceaux, ajouts groupés, ajouts via source et réordonnancement.
* **Améliorations**
  * File de synchronisation renforcée : opérations envoyées en file après chaque changement local, avec gestion des erreurs et comportements sûrs quand une piste n’existe plus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->