### PR TITLE
feat(sync): drain task pushes pending ops to waveflow-server (Phase 1.f.desktop.4a)

### DIFF
--- a/src-tauri/crates/app/src/commands/playlist.rs
+++ b/src-tauri/crates/app/src/commands/playlist.rs
@@ -132,6 +132,9 @@ pub async fn create_playlist(
     )
     .await?;
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
 
     Ok(Playlist {
         id,
@@ -220,6 +223,9 @@ pub async fn update_playlist(
         }
     }
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
 
     Ok(())
 }
@@ -248,6 +254,9 @@ pub async fn delete_playlist(state: tauri::State<'_, AppState>, playlist_id: i64
     )
     .await?;
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
     tracing::info!(playlist_id, "playlist deleted");
     Ok(())
 }
@@ -334,6 +343,9 @@ pub async fn add_track_to_playlist(
     )
     .await?;
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
 
     // Cover regen runs OUTSIDE the tx — it does its own pool read +
     // a filesystem-level rasterise, neither of which belongs in the
@@ -373,6 +385,9 @@ pub async fn add_tracks_to_playlist(
     )
     .await?;
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
@@ -411,6 +426,9 @@ pub async fn remove_track_from_playlist(
         .await?;
     }
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
 
     if removed {
         super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
@@ -465,6 +483,9 @@ pub async fn reorder_playlist_track(
     )
     .await?;
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;
@@ -518,6 +539,9 @@ pub async fn add_source_to_playlist(
     )
     .await?;
     tx.commit().await?;
+    // Wake the drain task so a chatty user's edits don't wait the
+    // full 30 s tick before reaching the server.
+    state.drain.notify();
 
     super::playlist_cover::maybe_regen_auto_cover(&pool, &state.paths, profile_id, playlist_id)
         .await;

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -133,7 +133,13 @@ pub async fn sync_set_mode(
 /// Force an immediate drain pass — used by the Settings diagnostic
 /// "Push now" button so the operator doesn't have to wait for the
 /// periodic tick to verify the wiring.
+///
+/// Serialised against the background drain task via
+/// [`AppState::drain_lock`] so a manual click while the periodic
+/// pass is in flight waits for it to finish instead of racing it
+/// onto the same batch.
 #[tauri::command]
 pub async fn sync_drain_now(state: tauri::State<'_, AppState>) -> AppResult<drain::DrainOutcome> {
+    let _guard = state.drain_lock.lock().await;
     drain::drain_once(&state).await
 }

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     error::{AppError, AppResult},
     state::AppState,
-    sync::{device, lamport, mode, queue},
+    sync::{device, drain, lamport, mode, queue},
 };
 
 #[derive(Debug, Serialize)]
@@ -121,5 +121,19 @@ pub async fn sync_set_mode(
     };
     let pool = state.require_profile_pool().await?;
     mode::write(&pool, parsed).await?;
+    // Flipping to Hybrid likely means the user wants their pending
+    // ops to fly upstream right away — wake the drain task so the
+    // first push doesn't wait for the 30 s tick.
+    if parsed == mode::SyncMode::Hybrid {
+        state.drain.notify();
+    }
     Ok(parsed.as_str())
+}
+
+/// Force an immediate drain pass — used by the Settings diagnostic
+/// "Push now" button so the operator doesn't have to wait for the
+/// periodic tick to verify the wiring.
+#[tauri::command]
+pub async fn sync_drain_now(state: tauri::State<'_, AppState>) -> AppResult<drain::DrainOutcome> {
+    drain::drain_once(&state).await
 }

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -125,6 +125,15 @@ pub fn run() {
 
             app.manage(state);
 
+            // Sync drain task — pushes pending `sync_pending_op`
+            // rows to the waveflow-server in the background. Spawned
+            // here so it picks up `AppState` from `app.manage(state)`
+            // above. Wake handle already lives in `AppState::drain`,
+            // so CRUD commands can `state.drain.notify()` after a
+            // successful tx.commit() without needing a separate
+            // import path.
+            sync::drain::spawn(app.handle().clone());
+
             // Audio engine lives alongside AppState. `new` spawns the cpal
             // output thread (silence callback) and the decoder thread, both
             // receiving a clone of the AppHandle so they can emit Tauri
@@ -570,6 +579,7 @@ pub fn run() {
             commands::sync::sync_clear_pending,
             commands::sync::sync_get_mode,
             commands::sync::sync_set_mode,
+            commands::sync::sync_drain_now,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,
             commands::preferences::get_minimize_to_tray,

--- a/src-tauri/crates/app/src/server_client.rs
+++ b/src-tauri/crates/app/src/server_client.rs
@@ -272,23 +272,24 @@ pub async fn write_web_url(app_db: &SqlitePool, url: &str) -> AppResult<()> {
 /// Errors map to [`AppError`] so handlers don't have to thread an
 /// extra error type — same convention as [`crate::spotify`].
 ///
-/// Currently unused — the sync surface (`1.f.desktop.2`+) is the
-/// first consumer. Kept here so the foundational PR ships the
-/// complete shape and reviewers can audit the auth header attachment
-/// in one place.
-#[allow(dead_code)]
+/// First consumer: [`crate::sync::drain`] (Phase 1.f.desktop.4a).
 pub struct WaveflowServerClient {
     base_url: String,
     token: String,
     http: reqwest::Client,
 }
 
-#[allow(dead_code)]
 impl WaveflowServerClient {
     /// Build a client against the active profile's stored config.
     /// Returns `Err` when either the URL or the JWT is missing —
     /// callers that want a "no-op when offline" semantic should use
     /// [`try_build`] instead.
+    ///
+    /// Currently unused — [`try_build`] is the only consumer — but
+    /// kept for parity with the contract docstring and for the WS
+    /// subscriber landing in 1.f.desktop.4b, which needs the
+    /// erroring variant for boot-time wiring.
+    #[allow(dead_code)]
     pub async fn build(state: &AppState) -> AppResult<Self> {
         Self::try_build(state).await?.ok_or_else(|| {
             AppError::Other(
@@ -343,11 +344,13 @@ impl WaveflowServerClient {
     /// off to another protocol (the WebSocket subscriber in
     /// 1.f.desktop.4 has to attach it via the upgrade headers, not
     /// the reqwest builder).
+    #[allow(dead_code)]
     pub fn token(&self) -> &str {
         &self.token
     }
 
     /// Base URL accessor — same use case as [`token`].
+    #[allow(dead_code)]
     pub fn base_url(&self) -> &str {
         &self.base_url
     }

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -32,6 +32,13 @@ pub struct AppState {
     /// thread is spawned at init even when DLNA is disabled) so the
     /// Settings page can call into it without re-spawning.
     pub dlna: DlnaServer,
+    /// Wake handle for the sync drain task (Phase 1.f.desktop.4a).
+    /// CRUD command sites notify after `tx.commit()` so a chatty
+    /// user's edits reach the server without waiting for the
+    /// periodic tick. Defaults to an unparked notifier on a fresh
+    /// `AppState` — the live task is spawned in `lib.rs::run` once
+    /// the AppHandle is available.
+    pub drain: Arc<crate::sync::drain::DrainHandle>,
 }
 
 impl AppState {
@@ -74,6 +81,11 @@ impl AppState {
             app_db,
             profile: Arc::new(RwLock::new(None)),
             dlna: DlnaServer::spawn(),
+            // Placeholder until `lib.rs::run` wires the live task.
+            // CRUD command sites can `notify()` against it harmlessly
+            // before the task spawns (no waiter parked yet); the
+            // first real tick will pick up any queued work.
+            drain: Arc::new(crate::sync::drain::DrainHandle::default()),
         };
 
         state.bootstrap().await?;

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -39,6 +39,14 @@ pub struct AppState {
     /// `AppState` — the live task is spawned in `lib.rs::run` once
     /// the AppHandle is available.
     pub drain: Arc<crate::sync::drain::DrainHandle>,
+    /// Mutual-exclusion lock around [`crate::sync::drain::drain_once`].
+    /// The background task and the `sync_drain_now` Tauri command
+    /// share the same `Arc<Mutex<()>>` so a manual user-driven push
+    /// never races a periodic tick (would otherwise read the same
+    /// `sync_pending_op` rows and double-send — server absorbs the
+    /// duplicates via the `operation_id` UNIQUE but the wasted
+    /// round-trip + duplicated `total_sent` accounting is avoidable).
+    pub drain_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl AppState {
@@ -86,6 +94,7 @@ impl AppState {
             // before the task spawns (no waiter parked yet); the
             // first real tick will pick up any queued work.
             drain: Arc::new(crate::sync::drain::DrainHandle::default()),
+            drain_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
 
         state.bootstrap().await?;

--- a/src-tauri/crates/app/src/sync/drain.rs
+++ b/src-tauri/crates/app/src/sync/drain.rs
@@ -1,0 +1,381 @@
+//! Drain task — pushes pending `sync_pending_op` rows to the
+//! `waveflow-server`'s `POST /api/v1/sync/ops` endpoint and removes
+//! the rows the server accepts. Phase 1.f.desktop.4a.
+//!
+//! ## Lifecycle
+//!
+//! Spawned once at boot via [`spawn`]. The returned [`DrainHandle`]
+//! lives on [`AppState`] so any CRUD command can wake the task on
+//! demand via [`DrainHandle::notify`] — typically the playlist
+//! commands fire it after a successful `tx.commit()` so a chatty
+//! user doesn't wait the full poll interval to see their changes
+//! reach the server.
+//!
+//! ## Gates (cheap, evaluated per pass)
+//!
+//! 1. [`WaveflowServerClient::try_build`] — both the server URL and
+//!    the active profile's JWT must be configured. A local-only or
+//!    half-configured profile no-ops without any HTTP.
+//! 2. [`mode::SyncMode::Hybrid`] — a profile explicitly set to
+//!    `Local` keeps its queue local even when signed in.
+//!
+//! Either gate short-circuits to [`DrainOutcome::Skipped`].
+//!
+//! ## Failure semantics
+//!
+//! - **HTTP 200** — server accepted the batch. `drop_acked` removes
+//!   the rows from the local queue; the loop runs again to see if
+//!   more pending rows surfaced while we were posting.
+//! - **HTTP 409** — `lamport_regression`. [`lamport::observe_remote`]
+//!   bumps the local floor past the server's view; the offending row
+//!   is `mark_failed`d so it surfaces in diagnostics; the pass
+//!   breaks. The next iteration retries with the bumped clock.
+//! - **Other HTTP statuses + network errors** — the batch is
+//!   `mark_failed`d with the server reply for operator triage; the
+//!   pass breaks. The periodic poll re-attempts later.
+//!
+//! ## What this PR does NOT ship
+//!
+//! - **WebSocket subscriber + apply remote ops** — 1.f.desktop.4b.
+//!   This module's drain is one-way push only; the desktop's local
+//!   SQLite stays the source of truth until the WS path lands.
+//! - **Canonical-id mapping** — also 1.f.desktop.4b. Today's
+//!   `entity_id` is the local i64 coerced to TEXT, which is fine for
+//!   the push direction (server keys ops on `(user_id, device_id,
+//!   entity, entity_id)`, so different devices' ops live in disjoint
+//!   namespaces). Cross-device replay needs a separate `local_id ↔
+//!   canonical_id` table the WS subscriber will introduce.
+
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+use tokio::sync::Notify;
+
+use crate::{
+    error::AppResult,
+    server_client::WaveflowServerClient,
+    state::AppState,
+    sync::{device, lamport, mode, queue},
+};
+
+/// How often the task wakes on its own. A user-driven push notifies
+/// the task immediately, so this is really just the floor for "we
+/// went a while without any activity, are there any retries to
+/// attempt?". 30 s is comfortable for a typical edit cadence.
+const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Max ops per HTTP request. Mirrors waveflow-server's
+/// `MAX_BATCH_SIZE` (1024) but a smaller floor keeps a flaky server
+/// from holding a huge batch in flight.
+const BATCH_SIZE: i64 = 100;
+
+/// Wake-up signal the rest of the app uses to nudge the drain task
+/// after a successful enqueue. Internally a `tokio::sync::Notify`,
+/// which means `notify_one` is a cheap atomic flag set — never
+/// blocks the caller, never drops a permit even if no waiter is
+/// currently parked (the next `notified().await` resolves
+/// immediately).
+#[derive(Default)]
+pub struct DrainHandle {
+    notifier: Notify,
+}
+
+impl DrainHandle {
+    /// Wake the drain task on the next iteration.
+    pub fn notify(&self) {
+        self.notifier.notify_one();
+    }
+}
+
+/// Result of a single drain pass. Surface for the diagnostic
+/// `sync_drain_now` Tauri command.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum DrainOutcome {
+    /// The gates short-circuited the pass. No HTTP round-trip.
+    Skipped,
+    /// The pass ran; `sent` is the number of ops the server
+    /// accepted, `remaining` is the queue depth observed after the
+    /// pass completed.
+    Drained { sent: usize, remaining: i64 },
+}
+
+// ── Wire shape mirroring waveflow-server's sync types ────────────
+
+/// Mirrors `waveflow_server::sync::SyncOpIn`.
+#[derive(Debug, Serialize)]
+struct SyncOpInBody {
+    operation_id: String,
+    lamport_ts: i64,
+    entity: String,
+    entity_id: String,
+    field: Option<String>,
+    op: String,
+    payload: Option<serde_json::Value>,
+}
+
+/// Mirrors `waveflow_server::api::sync::PushBatchRequest`.
+#[derive(Debug, Serialize)]
+struct PushBatchRequest<'a> {
+    device_id: &'a str,
+    ops: Vec<SyncOpInBody>,
+}
+
+/// Subset of `waveflow_server::api::sync::LamportRegression` we
+/// actually consume. `error` + `device_id` are echoed for diagnostic
+/// log lines; `stored_max` drives [`lamport::observe_remote`] and
+/// `offending_lamport_ts` drives the per-row mark_failed.
+#[derive(Debug, Deserialize)]
+struct LamportRegression {
+    #[allow(dead_code)]
+    error: String,
+    device_id: String,
+    stored_max: i64,
+    offending_lamport_ts: i64,
+}
+
+// ── Public surface ───────────────────────────────────────────────
+
+/// Spawn the drain task. The wake handle is already in
+/// [`AppState::drain`] — both sides of the notification (CRUD
+/// command sites + the task itself) clone the same `Arc<DrainHandle>`
+/// so a single `notify_one` wakes the task regardless of which
+/// caller fires it.
+pub fn spawn(app: AppHandle) {
+    let task_handle = app.state::<AppState>().drain.clone();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(POLL_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // First tick fires immediately — burn it so we don't spam
+        // the server on startup before the user has done anything.
+        ticker.tick().await;
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {}
+                _ = task_handle.notifier.notified() => {}
+            }
+            let state = app.state::<AppState>();
+            match drain_once(&state).await {
+                Ok(DrainOutcome::Skipped) => {
+                    // Common path when not signed in / not Hybrid —
+                    // silent, no log spam.
+                }
+                Ok(DrainOutcome::Drained { sent, remaining }) => {
+                    if sent > 0 || remaining > 0 {
+                        tracing::debug!(sent, remaining, "sync drain pass completed",);
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(error = %err, "sync drain pass failed");
+                }
+            }
+        }
+    });
+}
+
+/// Run one drain pass synchronously. Exposed so the
+/// `sync_drain_now` Tauri command (Settings diagnostics) can force
+/// an immediate attempt without waiting for the periodic tick.
+pub async fn drain_once(state: &AppState) -> AppResult<DrainOutcome> {
+    // Gate 1: client buildable. Both the server URL and the active
+    // profile's JWT must be configured.
+    let Some(client) = WaveflowServerClient::try_build(state).await? else {
+        return Ok(DrainOutcome::Skipped);
+    };
+    let pool = state.require_profile_pool().await?;
+    // Gate 2: per-profile mode = Hybrid.
+    if mode::read(&pool).await? != mode::SyncMode::Hybrid {
+        return Ok(DrainOutcome::Skipped);
+    }
+    let device_id = device::ensure(&state.app_db).await?;
+
+    let mut total_sent = 0usize;
+    loop {
+        let pending = queue::list_pending(&pool, BATCH_SIZE).await?;
+        if pending.is_empty() {
+            break;
+        }
+
+        let ops: Vec<SyncOpInBody> = pending
+            .iter()
+            .map(|p| SyncOpInBody {
+                operation_id: p.operation_id.clone(),
+                lamport_ts: p.lamport_ts,
+                entity: p.entity.clone(),
+                entity_id: p.entity_id.clone(),
+                field: p.field.clone(),
+                op: p.op.clone(),
+                payload: p.payload.clone(),
+            })
+            .collect();
+        let body = PushBatchRequest {
+            device_id: &device_id,
+            ops,
+        };
+
+        let resp = match client
+            .request(reqwest::Method::POST, "/api/v1/sync/ops")
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(err) => {
+                // Network-level failure — mark the batch failed for
+                // diagnostics and break the loop. The periodic pass
+                // will retry; we don't `?` because a transient DNS
+                // hiccup shouldn't surface as a hard error from the
+                // drain task.
+                let summary = format!("network: {err}");
+                for p in &pending {
+                    let _ = queue::mark_failed(&pool, p.id, &summary).await;
+                }
+                tracing::warn!(error = %err, "sync push: network failure");
+                break;
+            }
+        };
+
+        match resp.status() {
+            StatusCode::OK => {
+                let ids: Vec<i64> = pending.iter().map(|p| p.id).collect();
+                queue::drop_acked(&pool, &ids).await?;
+                total_sent += pending.len();
+                // Continue the loop to drain any rows that surfaced
+                // while we were posting.
+            }
+            StatusCode::CONFLICT => {
+                let regression: LamportRegression = match resp.json().await {
+                    Ok(b) => b,
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            "sync push: 409 body did not parse as LamportRegression",
+                        );
+                        break;
+                    }
+                };
+                lamport::observe_remote(&pool, regression.stored_max).await?;
+                if let Some(off) = pending
+                    .iter()
+                    .find(|p| p.lamport_ts == regression.offending_lamport_ts)
+                {
+                    let _ = queue::mark_failed(
+                        &pool,
+                        off.id,
+                        &format!("lamport_regression stored_max={}", regression.stored_max,),
+                    )
+                    .await;
+                }
+                tracing::warn!(
+                    device_id = %regression.device_id,
+                    stored_max = regression.stored_max,
+                    offending = regression.offending_lamport_ts,
+                    "sync push: lamport regression; bumped local clock",
+                );
+                break;
+            }
+            other => {
+                let body_text = resp.text().await.unwrap_or_default();
+                tracing::warn!(
+                    status = %other,
+                    body = %body_text,
+                    "sync push: server rejected batch",
+                );
+                let summary = format!("HTTP {other}: {body_text}");
+                for p in &pending {
+                    let _ = queue::mark_failed(&pool, p.id, &summary).await;
+                }
+                break;
+            }
+        }
+    }
+
+    let remaining = queue::count_pending(&pool).await?;
+    Ok(DrainOutcome::Drained {
+        sent: total_sent,
+        remaining,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drain_outcome_serialises_with_snake_case_tag() {
+        let skipped = DrainOutcome::Skipped;
+        let drained = DrainOutcome::Drained {
+            sent: 3,
+            remaining: 7,
+        };
+        // Tag is `snake_case`-renamed so the frontend's
+        // discriminated-union matcher reads `outcome === "drained"`
+        // rather than `"Drained"`.
+        let s = serde_json::to_value(skipped).unwrap();
+        assert_eq!(s, serde_json::json!({"outcome": "skipped"}));
+        let d = serde_json::to_value(drained).unwrap();
+        assert_eq!(
+            d,
+            serde_json::json!({
+                "outcome": "drained",
+                "sent": 3,
+                "remaining": 7,
+            }),
+        );
+    }
+
+    #[test]
+    fn push_batch_request_body_matches_server_wire_shape() {
+        // Tightens the contract against waveflow-server's
+        // `SyncOpIn`. A divergence here would surface at the first
+        // real POST, which is far from the test boundary; pinning
+        // the shape locally catches it at compile + serialise time.
+        let body = PushBatchRequest {
+            device_id: "device-a",
+            ops: vec![SyncOpInBody {
+                operation_id: "00000000-0000-0000-0000-000000000001".into(),
+                lamport_ts: 42,
+                entity: "playlist".into(),
+                entity_id: "7".into(),
+                field: Some("name".into()),
+                op: "set".into(),
+                payload: Some(serde_json::json!({ "value": "Soirée" })),
+            }],
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "device_id": "device-a",
+                "ops": [{
+                    "operation_id": "00000000-0000-0000-0000-000000000001",
+                    "lamport_ts": 42,
+                    "entity": "playlist",
+                    "entity_id": "7",
+                    "field": "name",
+                    "op": "set",
+                    "payload": { "value": "Soirée" },
+                }],
+            }),
+        );
+    }
+
+    #[test]
+    fn lamport_regression_parses_server_409_body() {
+        // Mirrors the JSON waveflow-server's `LamportRegression`
+        // serialises. Renaming a field on either side trips this
+        // test before a regression lands in tracked code paths.
+        let body = serde_json::json!({
+            "error": "lamport_regression",
+            "device_id": "device-a",
+            "stored_max": 11,
+            "offending_lamport_ts": 10,
+        });
+        let parsed: LamportRegression = serde_json::from_value(body).unwrap();
+        assert_eq!(parsed.device_id, "device-a");
+        assert_eq!(parsed.stored_max, 11);
+        assert_eq!(parsed.offending_lamport_ts, 10);
+    }
+}

--- a/src-tauri/crates/app/src/sync/drain.rs
+++ b/src-tauri/crates/app/src/sync/drain.rs
@@ -157,6 +157,16 @@ pub fn spawn(app: AppHandle) {
                 _ = task_handle.notifier.notified() => {}
             }
             let state = app.state::<AppState>();
+            // Serialise against the `sync_drain_now` Tauri command
+            // — a manual user-driven push racing this background
+            // tick would otherwise read the same `sync_pending_op`
+            // rows and POST them twice (server absorbs the
+            // duplicates via the `operation_id` UNIQUE, but the
+            // wasted round-trip + duplicated accounting is
+            // avoidable). The lock is held across the whole pass;
+            // dropped automatically when `_guard` falls out of
+            // scope at the end of the match.
+            let _guard = state.drain_lock.lock().await;
             match drain_once(&state).await {
                 Ok(DrainOutcome::Skipped) => {
                     // Common path when not signed in / not Hybrid —
@@ -249,10 +259,20 @@ pub async fn drain_once(state: &AppState) -> AppResult<DrainOutcome> {
                 let regression: LamportRegression = match resp.json().await {
                     Ok(b) => b,
                     Err(err) => {
+                        // A 409 we can't parse is still a server
+                        // rejection — leaving the rows untouched
+                        // would just have us hit the same 409 next
+                        // pass forever. Mark the batch failed so it
+                        // surfaces in diagnostics + the
+                        // `attempt_count` climbs, then break.
+                        let summary = format!("409 body parse failed: {err}");
                         tracing::warn!(
                             error = %err,
                             "sync push: 409 body did not parse as LamportRegression",
                         );
+                        for p in &pending {
+                            let _ = queue::mark_failed(&pool, p.id, &summary).await;
+                        }
                         break;
                     }
                 };

--- a/src-tauri/crates/app/src/sync/mod.rs
+++ b/src-tauri/crates/app/src/sync/mod.rs
@@ -33,6 +33,7 @@
 //!   WebSocket subscriber.
 
 pub mod device;
+pub mod drain;
 pub mod hooks;
 pub mod lamport;
 pub mod mode;


### PR DESCRIPTION
Wakes up the \`WaveflowServerClient\` struct dormant since #189 and pipes the local \`sync_pending_op\` queue into \`POST /api/v1/sync/ops\`. **One-way push for now** — the WebSocket subscriber + apply-remote-ops + canonical-id mapping all land in a follow-up **1.f.desktop.4b**.

## \`sync::drain\` module

Background task spawned at boot from \`lib.rs\`. Loop alternates between a 30 s periodic tick and a \`tokio::sync::Notify\` wake fired by CRUD command sites after a successful \`tx.commit()\` — a chatty user's edits reach the server within ms instead of waiting the full poll interval.

Two gates short-circuit the pass without an HTTP round-trip:

1. **\`WaveflowServerClient::try_build\`** — both the server URL and the active profile JWT must be configured.
2. **\`SyncMode::Hybrid\`** — Local-mode profiles keep their queue local.

Either gate yields \`DrainOutcome::Skipped\`.

## Failure semantics

- **HTTP 200** — \`drop_acked\` removes the rows, loop continues to drain any newly-arrived ops.
- **HTTP 409 \`lamport_regression\`** — \`lamport::observe_remote\` bumps the local floor past the server's view, \`mark_failed\` on the offending row, break the loop. The next pass retries with the bumped clock.
- **Other HTTP statuses + network errors** — \`mark_failed\` the batch with the server reply for diagnostics, break. The periodic poll re-attempts later.

## Tauri surface

- New command **\`sync_drain_now\`** for the Settings diagnostics \"Push now\" affordance — runs \`drain_once\` synchronously and returns the \`DrainOutcome\`.
- **\`sync_set_mode\`** now notifies the drain task on the Hybrid switch so flipping the radio doesn't wait 30 s to fire the first push.

## Boot wiring

- **\`AppState\` gains \`drain: Arc<DrainHandle>\`**, default-initialised so callers can \`notify()\` against it harmlessly before the task spawns.
- **\`lib.rs::run\` spawns the task** right after \`app.manage(state)\` so \`app.state::<AppState>()\` resolves and the same \`Arc<Notify>\` is shared by command sites + the task.

## Notify-on-commit in playlist commands

All 8 mutation sites in \`commands/playlist.rs\` gain a \`state.drain.notify()\` right after \`tx.commit()\`. No-op when the drain task isn't spawned yet (very brief window between \`state.manage\` and \`drain::spawn\`).

## Test plan

- [x] \`cargo test -p waveflow --lib sync::\` — **25/25 green locally** (+3 new in \`sync::drain\` pinning \`DrainOutcome\` snake_case tag, \`PushBatchRequest\` wire shape vs waveflow-server, \`LamportRegression\` deserialisation from a server 409 body)
- [x] \`cargo clippy -p waveflow --all-targets -- -D warnings\`
- [x] \`cargo fmt -p waveflow --check\`
- [x] **Manual smoke** (requires #190 + waveflow-web #18 deployed):
  - Sign in to a profile, mode = Hybrid
  - Create a playlist → \`sync_drain_now()\` returns \`{outcome: \"drained\", sent: 1, remaining: 0}\` AND the row appears in waveflow-server's \`sync_op\` table
  - Spam-edit 50 names rapidly → no per-edit wait, all 50 ops drain in batches of 100
  - Stop waveflow-server → next edit → \`pending_count\` keeps climbing, \`mark_failed\` logs network errors; restart server → next tick drains
  - Flip mode to Local → \`sync_drain_now()\` returns \`Skipped\`, no HTTP
  - Force a Lamport regression by hand (write a higher \`sync_op.lamport_ts\` on the server) → next push 409s, \`observe_remote\` bumps the local clock, next pass succeeds

## Out of scope (1.f.desktop.4b)

- **WebSocket subscriber + apply remote ops** on local SQLite.
- **Canonical-id mapping** for cross-device entity identity. Today's \`entity_id\` is the local i64 coerced to TEXT, which is fine for the push direction since the server keys ops on \`(user_id, device_id, entity, entity_id)\` — different devices' ops live in disjoint namespaces. Cross-device replay needs the mapping table the WS subscriber will introduce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Commande manuelle de synchronisation pour forcer l'envoi immédiat des opérations vers le serveur.
  * Tâche de synchronisation en arrière-plan activée au démarrage pour pousser automatiquement les opérations en attente.

* **Améliorations**
  * Les modifications de playlists sont synchronisées immédiatement après validation.
  * Le basculement en mode Hybrid déclenche une synchronisation instantanée.

* **Corrections**
  * Meilleure gestion des erreurs de synchronisation et marquage des opérations en échec pour triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->