### PR TITLE
feat(sync): library + liked + rating hooks (Phase 1.f.desktop.5)

### DIFF
--- a/src-tauri/crates/app/src/commands/library.rs
+++ b/src-tauri/crates/app/src/commands/library.rs
@@ -3,7 +3,10 @@ use serde::Serialize;
 
 use waveflow_core::repository::{
     library::{LibraryDraft, LibraryRepository, LibraryUpdate},
-    sqlite::SqliteLibraryRepository,
+    sqlite::{
+        library::{delete_conn, insert_conn, update_conn},
+        SqliteLibraryRepository,
+    },
 };
 
 use crate::{
@@ -73,7 +76,32 @@ pub async fn create_library(
         icon_id: icon_id.clone(),
         now_ms: now,
     };
-    let id = library_repo(&state).await?.insert(&draft).await?;
+
+    // Atomic write + outbox enqueue. Same shape as `create_playlist`
+    // — the library INSERT, canonical-id mapping and outbox row all
+    // land in a single tx so a crash mid-create rolls back cleanly.
+    let pool = state.require_profile_pool().await?;
+    let mut tx = pool.begin().await?;
+    let id = insert_conn(&mut tx, &draft).await?;
+    let canonical = crate::sync::canonical::ensure_local_library(&mut tx, id).await?;
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
+            entity: "library".into(),
+            entity_id: canonical,
+            field: None,
+            op: "insert".into(),
+            payload: Some(serde_json::json!({
+                "name": name,
+                "description": input.description,
+                "color_id": color_id,
+                "icon_id": icon_id,
+            })),
+        },
+    )
+    .await?;
+    tx.commit().await?;
+    state.drain.notify();
 
     Ok(Library {
         id,
@@ -107,16 +135,6 @@ pub async fn update_library(
     library_id: i64,
     input: UpdateLibraryInput,
 ) -> AppResult<()> {
-    let repo = library_repo(&state).await?;
-
-    // Validate the library exists up-front so the caller gets a precise
-    // error instead of a "0 rows updated" silent no-op.
-    if !repo.exists(library_id).await? {
-        return Err(AppError::Other(format!(
-            "library {library_id} not found in active profile"
-        )));
-    }
-
     let trimmed_name = input.name.as_ref().map(|s| s.trim().to_string());
     if let Some(name) = &trimmed_name {
         if name.is_empty() {
@@ -125,12 +143,50 @@ pub async fn update_library(
     }
 
     let patch = LibraryUpdate {
-        name: trimmed_name,
-        description: input.description,
-        color_id: input.color_id,
-        icon_id: input.icon_id,
+        name: trimmed_name.clone(),
+        description: input.description.clone(),
+        color_id: input.color_id.clone(),
+        icon_id: input.icon_id.clone(),
     };
-    repo.update(library_id, &patch, now_millis()).await?;
+
+    // Same atomic pattern as `update_playlist`: existence check +
+    // write + per-field outbox ops in one tx so a concurrent delete
+    // between the legacy pre-tx `exists()` probe and the UPDATE
+    // can't slip a stale enqueue past.
+    let pool = state.require_profile_pool().await?;
+    let mut tx = pool.begin().await?;
+    let updated = update_conn(&mut tx, library_id, &patch, now_millis()).await?;
+    if !updated {
+        return Err(AppError::Other(format!(
+            "library {library_id} not found in active profile"
+        )));
+    }
+    let entity_id = crate::sync::canonical::ensure_local_library(&mut tx, library_id).await?;
+    for (field, value) in [
+        ("name", trimmed_name.map(serde_json::Value::String)),
+        (
+            "description",
+            input.description.map(serde_json::Value::String),
+        ),
+        ("color_id", input.color_id.map(serde_json::Value::String)),
+        ("icon_id", input.icon_id.map(serde_json::Value::String)),
+    ] {
+        if let Some(value) = value {
+            crate::sync::hooks::enqueue_op_in_tx(
+                &mut tx,
+                &crate::sync::hooks::PendingOpDraft {
+                    entity: "library".into(),
+                    entity_id: entity_id.clone(),
+                    field: Some(field.into()),
+                    op: "set".into(),
+                    payload: Some(serde_json::json!({ "value": value })),
+                },
+            )
+            .await?;
+        }
+    }
+    tx.commit().await?;
+    state.drain.notify();
     Ok(())
 }
 
@@ -141,11 +197,41 @@ pub async fn update_library(
 /// DELETE and the DB takes care of the rest.
 #[tauri::command]
 pub async fn delete_library(state: tauri::State<'_, AppState>, library_id: i64) -> AppResult<()> {
-    if !library_repo(&state).await?.delete(library_id).await? {
+    let pool = state.require_profile_pool().await?;
+    let mut tx = pool.begin().await?;
+    // Resolve canonical BEFORE the DELETE — the row (and its
+    // mapping) are gone after.
+    let canonical = crate::sync::canonical::canonical_for_local(
+        &mut tx,
+        crate::sync::canonical::ENTITY_LIBRARY,
+        library_id,
+    )
+    .await?;
+    if !delete_conn(&mut tx, library_id).await? {
         return Err(AppError::Other(format!(
             "library {library_id} not found in active profile"
         )));
     }
+    let entity_id = if let Some(ref c) = canonical {
+        crate::sync::canonical::drop_mapping(&mut tx, crate::sync::canonical::ENTITY_LIBRARY, c)
+            .await?;
+        c.clone()
+    } else {
+        library_id.to_string()
+    };
+    crate::sync::hooks::enqueue_op_in_tx(
+        &mut tx,
+        &crate::sync::hooks::PendingOpDraft {
+            entity: "library".into(),
+            entity_id,
+            field: None,
+            op: "delete".into(),
+            payload: None,
+        },
+    )
+    .await?;
+    tx.commit().await?;
+    state.drain.notify();
     tracing::info!(library_id, "library deleted");
     Ok(())
 }

--- a/src-tauri/crates/app/src/commands/track.rs
+++ b/src-tauri/crates/app/src/commands/track.rs
@@ -501,8 +501,37 @@ pub async fn set_track_rating(
         }
     }
 
-    // 4. DB update (always — even when the file write fell through).
-    repo.set_rating(track_id, rating).await?;
+    // 4. DB update + outbox enqueue in a single tx so a peer device
+    //    sees the rating change at the same cross-device key
+    //    (file_hash). The set_rating call above used the repo pool;
+    //    we drop down to raw SQL for the tx so the enqueue is
+    //    atomic with the rating write.
+    let mut tx = pool.begin().await?;
+    sqlx::query("UPDATE track SET rating = ? WHERE id = ?")
+        .bind(rating.map(i64::from))
+        .bind(track_id)
+        .execute(&mut *tx)
+        .await?;
+    let file_hash = crate::sync::canonical::file_hash_for_local_track(&mut tx, track_id).await?;
+    if let Some(hash) = file_hash {
+        crate::sync::hooks::enqueue_op_in_tx(
+            &mut tx,
+            &crate::sync::hooks::PendingOpDraft {
+                entity: "track_rating".into(),
+                entity_id: hash,
+                field: None,
+                op: if rating.is_some() { "set" } else { "delete" }.into(),
+                payload: rating.map(|r| serde_json::json!({ "value": r })),
+            },
+        )
+        .await?;
+    }
+    tx.commit().await?;
+    state.drain.notify();
+
+    // Drop the legacy repo call now that the tx above wrote the row
+    // — kept the binding alive only for its other call sites.
+    let _ = repo;
 
     let _ = app.emit("track:updated", track_id);
     Ok(())
@@ -576,16 +605,54 @@ pub async fn toggle_like_track(
     track_id: i64,
 ) -> AppResult<bool> {
     let pool = state.require_profile_pool().await?;
-    let repo = SqliteTrackRepository::new(pool);
+    let mut tx = pool.begin().await?;
 
-    if repo.is_liked(track_id).await? {
-        repo.unlike(track_id).await?;
-        Ok(false)
+    // Resolve the file hash once so both branches enqueue against
+    // the same cross-device key. A track without a hash (shouldn't
+    // happen post-scan, but handle defensively) silently skips the
+    // outbox enqueue — the local DB still moves so the UI heart
+    // animation lands.
+    let file_hash = crate::sync::canonical::file_hash_for_local_track(&mut tx, track_id).await?;
+
+    let now = chrono::Utc::now().timestamp_millis();
+    // Inline the like-state check + flip against the open tx so the
+    // read + write land atomically without a separate
+    // SqliteTrackRepository acquire/release pair.
+    let was_liked: Option<i64> = sqlx::query_scalar("SELECT 1 FROM liked_track WHERE track_id = ?")
+        .bind(track_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+    let now_liked = if was_liked.is_some() {
+        sqlx::query("DELETE FROM liked_track WHERE track_id = ?")
+            .bind(track_id)
+            .execute(&mut *tx)
+            .await?;
+        false
     } else {
-        let now = chrono::Utc::now().timestamp_millis();
-        repo.like(track_id, now).await?;
-        Ok(true)
+        sqlx::query("INSERT OR IGNORE INTO liked_track (track_id, liked_at) VALUES (?, ?)")
+            .bind(track_id)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+        true
+    };
+
+    if let Some(hash) = file_hash {
+        crate::sync::hooks::enqueue_op_in_tx(
+            &mut tx,
+            &crate::sync::hooks::PendingOpDraft {
+                entity: "liked_track".into(),
+                entity_id: hash,
+                field: None,
+                op: if now_liked { "insert" } else { "delete" }.into(),
+                payload: None,
+            },
+        )
+        .await?;
     }
+    tx.commit().await?;
+    state.drain.notify();
+    Ok(now_liked)
 }
 
 /// Return the set of liked track IDs so the frontend can render hearts

--- a/src-tauri/crates/app/src/commands/track.rs
+++ b/src-tauri/crates/app/src/commands/track.rs
@@ -622,33 +622,49 @@ pub async fn toggle_like_track(
         .bind(track_id)
         .fetch_optional(&mut *tx)
         .await?;
-    let now_liked = if was_liked.is_some() {
-        sqlx::query("DELETE FROM liked_track WHERE track_id = ?")
+    // Both branches derive the post-state from `rows_affected()`
+    // rather than assuming the action landed. `INSERT OR IGNORE`
+    // silently no-ops on an FK violation (the scanner removed the
+    // track between the UI render and this command, or a future
+    // UNIQUE constraint trips), and we don't want to return
+    // `now_liked = true` to a UI rendering a heart against a row
+    // that doesn't exist anymore. A DELETE that matched 0 rows
+    // means a concurrent unlike already happened — the post-state
+    // is still "not liked".
+    let (now_liked, did_change) = if was_liked.is_some() {
+        let res = sqlx::query("DELETE FROM liked_track WHERE track_id = ?")
             .bind(track_id)
             .execute(&mut *tx)
             .await?;
-        false
+        (false, res.rows_affected() > 0)
     } else {
-        sqlx::query("INSERT OR IGNORE INTO liked_track (track_id, liked_at) VALUES (?, ?)")
-            .bind(track_id)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
-        true
+        let res =
+            sqlx::query("INSERT OR IGNORE INTO liked_track (track_id, liked_at) VALUES (?, ?)")
+                .bind(track_id)
+                .bind(now)
+                .execute(&mut *tx)
+                .await?;
+        let actually_inserted = res.rows_affected() > 0;
+        (actually_inserted, actually_inserted)
     };
 
-    if let Some(hash) = file_hash {
-        crate::sync::hooks::enqueue_op_in_tx(
-            &mut tx,
-            &crate::sync::hooks::PendingOpDraft {
-                entity: "liked_track".into(),
-                entity_id: hash,
-                field: None,
-                op: if now_liked { "insert" } else { "delete" }.into(),
-                payload: None,
-            },
-        )
-        .await?;
+    // Only enqueue when the local DB actually moved — emitting a
+    // phantom op for a no-op INSERT wastes a Lamport draw and
+    // bloats the queue with a like the peer can't resolve anyway.
+    if did_change {
+        if let Some(hash) = file_hash {
+            crate::sync::hooks::enqueue_op_in_tx(
+                &mut tx,
+                &crate::sync::hooks::PendingOpDraft {
+                    entity: "liked_track".into(),
+                    entity_id: hash,
+                    field: None,
+                    op: if now_liked { "insert" } else { "delete" }.into(),
+                    payload: None,
+                },
+            )
+            .await?;
+        }
     }
     tx.commit().await?;
     state.drain.notify();

--- a/src-tauri/crates/app/src/sync/apply.rs
+++ b/src-tauri/crates/app/src/sync/apply.rs
@@ -31,7 +31,12 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sqlx::SqliteConnection;
 
+use waveflow_core::repository::library::{LibraryDraft, LibraryUpdate};
 use waveflow_core::repository::playlist::{PlaylistDraft, PlaylistUpdate};
+use waveflow_core::repository::sqlite::library::{
+    delete_conn as library_delete_conn, insert_conn as library_insert_conn,
+    update_conn as library_update_conn,
+};
 use waveflow_core::repository::sqlite::playlist::{
     append_tracks_conn, delete_conn, insert_custom_conn, remove_track_conn, reorder_track_conn,
     update_conn,
@@ -119,6 +124,9 @@ pub async fn apply_remote_op_in_tx(
 
     match op.entity.as_str() {
         canonical::ENTITY_PLAYLIST => apply_playlist_op(conn, op).await,
+        canonical::ENTITY_LIBRARY => apply_library_op(conn, op).await,
+        canonical::ENTITY_LIKED_TRACK => apply_liked_track_op(conn, op).await,
+        canonical::ENTITY_TRACK_RATING => apply_track_rating_op(conn, op).await,
         other => {
             // Forward compat: a future entity (`library`, `track`, …)
             // arrives but this desktop doesn't know how to apply it.
@@ -327,6 +335,241 @@ async fn apply_playlist_op(
     }
 }
 
+async fn apply_library_op(
+    conn: &mut SqliteConnection,
+    op: &RemoteSyncOp,
+) -> AppResult<AppliedOutcome> {
+    let now = now_ms();
+    let entity = canonical::ENTITY_LIBRARY;
+    match (op.op.as_str(), op.field.as_deref()) {
+        ("insert", None) => {
+            if canonical::local_for_canonical(conn, entity, &op.entity_id)
+                .await?
+                .is_some()
+            {
+                return Ok(AppliedOutcome::Skipped);
+            }
+            let draft = match library_draft_from_payload(op, now) {
+                Ok(d) => d,
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        canonical = %op.entity_id,
+                        "apply: malformed library insert payload, ignoring"
+                    );
+                    return Ok(AppliedOutcome::Ignored);
+                }
+            };
+            let local_id = library_insert_conn(conn, &draft).await?;
+            canonical::set_canonical_library(conn, local_id, &op.entity_id).await?;
+            Ok(AppliedOutcome::Applied)
+        }
+        ("delete", None) => {
+            let Some(local_id) =
+                canonical::local_for_canonical(conn, entity, &op.entity_id).await?
+            else {
+                return Ok(AppliedOutcome::Ignored);
+            };
+            let removed = library_delete_conn(conn, local_id).await?;
+            canonical::drop_mapping(conn, entity, &op.entity_id).await?;
+            Ok(if removed {
+                AppliedOutcome::Applied
+            } else {
+                AppliedOutcome::Ignored
+            })
+        }
+        ("set", Some(field @ ("name" | "description" | "color_id" | "icon_id"))) => {
+            let Some(local_id) =
+                canonical::local_for_canonical(conn, entity, &op.entity_id).await?
+            else {
+                return Ok(AppliedOutcome::Ignored);
+            };
+            let value = match string_value_from_payload(op, field) {
+                Ok(v) => v,
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        field = %field,
+                        canonical = %op.entity_id,
+                        "apply: malformed library set payload, ignoring"
+                    );
+                    return Ok(AppliedOutcome::Ignored);
+                }
+            };
+            let patch = build_library_patch(field, Some(value));
+            let updated = library_update_conn(conn, local_id, &patch, now).await?;
+            Ok(if updated {
+                AppliedOutcome::Applied
+            } else {
+                AppliedOutcome::Ignored
+            })
+        }
+        other => {
+            tracing::debug!(
+                entity = "library",
+                op = ?other,
+                "apply_library_op: unknown (op, field), ignored"
+            );
+            Ok(AppliedOutcome::Ignored)
+        }
+    }
+}
+
+/// `liked_track` ops carry the BLAKE3 file_hash as `entity_id`. The
+/// apply path resolves the hash against the local `track` table; a
+/// miss (file not scanned on this device) lands Ignored — the user
+/// sees the like materialise the next time they re-scan the same
+/// file.
+async fn apply_liked_track_op(
+    conn: &mut SqliteConnection,
+    op: &RemoteSyncOp,
+) -> AppResult<AppliedOutcome> {
+    let now = now_ms();
+    let Some(local_track_id) = canonical::local_track_for_hash(conn, &op.entity_id).await? else {
+        return Ok(AppliedOutcome::Ignored);
+    };
+    match op.op.as_str() {
+        "insert" => {
+            let res =
+                sqlx::query("INSERT OR IGNORE INTO liked_track (track_id, liked_at) VALUES (?, ?)")
+                    .bind(local_track_id)
+                    .bind(now)
+                    .execute(conn)
+                    .await?;
+            Ok(if res.rows_affected() > 0 {
+                AppliedOutcome::Applied
+            } else {
+                // Already liked — idempotent skip.
+                AppliedOutcome::Skipped
+            })
+        }
+        "delete" => {
+            let res = sqlx::query("DELETE FROM liked_track WHERE track_id = ?")
+                .bind(local_track_id)
+                .execute(conn)
+                .await?;
+            Ok(if res.rows_affected() > 0 {
+                AppliedOutcome::Applied
+            } else {
+                AppliedOutcome::Ignored
+            })
+        }
+        other => {
+            tracing::debug!(
+                op = %other,
+                "apply_liked_track_op: unknown op, ignored"
+            );
+            Ok(AppliedOutcome::Ignored)
+        }
+    }
+}
+
+/// `track_rating` ops set / clear a 0-5 star rating on the local
+/// row matching the broadcast file_hash. Same hash-keyed routing as
+/// `liked_track`.
+async fn apply_track_rating_op(
+    conn: &mut SqliteConnection,
+    op: &RemoteSyncOp,
+) -> AppResult<AppliedOutcome> {
+    let Some(local_track_id) = canonical::local_track_for_hash(conn, &op.entity_id).await? else {
+        return Ok(AppliedOutcome::Ignored);
+    };
+    match op.op.as_str() {
+        "set" => {
+            // Strict shape: `{"value": 0..=5}`. Anything else lands
+            // Ignored (cursor still advances).
+            let Some(payload) = op.payload.as_ref() else {
+                return Ok(AppliedOutcome::Ignored);
+            };
+            let Some(value) = payload.get("value").and_then(|v| v.as_i64()) else {
+                return Ok(AppliedOutcome::Ignored);
+            };
+            if !(0..=5).contains(&value) {
+                return Ok(AppliedOutcome::Ignored);
+            }
+            let res = sqlx::query("UPDATE track SET rating = ? WHERE id = ?")
+                .bind(value)
+                .bind(local_track_id)
+                .execute(conn)
+                .await?;
+            Ok(if res.rows_affected() > 0 {
+                AppliedOutcome::Applied
+            } else {
+                AppliedOutcome::Ignored
+            })
+        }
+        "delete" => {
+            let res = sqlx::query("UPDATE track SET rating = NULL WHERE id = ?")
+                .bind(local_track_id)
+                .execute(conn)
+                .await?;
+            Ok(if res.rows_affected() > 0 {
+                AppliedOutcome::Applied
+            } else {
+                AppliedOutcome::Ignored
+            })
+        }
+        other => {
+            tracing::debug!(
+                op = %other,
+                "apply_track_rating_op: unknown op, ignored"
+            );
+            Ok(AppliedOutcome::Ignored)
+        }
+    }
+}
+
+/// Build a [`LibraryDraft`] from the inbound `insert` op. Same blob
+/// shape as the outbound hook in `commands::library::create_library`.
+fn library_draft_from_payload(op: &RemoteSyncOp, now_ms: i64) -> AppResult<LibraryDraft> {
+    let payload = op.payload.as_ref().ok_or_else(|| {
+        AppError::Other("insert library op missing payload (expected name/…)".into())
+    })?;
+    let name = payload
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Other("insert library op: name missing".into()))?
+        .to_string();
+    let description = payload
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let color_id = payload
+        .get("color_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("emerald")
+        .to_string();
+    let icon_id = payload
+        .get("icon_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("library")
+        .to_string();
+    Ok(LibraryDraft {
+        name,
+        description,
+        color_id,
+        icon_id,
+        now_ms,
+    })
+}
+
+fn build_library_patch(field: &str, value: Option<String>) -> LibraryUpdate {
+    let mut patch = LibraryUpdate {
+        name: None,
+        description: None,
+        color_id: None,
+        icon_id: None,
+    };
+    match field {
+        "name" => patch.name = value,
+        "description" => patch.description = value,
+        "color_id" => patch.color_id = value,
+        "icon_id" => patch.icon_id = value,
+        _ => {}
+    }
+    patch
+}
+
 /// Build a [`PlaylistDraft`] from the `insert` op's payload. Hooks
 /// outbound at [`crate::commands::playlist::create_playlist`] send a
 /// `{name, description, color_id, icon_id}` blob; mirror it here.
@@ -524,7 +767,33 @@ mod tests {
         sqlx::query(
             "CREATE TABLE track (
                 id INTEGER PRIMARY KEY,
-                title TEXT NOT NULL
+                title TEXT NOT NULL,
+                file_hash TEXT,
+                rating INTEGER
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                color_id TEXT NOT NULL DEFAULT 'emerald',
+                icon_id TEXT NOT NULL DEFAULT 'library',
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                canonical_id TEXT
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE liked_track (
+                track_id INTEGER PRIMARY KEY,
+                liked_at INTEGER NOT NULL
             )",
         )
         .execute(&pool)
@@ -1045,6 +1314,187 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    fn library_op(
+        device: &str,
+        canonical_id: &str,
+        op: &str,
+        field: Option<&str>,
+        payload: Option<serde_json::Value>,
+        lamport: i64,
+    ) -> RemoteSyncOp {
+        RemoteSyncOp {
+            id: lamport,
+            lamport_ts: lamport,
+            device_id: device.into(),
+            entity: "library".into(),
+            entity_id: canonical_id.into(),
+            field: field.map(str::to_string),
+            op: op.into(),
+            payload,
+        }
+    }
+
+    fn hash_op(
+        device: &str,
+        entity: &str,
+        file_hash: &str,
+        op: &str,
+        payload: Option<serde_json::Value>,
+        lamport: i64,
+    ) -> RemoteSyncOp {
+        RemoteSyncOp {
+            id: lamport,
+            lamport_ts: lamport,
+            device_id: device.into(),
+            entity: entity.into(),
+            entity_id: file_hash.into(),
+            field: None,
+            op: op.into(),
+            payload,
+        }
+    }
+
+    #[tokio::test]
+    async fn applies_remote_library_insert() {
+        let pool = pool().await;
+        let canonical = Uuid::new_v4().to_string();
+        let outcome = {
+            let mut conn = pool.acquire().await.unwrap();
+            apply_remote_op_in_tx(
+                &mut conn,
+                &library_op(
+                    "device-b",
+                    &canonical,
+                    "insert",
+                    None,
+                    Some(serde_json::json!({
+                        "name": "Vinyles",
+                        "color_id": "amber",
+                        "icon_id": "disc"
+                    })),
+                    3,
+                ),
+                "device-a",
+            )
+            .await
+            .unwrap()
+        };
+        assert_eq!(outcome, AppliedOutcome::Applied);
+        let name: String = sqlx::query_scalar("SELECT name FROM library WHERE canonical_id = ?")
+            .bind(&canonical)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(name, "Vinyles");
+    }
+
+    #[tokio::test]
+    async fn applies_liked_track_via_file_hash() {
+        let pool = pool().await;
+        // Seed a track with a known hash so the apply path's
+        // hash → local id lookup hits.
+        sqlx::query("INSERT INTO track (id, title, file_hash) VALUES (1, 't', 'blake3-abc')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let outcome = {
+            let mut conn = pool.acquire().await.unwrap();
+            apply_remote_op_in_tx(
+                &mut conn,
+                &hash_op("device-b", "liked_track", "blake3-abc", "insert", None, 1),
+                "device-a",
+            )
+            .await
+            .unwrap()
+        };
+        assert_eq!(outcome, AppliedOutcome::Applied);
+        let liked: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM liked_track WHERE track_id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(liked, 1);
+    }
+
+    #[tokio::test]
+    async fn liked_track_for_unknown_hash_is_ignored() {
+        let pool = pool().await;
+        let outcome = {
+            let mut conn = pool.acquire().await.unwrap();
+            apply_remote_op_in_tx(
+                &mut conn,
+                &hash_op("device-b", "liked_track", "no-such-hash", "insert", None, 1),
+                "device-a",
+            )
+            .await
+            .unwrap()
+        };
+        assert_eq!(outcome, AppliedOutcome::Ignored);
+    }
+
+    #[tokio::test]
+    async fn applies_track_rating_via_file_hash() {
+        let pool = pool().await;
+        sqlx::query("INSERT INTO track (id, title, file_hash) VALUES (1, 't', 'h')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let outcome = {
+            let mut conn = pool.acquire().await.unwrap();
+            apply_remote_op_in_tx(
+                &mut conn,
+                &hash_op(
+                    "device-b",
+                    "track_rating",
+                    "h",
+                    "set",
+                    Some(serde_json::json!({ "value": 4 })),
+                    1,
+                ),
+                "device-a",
+            )
+            .await
+            .unwrap()
+        };
+        assert_eq!(outcome, AppliedOutcome::Applied);
+        let rating: Option<i64> = sqlx::query_scalar("SELECT rating FROM track WHERE id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rating, Some(4));
+    }
+
+    #[tokio::test]
+    async fn track_rating_out_of_range_is_ignored() {
+        let pool = pool().await;
+        sqlx::query("INSERT INTO track (id, title, file_hash) VALUES (1, 't', 'h')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let outcome = {
+            let mut conn = pool.acquire().await.unwrap();
+            apply_remote_op_in_tx(
+                &mut conn,
+                &hash_op(
+                    "device-b",
+                    "track_rating",
+                    "h",
+                    "set",
+                    Some(serde_json::json!({ "value": 99 })),
+                    1,
+                ),
+                "device-a",
+            )
+            .await
+            .unwrap()
+        };
+        assert_eq!(outcome, AppliedOutcome::Ignored);
+        let rating: Option<i64> = sqlx::query_scalar("SELECT rating FROM track WHERE id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rating, None);
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/sync/canonical.rs
+++ b/src-tauri/crates/app/src/sync/canonical.rs
@@ -30,9 +30,23 @@ use uuid::Uuid;
 use crate::error::AppResult;
 
 /// Entity tags. Free-form `TEXT` in the schema so a new family
-/// (`library`, `track`, …) doesn't need a CHECK-constraint migration —
-/// pinning them as constants keeps the call sites typo-safe.
+/// doesn't need a CHECK-constraint migration — pinning them as
+/// constants keeps the call sites typo-safe.
 pub const ENTITY_PLAYLIST: &str = "playlist";
+
+/// Library entity tag. Phase 1.f.desktop.5 — same canonical-id-UUID
+/// pattern as playlist (user-curated, no natural cross-device key).
+pub const ENTITY_LIBRARY: &str = "library";
+
+/// Liked-track entity tag. Phase 1.f.desktop.5. `entity_id` carries
+/// the BLAKE3 `track.file_hash` directly — same physical file on a
+/// peer device hashes identically, so no mapping table is needed.
+pub const ENTITY_LIKED_TRACK: &str = "liked_track";
+
+/// Track-rating entity tag. Phase 1.f.desktop.5. Same key strategy
+/// as `liked_track` — `entity_id` is the BLAKE3 file hash, the
+/// payload carries the 0-5 rating (or null to clear).
+pub const ENTITY_TRACK_RATING: &str = "track_rating";
 
 /// Resolve a local rowid to its canonical UUID. Returns `None` when
 /// no mapping row exists — the caller decides whether that's a hard
@@ -107,6 +121,97 @@ pub async fn ensure_local_playlist(
     };
     set_canonical_playlist(conn, local_id, &canonical).await?;
     Ok(canonical)
+}
+
+/// Library variant of [`ensure_local_playlist`]. Same flow: prefer
+/// an existing mapping, fall back to the column the migration's
+/// AFTER INSERT trigger filled in, mint a fresh UUID only if both
+/// are missing. Single trip through [`set_canonical_library`] keeps
+/// the playlist column + sync_id_map row coherent.
+pub async fn ensure_local_library(conn: &mut SqliteConnection, local_id: i64) -> AppResult<String> {
+    if let Some(existing) = canonical_for_local(conn, ENTITY_LIBRARY, local_id).await? {
+        return Ok(existing);
+    }
+    let existing_col: Option<String> =
+        sqlx::query_scalar("SELECT canonical_id FROM library WHERE id = ?")
+            .bind(local_id)
+            .fetch_optional(&mut *conn)
+            .await?;
+    let canonical = match existing_col.as_deref().map(str::trim) {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => Uuid::new_v4().to_string(),
+    };
+    set_canonical_library(conn, local_id, &canonical).await?;
+    Ok(canonical)
+}
+
+/// Library variant of [`set_canonical_playlist`]. Same defensive
+/// DELETE of any prior `(entity, local_id)` row pointing at a
+/// different canonical before the INSERT OR IGNORE.
+pub async fn set_canonical_library(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+    canonical_id: &str,
+) -> AppResult<()> {
+    sqlx::query("UPDATE library SET canonical_id = ? WHERE id = ?")
+        .bind(canonical_id)
+        .bind(local_id)
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query(
+        "DELETE FROM sync_id_map
+          WHERE entity = ?
+            AND local_id = ?
+            AND canonical_id != ?",
+    )
+    .bind(ENTITY_LIBRARY)
+    .bind(local_id)
+    .bind(canonical_id)
+    .execute(&mut *conn)
+    .await?;
+    sqlx::query(
+        "INSERT OR IGNORE INTO sync_id_map (entity, canonical_id, local_id)
+         VALUES (?, ?, ?)",
+    )
+    .bind(ENTITY_LIBRARY)
+    .bind(canonical_id)
+    .bind(local_id)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Look up a local `track.id` by its BLAKE3 file hash. Tracks don't
+/// carry a canonical_id column — the file content already is the
+/// cross-device key, so the inbound apply path resolves
+/// `liked_track` / `track_rating` ops by hash → local track id
+/// directly against `track`. Returns `None` when the file hasn't
+/// been scanned on this device yet (the apply branch surfaces it as
+/// Ignored so the cursor still advances).
+pub async fn local_track_for_hash(
+    conn: &mut SqliteConnection,
+    file_hash: &str,
+) -> AppResult<Option<i64>> {
+    let row: Option<i64> = sqlx::query_scalar("SELECT id FROM track WHERE file_hash = ?")
+        .bind(file_hash)
+        .fetch_optional(conn)
+        .await?;
+    Ok(row)
+}
+
+/// Read a track's `file_hash` by its local rowid. Used by the
+/// outbound hooks (`toggle_like_track`, `set_track_rating`) to
+/// stamp the op's `entity_id` with the file-content key the peer
+/// device will use for the reverse lookup.
+pub async fn file_hash_for_local_track(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+) -> AppResult<Option<String>> {
+    let row: Option<String> = sqlx::query_scalar("SELECT file_hash FROM track WHERE id = ?")
+        .bind(local_id)
+        .fetch_optional(conn)
+        .await?;
+    Ok(row)
 }
 
 /// Mint a canonical id on the local row + plant the mapping. Shared

--- a/src-tauri/crates/core/src/repository/sqlite/library.rs
+++ b/src-tauri/crates/core/src/repository/sqlite/library.rs
@@ -1,13 +1,80 @@
 //! SQLite implementation of [`LibraryRepository`].
+//!
+//! Same two-flavour shape as the playlist repo: a trait impl on
+//! [`SqliteLibraryRepository`] for legacy callers, plus free
+//! `*_conn` helpers that take `&mut SqliteConnection` so the
+//! desktop's CRUD commands can compose the library write + an
+//! `enqueue_op_in_tx` outbox row + a `set_canonical_library`
+//! mapping update inside a single transaction. The trait methods
+//! just `pool.acquire()` + delegate.
 
 use async_trait::async_trait;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::{
     domain::library::{Library, LibraryFolder},
     error::CoreResult,
     repository::library::{LibraryDraft, LibraryRepository, LibraryUpdate},
 };
+
+// ── Connection-taking helpers ───────────────────────────────────
+
+/// Insert a new library row. Returns the assigned rowid.
+pub async fn insert_conn(conn: &mut SqliteConnection, draft: &LibraryDraft) -> CoreResult<i64> {
+    let insert = sqlx::query(
+        "INSERT INTO library (name, description, color_id, icon_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&draft.name)
+    .bind(draft.description.as_deref())
+    .bind(&draft.color_id)
+    .bind(&draft.icon_id)
+    .bind(draft.now_ms)
+    .bind(draft.now_ms)
+    .execute(conn)
+    .await?;
+    Ok(insert.last_insert_rowid())
+}
+
+/// Partial `UPDATE library` via COALESCE. Returns `true` when a row
+/// was actually touched. Mirrors the playlist `update_conn` shape so
+/// the desktop's tx-aware caller can collapse the pre-tx exists()
+/// probe into the same transaction as the update + outbox enqueue.
+pub async fn update_conn(
+    conn: &mut SqliteConnection,
+    id: i64,
+    patch: &LibraryUpdate,
+    now_ms: i64,
+) -> CoreResult<bool> {
+    let res = sqlx::query(
+        "UPDATE library
+            SET name        = COALESCE(?, name),
+                description = COALESCE(?, description),
+                color_id    = COALESCE(?, color_id),
+                icon_id     = COALESCE(?, icon_id),
+                updated_at  = ?
+          WHERE id = ?",
+    )
+    .bind(patch.name.as_deref())
+    .bind(patch.description.as_deref())
+    .bind(patch.color_id.as_deref())
+    .bind(patch.icon_id.as_deref())
+    .bind(now_ms)
+    .bind(id)
+    .execute(conn)
+    .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Delete a library. `true` when a row was deleted, `false` when no
+/// row matched. Cascades through `library_folder`, `track`, …
+pub async fn delete_conn(conn: &mut SqliteConnection, id: i64) -> CoreResult<bool> {
+    let result = sqlx::query("DELETE FROM library WHERE id = ?")
+        .bind(id)
+        .execute(conn)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
 
 #[derive(Debug, Clone)]
 pub struct SqliteLibraryRepository {
@@ -81,48 +148,23 @@ impl LibraryRepository for SqliteLibraryRepository {
     }
 
     async fn insert(&self, draft: &LibraryDraft) -> CoreResult<i64> {
-        let insert = sqlx::query(
-            "INSERT INTO library (name, description, color_id, icon_id, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(&draft.name)
-        .bind(draft.description.as_deref())
-        .bind(&draft.color_id)
-        .bind(&draft.icon_id)
-        .bind(draft.now_ms)
-        .bind(draft.now_ms)
-        .execute(&self.pool)
-        .await?;
-        Ok(insert.last_insert_rowid())
+        let mut conn = self.pool.acquire().await?;
+        insert_conn(&mut conn, draft).await
     }
 
     async fn update(&self, id: i64, patch: &LibraryUpdate, now_ms: i64) -> CoreResult<()> {
-        sqlx::query(
-            "UPDATE library
-                SET name        = COALESCE(?, name),
-                    description = COALESCE(?, description),
-                    color_id    = COALESCE(?, color_id),
-                    icon_id     = COALESCE(?, icon_id),
-                    updated_at  = ?
-              WHERE id = ?",
-        )
-        .bind(patch.name.as_deref())
-        .bind(patch.description.as_deref())
-        .bind(patch.color_id.as_deref())
-        .bind(patch.icon_id.as_deref())
-        .bind(now_ms)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
+        let mut conn = self.pool.acquire().await?;
+        // Drop the boolean for trait back-compat — the existing
+        // callers don't read it. Tx-aware sites call `update_conn`
+        // directly so they can collapse the existence-check into
+        // the write.
+        let _ = update_conn(&mut conn, id, patch, now_ms).await?;
         Ok(())
     }
 
     async fn delete(&self, id: i64) -> CoreResult<bool> {
-        let result = sqlx::query("DELETE FROM library WHERE id = ?")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(result.rows_affected() > 0)
+        let mut conn = self.pool.acquire().await?;
+        delete_conn(&mut conn, id).await
     }
 
     async fn touch_updated_at(&self, id: i64, now_ms: i64) -> CoreResult<()> {

--- a/src-tauri/crates/core/src/repository/sqlite/playlist.rs
+++ b/src-tauri/crates/core/src/repository/sqlite/playlist.rs
@@ -445,8 +445,8 @@ impl PlaylistRepository for SqlitePlaylistRepository {
         now_ms: i64,
     ) -> CoreResult<bool> {
         let mut tx = self.pool.begin().await?;
-        let effective = reorder_track_conn(&mut tx, playlist_id, track_id, new_position, now_ms)
-            .await?;
+        let effective =
+            reorder_track_conn(&mut tx, playlist_id, track_id, new_position, now_ms).await?;
         tx.commit().await?;
         Ok(effective.is_some())
     }

--- a/src-tauri/migrations/profile/20260603000001_sync_library_canonical_id.sql
+++ b/src-tauri/migrations/profile/20260603000001_sync_library_canonical_id.sql
@@ -1,0 +1,76 @@
+-- Canonical entity ids for the `library` table. Phase 1.f.desktop.5.
+--
+-- Same shape as the playlist migration in 20260603000000: add a
+-- nullable `canonical_id TEXT` column, backfill every existing row
+-- with a fresh UUIDv4, plant a UNIQUE index, install AFTER INSERT +
+-- BEFORE UPDATE triggers so the column behaves as NOT NULL UNIQUE
+-- without an ALTER COLUMN (unsupported in SQLite).
+--
+-- Track / liked_track do NOT need their own canonical column or
+-- mapping row: `track.file_hash` (BLAKE3) is already a stable,
+-- cross-device identifier (same file content → same hash on every
+-- install), so liked / rating ops carry the file_hash as
+-- `entity_id` directly. Library, in contrast, is user-curated and
+-- has no natural cross-device key, so it follows the playlist
+-- pattern.
+
+ALTER TABLE library ADD COLUMN canonical_id TEXT;
+
+WITH src AS (
+    SELECT id, lower(hex(randomblob(16))) AS h
+      FROM library
+)
+UPDATE library
+   SET canonical_id = (
+       SELECT substr(s.h,  1, 8)              || '-'
+           || substr(s.h,  9, 4)              || '-'
+           || '4' || substr(s.h, 14, 3)       || '-'
+           || substr('89ab', (random() & 3) + 1, 1)
+                  || substr(s.h, 18, 3)       || '-'
+           || substr(s.h, 21, 12)
+         FROM src s
+        WHERE s.id = library.id
+   )
+ WHERE canonical_id IS NULL;
+
+CREATE UNIQUE INDEX idx_library_canonical_id ON library(canonical_id);
+
+-- Runtime invariant: identical setup to playlist (see the matching
+-- migration's comment for the design rationale — BEFORE INSERT
+-- triggers can't mutate NEW in SQLite, so we use AFTER INSERT to
+-- fill in the column when missing).
+
+CREATE TRIGGER trg_library_set_canonical_id_on_insert
+AFTER INSERT ON library
+FOR EACH ROW
+WHEN NEW.canonical_id IS NULL
+BEGIN
+    UPDATE library
+       SET canonical_id = (
+           WITH s(h) AS (SELECT lower(hex(randomblob(16))))
+           SELECT substr(s.h,  1, 8)              || '-'
+               || substr(s.h,  9, 4)              || '-'
+               || '4' || substr(s.h, 14, 3)       || '-'
+               || substr('89ab', (random() & 3) + 1, 1)
+                      || substr(s.h, 18, 3)       || '-'
+               || substr(s.h, 21, 12)
+             FROM s
+       )
+     WHERE id = NEW.id AND canonical_id IS NULL;
+END;
+
+CREATE TRIGGER trg_library_prevent_null_canonical_id_on_update
+BEFORE UPDATE OF canonical_id ON library
+FOR EACH ROW
+WHEN NEW.canonical_id IS NULL
+BEGIN
+    SELECT RAISE(ABORT, 'library.canonical_id may not be NULL');
+END;
+
+-- Seed sync_id_map for every existing library so inbound ops the
+-- WS subscriber receives can resolve immediately without an
+-- ensure-on-miss roundtrip.
+INSERT INTO sync_id_map (entity, canonical_id, local_id)
+SELECT 'library', canonical_id, id
+  FROM library
+ WHERE canonical_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Extends the canonical-id sync loop from 4b ([#199](https://github.com/InstaZDLL/WaveFlow/pull/199)) to three new entities. Same patterns, no new architecture.

- **library** — full CRUD sync, mirror direct du pattern playlist (canonical-id UUID, migration + triggers + sync_id_map seed, hooks outbound dans `commands/library.rs`, branche `apply_library_op`).
- **liked_track** — toggle ❤️ sync. `entity_id = track.file_hash` (BLAKE3 already cross-device-stable), pas de canonical column ni mapping table.
- **track_rating** — set/clear 0-5 stars. Même hash-routing que liked_track. Apply valide la range, out-of-range = Ignored.

## Architecture invariants (rappel)

- Outbound : tx wrap `entity write + canonical lookup + enqueue_op_in_tx`. `state.drain.notify()` après `tx.commit()`.
- Inbound : `apply_remote_op_in_tx` bypass `enqueue_op_in_tx` (anti-ping-pong). Tx per op : `observe_remote_conn + apply + cursor advance`. Echoes (`device_id` match) = Skipped, mapping miss / unknown entity / malformed = Ignored.

## File hash routing

Pour `liked_track` et `track_rating`, le `entity_id` est le BLAKE3 file_hash directement. Trade-off : si le fichier n'a pas été scanné sur device B, l'op est Ignored (le user verra le like / rating apparaître au prochain rescan du même fichier). Pas de mapping table pour track parce que le contenu du fichier EST le canonical key naturel.

## What lands

**Migration** `20260603000001_sync_library_canonical_id.sql` — `library.canonical_id TEXT` + UUIDv4 backfill (avec `random() & 3` bitmask, leçon CR de 4b) + UNIQUE index + AFTER INSERT/BEFORE UPDATE triggers + sync_id_map seed.

**Core** — `library::{insert_conn, update_conn, delete_conn}` extraits (même pattern que playlist atomicity refactor [#195](https://github.com/InstaZDLL/WaveFlow/pull/195)). Trait methods délèguent.

**sync::canonical** — 3 nouvelles ENTITY_* constantes + `ensure_local_library` / `set_canonical_library` (mirror playlist) + `local_track_for_hash` / `file_hash_for_local_track` pour le hash routing.

**Outbound hooks** :
- `commands/library.rs::create_library/update_library/delete_library` — tx + enqueue
- `commands/track.rs::toggle_like_track` — tx + enqueue `liked_track` (insert/delete)
- `commands/track.rs::set_track_rating` — tx + enqueue `track_rating` (set/delete)

**Apply** — 3 nouveaux dispatchers (`apply_library_op`, `apply_liked_track_op`, `apply_track_rating_op`) routés depuis `apply_remote_op_in_tx`.

**Tests** — 5 nouveaux tests dans `sync::apply` :
- `applies_remote_library_insert`
- `applies_liked_track_via_file_hash`
- `liked_track_for_unknown_hash_is_ignored`
- `applies_track_rating_via_file_hash`
- `track_rating_out_of_range_is_ignored`

## Out of scope

- Tag editor sync (`commands/edit.rs::update_track_tags`) — le filesystem est source of truth, rescan résout. Cross-device tag sync est une autre feature.
- Settings diagnostic UI pour SubscribeOutcome counts.
- library_folder + watcher sync — les folders sont path-local, ne traversent pas device boundaries.

## Test plan

- [x] Créer une library "Vinyles" sur device A → apparaît sur device B
- [x] Rename + recolor → propagent
- [x] Delete → cascade (track / liked_track / playlist_track) gère côté DB
- [x] Like un track sur A → ❤️ sur B (à condition que le même fichier soit scanné)
- [x] Rating 4★ sur A → reflète sur B
- [x] Rating sur un fichier non-scanné sur B → Ignored, pas d'erreur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Nouvelles Fonctionnalités**
  * Synchronisation étendue : gestion des bibliothèques, évaluations de piste et marquages favoris entre appareils.

* **Améliorations**
  * Écritures atomiques avec file d’outbound pour garantir cohérence et propagation fiable des changements.
  * Application distante renforcée : handlers idempotents et validations (ex. plage de notes).

* **Migration**
  * Ajout et backfill d’un identifiant canonique pour les bibliothèques dans la base de données.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->