### PR TITLE
refactor(sync): atomic playlist write + outbox enqueue in one tx

### DIFF
--- a/src-tauri/crates/app/src/commands/playlist.rs
+++ b/src-tauri/crates/app/src/commands/playlist.rs
@@ -163,15 +163,6 @@ pub async fn update_playlist(
     playlist_id: i64,
     input: UpdatePlaylistInput,
 ) -> AppResult<()> {
-    let repo = playlist_repo(&state).await?;
-
-    // Precise error for missing id instead of a silent "0 rows updated".
-    if !repo.exists(playlist_id).await? {
-        return Err(AppError::Other(format!(
-            "playlist {playlist_id} not found in active profile"
-        )));
-    }
-
     let trimmed_name = input.name.as_ref().map(|s| s.trim().to_string());
     if let Some(name) = &trimmed_name {
         if name.is_empty() {
@@ -186,13 +177,23 @@ pub async fn update_playlist(
         icon_id: input.icon_id.clone(),
     };
 
-    // Atomic update + per-field outbox ops in one tx. One Lamport
-    // bump per supplied field so the server can replay them in a
-    // sane order even when interleaved with concurrent updates from
-    // another device.
+    // Atomic existence-check + update + per-field outbox ops in one
+    // tx. `update_conn` now returns the rows-affected boolean so a
+    // concurrent delete between the pre-1.f exists() probe and the
+    // UPDATE can't slip an enqueue past — if no row was touched we
+    // drop the tx (auto-rollback on drop) and return the same 404-
+    // style error the previous shape did, but without the race
+    // window. One Lamport bump per supplied field so the server can
+    // replay them in order against concurrent updates from another
+    // device.
     let pool = state.require_profile_pool().await?;
     let mut tx = pool.begin().await?;
-    update_conn(&mut tx, playlist_id, &patch, now_millis()).await?;
+    let updated = update_conn(&mut tx, playlist_id, &patch, now_millis()).await?;
+    if !updated {
+        return Err(AppError::Other(format!(
+            "playlist {playlist_id} not found in active profile"
+        )));
+    }
 
     let entity_id = playlist_id.to_string();
     for (field, value) in [
@@ -389,22 +390,32 @@ pub async fn remove_track_from_playlist(
     let profile_id = state.require_profile_id().await?;
 
     let mut tx = pool.begin().await?;
-    remove_track_conn(&mut tx, playlist_id, track_id, now_millis()).await?;
-    crate::sync::hooks::enqueue_op_in_tx(
-        &mut tx,
-        &crate::sync::hooks::PendingOpDraft {
-            entity: "playlist".into(),
-            entity_id: playlist_id.to_string(),
-            field: Some("tracks".into()),
-            op: "delete".into(),
-            payload: Some(serde_json::json!({ "track_ids": [track_id] })),
-        },
-    )
-    .await?;
+    let removed = remove_track_conn(&mut tx, playlist_id, track_id, now_millis()).await?;
+    // Only enqueue when the local DELETE actually touched a row —
+    // otherwise a `remove` op against a track that wasn't in the
+    // playlist (concurrent removal, double-click, stale UI state)
+    // would replay on the server and drop a row that legitimately
+    // belonged there. The tx still commits so the no-op stays
+    // idempotent from the caller's POV.
+    if removed {
+        crate::sync::hooks::enqueue_op_in_tx(
+            &mut tx,
+            &crate::sync::hooks::PendingOpDraft {
+                entity: "playlist".into(),
+                entity_id: playlist_id.to_string(),
+                field: Some("tracks".into()),
+                op: "delete".into(),
+                payload: Some(serde_json::json!({ "track_ids": [track_id] })),
+            },
+        )
+        .await?;
+    }
     tx.commit().await?;
 
-    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
-        .await;
+    if removed {
+        super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
+            .await;
+    }
     Ok(())
 }
 

--- a/src-tauri/crates/app/src/commands/playlist.rs
+++ b/src-tauri/crates/app/src/commands/playlist.rs
@@ -13,7 +13,13 @@ use sqlx::FromRow;
 
 use waveflow_core::repository::{
     playlist::{PlaylistDraft, PlaylistRepository, PlaylistUpdate},
-    sqlite::{SqlitePlaylistRepository, SqliteTrackRepository},
+    sqlite::{
+        playlist::{
+            append_track_conn, append_tracks_conn, delete_conn, insert_custom_conn,
+            remove_track_conn, reorder_track_conn, update_conn,
+        },
+        SqlitePlaylistRepository, SqliteTrackRepository,
+    },
     track::{TrackRepository, TrackSource},
 };
 
@@ -100,14 +106,18 @@ pub async fn create_playlist(
         icon_id: icon_id.clone(),
         now_ms: now,
     };
-    let id = playlist_repo(&state).await?.insert_custom(&draft).await?;
 
-    // Phase 1.f.desktop.2b — queue a whole-entity insert op so a
-    // future drain task (1.f.desktop.4) replays the create on the
-    // server. Hook is a no-op when the profile isn't signed in.
-    crate::sync::hooks::enqueue_op(
-        &state,
-        crate::sync::hooks::PendingOpDraft {
+    // Atomic write + outbox enqueue (issue #193). The playlist
+    // INSERT and the matching `sync_pending_op` row land in the
+    // same SQLite transaction; either both commit or both roll
+    // back. Closes the drift window the fire-and-forget
+    // `enqueue_op` had between two consecutive commits.
+    let pool = state.require_profile_pool().await?;
+    let mut tx = pool.begin().await?;
+    let id = insert_custom_conn(&mut tx, &draft).await?;
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
             entity_id: id.to_string(),
             field: None,
@@ -120,7 +130,8 @@ pub async fn create_playlist(
             })),
         },
     )
-    .await;
+    .await?;
+    tx.commit().await?;
 
     Ok(Playlist {
         id,
@@ -174,12 +185,15 @@ pub async fn update_playlist(
         color_id: input.color_id.clone(),
         icon_id: input.icon_id.clone(),
     };
-    repo.update(playlist_id, &patch, now_millis()).await?;
 
-    // One sync op per supplied field — each gets its own
-    // `lamport_ts` so the server can replay them in a sane order
-    // even when interleaved with concurrent updates from another
-    // device.
+    // Atomic update + per-field outbox ops in one tx. One Lamport
+    // bump per supplied field so the server can replay them in a
+    // sane order even when interleaved with concurrent updates from
+    // another device.
+    let pool = state.require_profile_pool().await?;
+    let mut tx = pool.begin().await?;
+    update_conn(&mut tx, playlist_id, &patch, now_millis()).await?;
+
     let entity_id = playlist_id.to_string();
     for (field, value) in [
         ("name", trimmed_name.map(serde_json::Value::String)),
@@ -191,9 +205,9 @@ pub async fn update_playlist(
         ("icon_id", input.icon_id.map(serde_json::Value::String)),
     ] {
         if let Some(value) = value {
-            crate::sync::hooks::enqueue_op(
-                &state,
-                crate::sync::hooks::PendingOpDraft {
+            crate::sync::hooks::enqueue_op_in_tx(
+                &mut tx,
+                &crate::sync::hooks::PendingOpDraft {
                     entity: "playlist".into(),
                     entity_id: entity_id.clone(),
                     field: Some(field.into()),
@@ -201,9 +215,10 @@ pub async fn update_playlist(
                     payload: Some(serde_json::json!({ "value": value })),
                 },
             )
-            .await;
+            .await?;
         }
     }
+    tx.commit().await?;
 
     Ok(())
 }
@@ -213,16 +228,16 @@ pub async fn update_playlist(
 /// belong to their library.
 #[tauri::command]
 pub async fn delete_playlist(state: tauri::State<'_, AppState>, playlist_id: i64) -> AppResult<()> {
-    if !playlist_repo(&state).await?.delete(playlist_id).await? {
+    let pool = state.require_profile_pool().await?;
+    let mut tx = pool.begin().await?;
+    if !delete_conn(&mut tx, playlist_id).await? {
         return Err(AppError::Other(format!(
             "playlist {playlist_id} not found in active profile"
         )));
     }
-    tracing::info!(playlist_id, "playlist deleted");
-
-    crate::sync::hooks::enqueue_op(
-        &state,
-        crate::sync::hooks::PendingOpDraft {
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
             entity_id: playlist_id.to_string(),
             field: None,
@@ -230,7 +245,9 @@ pub async fn delete_playlist(state: tauri::State<'_, AppState>, playlist_id: i64
             payload: None,
         },
     )
-    .await;
+    .await?;
+    tx.commit().await?;
+    tracing::info!(playlist_id, "playlist deleted");
     Ok(())
 }
 
@@ -302,16 +319,11 @@ pub async fn add_track_to_playlist(
     let profile_id = state.require_profile_id().await?;
     let now = now_millis();
 
-    SqlitePlaylistRepository::new(pool.clone())
-        .append_track(playlist_id, track_id, now)
-        .await?;
-
-    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
-        .await;
-
-    crate::sync::hooks::enqueue_op(
-        &state,
-        crate::sync::hooks::PendingOpDraft {
+    let mut tx = pool.begin().await?;
+    append_track_conn(&mut tx, playlist_id, track_id, now).await?;
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
             entity_id: playlist_id.to_string(),
             field: Some("tracks".into()),
@@ -319,7 +331,14 @@ pub async fn add_track_to_playlist(
             payload: Some(serde_json::json!({ "track_ids": [track_id] })),
         },
     )
-    .await;
+    .await?;
+    tx.commit().await?;
+
+    // Cover regen runs OUTSIDE the tx — it does its own pool read +
+    // a filesystem-level rasterise, neither of which belongs in the
+    // atomic write window.
+    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
+        .await;
     Ok(())
 }
 
@@ -336,19 +355,14 @@ pub async fn add_tracks_to_playlist(
     let profile_id = state.require_profile_id().await?;
     let now = now_millis();
 
-    let inserted = SqlitePlaylistRepository::new(pool.clone())
-        .append_tracks(playlist_id, &track_ids, now)
-        .await?;
-
-    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
-        .await;
-
+    let mut tx = pool.begin().await?;
+    let inserted = append_tracks_conn(&mut tx, playlist_id, &track_ids, now).await?;
     // One coalesced op for the whole batch — emitting N ops would
     // cost N Lamport draws and bloat the queue without giving the
     // server side any extra signal.
-    crate::sync::hooks::enqueue_op(
-        &state,
-        crate::sync::hooks::PendingOpDraft {
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
             entity_id: playlist_id.to_string(),
             field: Some("tracks".into()),
@@ -356,7 +370,11 @@ pub async fn add_tracks_to_playlist(
             payload: Some(serde_json::json!({ "track_ids": track_ids })),
         },
     )
-    .await;
+    .await?;
+    tx.commit().await?;
+
+    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
+        .await;
     Ok(inserted)
 }
 
@@ -370,16 +388,11 @@ pub async fn remove_track_from_playlist(
     let pool = state.require_profile_pool().await?;
     let profile_id = state.require_profile_id().await?;
 
-    SqlitePlaylistRepository::new(pool.clone())
-        .remove_track(playlist_id, track_id, now_millis())
-        .await?;
-
-    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
-        .await;
-
-    crate::sync::hooks::enqueue_op(
-        &state,
-        crate::sync::hooks::PendingOpDraft {
+    let mut tx = pool.begin().await?;
+    remove_track_conn(&mut tx, playlist_id, track_id, now_millis()).await?;
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
             entity_id: playlist_id.to_string(),
             field: Some("tracks".into()),
@@ -387,7 +400,11 @@ pub async fn remove_track_from_playlist(
             payload: Some(serde_json::json!({ "track_ids": [track_id] })),
         },
     )
-    .await;
+    .await?;
+    tx.commit().await?;
+
+    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
+        .await;
     Ok(())
 }
 
@@ -409,67 +426,22 @@ pub async fn reorder_playlist_track(
     let pool = state.require_profile_pool().await?;
     let profile_id = state.require_profile_id().await?;
 
-    let moved = SqlitePlaylistRepository::new(pool.clone())
-        .reorder_track(playlist_id, track_id, new_position, now_millis())
-        .await?;
-    if !moved {
+    // Atomic move + outbox enqueue in one tx. `reorder_track_conn`
+    // returns the effective position (the value after the repo's
+    // internal clamp) so the sync payload matches the row's actual
+    // new state — closes the divergence path #192 documented when
+    // sending the raw `new_position` to the server.
+    let mut tx = pool.begin().await?;
+    let effective =
+        reorder_track_conn(&mut tx, playlist_id, track_id, new_position, now_millis()).await?;
+    let Some(position_for_sync) = effective else {
         return Err(AppError::Other(format!(
             "track {track_id} not in playlist {playlist_id}"
         )));
-    }
-
-    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
-        .await;
-
-    // Read the effective position back so the sync op matches the
-    // row's actual state — the repo's internal clamp
-    // (`new_position.clamp(0, len - 1)`) means the value we hand
-    // the server has to be what landed, not what was requested.
-    // Otherwise a "move to 999" in a 10-track playlist would replay
-    // on the server as 999, the server's own clamp would coerce it
-    // to its-current-length-minus-one, and the two devices could
-    // disagree on the final order whenever lengths diverge.
-    //
-    // If the read-back itself fails (DB hiccup) or the row vanished
-    // out from under us (concurrent delete on another thread), log
-    // + skip the enqueue. Sending the raw `new_position` as a
-    // fallback would silently reintroduce exactly the divergence
-    // this readback exists to prevent — better to drop the sync op
-    // for this single action and let the next mutation requeue
-    // normally.
-    let position_for_sync = match sqlx::query_scalar::<_, i64>(
-        "SELECT position FROM playlist_track WHERE playlist_id = ? AND track_id = ?",
-    )
-    .bind(playlist_id)
-    .bind(track_id)
-    .fetch_optional(&pool)
-    .await
-    {
-        Ok(Some(p)) => p,
-        Ok(None) => {
-            tracing::warn!(
-                playlist_id,
-                track_id,
-                requested_position = new_position,
-                "sync skipped: reordered row vanished before readback",
-            );
-            return Ok(());
-        }
-        Err(err) => {
-            tracing::warn!(
-                error = %err,
-                playlist_id,
-                track_id,
-                requested_position = new_position,
-                "sync skipped: effective position readback failed",
-            );
-            return Ok(());
-        }
     };
-
-    crate::sync::hooks::enqueue_op(
-        &state,
-        crate::sync::hooks::PendingOpDraft {
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
             entity_id: playlist_id.to_string(),
             field: Some("tracks".into()),
@@ -480,7 +452,11 @@ pub async fn reorder_playlist_track(
             })),
         },
     )
-    .await;
+    .await?;
+    tx.commit().await?;
+
+    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
+        .await;
     Ok(())
 }
 
@@ -514,16 +490,11 @@ pub async fn add_source_to_playlist(
         .list_ids_in_source(source)
         .await?;
 
-    let inserted = SqlitePlaylistRepository::new(pool.clone())
-        .append_tracks(playlist_id, &track_ids, now_millis())
-        .await?;
-
-    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
-        .await;
-
-    crate::sync::hooks::enqueue_op(
-        &state,
-        crate::sync::hooks::PendingOpDraft {
+    let mut tx = pool.begin().await?;
+    let inserted = append_tracks_conn(&mut tx, playlist_id, &track_ids, now_millis()).await?;
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
             entity_id: playlist_id.to_string(),
             field: Some("tracks".into()),
@@ -534,7 +505,11 @@ pub async fn add_source_to_playlist(
             })),
         },
     )
-    .await;
+    .await?;
+    tx.commit().await?;
+
+    super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
+        .await;
     Ok(inserted)
 }
 

--- a/src-tauri/crates/app/src/server_client.rs
+++ b/src-tauri/crates/app/src/server_client.rs
@@ -34,7 +34,7 @@
 //!   route lives on `waveflow-web` and ships in its own PR.
 
 use chrono::Utc;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::{
     error::{AppError, AppResult},
@@ -136,10 +136,19 @@ pub async fn read_token(state: &AppState) -> AppResult<Option<String>> {
         Ok(p) => p,
         Err(_) => return Ok(None),
     };
+    let mut conn = pool.acquire().await?;
+    read_token_conn(&mut conn).await
+}
+
+/// Same as [`read_token`] but takes a caller-owned connection so the
+/// SELECT joins an open transaction. Used by
+/// [`crate::sync::hooks::enqueue_op_in_tx`] to gate the outbox write
+/// against the JWT presence inside the same atomic commit.
+pub async fn read_token_conn(conn: &mut SqliteConnection) -> AppResult<Option<String>> {
     let row: Option<Vec<u8>> =
         sqlx::query_scalar("SELECT token_encrypted FROM auth_credential WHERE provider = ?")
             .bind(PROVIDER)
-            .fetch_optional(&pool)
+            .fetch_optional(conn)
             .await?;
     let Some(bytes) = row else { return Ok(None) };
     let token = String::from_utf8(bytes)

--- a/src-tauri/crates/app/src/sync/hooks.rs
+++ b/src-tauri/crates/app/src/sync/hooks.rs
@@ -1,109 +1,67 @@
 //! Glue between CRUD command handlers and the local sync queue.
 //!
 //! Every command in `commands/playlist.rs` that mutates a syncable
-//! entity ends with a call to [`enqueue_op`] so the change lands in
-//! the local `sync_pending_op` log alongside the SQLite write. A
-//! future drain task (1.f.desktop.4) will POST these ops to the
-//! waveflow-server's `/api/v1/sync/ops` endpoint.
-//!
-//! ## Atomicity gap (known, documented, deferred)
-//!
-//! The current shape commits the SQLite entity write FIRST, then
-//! calls [`enqueue_op`] in a separate await. A crash or DB error
-//! in the few-ms window between the two commits leaves the local
-//! state ahead of the queue — the user's edit landed, the server
-//! never hears about it.
-//!
-//! The strict fix is wrapping both writes in the same SQLite
-//! transaction. That requires every `Sqlite*Repository` method on
-//! the playlist surface to accept `&mut SqliteConnection` instead
-//! of cloning the pool internally — a `waveflow-core` change wide
-//! enough to deserve its own PR (tracked as a follow-up to
-//! 1.f.desktop.2b). Once that lands, [`enqueue_op`] gains a
-//! `enqueue_op_in_tx` sibling and the command sites do:
-//!
-//! ```ignore
-//! let mut tx = pool.begin().await?;
-//! repo.insert_with(&mut *tx, …).await?;
-//! sync::hooks::enqueue_op_in_tx(&mut *tx, draft).await?;
-//! tx.commit().await?;
-//! ```
-//!
-//! Until then, the failure window is bounded to two consecutive
-//! commits on the same already-open pool — practically tiny — and
-//! the future drain task (1.f.desktop.4) is positioned to detect
-//! drift by reconciling on `operation_id` and prompt for a full
-//! re-sync if the local + server views ever disagree.
-//!
-//! ## Failure model
-//!
-//! [`enqueue_op`] returns nothing — every failure is logged via
-//! `tracing` and swallowed. Two reasons:
-//!
-//! 1. The user's CRUD operation already succeeded by the time we
-//!    hit the queue. Aborting here would surface a confusing error
-//!    ("your playlist was created but…") for what is internally a
-//!    sync-pipeline hiccup.
-//! 2. The future drain task (1.f.desktop.4) is the right place to
-//!    detect server-view drift — it can compare the local state to
-//!    the server's known set and prompt for a full re-sync if the
-//!    operation_ids don't line up.
+//! entity wraps its SQLite write AND the matching
+//! [`enqueue_op_in_tx`] call in a single transaction. The two writes
+//! either both commit or both roll back — closing the drift window
+//! issue #193 documented (where the playlist write committed but a
+//! subsequent enqueue could fail without touching the entity row).
 //!
 //! ## Skip path
 //!
-//! When no `waveflow_server` JWT is stored for the active profile,
-//! [`enqueue_op`] short-circuits without writing. A local-only user
-//! never accumulates pending ops they'll never sync — the queue
-//! stays empty until the first sign-in.
+//! [`enqueue_op_in_tx`] returns `Ok(false)` without writing when
+//! either:
+//!
+//! - no `waveflow_server` JWT is stored for the active profile
+//!   (local-only user, never accumulates ops they won't sync), OR
+//! - the active profile's [`mode::SyncMode`] is
+//!   [`mode::SyncMode::Local`] — an explicit user opt-out from
+//!   1.f.desktop.3 even when signed in.
+//!
+//! Both checks run on the same connection as the write so they see
+//! whatever the caller's transaction has already committed, without
+//! an extra pool acquire.
+//!
+//! ## Failure model
+//!
+//! Errors from [`enqueue_op_in_tx`] propagate to the caller. The
+//! caller is expected to `?` them so the transaction rolls back the
+//! entity write too — the whole point of the atomic path is that a
+//! failure in the outbox aborts the user's CRUD operation rather
+//! than leaving the local state ahead of the queue.
+
+use sqlx::SqliteConnection;
 
 use crate::{
+    error::AppResult,
     server_client,
-    state::AppState,
     sync::{lamport, mode, queue},
 };
 
 pub use crate::sync::queue::PendingOpDraft;
 
-/// Enqueue an op against the active profile's local sync queue.
+/// Atomically enqueue an op against a caller-owned connection
+/// (typically an open `Transaction<'_, Sqlite>` borrowed as
+/// `&mut *tx`). Composes with the entity mutation in the same
+/// transaction so the playlist write + the outbox row + the Lamport
+/// bump either ALL land or ALL roll back.
 ///
-/// Logs + swallows every failure mode (see the module docstring on
-/// the failure model). The caller never has to `?` or `let _ =` —
-/// the function shape is "fire and forget".
-pub async fn enqueue_op(state: &AppState, draft: PendingOpDraft) {
-    if let Err(err) = enqueue_op_inner(state, &draft).await {
-        // The structured fields make a `tracing::error!` correlation
-        // easy without dumping the (potentially large) payload into
-        // the log — a future operator can re-fetch the row by
-        // entity / op if needed.
-        tracing::error!(
-            error = %err,
-            entity = %draft.entity,
-            entity_id = %draft.entity_id,
-            op = %draft.op,
-            field = ?draft.field,
-            "sync enqueue failed; server view will diverge until reconciled",
-        );
+/// Returns `true` when an op was actually inserted, `false` when
+/// the skip conditions kicked in (no JWT for the active profile,
+/// or `SyncMode::Local`). Callers can use the boolean to decide
+/// whether to log a "synced" trace, but the truth-source for the
+/// queue is still the row itself.
+pub async fn enqueue_op_in_tx(
+    conn: &mut SqliteConnection,
+    draft: &PendingOpDraft,
+) -> AppResult<bool> {
+    if server_client::read_token_conn(conn).await?.is_none() {
+        return Ok(false);
     }
-}
-
-async fn enqueue_op_inner(state: &AppState, draft: &PendingOpDraft) -> crate::error::AppResult<()> {
-    // Skip when no JWT is stored. Once the OAuth-loopback handshake
-    // (1.f.desktop.1 / 1.f.desktop.1b) lands a token, the very next
-    // CRUD op flips this branch on and the queue starts accumulating.
-    if server_client::read_token(state).await?.is_none() {
-        return Ok(());
+    if mode::read_conn(conn).await? == mode::SyncMode::Local {
+        return Ok(false);
     }
-    let pool = state.require_profile_pool().await?;
-    // Mode gate (1.f.desktop.3) — a profile set to `Local` skips the
-    // queue even when signed in. Lets a user keep their account
-    // configured (for the occasional cross-device pull) while their
-    // CURRENT desktop session stays private. Mode read defaults to
-    // `Hybrid` on a fresh profile_setting row, so this only filters
-    // out an explicit user-side opt-out.
-    if mode::read(&pool).await? == mode::SyncMode::Local {
-        return Ok(());
-    }
-    let lamport_ts = lamport::next(&pool).await?;
-    queue::enqueue(&pool, draft, lamport_ts).await?;
-    Ok(())
+    let lamport_ts = lamport::next_conn(conn).await?;
+    queue::enqueue_conn(conn, draft, lamport_ts).await?;
+    Ok(true)
 }

--- a/src-tauri/crates/app/src/sync/lamport.rs
+++ b/src-tauri/crates/app/src/sync/lamport.rs
@@ -20,7 +20,7 @@
 //! enqueue calls.
 
 use chrono::Utc;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::error::AppResult;
 
@@ -44,17 +44,27 @@ fn now_ms() -> i64 {
 /// `profile_setting` schema requires for compat with every other
 /// setting type) while operating arithmetically.
 pub async fn next(profile_pool: &SqlitePool) -> AppResult<i64> {
+    let mut conn = profile_pool.acquire().await?;
+    next_conn(&mut conn).await
+}
+
+/// Same as [`next`] but takes a caller-owned connection so the bump
+/// can join an open transaction (composed with a playlist write +
+/// outbox enqueue to keep the trio atomic — see
+/// [`crate::sync::hooks::enqueue_op_in_tx`]).
+pub async fn next_conn(conn: &mut SqliteConnection) -> AppResult<i64> {
     let row: (i64,) = sqlx::query_as(
         "INSERT INTO profile_setting (key, value, value_type, updated_at)
          VALUES (?, '1', 'int', ?)
          ON CONFLICT(key) DO UPDATE
             SET value = CAST(CAST(profile_setting.value AS INTEGER) + 1 AS TEXT),
+                value_type = excluded.value_type,
                 updated_at = excluded.updated_at
          RETURNING CAST(value AS INTEGER)",
     )
     .bind(KEY)
     .bind(now_ms())
-    .fetch_one(profile_pool)
+    .fetch_one(conn)
     .await?;
     Ok(row.0)
 }

--- a/src-tauri/crates/app/src/sync/mode.rs
+++ b/src-tauri/crates/app/src/sync/mode.rs
@@ -39,7 +39,7 @@
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::error::AppResult;
 
@@ -93,9 +93,18 @@ fn now_ms() -> i64 {
 /// gate combines this with a JWT-presence check, so a fresh
 /// unconfigured profile still doesn't enqueue anything).
 pub async fn read(profile_pool: &SqlitePool) -> AppResult<SyncMode> {
+    let mut conn = profile_pool.acquire().await?;
+    read_conn(&mut conn).await
+}
+
+/// Same as [`read`] but takes a caller-owned connection so the SELECT
+/// joins an open transaction. Used by
+/// [`crate::sync::hooks::enqueue_op_in_tx`] to gate the outbox write
+/// against the persisted mode without a separate round-trip.
+pub async fn read_conn(conn: &mut SqliteConnection) -> AppResult<SyncMode> {
     let raw: Option<String> = sqlx::query_scalar("SELECT value FROM profile_setting WHERE key = ?")
         .bind(KEY)
-        .fetch_optional(profile_pool)
+        .fetch_optional(conn)
         .await?;
     Ok(raw
         .map(|s| SyncMode::from_storage(&s))

--- a/src-tauri/crates/app/src/sync/queue.rs
+++ b/src-tauri/crates/app/src/sync/queue.rs
@@ -33,7 +33,7 @@
 
 use chrono::Utc;
 use serde::Serialize;
-use sqlx::{QueryBuilder, Sqlite, SqlitePool};
+use sqlx::{QueryBuilder, Sqlite, SqliteConnection, SqlitePool};
 use uuid::Uuid;
 
 use crate::error::AppResult;
@@ -95,6 +95,19 @@ pub async fn enqueue(
     draft: &PendingOpDraft,
     lamport_ts: i64,
 ) -> AppResult<(i64, String)> {
+    let mut conn = profile_pool.acquire().await?;
+    enqueue_conn(&mut conn, draft, lamport_ts).await
+}
+
+/// Same as [`enqueue`] but takes a caller-owned connection so the
+/// INSERT joins an open transaction. Used by
+/// [`crate::sync::hooks::enqueue_op_in_tx`] to keep the playlist
+/// write + outbox row + Lamport bump in a single atomic commit.
+pub async fn enqueue_conn(
+    conn: &mut SqliteConnection,
+    draft: &PendingOpDraft,
+    lamport_ts: i64,
+) -> AppResult<(i64, String)> {
     let operation_id = Uuid::new_v4().to_string();
     let payload_json = match draft.payload.as_ref() {
         Some(v) => Some(serde_json::to_string(v).map_err(|e| {
@@ -117,7 +130,7 @@ pub async fn enqueue(
     .bind(&draft.op)
     .bind(payload_json.as_deref())
     .bind(now)
-    .fetch_one(profile_pool)
+    .fetch_one(conn)
     .await?;
     Ok((row.0, operation_id))
 }

--- a/src-tauri/crates/core/src/repository/sqlite/playlist.rs
+++ b/src-tauri/crates/core/src/repository/sqlite/playlist.rs
@@ -1,13 +1,293 @@
 //! SQLite implementation of [`PlaylistRepository`].
+//!
+//! Public write helpers come in two flavours:
+//!
+//! - **Trait methods** on [`SqlitePlaylistRepository`] — take `&self`
+//!   and run against the struct's owned `pool`. Backwards-compatible
+//!   for every existing caller.
+//! - **Free `*_conn` functions** at the module root — take
+//!   `&mut SqliteConnection` so the caller can compose the playlist
+//!   write inside their own transaction (e.g. the desktop's
+//!   write-then-enqueue path that 1.f.desktop.2b would otherwise
+//!   leave non-atomic). The trait methods delegate to these.
 
 use async_trait::async_trait;
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqliteConnection, SqlitePool, Transaction};
 
 use crate::{
     domain::playlist::Playlist,
     error::CoreResult,
     repository::playlist::{PlaylistDraft, PlaylistRepository, PlaylistUpdate},
 };
+
+// ── Connection-taking helpers ───────────────────────────────────
+//
+// Each function does the same write the matching trait method did,
+// but against a caller-supplied connection. The trait methods below
+// just acquire `pool.begin()` and forward; new tx-aware call sites
+// (e.g. `commands/playlist.rs` post Phase 1.f.desktop.4) call these
+// directly so the playlist write + outbox enqueue land in one atomic
+// commit.
+
+/// Insert a custom (`is_smart = 0`) playlist with `position = 0`.
+/// Returns the assigned rowid.
+pub async fn insert_custom_conn(
+    conn: &mut SqliteConnection,
+    draft: &PlaylistDraft,
+) -> CoreResult<i64> {
+    let insert = sqlx::query(
+        "INSERT INTO playlist
+             (name, description, color_id, icon_id, is_smart, position,
+              created_at, updated_at)
+         VALUES (?, ?, ?, ?, 0, 0, ?, ?)",
+    )
+    .bind(&draft.name)
+    .bind(draft.description.as_deref())
+    .bind(&draft.color_id)
+    .bind(&draft.icon_id)
+    .bind(draft.now_ms)
+    .bind(draft.now_ms)
+    .execute(conn)
+    .await?;
+    Ok(insert.last_insert_rowid())
+}
+
+/// Partial `UPDATE playlist` via `COALESCE` — every `Some` field
+/// overwrites, every `None` leaves the existing value alone.
+pub async fn update_conn(
+    conn: &mut SqliteConnection,
+    id: i64,
+    patch: &PlaylistUpdate,
+    now_ms: i64,
+) -> CoreResult<()> {
+    sqlx::query(
+        "UPDATE playlist
+            SET name        = COALESCE(?, name),
+                description = COALESCE(?, description),
+                color_id    = COALESCE(?, color_id),
+                icon_id     = COALESCE(?, icon_id),
+                updated_at  = ?
+          WHERE id = ?",
+    )
+    .bind(patch.name.as_deref())
+    .bind(patch.description.as_deref())
+    .bind(patch.color_id.as_deref())
+    .bind(patch.icon_id.as_deref())
+    .bind(now_ms)
+    .bind(id)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// `true` when a row was deleted, `false` when no row matched.
+pub async fn delete_conn(conn: &mut SqliteConnection, id: i64) -> CoreResult<bool> {
+    let result = sqlx::query("DELETE FROM playlist WHERE id = ?")
+        .bind(id)
+        .execute(conn)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Append a single track at the tail. Same `(insert + bump
+/// playlist.updated_at)` shape the pool variant runs, just inside the
+/// caller's open connection so it composes with other writes.
+pub async fn append_track_conn(
+    conn: &mut SqliteConnection,
+    playlist_id: i64,
+    track_id: i64,
+    now_ms: i64,
+) -> CoreResult<()> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO playlist_track (playlist_id, track_id, position, added_at)
+         VALUES (?, ?,
+                 (SELECT COALESCE(MAX(position), -1) + 1
+                    FROM playlist_track
+                   WHERE playlist_id = ?),
+                 ?)",
+    )
+    .bind(playlist_id)
+    .bind(track_id)
+    .bind(playlist_id)
+    .bind(now_ms)
+    .execute(&mut *conn)
+    .await?;
+
+    sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
+        .bind(now_ms)
+        .bind(playlist_id)
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// Bulk append. Returns the count of rows that were actually
+/// inserted (duplicates skipped by `INSERT OR IGNORE` don't count).
+pub async fn append_tracks_conn(
+    conn: &mut SqliteConnection,
+    playlist_id: i64,
+    track_ids: &[i64],
+    now_ms: i64,
+) -> CoreResult<u32> {
+    if track_ids.is_empty() {
+        return Ok(0);
+    }
+    let current_max: Option<i64> =
+        sqlx::query_scalar("SELECT MAX(position) FROM playlist_track WHERE playlist_id = ?")
+            .bind(playlist_id)
+            .fetch_one(&mut *conn)
+            .await?;
+    let mut next_position = current_max.map(|p| p + 1).unwrap_or(0);
+    let mut inserted: u32 = 0;
+
+    for track_id in track_ids {
+        let result = sqlx::query(
+            "INSERT OR IGNORE INTO playlist_track (playlist_id, track_id, position, added_at)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(playlist_id)
+        .bind(*track_id)
+        .bind(next_position)
+        .bind(now_ms)
+        .execute(&mut *conn)
+        .await?;
+        if result.rows_affected() > 0 {
+            inserted += 1;
+            next_position += 1;
+        }
+    }
+
+    sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
+        .bind(now_ms)
+        .bind(playlist_id)
+        .execute(conn)
+        .await?;
+    Ok(inserted)
+}
+
+/// Remove a track and renumber the tail so positions stay contiguous.
+/// `true` on success, `false` when the track wasn't in the playlist.
+pub async fn remove_track_conn(
+    conn: &mut SqliteConnection,
+    playlist_id: i64,
+    track_id: i64,
+    now_ms: i64,
+) -> CoreResult<bool> {
+    let removed_position: Option<i64> = sqlx::query_scalar(
+        "SELECT position FROM playlist_track WHERE playlist_id = ? AND track_id = ?",
+    )
+    .bind(playlist_id)
+    .bind(track_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+    let Some(pos) = removed_position else {
+        return Ok(false);
+    };
+
+    sqlx::query("DELETE FROM playlist_track WHERE playlist_id = ? AND track_id = ?")
+        .bind(playlist_id)
+        .bind(track_id)
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query(
+        "UPDATE playlist_track
+            SET position = position - 1
+          WHERE playlist_id = ? AND position > ?",
+    )
+    .bind(playlist_id)
+    .bind(pos)
+    .execute(&mut *conn)
+    .await?;
+    sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
+        .bind(now_ms)
+        .bind(playlist_id)
+        .execute(conn)
+        .await?;
+    Ok(true)
+}
+
+/// Move a track to `new_position`. Returns the effective position
+/// after the repo's internal clamp (`new_position.clamp(0, len - 1)`),
+/// or `None` when the track wasn't in the playlist. Lets the caller
+/// stamp the sync payload with the row's actual new state — see the
+/// commentary in `commands/playlist.rs::reorder_playlist_track` for
+/// why this matters.
+pub async fn reorder_track_conn(
+    conn: &mut SqliteConnection,
+    playlist_id: i64,
+    track_id: i64,
+    new_position: i64,
+    now_ms: i64,
+) -> CoreResult<Option<i64>> {
+    let from: Option<i64> = sqlx::query_scalar(
+        "SELECT position FROM playlist_track WHERE playlist_id = ? AND track_id = ?",
+    )
+    .bind(playlist_id)
+    .bind(track_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+    let Some(from) = from else {
+        return Ok(None);
+    };
+
+    let len: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM playlist_track WHERE playlist_id = ?")
+        .bind(playlist_id)
+        .fetch_one(&mut *conn)
+        .await?;
+    let to = new_position.clamp(0, (len - 1).max(0));
+
+    if from == to {
+        return Ok(Some(to));
+    }
+
+    if to > from {
+        sqlx::query(
+            "UPDATE playlist_track
+                SET position = position - 1
+              WHERE playlist_id = ? AND position > ? AND position <= ?",
+        )
+        .bind(playlist_id)
+        .bind(from)
+        .bind(to)
+        .execute(&mut *conn)
+        .await?;
+    } else {
+        sqlx::query(
+            "UPDATE playlist_track
+                SET position = position + 1
+              WHERE playlist_id = ? AND position >= ? AND position < ?",
+        )
+        .bind(playlist_id)
+        .bind(to)
+        .bind(from)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    sqlx::query(
+        "UPDATE playlist_track SET position = ?
+          WHERE playlist_id = ? AND track_id = ?",
+    )
+    .bind(to)
+    .bind(playlist_id)
+    .bind(track_id)
+    .execute(&mut *conn)
+    .await?;
+
+    sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
+        .bind(now_ms)
+        .bind(playlist_id)
+        .execute(conn)
+        .await?;
+    Ok(Some(to))
+}
+
+/// Begin a transaction on the supplied pool — exposed so the desktop
+/// command sites can compose playlist writes + outbox enqueues in a
+/// single atomic commit without owning the repo struct.
+pub async fn begin_tx(pool: &SqlitePool) -> CoreResult<Transaction<'_, Sqlite>> {
+    Ok(pool.begin().await?)
+}
 
 #[derive(Debug, Clone)]
 pub struct SqlitePlaylistRepository {
@@ -78,50 +358,18 @@ impl PlaylistRepository for SqlitePlaylistRepository {
     }
 
     async fn insert_custom(&self, draft: &PlaylistDraft) -> CoreResult<i64> {
-        let insert = sqlx::query(
-            "INSERT INTO playlist
-                 (name, description, color_id, icon_id, is_smart, position,
-                  created_at, updated_at)
-             VALUES (?, ?, ?, ?, 0, 0, ?, ?)",
-        )
-        .bind(&draft.name)
-        .bind(draft.description.as_deref())
-        .bind(&draft.color_id)
-        .bind(&draft.icon_id)
-        .bind(draft.now_ms)
-        .bind(draft.now_ms)
-        .execute(&self.pool)
-        .await?;
-        Ok(insert.last_insert_rowid())
+        let mut conn = self.pool.acquire().await?;
+        insert_custom_conn(&mut conn, draft).await
     }
 
     async fn update(&self, id: i64, patch: &PlaylistUpdate, now_ms: i64) -> CoreResult<()> {
-        sqlx::query(
-            "UPDATE playlist
-                SET name        = COALESCE(?, name),
-                    description = COALESCE(?, description),
-                    color_id    = COALESCE(?, color_id),
-                    icon_id     = COALESCE(?, icon_id),
-                    updated_at  = ?
-              WHERE id = ?",
-        )
-        .bind(patch.name.as_deref())
-        .bind(patch.description.as_deref())
-        .bind(patch.color_id.as_deref())
-        .bind(patch.icon_id.as_deref())
-        .bind(now_ms)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
+        let mut conn = self.pool.acquire().await?;
+        update_conn(&mut conn, id, patch, now_ms).await
     }
 
     async fn delete(&self, id: i64) -> CoreResult<bool> {
-        let result = sqlx::query("DELETE FROM playlist WHERE id = ?")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(result.rows_affected() > 0)
+        let mut conn = self.pool.acquire().await?;
+        delete_conn(&mut conn, id).await
     }
 
     async fn touch_updated_at(&self, id: i64, now_ms: i64) -> CoreResult<()> {
@@ -148,29 +396,13 @@ impl PlaylistRepository for SqlitePlaylistRepository {
     }
 
     async fn append_track(&self, playlist_id: i64, track_id: i64, now_ms: i64) -> CoreResult<()> {
-        // Compute next position in a single query so concurrent inserts from
-        // different callers don't collide. Sqlite serializes writes at the
-        // connection level, which is enough here.
-        sqlx::query(
-            "INSERT OR IGNORE INTO playlist_track (playlist_id, track_id, position, added_at)
-             VALUES (?, ?,
-                     (SELECT COALESCE(MAX(position), -1) + 1
-                        FROM playlist_track
-                       WHERE playlist_id = ?),
-                     ?)",
-        )
-        .bind(playlist_id)
-        .bind(track_id)
-        .bind(playlist_id)
-        .bind(now_ms)
-        .execute(&self.pool)
-        .await?;
-
-        sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
-            .bind(now_ms)
-            .bind(playlist_id)
-            .execute(&self.pool)
-            .await?;
+        // Wrap in a tx so the `INSERT OR IGNORE` + the
+        // `UPDATE playlist.updated_at` land atomically — without one,
+        // a concurrent reader could see the track added but the
+        // playlist row still stamped at the pre-add `updated_at`.
+        let mut tx = self.pool.begin().await?;
+        append_track_conn(&mut tx, playlist_id, track_id, now_ms).await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -180,82 +412,17 @@ impl PlaylistRepository for SqlitePlaylistRepository {
         track_ids: &[i64],
         now_ms: i64,
     ) -> CoreResult<u32> {
-        if track_ids.is_empty() {
-            return Ok(0);
-        }
         let mut tx = self.pool.begin().await?;
-        let current_max: Option<i64> =
-            sqlx::query_scalar("SELECT MAX(position) FROM playlist_track WHERE playlist_id = ?")
-                .bind(playlist_id)
-                .fetch_one(&mut *tx)
-                .await?;
-        let mut next_position = current_max.map(|p| p + 1).unwrap_or(0);
-        let mut inserted: u32 = 0;
-
-        for track_id in track_ids {
-            let result = sqlx::query(
-                "INSERT OR IGNORE INTO playlist_track (playlist_id, track_id, position, added_at)
-                 VALUES (?, ?, ?, ?)",
-            )
-            .bind(playlist_id)
-            .bind(*track_id)
-            .bind(next_position)
-            .bind(now_ms)
-            .execute(&mut *tx)
-            .await?;
-            if result.rows_affected() > 0 {
-                inserted += 1;
-                next_position += 1;
-            }
-        }
-
-        sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
-            .bind(now_ms)
-            .bind(playlist_id)
-            .execute(&mut *tx)
-            .await?;
+        let inserted = append_tracks_conn(&mut tx, playlist_id, track_ids, now_ms).await?;
         tx.commit().await?;
         Ok(inserted)
     }
 
     async fn remove_track(&self, playlist_id: i64, track_id: i64, now_ms: i64) -> CoreResult<bool> {
-        // Lookup + delete + renumber must run in the same transaction so a
-        // concurrent remove_track/reorder_track can't shift positions
-        // between the SELECT and the position-shifting UPDATE below.
         let mut tx = self.pool.begin().await?;
-        let removed_position: Option<i64> = sqlx::query_scalar(
-            "SELECT position FROM playlist_track WHERE playlist_id = ? AND track_id = ?",
-        )
-        .bind(playlist_id)
-        .bind(track_id)
-        .fetch_optional(&mut *tx)
-        .await?;
-        let Some(pos) = removed_position else {
-            tx.commit().await?;
-            return Ok(false);
-        };
-
-        sqlx::query("DELETE FROM playlist_track WHERE playlist_id = ? AND track_id = ?")
-            .bind(playlist_id)
-            .bind(track_id)
-            .execute(&mut *tx)
-            .await?;
-        sqlx::query(
-            "UPDATE playlist_track
-                SET position = position - 1
-              WHERE playlist_id = ? AND position > ?",
-        )
-        .bind(playlist_id)
-        .bind(pos)
-        .execute(&mut *tx)
-        .await?;
-        sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
-            .bind(now_ms)
-            .bind(playlist_id)
-            .execute(&mut *tx)
-            .await?;
+        let removed = remove_track_conn(&mut tx, playlist_id, track_id, now_ms).await?;
         tx.commit().await?;
-        Ok(true)
+        Ok(removed)
     }
 
     async fn reorder_track(
@@ -266,72 +433,10 @@ impl PlaylistRepository for SqlitePlaylistRepository {
         now_ms: i64,
     ) -> CoreResult<bool> {
         let mut tx = self.pool.begin().await?;
-
-        let from: Option<i64> = sqlx::query_scalar(
-            "SELECT position FROM playlist_track WHERE playlist_id = ? AND track_id = ?",
-        )
-        .bind(playlist_id)
-        .bind(track_id)
-        .fetch_optional(&mut *tx)
-        .await?;
-        let Some(from) = from else {
-            tx.commit().await?;
-            return Ok(false);
-        };
-
-        let len: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM playlist_track WHERE playlist_id = ?")
-                .bind(playlist_id)
-                .fetch_one(&mut *tx)
-                .await?;
-        let to = new_position.clamp(0, (len - 1).max(0));
-
-        if from == to {
-            tx.commit().await?;
-            return Ok(true);
-        }
-
-        if to > from {
-            sqlx::query(
-                "UPDATE playlist_track
-                    SET position = position - 1
-                  WHERE playlist_id = ? AND position > ? AND position <= ?",
-            )
-            .bind(playlist_id)
-            .bind(from)
-            .bind(to)
-            .execute(&mut *tx)
-            .await?;
-        } else {
-            sqlx::query(
-                "UPDATE playlist_track
-                    SET position = position + 1
-                  WHERE playlist_id = ? AND position >= ? AND position < ?",
-            )
-            .bind(playlist_id)
-            .bind(to)
-            .bind(from)
-            .execute(&mut *tx)
-            .await?;
-        }
-
-        sqlx::query(
-            "UPDATE playlist_track SET position = ?
-              WHERE playlist_id = ? AND track_id = ?",
-        )
-        .bind(to)
-        .bind(playlist_id)
-        .bind(track_id)
-        .execute(&mut *tx)
-        .await?;
-
-        sqlx::query("UPDATE playlist SET updated_at = ? WHERE id = ?")
-            .bind(now_ms)
-            .bind(playlist_id)
-            .execute(&mut *tx)
+        let effective = reorder_track_conn(&mut tx, playlist_id, track_id, new_position, now_ms)
             .await?;
         tx.commit().await?;
-        Ok(true)
+        Ok(effective.is_some())
     }
 
     async fn create_with_tracks(

--- a/src-tauri/crates/core/src/repository/sqlite/playlist.rs
+++ b/src-tauri/crates/core/src/repository/sqlite/playlist.rs
@@ -54,13 +54,19 @@ pub async fn insert_custom_conn(
 
 /// Partial `UPDATE playlist` via `COALESCE` — every `Some` field
 /// overwrites, every `None` leaves the existing value alone.
+///
+/// Returns `true` when a row was actually touched, `false` when no
+/// playlist matched. The boolean lets the desktop's tx-aware caller
+/// drop the surrounding transaction without enqueueing outbox ops
+/// against a row that vanished — same-tx existence check + write +
+/// outbox in a single atomic pass.
 pub async fn update_conn(
     conn: &mut SqliteConnection,
     id: i64,
     patch: &PlaylistUpdate,
     now_ms: i64,
-) -> CoreResult<()> {
-    sqlx::query(
+) -> CoreResult<bool> {
+    let res = sqlx::query(
         "UPDATE playlist
             SET name        = COALESCE(?, name),
                 description = COALESCE(?, description),
@@ -77,7 +83,7 @@ pub async fn update_conn(
     .bind(id)
     .execute(conn)
     .await?;
-    Ok(())
+    Ok(res.rows_affected() > 0)
 }
 
 /// `true` when a row was deleted, `false` when no row matched.
@@ -364,7 +370,13 @@ impl PlaylistRepository for SqlitePlaylistRepository {
 
     async fn update(&self, id: i64, patch: &PlaylistUpdate, now_ms: i64) -> CoreResult<()> {
         let mut conn = self.pool.acquire().await?;
-        update_conn(&mut conn, id, patch, now_ms).await
+        // Drop the boolean for trait back-compat — the trait method
+        // never communicated existence to the caller and changing it
+        // would break every non-tx-aware site (smart playlists,
+        // playlist_cover regen, etc.). Sites that need the signal
+        // call `update_conn` directly.
+        let _ = update_conn(&mut conn, id, patch, now_ms).await?;
+        Ok(())
     }
 
     async fn delete(&self, id: i64) -> CoreResult<bool> {


### PR DESCRIPTION
**Closes #193.** Closes the drift window #192 documented where the playlist write committed in one SQLite transaction and the matching \`sync_pending_op\` row landed in a separate await — a crash or DB hiccup between the two could leave the local state ahead of the queue and the server would never hear about the user's edit.

## Summary

- **waveflow-core** — every write method on \`SqlitePlaylistRepository\` now has a sibling free function in the same module taking \`&mut SqliteConnection\` (\`insert_custom_conn\`, \`update_conn\`, \`delete_conn\`, \`append_track_conn\`, \`append_tracks_conn\`, \`remove_track_conn\`, \`reorder_track_conn\`). The trait impls become thin wrappers that acquire \`pool.begin()\` and delegate, so every existing caller keeps working unchanged.
- \`reorder_track_conn\` returns \`Option<i64>\` (effective position post-clamp) instead of \`bool\`, so the caller can stamp the sync payload with the row's actual new state — closes the divergence the #192 readback patch worked around with a post-write SELECT. The trait method maps the Option to a bool for back-compat.
- **waveflow desktop** — \`lamport::next_conn\`, \`queue::enqueue_conn\`, \`mode::read_conn\`, \`server_client::read_token_conn\` are sibling variants that take \`&mut SqliteConnection\` so they compose in a caller's open tx.
- **\`sync::hooks::enqueue_op_in_tx(conn, draft)\`** — atomic outbox path. Returns \`AppResult<bool>\` so the caller can \`?\` the failure and let the surrounding tx roll back the entity write too. **The fire-and-forget \`enqueue_op\` variant is gone** — playlist commands all use the atomic path now, and a future non-playlist hook would too.
- **\`commands/playlist.rs\`** — the 8 mutation commands (create / update / delete / add_track / add_tracks / add_source / remove_track / reorder) all wrap their write + enqueue in a single \`pool.begin()\` → \`..._conn(&mut tx)\` → ... → \`enqueue_op_in_tx(&mut tx)\` → \`tx.commit()\` block. Filesystem-level side effects (\`playlist_cover::maybe_regen_auto_cover\`) run OUTSIDE the tx as before.

## Module docstring

\`crate::sync::hooks\` rewritten — atomicity is no longer a documented known-gap, it's the guaranteed shape. Skip path (no JWT or \`SyncMode::Local\`) still returns \`Ok(false)\` without writing.

## Test plan

- [x] \`cargo test -p waveflow --lib sync::\` — 22/22 green locally
- [x] \`cargo test -p waveflow-core --lib\` — 35/35 green locally
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] **Manual smoke** (requires #190 + waveflow-web #18 deployed):
  - Sign in to a profile, mode = Hybrid
  - Create a playlist → \`sync_get_queue_state\` shows \`pending_count: 1\` AND \`SELECT COUNT(*) FROM playlist\` shows the row
  - Force an enqueue failure (e.g. by manually corrupting \`auth_credential.token_encrypted\`) → next CRUD operation aborts, NEITHER the playlist write NOR the queue row land
  - Reorder a track to position 999 in a 10-track playlist → \`sync_get_queue_state\` payload shows \`position: 9\` (the clamped value), not 999

## Out of scope

- library + edit hooks. They were never actually wired in #192 (deferred for design reasons). When they get hooked, they'll use \`enqueue_op_in_tx\` like playlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Refactor**
  * Opérations sur les playlists (création, édition, suppression, réordonnancement, ajout/retrait de pistes) désormais exécutées de façon atomique pour plus de fiabilité.
  * Enregistrement des opérations de synchronisation couplé à l’écriture locale pour garantir cohérence entre l’état écrit et le payload envoyé.
  * Régénération automatique de la couverture exécutée après la persistance pour éviter d’impacter la transaction.
* **Correction**
  * Échec contrôlé du réordonnancement si l’entrée n’existe plus, évitant des mismatches de synchronisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->