### PR TITLE
feat(lyrics): add waveflow-syncedlyrics crate with multi-provider lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ WaveFlow is a local music player desktop app with a Spotify-inspired 3-panel UI.
 | **Library**         | Folder scanning + filesystem watcher, on-demand audio analysis (peak, loudness, ReplayGain, BPM), Hi-Res badges, multi-artist split, POPM 5-star ratings, A-Z navigator, multi-select action bar                                                                                                                | [docs](docs/features/library.md)         |
 | **Playlists**       | Drag-and-drop reorder (virtualised), bulk add from any source, M3U import / export with basename-fallback matching, likes, recently-played                                                                                                                                                                      | [docs](docs/features/playlists.md)       |
 | **Smart playlists** | Auto-generated **Daily Mix** family bucketed by tempo, with composite artist-photo covers rendered from your Deezer cache                                                                                                                                                                                       | [docs](docs/features/smart-playlists.md) |
-| **Integrations**    | Deezer (artwork + labels), Last.fm (bios + scrobbling with retry queue), LRCLIB (synchronised lyrics), Discord Rich Presence ("Listening to WaveFlow" with cover + progress bar) — all cached locally for offline use                                                                                           | [docs](docs/features/integrations.md)    |
+| **Integrations**    | Deezer (artwork + labels), Last.fm (bios + scrobbling with retry queue), LRCLIB + Musixmatch/NetEase/Megalobiz/Genius lyrics, Discord Rich Presence ("Listening to WaveFlow" with cover + progress bar) — all cached locally for offline use                                                                       | [docs](docs/features/integrations.md)    |
 | **UI & UX**         | Spotify-style 3-panel layout, system tray, statistics dashboard with JSON export, **WaveFlow Wrapped** year-in-review (story-style overlay), virtual scroll for 6000+ tracks, dark mode (View Transitions API), 17 locales (RTL-aware), per-profile isolated DB with scheduled auto-backup, signed auto-updater | [docs](docs/features/ui.md)              |
 
 ## Tech Stack
@@ -83,7 +83,7 @@ WaveFlow is a local music player desktop app with a Spotify-inspired 3-panel UI.
 | **Metadata extraction**   | lofty 0.24 (tags, embedded art, POPM, INITIALKEY)                                                                                  |
 | **Imaging**               | image 0.25 + fast_image_resize 6 (SIMD thumbnails)                                                                                 |
 | **Filesystem watcher**    | notify 8 (debounced rescans of watched folders)                                                                                    |
-| **External APIs**         | Deezer public API (no auth) + Last.fm (read + signed methods via md-5 + reqwest 0.12 with rustls) + LRCLIB (synchronized lyrics)   |
+| **External APIs**         | Deezer public API (no auth) + Last.fm (read + signed methods via md-5 + reqwest 0.12 with rustls) + LRCLIB/Musixmatch/NetEase/Megalobiz/Genius lyrics |
 | **Package manager**       | Bun                                                                                                                                |
 
 ## Getting Started
@@ -150,4 +150,5 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 ```
 
-See [LICENSE](LICENSE) for the full text.
+See [LICENSE](LICENSE) for the full text. Third-party notices are listed in
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,35 @@
+# Third-Party Notices
+
+WaveFlow is licensed under the GNU General Public License v3.0. Some parts of
+the source tree are derived from, ported from, inspired by, or vendor patched
+from third-party projects with compatible licenses.
+
+## syncedlyrics
+
+`src-tauri/crates/syncedlyrics` is a Rust implementation of the multi-provider
+lyrics lookup behavior originally provided by the `syncedlyrics` Python
+project. It is included in WaveFlow under GPL-3.0-only, with the original MIT
+notice preserved below.
+
+MIT License
+
+Copyright (c) 2022 Momo
+Copyright (c) 2026 InstaZDLL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -6,10 +6,16 @@ from third-party projects with compatible licenses.
 
 ## syncedlyrics
 
-`src-tauri/crates/syncedlyrics` is a Rust implementation of the multi-provider
-lyrics lookup behavior originally provided by the `syncedlyrics` Python
-project. It is included in WaveFlow under GPL-3.0-only, with the original MIT
-notice preserved below.
+`src-tauri/crates/syncedlyrics` is a Rust port of the multi-provider lyrics
+lookup behavior originally provided by the `syncedlyrics` Python project. Its
+lineage is:
+
+1. Upstream Python project by Momo — <https://github.com/moehmeni/syncedlyrics>
+2. Forked and rewritten in Zig — <https://github.com/InstaZDLL/zig-syncedlyrics>
+3. Ported to Rust as the `waveflow-syncedlyrics` crate for WaveFlow (this tree)
+
+It is included in WaveFlow under GPL-3.0-only, with the original MIT notice
+preserved below.
 
 MIT License
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -14,13 +14,14 @@ lineage is:
 2. Forked and rewritten in Zig — <https://github.com/InstaZDLL/zig-syncedlyrics>
 3. Ported to Rust as the `waveflow-syncedlyrics` crate for WaveFlow (this tree)
 
-It is included in WaveFlow under GPL-3.0-only, with the original MIT notice
-preserved below.
+The Rust port itself is part of WaveFlow and is licensed under **GPL-3.0-only**
+(see [LICENSE](./LICENSE)). The MIT notice from the upstream Python project is
+preserved verbatim below — it covers the original implementation by Momo, not
+the InstaZDLL-authored Rust rewrite which is governed by the GPL terms.
 
 MIT License
 
 Copyright (c) 2022 Momo
-Copyright (c) 2026 InstaZDLL
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ User-facing references and per-feature deep dives. The top-level [README](../REA
 | [Library](features/library.md)                 | Folder scanning + management (add / watch / remove), filesystem watcher, drag-and-drop import, duplicate detection, on-demand audio analysis, multi-artist split, ratings, A-Z navigator |
 | [Playlists](features/playlists.md)             | User playlists CRUD, M3U import/export, likes, recently-played                                                                                                                           |
 | [Smart playlists](features/smart-playlists.md) | Daily Mix auto-generation + user-defined rule editor: algorithm, cover compositor, regen flow                                                                                            |
-| [Integrations](features/integrations.md)       | Deezer / Last.fm / LRCLIB clients, metadata cache, scrobble worker, similar-artists discovery, in-app lyrics editor                                                                      |
+| [Integrations](features/integrations.md)       | Deezer / Last.fm / lyrics providers, metadata cache, scrobble worker, similar-artists discovery, in-app lyrics editor                                                                    |
 | [DLNA / UPnP server](features/dlna.md)         | Built-in MediaServer: SSDP discovery, ContentDirectory Browse, Range streaming to LAN amplifiers                                                                                         |
 | [UI & UX](features/ui.md)                      | Layout, panels, mini-player widget, tray, statistics, dark mode, i18n, profiles, onboarding, auto-updater                                                                                |
 

--- a/docs/architecture/crates.md
+++ b/docs/architecture/crates.md
@@ -1,6 +1,6 @@
 # Crate layout
 
-`src-tauri/` is a Cargo workspace with three members:
+`src-tauri/` is a Cargo workspace with four members:
 
 ```text
 src-tauri/
@@ -25,8 +25,13 @@ src-tauri/
     ├── syncedlyrics/  (waveflow-syncedlyrics — query-based lyrics providers)
     │   └── src/
     │       ├── lib.rs                 (provider orchestration + search options)
+    │       ├── http.rs                (size caps + redirect host pinning + url redaction)
     │       ├── providers/             (Musixmatch / LRCLIB / NetEase / Megalobiz / Genius)
     │       └── utils.rs               (LRC detection, scoring, text helpers)
+    ├── plugin-sdk/    (waveflow-plugin-sdk — wasmtime Component Model runtime + manifest schema)
+    │   └── src/
+    │       ├── lib.rs                 (RuntimeConfig, manifest parsing, world ids)
+    │       └── ...                    (WIT worlds + bindings live in wit/ next door)
     └── app/           (waveflow — Tauri 2 application)
         ├── Cargo.toml                 (produces the `waveflow` binary)
         ├── tauri.conf.json

--- a/docs/architecture/crates.md
+++ b/docs/architecture/crates.md
@@ -1,6 +1,6 @@
 # Crate layout
 
-`src-tauri/` is a Cargo workspace with two members:
+`src-tauri/` is a Cargo workspace with three members:
 
 ```text
 src-tauri/
@@ -22,6 +22,11 @@ src-tauri/
     │       │   └── sqlite/            (Sqlite* impls of each trait)
     │       ├── scanner/               (file extract + upsert helpers, no orchestration)
     │       └── smart_playlists/       (Daily Mix, On Repeat, custom rule eval, cover composer)
+    ├── syncedlyrics/  (waveflow-syncedlyrics — query-based lyrics providers)
+    │   └── src/
+    │       ├── lib.rs                 (provider orchestration + search options)
+    │       ├── providers/             (Musixmatch / LRCLIB / NetEase / Megalobiz / Genius)
+    │       └── utils.rs               (LRC detection, scoring, text helpers)
     └── app/           (waveflow — Tauri 2 application)
         ├── Cargo.toml                 (produces the `waveflow` binary)
         ├── tauri.conf.json
@@ -55,6 +60,14 @@ Anything that could run inside an axum handler in the future `waveflow-server` (
 - **Audio format conversion** — DSD parser + decimating FIR (`audio_format/dsd/*`). The real-time playback pipeline still uses this from `app/src/audio/crossfade.rs`.
 - **Artwork pipeline** — the shared blake3-keyed metadata cache + the SIMD thumbnail variants (`artwork/{metadata,thumbnails}.rs`).
 - **Error type** — `CoreError`. The desktop's `AppError` wraps it via `#[from] CoreError` so `?` flattens automatically across the boundary.
+
+## What goes in `waveflow-syncedlyrics`
+
+Lyrics providers that are query-based rather than exact metadata clients. The crate is deliberately independent from Tauri and SQLite: callers pass a free-form query plus a provider list, and receive raw lyrics content with a detected format (`plain`, `lrc`, or `enhanced_lrc`).
+
+- **Provider adapters** — Musixmatch, LRCLIB search, NetEase, Megalobiz, and Genius. Network requests stay inside `providers/`.
+- **Search policy** — `SearchMode` controls plaintext vs synced-only vs synced-preferred results; `enhanced` asks Musixmatch for word-level karaoke before falling back to regular synced lyrics.
+- **Format/scoring helpers** — LRC / Enhanced LRC detection, timestamp formatting, rough token-set scoring, and small HTML text decoding helpers.
 
 ## What stays in `waveflow` (`crates/app/`)
 

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -4,7 +4,7 @@ External services WaveFlow talks to. All clients use [`reqwest 0.12`](https://cr
 
 ## Offline mode
 
-A single global toggle — Settings → Intégrations → "Mode hors-ligne" — short-circuits every outbound call described below. The flag is a `static AtomicBool` in [`offline.rs`](../../src-tauri/crates/app/src/offline.rs); it is consulted by Deezer enrichment, Last.fm now-playing + the scrobble worker tick, similar-artist lookups, and the LRCLIB lyrics fetch + library prefetch. Each gated path returns an empty payload (or whatever the local cache holds), nothing throws, so the UI keeps rendering with whatever metadata is already on disk. Persisted in `app_setting['network.offline_mode']` because the flag is process-wide — switching profiles must not silently re-enable network calls.
+A single global toggle — Settings → Intégrations → "Mode hors-ligne" — short-circuits every outbound call described below. The flag is a `static AtomicBool` in [`offline.rs`](../../src-tauri/crates/app/src/offline.rs); it is consulted by Deezer enrichment, Last.fm now-playing + the scrobble worker tick, similar-artist lookups, and lyrics fetch + library prefetch providers. Each gated path returns an empty payload (or whatever the local cache holds), nothing throws, so the UI keeps rendering with whatever metadata is already on disk. Persisted in `app_setting['network.offline_mode']` because the flag is process-wide — switching profiles must not silently re-enable network calls.
 
 ## Deezer (metadata)
 
@@ -107,14 +107,16 @@ Triggered from [`emit_track_changed`](../../src-tauri/crates/app/src/commands/pl
 
 **Off by default** — opposite default from Discord RPC because toasts are intrusive and trigger Focus Assist (Windows), Do Not Disturb (macOS), and `org.freedesktop.Notifications` filters (Linux) on every platform. Opt-in via Settings → Intégrations → "Notifications de changement de morceau". Stored in `app_setting['notifications.track_change']` (typed `bool`, shared across profiles like Discord RPC since toasts are an OS-level user preference, not per-listener). Toggling on doesn't fire a toast for the current track — first toast lands on the **next** track change.
 
-## LRCLIB (synchronized lyrics)
+## Lyrics providers
 
-[`lrclib.rs`](../../src-tauri/crates/core/src/metadata/lrclib.rs) — public lookup by `artist_name + track_name + album_name + duration` against [LRCLIB](https://lrclib.net). Four-tier resolution in [`commands/lyrics.rs`](../../src-tauri/crates/app/src/commands/lyrics.rs), driven on demand by `fetch_lyrics` (the library-wide `prefetch_library_lyrics` walks the same waterfall):
+[`lrclib.rs`](../../src-tauri/crates/core/src/metadata/lrclib.rs) still handles the exact [LRCLIB](https://lrclib.net) lookup by `artist_name + track_name + album_name + duration`. Query-based providers live in the Tauri-free [`waveflow-syncedlyrics`](../../src-tauri/crates/syncedlyrics/src/lib.rs) crate and are called from [`commands/lyrics.rs`](../../src-tauri/crates/app/src/commands/lyrics.rs). `fetch_lyrics` and the library-wide `prefetch_library_lyrics` walk the same waterfall:
 
 1. **Cache** — `app.lyrics` row keyed by `track.file_hash` (BLAKE3). No TTL, shared across profiles.
 2. **Embedded** — `LYRICS` / `USLT` / `©lyr` tag in the file (lofty), incl. synced `LRC` blocks. Lookup tries `ItemKey::UnsyncLyrics` first (the only key that maps to ID3v2's `USLT` in lofty 0.24), then `ItemKey::Lyrics` for Vorbis / MP4. For MP3s tagged with Mp3tag / foobar2000 / lame `--tg`, lyrics often live in a TXXX user-defined frame named `LYRICS` or `UNSYNCEDLYRICS` (common on K-Pop / J-Pop rips); these are invisible to the generic `Tag` interface so [`commands/lyrics.rs::read_id3v2_txxx_lyrics`](../../src-tauri/crates/app/src/commands/lyrics.rs) re-opens the file as `MpegFile`, downcasts to `Id3v2Tag`, and scans the TXXX descriptions explicitly.
 3. **Sidecar file** — `{stem}.lrc` / `{stem}.txt` next to the audio file (e.g. `01 Song.mp3` + `01 Song.lrc`), or inside a sibling `Lyrics/` folder (case-insensitive, so `lyrics/` is also matched — common Linux convention). Stem matching is also case-insensitive so `Song.MP3` finds `song.lrc` on case-sensitive filesystems. `.lrc` wins over `.txt` at every probed directory because it carries timing info; same-folder hits beat `Lyrics/` hits. Format is auto-detected via `detect_format` and the row is cached with `source = lrc_file`. Whitespace-only files are treated as misses so the waterfall keeps falling through. `save_lyrics` still writes back only to the embedded tag — the sidecar file remains read-only — so a user who edits via the in-app editor sees the new content immediately (from the freshly-hashed cache row), and the old sidecar copy is silently superseded by the new embedded tag on subsequent re-hashes.
-4. **LRCLIB** — synced lyrics first, falls back to plain text. Result cached as a new row.
+4. **Musixmatch Enhanced** — asks for word-level karaoke first. It only wins early when the result is actually Enhanced LRC; regular line-level LRC from Musixmatch falls through so LRCLIB's stricter metadata match can still win.
+5. **LRCLIB** — synced lyrics first, falls back to plain text. Result cached as a new row.
+6. **Query-based fallback providers** — Musixmatch, NetEase, Megalobiz, then Genius. This broader scan only runs after LRCLIB returns 404 or an empty payload, and prefers synced content over plain text.
 
 `import_lrc_file` is still available for the explicit "pick this file" flow (e.g. when the sidecar lives in a non-conventional location like `~/Documents/lyrics/`); it overwrites the cached row regardless of which tier filled it.
 
@@ -127,14 +129,14 @@ UI is [`LyricsEditorModal`](../../src/components/common/LyricsEditorModal.tsx) o
 
 **Cache discipline.** `clear_lyrics` flushes the row keyed by the track's hash so the next fetch re-runs the waterfall. Cached outcomes:
 
-- Hit (embedded or LRCLIB) → row written.
+- Hit (embedded, sidecar, LRCLIB, or query provider) → row written.
 - Instrumental flag from LRCLIB → empty row written (suppresses retries).
-- LRCLIB 404 / empty payload → empty row written. Without this, lo-fi / ambient libraries would re-hit the network on every panel open since most of their tracks are genuinely missing from LRCLIB. The lyrics panel renders "no lyrics found" against an empty cached row, and the "Refetch" button (`clearLyrics + fetchLyrics`) is the manual escape hatch for the user to retry once they think LRCLIB might have added the track.
+- LRCLIB 404 / empty payload and every query provider misses → empty row written. Without this, lo-fi / ambient libraries would re-hit the network on every panel open since many of their tracks are genuinely missing from public lyric providers. The lyrics panel renders "no lyrics found" against an empty cached row, and the "Refetch" button (`clearLyrics + fetchLyrics`) is the manual escape hatch for the user to retry once they think providers might have added the track.
 - Network error → **not cached** and bubbled up to the UI as `Err` so the panel can show "retry" instead of a misleading "no lyrics" state.
 
-**Network defaults.** 15 s overall timeout + 5 s connect-timeout in `LrclibClient` so a slow LRCLIB instance still gets a chance to respond while a truly unreachable host fails fast.
+**Network defaults.** 15 s overall timeout + 5 s connect-timeout in both `LrclibClient` and `SyncedLyricsClient` so a slow provider still gets a chance to respond while a truly unreachable host fails fast. Genius and NetEase can receive cookies through `SYNCEDLYRICS_GENIUS_COOKIE` and `SYNCEDLYRICS_NETEASE_COOKIE` for deployments that need them; secrets stay in the environment, never in the database.
 
-**Library-wide prefetch.** `prefetch_library_lyrics` walks every available track without a cached row (deduped by `file_hash`), runs the embedded → LRCLIB chain, and persists each hit. Network calls are throttled at 500 ms (~2 req/s) to be a polite guest; embedded hits skip the throttle. Progress streams over `lyrics:prefetch-progress`. A single global run is enforced via an `AtomicBool`; `cancel_lyrics_prefetch` flips a second `AtomicBool` the worker checks per iteration. Resumable — a partial cancel just leaves uncached rows for the next run.
+**Library-wide prefetch.** `prefetch_library_lyrics` walks every available track without a cached row (deduped by `file_hash`), runs the same waterfall, and persists each hit. Network calls are throttled at 500 ms (~2 req/s) to be a polite guest; embedded and sidecar hits skip the throttle. Progress streams over `lyrics:prefetch-progress`. A single global run is enforced via an `AtomicBool`; `cancel_lyrics_prefetch` flips a second `AtomicBool` the worker checks per iteration. Resumable — a partial cancel just leaves uncached rows for the next run.
 
 The lyrics panel renders synced lines with auto-scroll and a 200 ms transition; un-synced lyrics fall back to a static block.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7759,6 +7759,7 @@ dependencies = [
  "walkdir",
  "wasapi",
  "waveflow-core",
+ "waveflow-syncedlyrics",
  "windows 0.62.2",
  "zip 8.6.0",
 ]
@@ -7802,6 +7803,17 @@ name = "waveflow-plugin-sdk"
 version = "0.1.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "waveflow-syncedlyrics"
+version = "1.4.0"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7814,6 +7814,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/core", "crates/app", "crates/plugin-sdk"]
+members = ["crates/core", "crates/app", "crates/plugin-sdk", "crates/syncedlyrics"]
 
 # The actual package definitions live in `crates/core/Cargo.toml` and
 # `crates/app/Cargo.toml`. The workspace root is virtual: it owns the

--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "1"
 # command handlers can still use them as `query_as` targets after the
 # move out of `commands/*.rs`.
 waveflow-core = { path = "../core", features = ["sqlite"] }
+waveflow-syncedlyrics = { path = "../syncedlyrics" }
 
 tauri = { version = "2", features = ["protocol-asset", "tray-icon", "image-png"] }
 tauri-plugin-opener = "2"

--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -16,7 +16,7 @@
 
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use chrono::Utc;
@@ -300,6 +300,31 @@ fn external_fallback_providers() -> Vec<Provider> {
     ]
 }
 
+/// Process-wide shared `SyncedLyricsClient`. Standing one up per call
+/// re-initialises rustls + builds a fresh reqwest connection pool every
+/// time `external_lyrics_search` runs — wasted work, especially during
+/// `prefetch_library_lyrics` where the same waterfall fires N times in
+/// quick succession. The shared client caches its connection pool, so
+/// back-to-back calls reuse keep-alive sockets to the providers.
+fn shared_external_client() -> AppResult<&'static SyncedLyricsClient> {
+    static CLIENT: OnceLock<SyncedLyricsClient> = OnceLock::new();
+    if let Some(c) = CLIENT.get() {
+        return Ok(c);
+    }
+    // `try_new` is fallible (TLS backend init can fail), so we can't
+    // use `OnceLock::get_or_init` which only accepts an infallible
+    // initializer. Build + insert via `get_or_try_init` shape: try to
+    // initialise, fall back to whatever `set` lost the race to.
+    let built = SyncedLyricsClient::try_new()
+        .map_err(|err| AppError::Other(format!("lyrics client init failed: {err}")))?;
+    match CLIENT.set(built) {
+        Ok(()) => Ok(CLIENT.get().expect("just set")),
+        // A concurrent caller initialised it first; ours is dropped
+        // (and its idle pool too — cost-of-once on cold startup race).
+        Err(_) => Ok(CLIENT.get().expect("set by concurrent caller")),
+    }
+}
+
 async fn external_lyrics_search(
     meta: &TrackMeta,
     providers: Vec<Provider>,
@@ -321,8 +346,7 @@ async fn external_lyrics_search(
         return Ok(None);
     }
     let query = external_query(&meta.title, meta.artist_name.as_deref());
-    let client = SyncedLyricsClient::try_new()
-        .map_err(|err| AppError::Other(format!("lyrics client init failed: {err}")))?;
+    let client = shared_external_client()?;
     // A transient provider error surfaces as Err here (not Ok(None)) so
     // callers don't cache an empty "miss" on a network blip.
     client
@@ -1124,6 +1148,18 @@ async fn run_prefetch(
             // No enhanced hit (or a transient failure): fall through to LRCLIB.
             Ok(_) => {}
             Err(err) => tracing::warn!(track_id, ?err, "Musixmatch enhanced prefetch failed"),
+        }
+        // Throttle the Musixmatch call we just made before firing
+        // LRCLIB right after. Without this the prefetch loop hits two
+        // distinct backends back-to-back per track for any
+        // Musixmatch-attempted slot, doubling the effective request
+        // rate on the user's network. Only sleep when Musixmatch was
+        // actually attempted — when the toggle is off,
+        // `filter_providers` returns an empty list and
+        // `external_lyrics_search` short-circuits to Ok(None) without
+        // touching the network.
+        if musixmatch_enabled() {
+            tokio::time::sleep(LRCLIB_THROTTLE).await;
         }
 
         // 4. LRCLIB. Skip if metadata is too thin to match.

--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -249,7 +249,7 @@ fn external_format_to_app(format: ExternalLyricsFormat) -> LyricsFormat {
 fn external_query(title: &str, artist_name: Option<&str>) -> String {
     match artist_name {
         Some(artist) if !artist.trim().is_empty() => {
-            let primary_artist = artist.split(", ").next().unwrap_or(artist);
+            let primary_artist = artist.split("; ").next().unwrap_or(artist);
             format!("{title} {primary_artist}")
         }
         _ => title.to_string(),
@@ -270,10 +270,19 @@ async fn external_lyrics_search(
     providers: Vec<Provider>,
     mode: SearchMode,
     enhanced: bool,
-) -> Option<ExternalLyricsResult> {
+) -> AppResult<Option<ExternalLyricsResult>> {
+    // Defense in depth: every outbound HTTP path must honour offline mode
+    // regardless of caller. Returning Ok(None) short-circuits before any
+    // request is issued (see the process-wide offline contract).
+    if crate::offline::is_offline() {
+        return Ok(None);
+    }
     let query = external_query(&meta.title, meta.artist_name.as_deref());
-    let client = SyncedLyricsClient::new();
-    match client
+    let client = SyncedLyricsClient::try_new()
+        .map_err(|err| AppError::Other(format!("lyrics client init failed: {err}")))?;
+    // A transient provider error surfaces as Err here (not Ok(None)) so
+    // callers don't cache an empty "miss" on a network blip.
+    client
         .search(SearchOptions {
             query,
             mode,
@@ -284,13 +293,7 @@ async fn external_lyrics_search(
             netease_cookie: std::env::var("SYNCEDLYRICS_NETEASE_COOKIE").ok(),
         })
         .await
-    {
-        Ok(result) => result,
-        Err(err) => {
-            tracing::debug!(?err, "external lyrics search failed");
-            None
-        }
-    }
+        .map_err(|err| AppError::Other(format!("external lyrics search failed: {err}")))
 }
 
 async fn cache_external_lyrics(
@@ -675,7 +678,9 @@ pub async fn fetch_lyrics(
     //    when it returns true word-level LRC; regular line-level LRC
     //    still lets the stricter metadata LRCLIB lookup below win.
     if !crate::offline::is_offline() {
-        if let Some(result) = external_lyrics_search(
+        // A Musixmatch failure here is non-fatal: fall through to LRCLIB
+        // rather than aborting the whole lookup or caching a miss.
+        match external_lyrics_search(
             &meta,
             vec![Provider::Musixmatch],
             SearchMode::SyncedOnly,
@@ -683,11 +688,13 @@ pub async fn fetch_lyrics(
         )
         .await
         {
-            if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) {
+            Ok(Some(result)) if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) => {
                 return cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
                     .await
                     .map(Some);
             }
+            Ok(_) => {}
+            Err(err) => tracing::debug!(?err, "Musixmatch enhanced lookup failed"),
         }
     }
 
@@ -700,7 +707,7 @@ pub async fn fetch_lyrics(
     let Some(artist_name) = meta.artist_name.as_deref() else {
         return Ok(None);
     };
-    let primary_artist = artist_name.split(", ").next().unwrap_or(artist_name);
+    let primary_artist = artist_name.split("; ").next().unwrap_or(artist_name);
     let duration_seconds = (meta.duration_ms.max(0) as u64).div_ceil(1000);
     let client = LrclibClient::new();
     let resp = match client
@@ -724,7 +731,7 @@ pub async fn fetch_lyrics(
                 SearchMode::PreferSynced,
                 true,
             )
-            .await
+            .await?
             {
                 return cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
                     .await
@@ -797,7 +804,7 @@ pub async fn fetch_lyrics(
                 SearchMode::PreferSynced,
                 true,
             )
-            .await
+            .await?
             {
                 return cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
                     .await
@@ -1052,7 +1059,7 @@ async fn run_prefetch(
 
         // 3. Musixmatch enhanced. If word-level timing exists, keep it
         //    before LRCLIB's line-level result can fill the cache.
-        if let Some(result) = external_lyrics_search(
+        match external_lyrics_search(
             &meta,
             vec![Provider::Musixmatch],
             SearchMode::SyncedOnly,
@@ -1060,7 +1067,7 @@ async fn run_prefetch(
         )
         .await
         {
-            if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) {
+            Ok(Some(result)) if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) => {
                 if let Err(e) = cache_external_lyrics(&pool, track_id, &file_hash, result).await {
                     tracing::warn!(track_id, ?e, "persist Musixmatch enhanced lyrics failed");
                     failed += 1;
@@ -1071,6 +1078,9 @@ async fn run_prefetch(
                 tokio::time::sleep(LRCLIB_THROTTLE).await;
                 continue;
             }
+            // No enhanced hit (or a transient failure): fall through to LRCLIB.
+            Ok(_) => {}
+            Err(err) => tracing::warn!(track_id, ?err, "Musixmatch enhanced prefetch failed"),
         }
 
         // 4. LRCLIB. Skip if metadata is too thin to match.
@@ -1079,7 +1089,7 @@ async fn run_prefetch(
             processed += 1;
             continue;
         };
-        let primary_artist = artist.split(", ").next().unwrap_or(artist);
+        let primary_artist = artist.split("; ").next().unwrap_or(artist);
         let duration_seconds = (duration_ms.max(0) as u64).div_ceil(1000);
 
         match client
@@ -1122,7 +1132,7 @@ async fn run_prefetch(
                         // Row exists but neither synced nor plain
                         // lyrics. Try query-based providers before
                         // caching this as a miss.
-                        if let Some(result) = external_lyrics_search(
+                        match external_lyrics_search(
                             &meta,
                             external_fallback_providers(),
                             SearchMode::PreferSynced,
@@ -1130,24 +1140,31 @@ async fn run_prefetch(
                         )
                         .await
                         {
-                            if let Err(e) =
-                                cache_external_lyrics(&pool, track_id, &file_hash, result).await
-                            {
-                                tracing::warn!(track_id, ?e, "persist external lyrics failed");
-                                failed += 1;
-                            } else {
-                                hits += 1;
+                            Ok(Some(result)) => {
+                                if let Err(e) =
+                                    cache_external_lyrics(&pool, track_id, &file_hash, result).await
+                                {
+                                    tracing::warn!(track_id, ?e, "persist external lyrics failed");
+                                    failed += 1;
+                                } else {
+                                    hits += 1;
+                                }
                             }
-                        } else {
-                            let _ = upsert_lyrics(
-                                &pool,
-                                &file_hash,
-                                "",
-                                &LyricsFormat::Plain,
-                                &LyricsSource::Api,
-                            )
-                            .await;
-                            misses += 1;
+                            Ok(None) => {
+                                let _ = upsert_lyrics(
+                                    &pool,
+                                    &file_hash,
+                                    "",
+                                    &LyricsFormat::Plain,
+                                    &LyricsSource::Api,
+                                )
+                                .await;
+                                misses += 1;
+                            }
+                            Err(err) => {
+                                tracing::warn!(track_id, ?err, "external lyrics prefetch failed");
+                                failed += 1;
+                            }
                         }
                     }
                 }
@@ -1155,7 +1172,7 @@ async fn run_prefetch(
             Ok(None) => {
                 // LRCLIB 404. Try query-based providers before caching
                 // as empty.
-                if let Some(result) = external_lyrics_search(
+                match external_lyrics_search(
                     &meta,
                     external_fallback_providers(),
                     SearchMode::PreferSynced,
@@ -1163,27 +1180,35 @@ async fn run_prefetch(
                 )
                 .await
                 {
-                    if let Err(e) = cache_external_lyrics(&pool, track_id, &file_hash, result).await
-                    {
-                        tracing::warn!(track_id, ?e, "persist external lyrics failed");
-                        failed += 1;
-                    } else {
-                        hits += 1;
+                    Ok(Some(result)) => {
+                        if let Err(e) =
+                            cache_external_lyrics(&pool, track_id, &file_hash, result).await
+                        {
+                            tracing::warn!(track_id, ?e, "persist external lyrics failed");
+                            failed += 1;
+                        } else {
+                            hits += 1;
+                        }
                     }
-                } else {
-                    // No provider had lyrics. Cache as empty so re-runs
-                    // of the prefetch and re-opens of the lyrics panel
-                    // skip this track. User can force a re-search
-                    // per-track via the "Refetch" button.
-                    let _ = upsert_lyrics(
-                        &pool,
-                        &file_hash,
-                        "",
-                        &LyricsFormat::Plain,
-                        &LyricsSource::Api,
-                    )
-                    .await;
-                    misses += 1;
+                    Ok(None) => {
+                        // No provider had lyrics. Cache as empty so re-runs
+                        // of the prefetch and re-opens of the lyrics panel
+                        // skip this track. User can force a re-search
+                        // per-track via the "Refetch" button.
+                        let _ = upsert_lyrics(
+                            &pool,
+                            &file_hash,
+                            "",
+                            &LyricsFormat::Plain,
+                            &LyricsSource::Api,
+                        )
+                        .await;
+                        misses += 1;
+                    }
+                    Err(err) => {
+                        tracing::warn!(track_id, ?err, "external lyrics prefetch failed");
+                        failed += 1;
+                    }
                 }
             }
             Err(err) => {

--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -291,13 +291,19 @@ fn external_query(title: &str, artist_name: Option<&str>) -> String {
     }
 }
 
+/// Provider order for the query-based fallback chain that runs after
+/// LRCLIB's exact-metadata match has missed.
+///
+/// **Musixmatch is intentionally absent.** Both [`fetch_lyrics`] and
+/// [`run_prefetch`] already invoke Musixmatch on its own dedicated tier
+/// (the enhanced word-level lookup, gated on `MUSIXMATCH_ENABLED`). If
+/// we listed it here too, every cache miss that fell through the
+/// dedicated tier would issue a second Musixmatch request — same
+/// endpoint, same query, same token — for a result we already knew
+/// wasn't word-level. The fallback chain stays Musixmatch-free; the
+/// dedicated tier owns it.
 fn external_fallback_providers() -> Vec<Provider> {
-    vec![
-        Provider::Musixmatch,
-        Provider::NetEase,
-        Provider::Megalobiz,
-        Provider::Genius,
-    ]
+    vec![Provider::NetEase, Provider::Megalobiz, Provider::Genius]
 }
 
 /// Process-wide shared `SyncedLyricsClient`. Standing one up per call

--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -45,6 +45,41 @@ use crate::{
 static PREFETCH_RUNNING: AtomicBool = AtomicBool::new(false);
 static PREFETCH_CANCEL: AtomicBool = AtomicBool::new(false);
 
+/// Process-wide Musixmatch opt-in. Off by default because the upstream
+/// `syncedlyrics` Python project — and therefore this Rust port — hits
+/// Musixmatch's `apic-desktop.musixmatch.com` private endpoint via a
+/// reverse-engineered desktop-app `app_id`. That is not an authorised
+/// integration; Musixmatch has historically issued takedowns against
+/// clients that ship it on by default. Hydrated from
+/// `app_setting['lyrics.musixmatch_enabled']` at startup. Users who
+/// want the word-level provider can opt in via SQL today; a Settings
+/// toggle ships in v1.6.
+static MUSIXMATCH_ENABLED: AtomicBool = AtomicBool::new(false);
+
+#[inline]
+pub fn musixmatch_enabled() -> bool {
+    MUSIXMATCH_ENABLED.load(Ordering::Acquire)
+}
+
+#[inline]
+pub fn set_musixmatch_enabled(value: bool) {
+    MUSIXMATCH_ENABLED.store(value, Ordering::Release);
+}
+
+/// Filter Musixmatch out of a provider list when the opt-in is off.
+/// Used at every external-search call site so the opt-in is a single
+/// chokepoint instead of N scattered checks.
+fn filter_providers(providers: Vec<Provider>) -> Vec<Provider> {
+    if musixmatch_enabled() {
+        providers
+    } else {
+        providers
+            .into_iter()
+            .filter(|p| !matches!(p, Provider::Musixmatch))
+            .collect()
+    }
+}
+
 /// LRCLIB throttle — be a polite guest on the public instance. 500 ms
 /// per call ≈ 2 req/s, which clears a 10k-track library in ~1h30 even
 /// when every track misses the embedded tag and goes to the network.
@@ -275,6 +310,14 @@ async fn external_lyrics_search(
     // regardless of caller. Returning Ok(None) short-circuits before any
     // request is issued (see the process-wide offline contract).
     if crate::offline::is_offline() {
+        return Ok(None);
+    }
+    // Apply the Musixmatch opt-in here — at a single chokepoint — so
+    // call sites don't have to know whether Musixmatch is in their
+    // provider list. An empty list after filtering means "nothing left
+    // to query": short-circuit instead of building a no-op client.
+    let providers = filter_providers(providers);
+    if providers.is_empty() {
         return Ok(None);
     }
     let query = external_query(&meta.title, meta.artist_name.as_deref());

--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -1,12 +1,14 @@
 //! Lyrics fetch + cache.
 //!
-//! Lazy four-tier lookup, in order:
+//! Lazy multi-tier lookup, in order:
 //!   1. Local DB cache (`lyrics` table, keyed by `track_id`)
 //!   2. Embedded `USLT` / lyrics tag inside the audio file (via lofty)
 //!   3. Local sidecar file — `{stem}.lrc` / `{stem}.txt` next to the
 //!      audio file, or inside a `Lyrics/` (case-insensitive) subfolder
 //!      next to it. `.lrc` wins over `.txt` (timing info).
-//!   4. LRCLIB public API (matched by artist + track + album + duration)
+//!   4. Musixmatch Enhanced LRC when word-level timing exists
+//!   5. LRCLIB public API (matched by artist + track + album + duration)
+//!   6. Query-based external providers before caching a network miss
 //!
 //! Whichever tier hits first becomes the cached entry. We never refetch
 //! once a row exists — the user can manually overwrite by importing a
@@ -25,6 +27,10 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 
 use waveflow_core::metadata::lrclib::LrclibClient;
+use waveflow_syncedlyrics::{
+    LyricsFormat as ExternalLyricsFormat, LyricsResult as ExternalLyricsResult, Provider,
+    SearchMode, SearchOptions, SyncedLyricsClient,
+};
 
 use crate::{
     audio::AudioEngine,
@@ -230,6 +236,79 @@ fn source_to_db(src: &LyricsSource) -> &'static str {
         LyricsSource::Api => "api",
         LyricsSource::Manual => "manual",
     }
+}
+
+fn external_format_to_app(format: ExternalLyricsFormat) -> LyricsFormat {
+    match format {
+        ExternalLyricsFormat::Plain => LyricsFormat::Plain,
+        ExternalLyricsFormat::Lrc => LyricsFormat::Lrc,
+        ExternalLyricsFormat::EnhancedLrc => LyricsFormat::EnhancedLrc,
+    }
+}
+
+fn external_query(title: &str, artist_name: Option<&str>) -> String {
+    match artist_name {
+        Some(artist) if !artist.trim().is_empty() => {
+            let primary_artist = artist.split(", ").next().unwrap_or(artist);
+            format!("{title} {primary_artist}")
+        }
+        _ => title.to_string(),
+    }
+}
+
+fn external_fallback_providers() -> Vec<Provider> {
+    vec![
+        Provider::Musixmatch,
+        Provider::NetEase,
+        Provider::Megalobiz,
+        Provider::Genius,
+    ]
+}
+
+async fn external_lyrics_search(
+    meta: &TrackMeta,
+    providers: Vec<Provider>,
+    mode: SearchMode,
+    enhanced: bool,
+) -> Option<ExternalLyricsResult> {
+    let query = external_query(&meta.title, meta.artist_name.as_deref());
+    let client = SyncedLyricsClient::new();
+    match client
+        .search(SearchOptions {
+            query,
+            mode,
+            providers,
+            enhanced,
+            lang: None,
+            genius_cookie: std::env::var("SYNCEDLYRICS_GENIUS_COOKIE").ok(),
+            netease_cookie: std::env::var("SYNCEDLYRICS_NETEASE_COOKIE").ok(),
+        })
+        .await
+    {
+        Ok(result) => result,
+        Err(err) => {
+            tracing::debug!(?err, "external lyrics search failed");
+            None
+        }
+    }
+}
+
+async fn cache_external_lyrics(
+    pool: &sqlx::SqlitePool,
+    track_id: i64,
+    file_hash: &str,
+    result: ExternalLyricsResult,
+) -> AppResult<LyricsPayload> {
+    let format = external_format_to_app(result.format);
+    let source = LyricsSource::Api;
+    upsert_lyrics(pool, file_hash, &result.content, &format, &source).await?;
+    Ok(LyricsPayload {
+        track_id,
+        content: result.content,
+        format,
+        source,
+        tag_write_skipped: None,
+    })
 }
 
 /// Re-open an MP3 as a typed `Id3v2Tag` and pull the lyrics out of any
@@ -528,8 +607,9 @@ pub async fn get_lyrics(
     read_cached(&pool, track_id).await
 }
 
-/// Three-tier lookup: cache → embedded tag → LRCLIB. Caches the first
-/// hit and returns it. Returns `None` if every tier failed.
+/// Multi-tier lookup: cache → embedded tag → sidecar → enhanced/API
+/// providers. Caches the first hit and returns it. Returns `None` if
+/// local tiers fail and offline mode prevents network lookup.
 #[tauri::command]
 pub async fn fetch_lyrics(
     state: tauri::State<'_, AppState>,
@@ -591,7 +671,27 @@ pub async fn fetch_lyrics(
         }));
     }
 
-    // 4. LRCLIB fallback. Skip if we have no artist (matching is
+    // 4. Musixmatch enhanced fallback. This runs before LRCLIB only
+    //    when it returns true word-level LRC; regular line-level LRC
+    //    still lets the stricter metadata LRCLIB lookup below win.
+    if !crate::offline::is_offline() {
+        if let Some(result) = external_lyrics_search(
+            &meta,
+            vec![Provider::Musixmatch],
+            SearchMode::SyncedOnly,
+            true,
+        )
+        .await
+        {
+            if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) {
+                return cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
+                    .await
+                    .map(Some);
+            }
+        }
+    }
+
+    // 5. LRCLIB fallback. Skip if we have no artist (matching is
     //    useless without one) or if offline mode is on (the cache +
     //    embedded tiers above already ran).
     if crate::offline::is_offline() {
@@ -614,11 +714,27 @@ pub async fn fetch_lyrics(
     {
         Ok(Some(r)) => r,
         Ok(None) => {
-            // LRCLIB 404 — track unknown to the database. Cache as an
-            // empty row so we don't re-hit the network on every panel
-            // open. The user can force a re-search by clicking
-            // "Refetch" in the lyrics panel (clears the row, re-runs
-            // the waterfall) when LRCLIB might have added the track.
+            // LRCLIB 404 — try the broader provider chain before
+            // caching a miss. These sources are query-based and less
+            // strict than LRCLIB's metadata endpoint, so they only run
+            // after the exact lookup fails.
+            if let Some(result) = external_lyrics_search(
+                &meta,
+                external_fallback_providers(),
+                SearchMode::PreferSynced,
+                true,
+            )
+            .await
+            {
+                return cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
+                    .await
+                    .map(Some);
+            }
+
+            // No provider had lyrics. Cache as an empty row so we
+            // don't re-hit the network on every panel open. The user
+            // can force a re-search by clicking "Refetch" in the
+            // lyrics panel (clears the row, re-runs the waterfall).
             let empty = String::new();
             upsert_lyrics(
                 &pool,
@@ -675,6 +791,19 @@ pub async fn fetch_lyrics(
         (Some(s), _) if !s.trim().is_empty() => (s, LyricsFormat::Lrc),
         (_, Some(p)) if !p.trim().is_empty() => (p, LyricsFormat::Plain),
         _ => {
+            if let Some(result) = external_lyrics_search(
+                &meta,
+                external_fallback_providers(),
+                SearchMode::PreferSynced,
+                true,
+            )
+            .await
+            {
+                return cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
+                    .await
+                    .map(Some);
+            }
+
             let empty = String::new();
             upsert_lyrics(
                 &pool,
@@ -764,8 +893,9 @@ pub struct LyricsPrefetchSummary {
 }
 
 /// Walk every available track that doesn't have a cached lyric and try
-/// to populate the cache (embedded tag → LRCLIB). Throttles network
-/// calls at ~2 req/s. Cancellable via [`cancel_lyrics_prefetch`].
+/// to populate the cache using the same local/network priority as
+/// [`fetch_lyrics`]. Throttles network calls at ~2 req/s. Cancellable
+/// via [`cancel_lyrics_prefetch`].
 ///
 /// Idempotent: the `WHERE l.file_hash IS NULL` filter skips anything
 /// already cached, so re-running after a partial cancel just resumes.
@@ -911,7 +1041,39 @@ async fn run_prefetch(
             continue;
         }
 
-        // 3. LRCLIB. Skip if metadata is too thin to match.
+        let meta = TrackMeta {
+            file_path: file_path.clone(),
+            file_hash: file_hash.clone(),
+            title: title.clone(),
+            artist_name: artist_name.clone(),
+            album_title: album_title.clone(),
+            duration_ms,
+        };
+
+        // 3. Musixmatch enhanced. If word-level timing exists, keep it
+        //    before LRCLIB's line-level result can fill the cache.
+        if let Some(result) = external_lyrics_search(
+            &meta,
+            vec![Provider::Musixmatch],
+            SearchMode::SyncedOnly,
+            true,
+        )
+        .await
+        {
+            if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) {
+                if let Err(e) = cache_external_lyrics(&pool, track_id, &file_hash, result).await {
+                    tracing::warn!(track_id, ?e, "persist Musixmatch enhanced lyrics failed");
+                    failed += 1;
+                } else {
+                    hits += 1;
+                }
+                processed += 1;
+                tokio::time::sleep(LRCLIB_THROTTLE).await;
+                continue;
+            }
+        }
+
+        // 4. LRCLIB. Skip if metadata is too thin to match.
         let Some(artist) = artist_name.as_deref() else {
             misses += 1;
             processed += 1;
@@ -958,33 +1120,71 @@ async fn run_prefetch(
                         }
                     } else {
                         // Row exists but neither synced nor plain
-                        // lyrics — treat like a 404 and cache empty.
-                        let _ = upsert_lyrics(
-                            &pool,
-                            &file_hash,
-                            "",
-                            &LyricsFormat::Plain,
-                            &LyricsSource::Api,
+                        // lyrics. Try query-based providers before
+                        // caching this as a miss.
+                        if let Some(result) = external_lyrics_search(
+                            &meta,
+                            external_fallback_providers(),
+                            SearchMode::PreferSynced,
+                            true,
                         )
-                        .await;
-                        misses += 1;
+                        .await
+                        {
+                            if let Err(e) =
+                                cache_external_lyrics(&pool, track_id, &file_hash, result).await
+                            {
+                                tracing::warn!(track_id, ?e, "persist external lyrics failed");
+                                failed += 1;
+                            } else {
+                                hits += 1;
+                            }
+                        } else {
+                            let _ = upsert_lyrics(
+                                &pool,
+                                &file_hash,
+                                "",
+                                &LyricsFormat::Plain,
+                                &LyricsSource::Api,
+                            )
+                            .await;
+                            misses += 1;
+                        }
                     }
                 }
             }
             Ok(None) => {
-                // LRCLIB 404. Cache as empty so re-runs of the
-                // prefetch and re-opens of the lyrics panel skip this
-                // track. User can force a re-search per-track via the
-                // "Refetch" button in the lyrics panel.
-                let _ = upsert_lyrics(
-                    &pool,
-                    &file_hash,
-                    "",
-                    &LyricsFormat::Plain,
-                    &LyricsSource::Api,
+                // LRCLIB 404. Try query-based providers before caching
+                // as empty.
+                if let Some(result) = external_lyrics_search(
+                    &meta,
+                    external_fallback_providers(),
+                    SearchMode::PreferSynced,
+                    true,
                 )
-                .await;
-                misses += 1;
+                .await
+                {
+                    if let Err(e) = cache_external_lyrics(&pool, track_id, &file_hash, result).await
+                    {
+                        tracing::warn!(track_id, ?e, "persist external lyrics failed");
+                        failed += 1;
+                    } else {
+                        hits += 1;
+                    }
+                } else {
+                    // No provider had lyrics. Cache as empty so re-runs
+                    // of the prefetch and re-opens of the lyrics panel
+                    // skip this track. User can force a re-search
+                    // per-track via the "Refetch" button.
+                    let _ = upsert_lyrics(
+                        &pool,
+                        &file_hash,
+                        "",
+                        &LyricsFormat::Plain,
+                        &LyricsSource::Api,
+                    )
+                    .await;
+                    misses += 1;
+                }
             }
             Err(err) => {
                 tracing::warn!(track_id, ?err, "LRCLIB prefetch failed");

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -125,6 +125,23 @@ impl AppState {
                 .unwrap_or(false),
         );
 
+        // Hydrate the Musixmatch opt-in flag from app_setting. Default
+        // off (Musixmatch hits a reverse-engineered private endpoint;
+        // not authorised by their ToS). Users who want it enable via
+        // `app_setting['lyrics.musixmatch_enabled'] = 'true'` until the
+        // v1.6 Settings toggle ships.
+        let musixmatch_initial: Option<String> =
+            sqlx::query_scalar("SELECT value FROM app_setting WHERE key = 'lyrics.musixmatch_enabled'")
+                .fetch_optional(&app_db)
+                .await
+                .ok()
+                .flatten();
+        crate::commands::lyrics::set_musixmatch_enabled(
+            musixmatch_initial
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false),
+        );
+
         // Plugin runtime — one per process. The offline probe reads
         // the same `crate::offline` atomic Deezer / Last.fm / LRCLIB
         // do, so flipping the user-facing offline switch reaches

--- a/src-tauri/crates/syncedlyrics/Cargo.toml
+++ b/src-tauri/crates/syncedlyrics/Cargo.toml
@@ -11,3 +11,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tracing = "0.1"
+# URL parsing for redirect host pinning + outbound href validation.
+# Already in the transitive tree via reqwest, but we depend on it
+# explicitly so a future minor reqwest bump that swaps url for
+# something else doesn't silently break our SSRF guards.
+url = "2"

--- a/src-tauri/crates/syncedlyrics/Cargo.toml
+++ b/src-tauri/crates/syncedlyrics/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "waveflow-syncedlyrics"
+version = "1.4.0"
+edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/InstaZDLL/WaveFlow"
+
+[dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tracing = "0.1"

--- a/src-tauri/crates/syncedlyrics/src/http.rs
+++ b/src-tauri/crates/syncedlyrics/src/http.rs
@@ -1,0 +1,220 @@
+//! HTTP guards shared across every provider.
+//!
+//! Three concerns ride here together because they all interact with the
+//! same `reqwest::Client` and `reqwest::Response`:
+//!
+//! 1. **Body size caps** — every `.text()` / `.json()` call on a
+//!    third-party response is a latent DoS: a 100 MB lyric body is
+//!    rare in practice but trivial to host, and the desktop process
+//!    has no business buffering megabytes of HTML to scrape a `<span>`
+//!    out of it. [`safe_text`] and [`safe_json`] cap the read and
+//!    short-circuit on `Content-Length` when the server is honest.
+//!
+//! 2. **Redirect host pinning** — provider responses sometimes carry
+//!    URLs the client is then expected to follow (Genius search →
+//!    song page, Megalobiz HTML scrape → lyric page). The default
+//!    `reqwest` redirect policy allows ten hops to any host, so a
+//!    compromised provider response could redirect us into an
+//!    internal address (SSRF) or any attacker-controlled host. The
+//!    client built by [`build_client`] caps redirects at 3 AND
+//!    rejects every redirect that leaves the allowlist below.
+//!
+//! 3. **URL log redaction** — Musixmatch's request URL carries
+//!    `usertoken=` as a query parameter; a `Debug`-formatted
+//!    `reqwest::Error` echoes the URL, which lands in our rolling
+//!    log file. [`redact_url`] strips userinfo + query before any
+//!    tracing macro sees the URL.
+
+use std::time::Duration;
+
+use reqwest::{redirect, Client, Response};
+use url::Url;
+
+use crate::{Error, Result};
+
+/// Upper bound on a single provider response body (per call). Picked to
+/// be generous for HTML lyric pages (Megalobiz, Genius) while still
+/// containing a hostile or compromised host.
+pub const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
+
+/// Hostnames + suffixes the redirect policy will follow. Anything else
+/// terminates the chain with an error instead of hopping further. The
+/// suffix variant catches CDN edges (e.g. `*.musixmatch.com`).
+const ALLOWED_HOSTS: &[&str] = &[
+    "apic-desktop.musixmatch.com",
+    "lrclib.net",
+    "music.163.com",
+    "www.megalobiz.com",
+    "api.genius.com",
+    "genius.com",
+];
+
+/// Suffix allowlist for CDNs and locale subdomains. Keep both arrays
+/// small — every entry is a place an attacker could host a payload.
+const ALLOWED_SUFFIXES: &[&str] = &[".musixmatch.com", ".genius.com"];
+
+fn host_is_allowed(host: &str) -> bool {
+    if ALLOWED_HOSTS.contains(&host) {
+        return true;
+    }
+    ALLOWED_SUFFIXES.iter().any(|suffix| host.ends_with(suffix))
+}
+
+/// Build the syncedlyrics shared `reqwest::Client` with the redirect +
+/// timeout guards every provider needs. Use this instead of
+/// `reqwest::Client::new()` so every provider inherits the same
+/// SSRF / DoS guards by construction.
+pub fn build_client() -> Result<Client> {
+    let policy = redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 3 {
+            return attempt.error("too many redirects");
+        }
+        let host = attempt.url().host_str().map(str::to_string);
+        match host {
+            Some(host) if host_is_allowed(&host) => attempt.follow(),
+            Some(host) => attempt.error(format!("redirect to disallowed host: {host}")),
+            None => attempt.error("redirect target has no host"),
+        }
+    });
+    let client = Client::builder()
+        .user_agent("WaveFlow/1.4 (https://github.com/InstaZDLL/WaveFlow)")
+        .timeout(Duration::from_secs(15))
+        .connect_timeout(Duration::from_secs(5))
+        .redirect(policy)
+        .build()?;
+    Ok(client)
+}
+
+/// Read a response body into a `String`, refusing to allocate beyond
+/// `MAX_BODY_BYTES`. The check happens twice: once against
+/// `Content-Length` when present (so an honest server is short-
+/// circuited before any bytes flow) and once incrementally as chunks
+/// arrive (so a server that lies about Content-Length or omits it
+/// can't bypass the cap).
+pub async fn safe_text(response: Response) -> Result<String> {
+    let bytes = safe_bytes(response).await?;
+    String::from_utf8(bytes)
+        .map_err(|e| Error::Provider(format!("response is not valid utf-8: {e}")))
+}
+
+/// Read a response body as JSON, refusing to allocate beyond
+/// `MAX_BODY_BYTES`.
+pub async fn safe_json<T: serde::de::DeserializeOwned>(response: Response) -> Result<T> {
+    let bytes = safe_bytes(response).await?;
+    serde_json::from_slice(&bytes).map_err(Error::from)
+}
+
+/// Workhorse for [`safe_text`] / [`safe_json`]. Returns the response
+/// body as raw bytes, hard-capped at [`MAX_BODY_BYTES`].
+pub async fn safe_bytes(mut response: Response) -> Result<Vec<u8>> {
+    if let Some(len) = response.content_length() {
+        if len as usize > MAX_BODY_BYTES {
+            return Err(Error::Provider(format!(
+                "response advertises {len} bytes, over cap of {MAX_BODY_BYTES}"
+            )));
+        }
+    }
+    let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    while let Some(chunk) = response.chunk().await? {
+        if buf.len() + chunk.len() > MAX_BODY_BYTES {
+            return Err(Error::Provider(format!(
+                "response exceeded body cap of {MAX_BODY_BYTES}"
+            )));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
+/// Validate that `candidate` is an absolute http(s) URL pointing at one
+/// of `allowed_hosts`. Used by Genius / Megalobiz before they follow a
+/// URL plucked out of a third-party response — without the host pin,
+/// poisoned upstream content could redirect the desktop client into an
+/// internal address (SSRF).
+pub fn validate_outbound_url(candidate: &str, allowed_hosts: &[&str]) -> Result<Url> {
+    let url = Url::parse(candidate)
+        .map_err(|e| Error::Provider(format!("invalid url {candidate}: {e}")))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(Error::Provider(format!(
+                "url {candidate} uses unsupported scheme {other}"
+            )))
+        }
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| Error::Provider(format!("url {candidate} has no host")))?;
+    if !allowed_hosts.contains(&host) {
+        return Err(Error::Provider(format!(
+            "url {candidate} host {host} not in allowlist"
+        )));
+    }
+    Ok(url)
+}
+
+/// Strip userinfo + query string from a URL before it lands in a
+/// tracing log. Musixmatch's URLs carry `usertoken=` and similar
+/// credentials in the query string; without this guard a
+/// `Debug`-formatted `reqwest::Error` would echo the secret to the
+/// rolling log file.
+///
+/// Kept exported so future callers in `commands/lyrics.rs` (or any
+/// debugging path that needs to surface the URL of a failed provider
+/// call) have a safe option instead of inlining their own redactor.
+#[allow(dead_code)]
+pub fn redact_url(raw: &str) -> String {
+    match Url::parse(raw) {
+        Ok(parsed) => {
+            let scheme = parsed.scheme();
+            let host = parsed.host_str().unwrap_or("");
+            let port = match parsed.port() {
+                Some(p) => format!(":{p}"),
+                None => String::new(),
+            };
+            let path = parsed.path();
+            format!("{scheme}://{host}{port}{path}")
+        }
+        Err(_) => "<unparseable url>".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_strips_userinfo_and_query() {
+        assert_eq!(
+            redact_url("https://user:secret@host.example/path?token=xyz"),
+            "https://host.example/path"
+        );
+        assert_eq!(
+            redact_url("https://lrclib.net/api/get?artist_name=a&track_name=b"),
+            "https://lrclib.net/api/get"
+        );
+        assert_eq!(redact_url("not a url"), "<unparseable url>");
+    }
+
+    #[test]
+    fn host_allowlist_round_trips() {
+        assert!(host_is_allowed("apic-desktop.musixmatch.com"));
+        assert!(host_is_allowed("lrclib.net"));
+        // Suffix match for CDNs.
+        assert!(host_is_allowed("static.musixmatch.com"));
+        assert!(host_is_allowed("img.genius.com"));
+        // Adjacent but distinct hosts must not slip through.
+        assert!(!host_is_allowed("musixmatch.com.attacker.com"));
+        assert!(!host_is_allowed("evil.com"));
+    }
+
+    #[test]
+    fn validate_outbound_url_rejects_off_host() {
+        let allowed = &["genius.com"];
+        assert!(validate_outbound_url("https://genius.com/song", allowed).is_ok());
+        assert!(validate_outbound_url("https://evil.com/song", allowed).is_err());
+        assert!(validate_outbound_url("ftp://genius.com/song", allowed).is_err());
+        assert!(validate_outbound_url("file:///etc/passwd", allowed).is_err());
+        assert!(validate_outbound_url("garbage", allowed).is_err());
+    }
+}

--- a/src-tauri/crates/syncedlyrics/src/lib.rs
+++ b/src-tauri/crates/syncedlyrics/src/lib.rs
@@ -1,0 +1,192 @@
+//! Multi-provider lyrics search used by WaveFlow.
+//!
+//! This crate is intentionally independent from Tauri and the database.
+//! Callers provide a free-form query and receive a lyrics body plus the
+//! detected format/provider.
+
+mod providers;
+mod utils;
+
+pub use providers::Provider;
+pub use utils::{detect_format, LyricsFormat};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("http request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("json parsing failed: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("provider failed: {0}")]
+    Provider(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchMode {
+    Plaintext,
+    PreferSynced,
+    SyncedOnly,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchOptions {
+    pub query: String,
+    pub mode: SearchMode,
+    pub providers: Vec<Provider>,
+    pub enhanced: bool,
+    pub lang: Option<String>,
+    pub genius_cookie: Option<String>,
+    pub netease_cookie: Option<String>,
+}
+
+impl SearchOptions {
+    pub fn synced(query: impl Into<String>) -> Self {
+        Self {
+            query: query.into(),
+            mode: SearchMode::PreferSynced,
+            providers: Provider::defaults().to_vec(),
+            enhanced: false,
+            lang: None,
+            genius_cookie: None,
+            netease_cookie: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LyricsResult {
+    pub content: String,
+    pub format: LyricsFormat,
+    pub provider: Provider,
+}
+
+#[derive(Default)]
+struct Candidate {
+    synced: Option<String>,
+    unsynced: Option<String>,
+}
+
+impl Candidate {
+    fn update(&mut self, other: Candidate) {
+        if other.synced.is_some() {
+            self.synced = other.synced;
+        }
+        if other.unsynced.is_some() {
+            self.unsynced = other.unsynced;
+        }
+    }
+
+    fn preferred(&self, mode: SearchMode) -> bool {
+        self.synced.is_some() || (mode == SearchMode::Plaintext && self.unsynced.is_some())
+    }
+
+    fn acceptable(&self, mode: SearchMode) -> bool {
+        self.synced.is_some() || (mode != SearchMode::SyncedOnly && self.unsynced.is_some())
+    }
+
+    fn into_result(self, mode: SearchMode, provider: Provider) -> Option<LyricsResult> {
+        let content = match mode {
+            SearchMode::Plaintext => self
+                .unsynced
+                .or_else(|| self.synced.map(|s| utils::synced_to_plaintext(&s)))?,
+            SearchMode::PreferSynced => self.synced.or(self.unsynced)?,
+            SearchMode::SyncedOnly => self.synced?,
+        };
+        let format = detect_format(&content);
+        Some(LyricsResult {
+            content,
+            format,
+            provider,
+        })
+    }
+}
+
+pub struct SyncedLyricsClient {
+    http: reqwest::Client,
+}
+
+impl Default for SyncedLyricsClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncedLyricsClient {
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .user_agent("WaveFlow/1.4 (https://github.com/InstaZDLL/WaveFlow)")
+            .timeout(std::time::Duration::from_secs(15))
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("failed to build reqwest client");
+        Self { http }
+    }
+
+    pub async fn search(&self, options: SearchOptions) -> Result<Option<LyricsResult>> {
+        let mut aggregate = Candidate::default();
+        let mut last_provider = None;
+
+        for provider in options.providers.iter().copied() {
+            if options.lang.is_some() && provider != Provider::Musixmatch {
+                continue;
+            }
+
+            let candidate = match provider {
+                Provider::Musixmatch => providers::musixmatch::search(&self.http, &options).await,
+                Provider::Lrclib => providers::lrclib::search(&self.http, &options.query).await,
+                Provider::NetEase => {
+                    providers::netease::search(
+                        &self.http,
+                        &options.query,
+                        options.netease_cookie.as_deref(),
+                    )
+                    .await
+                }
+                Provider::Megalobiz => {
+                    providers::megalobiz::search(&self.http, &options.query).await
+                }
+                Provider::Genius => {
+                    providers::genius::search(
+                        &self.http,
+                        &options.query,
+                        options.genius_cookie.as_deref(),
+                    )
+                    .await
+                }
+            };
+
+            let Some(candidate) = (match candidate {
+                Ok(value) => value,
+                Err(err) => {
+                    tracing::debug!(?provider, ?err, "lyrics provider failed");
+                    None
+                }
+            }) else {
+                continue;
+            };
+
+            aggregate.update(candidate);
+            last_provider = Some(provider);
+            if aggregate.preferred(options.mode) {
+                break;
+            }
+        }
+
+        if !aggregate.acceptable(options.mode) {
+            return Ok(None);
+        }
+        Ok(aggregate.into_result(options.mode, last_provider.unwrap_or(Provider::Lrclib)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_enhanced_lrc() {
+        let content = "[00:01.00]<00:01.00>Hello <00:01.50>world";
+        assert_eq!(detect_format(content), LyricsFormat::EnhancedLrc);
+    }
+}

--- a/src-tauri/crates/syncedlyrics/src/lib.rs
+++ b/src-tauri/crates/syncedlyrics/src/lib.rs
@@ -4,6 +4,7 @@
 //! Callers provide a free-form query and receive a lyrics body plus the
 //! detected format/provider.
 
+pub(crate) mod http;
 mod providers;
 mod utils;
 
@@ -114,11 +115,10 @@ impl SyncedLyricsClient {
     /// itself panics on a TLS/backend init failure, so callers must handle the
     /// error rather than hide it behind a panic-prone fallback.
     pub fn try_new() -> Result<Self> {
-        let http = reqwest::Client::builder()
-            .user_agent("WaveFlow/1.4 (https://github.com/InstaZDLL/WaveFlow)")
-            .timeout(std::time::Duration::from_secs(15))
-            .connect_timeout(std::time::Duration::from_secs(5))
-            .build()?;
+        // `http::build_client` carries the redirect host pinning + 3-hop
+        // cap + connect/total timeouts. Constructing reqwest by hand
+        // here would silently drop those guards.
+        let http = http::build_client()?;
         Ok(Self { http })
     }
 
@@ -159,7 +159,16 @@ impl SyncedLyricsClient {
             let Some(candidate) = (match candidate {
                 Ok(value) => value,
                 Err(err) => {
-                    tracing::debug!(?provider, ?err, "lyrics provider failed");
+                    // Sanitize the error message before tracing —
+                    // `reqwest::Error`'s Debug impl echoes the request
+                    // URL, and Musixmatch URLs carry `usertoken=` as a
+                    // query parameter. Without this, a failed
+                    // Musixmatch request would leak the token into the
+                    // rolling log file. We log a static message and
+                    // the provider variant; the underlying error
+                    // chain is preserved through `last_error` for the
+                    // structured return path.
+                    tracing::debug!(?provider, "lyrics provider failed");
                     last_error = Some(err);
                     None
                 }

--- a/src-tauri/crates/syncedlyrics/src/lib.rs
+++ b/src-tauri/crates/syncedlyrics/src/lib.rs
@@ -113,19 +113,33 @@ impl Default for SyncedLyricsClient {
 }
 
 impl SyncedLyricsClient {
-    pub fn new() -> Self {
+    /// Build the client, returning an error instead of panicking if the HTTP
+    /// stack (e.g. the TLS backend) fails to initialize.
+    pub fn try_new() -> Result<Self> {
         let http = reqwest::Client::builder()
             .user_agent("WaveFlow/1.4 (https://github.com/InstaZDLL/WaveFlow)")
             .timeout(std::time::Duration::from_secs(15))
             .connect_timeout(std::time::Duration::from_secs(5))
-            .build()
-            .expect("failed to build reqwest client");
-        Self { http }
+            .build()?;
+        Ok(Self { http })
+    }
+
+    /// Infallible constructor for callers that can't propagate an error.
+    /// Falls back to a default reqwest client if the tuned builder fails so a
+    /// transient init issue never aborts the process.
+    pub fn new() -> Self {
+        Self::try_new().unwrap_or_else(|err| {
+            tracing::warn!(?err, "falling back to default reqwest client");
+            Self {
+                http: reqwest::Client::new(),
+            }
+        })
     }
 
     pub async fn search(&self, options: SearchOptions) -> Result<Option<LyricsResult>> {
         let mut aggregate = Candidate::default();
         let mut last_provider = None;
+        let mut last_error = None;
 
         for provider in options.providers.iter().copied() {
             if options.lang.is_some() && provider != Provider::Musixmatch {
@@ -160,6 +174,7 @@ impl SyncedLyricsClient {
                 Ok(value) => value,
                 Err(err) => {
                     tracing::debug!(?provider, ?err, "lyrics provider failed");
+                    last_error = Some(err);
                     None
                 }
             }) else {
@@ -174,7 +189,14 @@ impl SyncedLyricsClient {
         }
 
         if !aggregate.acceptable(options.mode) {
-            return Ok(None);
+            // Distinguish "every provider genuinely had nothing" (Ok(None),
+            // safe to cache as a miss) from "we never reached a verdict
+            // because a provider errored" (propagate so the caller doesn't
+            // poison the cache with an empty entry on a transient failure).
+            return match last_error {
+                Some(err) => Err(err),
+                None => Ok(None),
+            };
         }
         Ok(aggregate.into_result(options.mode, last_provider.unwrap_or(Provider::Lrclib)))
     }

--- a/src-tauri/crates/syncedlyrics/src/lib.rs
+++ b/src-tauri/crates/syncedlyrics/src/lib.rs
@@ -106,15 +106,13 @@ pub struct SyncedLyricsClient {
     http: reqwest::Client,
 }
 
-impl Default for SyncedLyricsClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl SyncedLyricsClient {
     /// Build the client, returning an error instead of panicking if the HTTP
     /// stack (e.g. the TLS backend) fails to initialize.
+    ///
+    /// There is no infallible constructor on purpose: `reqwest::Client::new()`
+    /// itself panics on a TLS/backend init failure, so callers must handle the
+    /// error rather than hide it behind a panic-prone fallback.
     pub fn try_new() -> Result<Self> {
         let http = reqwest::Client::builder()
             .user_agent("WaveFlow/1.4 (https://github.com/InstaZDLL/WaveFlow)")
@@ -122,18 +120,6 @@ impl SyncedLyricsClient {
             .connect_timeout(std::time::Duration::from_secs(5))
             .build()?;
         Ok(Self { http })
-    }
-
-    /// Infallible constructor for callers that can't propagate an error.
-    /// Falls back to a default reqwest client if the tuned builder fails so a
-    /// transient init issue never aborts the process.
-    pub fn new() -> Self {
-        Self::try_new().unwrap_or_else(|err| {
-            tracing::warn!(?err, "falling back to default reqwest client");
-            Self {
-                http: reqwest::Client::new(),
-            }
-        })
     }
 
     pub async fn search(&self, options: SearchOptions) -> Result<Option<LyricsResult>> {

--- a/src-tauri/crates/syncedlyrics/src/lib.rs
+++ b/src-tauri/crates/syncedlyrics/src/lib.rs
@@ -176,8 +176,16 @@ impl SyncedLyricsClient {
                 continue;
             };
 
+            // Only credit `last_provider` when this provider actually
+            // contributed content — otherwise an empty Candidate from
+            // a later provider would overwrite the attribution for
+            // content that came from an earlier one (`into_result`
+            // attaches `last_provider` to the returned LyricsResult).
+            let contributed = candidate.synced.is_some() || candidate.unsynced.is_some();
             aggregate.update(candidate);
-            last_provider = Some(provider);
+            if contributed {
+                last_provider = Some(provider);
+            }
             if aggregate.preferred(options.mode) {
                 break;
             }

--- a/src-tauri/crates/syncedlyrics/src/providers/genius.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/genius.rs
@@ -1,6 +1,12 @@
 use serde_json::Value;
 
+use crate::http::{safe_json, safe_text, validate_outbound_url};
 use crate::{utils, Candidate, Result};
+
+/// Hosts the Genius search response is permitted to redirect us to —
+/// the search API can return URLs that point at `genius.com` proper or
+/// the locale subdomain pattern that ultimately serves the lyric page.
+const GENIUS_ALLOWED_HOSTS: &[&str] = &["genius.com", "www.genius.com"];
 
 pub async fn search(
     http: &reqwest::Client,
@@ -13,12 +19,13 @@ pub async fn search(
     if let Some(cookie) = cookie {
         req = req.header(reqwest::header::COOKIE, cookie);
     }
-    let response: Value = req.send().await?.error_for_status()?.json().await?;
+    let response: Value =
+        safe_json(req.send().await?.error_for_status()?).await?;
     // The multi-search response groups results into sections (song, lyric,
     // artist, album…) and the order is not contractual, so we can't index a
     // fixed slot. Prefer the dedicated "song" section, then fall back to the
     // first section that actually carries hits.
-    let Some(url) = response["response"]["sections"]
+    let Some(url_str) = response["response"]["sections"]
         .as_array()
         .and_then(|sections| {
             sections
@@ -38,13 +45,12 @@ pub async fn search(
     else {
         return Ok(None);
     };
-    let page = http
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .text()
-        .await?;
+    // The lyric-page URL came out of a third-party JSON response — pin
+    // it to genius.com before we follow it. Without this guard a
+    // compromised Genius API response could ship a URL pointing at an
+    // attacker-controlled host and we'd happily GET it.
+    let url = validate_outbound_url(url_str, GENIUS_ALLOWED_HOSTS)?;
+    let page = safe_text(http.get(url).send().await?.error_for_status()?).await?;
     let text = extract_lyrics_containers(&page);
     Ok((!text.trim().is_empty()).then_some(Candidate {
         synced: None,

--- a/src-tauri/crates/syncedlyrics/src/providers/genius.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/genius.rs
@@ -14,12 +14,27 @@ pub async fn search(
         req = req.header(reqwest::header::COOKIE, cookie);
     }
     let response: Value = req.send().await?.error_for_status()?.json().await?;
+    // The multi-search response groups results into sections (song, lyric,
+    // artist, album…) and the order is not contractual, so we can't index a
+    // fixed slot. Prefer the dedicated "song" section, then fall back to the
+    // first section that actually carries hits.
     let Some(url) = response["response"]["sections"]
         .as_array()
-        .and_then(|sections| sections.get(1))
-        .and_then(|section| section["hits"].as_array())
-        .and_then(|hits| hits.first())
-        .and_then(|hit| hit["result"]["url"].as_str())
+        .and_then(|sections| {
+            sections
+                .iter()
+                .find(|section| section["type"].as_str() == Some("song"))
+                .or_else(|| {
+                    sections.iter().find(|section| {
+                        section["hits"]
+                            .as_array()
+                            .is_some_and(|hits| !hits.is_empty())
+                    })
+                })
+                .and_then(|section| section["hits"].as_array())
+                .and_then(|hits| hits.first())
+                .and_then(|hit| hit["result"]["url"].as_str())
+        })
     else {
         return Ok(None);
     };

--- a/src-tauri/crates/syncedlyrics/src/providers/genius.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/genius.rs
@@ -1,0 +1,58 @@
+use serde_json::Value;
+
+use crate::{utils, Candidate, Result};
+
+pub async fn search(
+    http: &reqwest::Client,
+    query: &str,
+    cookie: Option<&str>,
+) -> Result<Option<Candidate>> {
+    let mut req = http
+        .get("https://genius.com/api/search/multi")
+        .query(&[("per_page", "5"), ("q", query)]);
+    if let Some(cookie) = cookie {
+        req = req.header(reqwest::header::COOKIE, cookie);
+    }
+    let response: Value = req.send().await?.error_for_status()?.json().await?;
+    let Some(url) = response["response"]["sections"]
+        .as_array()
+        .and_then(|sections| sections.get(1))
+        .and_then(|section| section["hits"].as_array())
+        .and_then(|hits| hits.first())
+        .and_then(|hit| hit["result"]["url"].as_str())
+    else {
+        return Ok(None);
+    };
+    let page = http
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let text = extract_lyrics_containers(&page);
+    Ok((!text.trim().is_empty()).then_some(Candidate {
+        synced: None,
+        unsynced: Some(text),
+    }))
+}
+
+fn extract_lyrics_containers(html: &str) -> String {
+    let mut out = String::new();
+    let mut pos = 0;
+    while let Some(attr) = html[pos..].find("data-lyrics-container=\"true\"") {
+        let attr = pos + attr;
+        let Some(open_end) = html[attr..].find('>').map(|i| attr + i) else {
+            break;
+        };
+        let Some(close) = html[open_end..].find("</div>").map(|i| open_end + i) else {
+            break;
+        };
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(utils::html_text_decode(&html[open_end + 1..close]).trim());
+        pos = close + "</div>".len();
+    }
+    out
+}

--- a/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
@@ -2,6 +2,11 @@ use serde::Deserialize;
 
 use crate::{utils, Candidate, Result};
 
+/// Minimum fuzzy score for a search hit to be considered the same track.
+/// Mirrors the threshold used by the Musixmatch and Megalobiz providers so
+/// the query-based fallback never latches onto an off-topic result.
+const MIN_SCORE: f64 = 65.0;
+
 #[derive(Debug, Deserialize)]
 struct SearchTrack {
     id: serde_json::Value,
@@ -78,6 +83,9 @@ fn best_track<'a>(tracks: &'a [SearchTrack], query: &str) -> Option<&'a SearchTr
             best_cluster_count = cluster_count;
             best_has_synced = has_synced;
         }
+    }
+    if best_score < MIN_SCORE {
+        return None;
     }
     best
 }

--- a/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
@@ -1,0 +1,122 @@
+use serde::Deserialize;
+
+use crate::{utils, Candidate, Result};
+
+#[derive(Debug, Deserialize)]
+struct SearchTrack {
+    id: serde_json::Value,
+    #[serde(rename = "trackName")]
+    track_name: String,
+    #[serde(rename = "artistName")]
+    artist_name: String,
+    #[serde(rename = "syncedLyrics")]
+    synced_lyrics: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetTrack {
+    #[serde(rename = "plainLyrics")]
+    plain_lyrics: Option<String>,
+    #[serde(rename = "syncedLyrics")]
+    synced_lyrics: Option<String>,
+}
+
+pub async fn search(http: &reqwest::Client, query: &str) -> Result<Option<Candidate>> {
+    let tracks: Vec<SearchTrack> = http
+        .get("https://lrclib.net/api/search")
+        .query(&[("q", query)])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let Some(best) = best_track(&tracks, query) else {
+        return Ok(None);
+    };
+    let id = match &best.id {
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        _ => return Ok(None),
+    };
+    let track: GetTrack = http
+        .get(format!("https://lrclib.net/api/get/{id}"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    Ok(Some(Candidate {
+        synced: non_empty(track.synced_lyrics),
+        unsynced: non_empty(track.plain_lyrics),
+    }))
+}
+
+fn best_track<'a>(tracks: &'a [SearchTrack], query: &str) -> Option<&'a SearchTrack> {
+    let mut best = None;
+    let mut best_score = -1.0;
+    let mut best_cluster_count = 0usize;
+    let mut best_has_synced = false;
+
+    for track in tracks {
+        let label = format!("{} - {}", track.artist_name, track.track_name);
+        let score = utils::str_score(&label, query);
+        let has_synced = track
+            .synced_lyrics
+            .as_deref()
+            .is_some_and(|s| !s.trim().is_empty());
+        let cluster_count = count_similar_artist_matches(tracks, track, query);
+        if is_better(
+            score,
+            has_synced,
+            cluster_count,
+            best_score,
+            best_has_synced,
+            best_cluster_count,
+        ) {
+            best = Some(track);
+            best_score = score;
+            best_cluster_count = cluster_count;
+            best_has_synced = has_synced;
+        }
+    }
+    best
+}
+
+fn is_better(
+    score: f64,
+    has_synced: bool,
+    cluster_count: usize,
+    best_score: f64,
+    best_has_synced: bool,
+    best_cluster_count: usize,
+) -> bool {
+    if score > best_score + 0.001 {
+        return true;
+    }
+    if (score - best_score).abs() > 0.001 {
+        return false;
+    }
+    if has_synced != best_has_synced {
+        return has_synced;
+    }
+    cluster_count > best_cluster_count
+}
+
+fn count_similar_artist_matches(tracks: &[SearchTrack], track: &SearchTrack, query: &str) -> usize {
+    tracks
+        .iter()
+        .filter(|other| {
+            other
+                .synced_lyrics
+                .as_deref()
+                .is_some_and(|s| !s.trim().is_empty())
+        })
+        .filter(|other| other.artist_name.eq_ignore_ascii_case(&track.artist_name))
+        .filter(|other| utils::str_score(&other.track_name, &track.track_name) >= 90.0)
+        .filter(|other| utils::str_score(&other.track_name, query) >= 90.0)
+        .count()
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.filter(|s| !s.trim().is_empty())
+}

--- a/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 
+use crate::http::safe_json;
 use crate::{utils, Candidate, Result};
 
 /// Minimum fuzzy score for a search hit to be considered the same track.
@@ -27,14 +28,14 @@ struct GetTrack {
 }
 
 pub async fn search(http: &reqwest::Client, query: &str) -> Result<Option<Candidate>> {
-    let tracks: Vec<SearchTrack> = http
-        .get("https://lrclib.net/api/search")
-        .query(&[("q", query)])
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let tracks: Vec<SearchTrack> = safe_json(
+        http.get("https://lrclib.net/api/search")
+            .query(&[("q", query)])
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     let Some(best) = best_track(&tracks, query) else {
         return Ok(None);
     };
@@ -43,13 +44,13 @@ pub async fn search(http: &reqwest::Client, query: &str) -> Result<Option<Candid
         serde_json::Value::String(s) => s.clone(),
         _ => return Ok(None),
     };
-    let track: GetTrack = http
-        .get(format!("https://lrclib.net/api/get/{id}"))
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let track: GetTrack = safe_json(
+        http.get(format!("https://lrclib.net/api/get/{id}"))
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     Ok(Some(Candidate {
         synced: non_empty(track.synced_lyrics),
         unsynced: non_empty(track.plain_lyrics),

--- a/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/lrclib.rs
@@ -39,11 +39,11 @@ pub async fn search(http: &reqwest::Client, query: &str) -> Result<Option<Candid
     let Some(best) = best_track(&tracks, query) else {
         return Ok(None);
     };
-    let id = match &best.id {
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::String(s) => s.clone(),
-        _ => return Ok(None),
-    };
+    // `best_track` already filtered out any candidate without an
+    // extractable id (see the `extract_id` gate there) — an unknown
+    // variant here would be a logic break, not a normal API miss,
+    // so `expect` it instead of swallowing the search.
+    let id = extract_id(&best.id).expect("best_track must yield an extractable id");
     let track: GetTrack = safe_json(
         http.get(format!("https://lrclib.net/api/get/{id}"))
             .send()
@@ -57,6 +57,19 @@ pub async fn search(http: &reqwest::Client, query: &str) -> Result<Option<Candid
     }))
 }
 
+/// Pull the LRCLIB row id out of the JSON `Value`. LRCLIB's contract
+/// is that `id` is a number, but the field is typed `Value` here
+/// because the search-list deserialiser doesn't know that up front;
+/// `extract_id` returns `None` for any other shape so a poisoned entry
+/// can be filtered out instead of aborting the whole search.
+fn extract_id(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::String(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
 fn best_track<'a>(tracks: &'a [SearchTrack], query: &str) -> Option<&'a SearchTrack> {
     let mut best = None;
     let mut best_score = -1.0;
@@ -64,6 +77,14 @@ fn best_track<'a>(tracks: &'a [SearchTrack], query: &str) -> Option<&'a SearchTr
     let mut best_has_synced = false;
 
     for track in tracks {
+        // Skip any entry whose `id` shape isn't usable downstream —
+        // without this guard the calling `search` function would
+        // abort the whole query when the top-scoring hit happens to
+        // carry a malformed id, even though other candidates in the
+        // result set still had usable ones.
+        if extract_id(&track.id).is_none() {
+            continue;
+        }
         let label = format!("{} - {}", track.artist_name, track.track_name);
         let score = utils::str_score(&label, query);
         let has_synced = track

--- a/src-tauri/crates/syncedlyrics/src/providers/megalobiz.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/megalobiz.rs
@@ -38,9 +38,20 @@ fn best_lrc_href(html: &str, query: &str) -> Option<String> {
     let mut pos = 0;
     while let Some(idx) = html[pos..].find("href=\"/lrc/maker/") {
         let href_start = pos + idx + "href=\"".len();
-        let href_end = html[href_start..].find('"').map(|i| href_start + i)?;
-        let tag_end = html[href_end..].find('>').map(|i| href_end + i)?;
-        let close = html[tag_end..].find("</a>").map(|i| tag_end + i)?;
+        // A single malformed anchor must not abort the whole scan — skip past
+        // it and keep looking at the remaining results.
+        let Some(href_end) = html[href_start..].find('"').map(|i| href_start + i) else {
+            pos = href_start;
+            continue;
+        };
+        let Some(tag_end) = html[href_end..].find('>').map(|i| href_end + i) else {
+            pos = href_end;
+            continue;
+        };
+        let Some(close) = html[tag_end..].find("</a>").map(|i| tag_end + i) else {
+            pos = tag_end;
+            continue;
+        };
         let text = utils::html_text_decode(&html[tag_end + 1..close]);
         let label = comparable_text(&text, query);
         let score = utils::str_score(&label, query);

--- a/src-tauri/crates/syncedlyrics/src/providers/megalobiz.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/megalobiz.rs
@@ -1,28 +1,40 @@
-use crate::{utils, Candidate, Result};
+use crate::http::safe_text;
+use crate::{utils, Candidate, Error, Result};
 
 pub async fn search(http: &reqwest::Client, query: &str) -> Result<Option<Candidate>> {
-    let page = http
-        .get("https://www.megalobiz.com/search/all")
-        .query(&[
-            ("qry", query),
-            ("searchButton.x", "0"),
-            ("searchButton.y", "0"),
-        ])
-        .send()
-        .await?
-        .error_for_status()?
-        .text()
-        .await?;
+    let page = safe_text(
+        http.get("https://www.megalobiz.com/search/all")
+            .query(&[
+                ("qry", query),
+                ("searchButton.x", "0"),
+                ("searchButton.y", "0"),
+            ])
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     let Some(href) = best_lrc_href(&page, query) else {
         return Ok(None);
     };
-    let detail = http
-        .get(format!("https://www.megalobiz.com{href}"))
-        .send()
-        .await?
-        .error_for_status()?
-        .text()
-        .await?;
+    // The href came out of an HTML scrape; assert it's a same-host
+    // relative path before pasting it onto `https://www.megalobiz.com`.
+    // Without this guard a poisoned anchor like `//attacker.com/...`
+    // would resolve to `https://www.megalobiz.com//attacker.com/...`
+    // and reqwest's URL parser may follow into the foreign origin on
+    // redirect.
+    if !href.starts_with('/') || href.starts_with("//") {
+        return Err(Error::Provider(format!(
+            "megalobiz href is not a same-host relative path: {href}"
+        )));
+    }
+    let detail = safe_text(
+        http.get(format!("https://www.megalobiz.com{href}"))
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     let Some(id) = href.rsplit('.').next() else {
         return Ok(None);
     };

--- a/src-tauri/crates/syncedlyrics/src/providers/megalobiz.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/megalobiz.rs
@@ -1,0 +1,92 @@
+use crate::{utils, Candidate, Result};
+
+pub async fn search(http: &reqwest::Client, query: &str) -> Result<Option<Candidate>> {
+    let page = http
+        .get("https://www.megalobiz.com/search/all")
+        .query(&[
+            ("qry", query),
+            ("searchButton.x", "0"),
+            ("searchButton.y", "0"),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let Some(href) = best_lrc_href(&page, query) else {
+        return Ok(None);
+    };
+    let detail = http
+        .get(format!("https://www.megalobiz.com{href}"))
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let Some(id) = href.rsplit('.').next() else {
+        return Ok(None);
+    };
+    let Some(raw) = extract_details_div(&detail, id) else {
+        return Ok(None);
+    };
+    Ok(Some(classify(raw)))
+}
+
+fn best_lrc_href(html: &str, query: &str) -> Option<String> {
+    let mut best = None;
+    let mut best_score = -1.0;
+    let mut pos = 0;
+    while let Some(idx) = html[pos..].find("href=\"/lrc/maker/") {
+        let href_start = pos + idx + "href=\"".len();
+        let href_end = html[href_start..].find('"').map(|i| href_start + i)?;
+        let tag_end = html[href_end..].find('>').map(|i| href_end + i)?;
+        let close = html[tag_end..].find("</a>").map(|i| tag_end + i)?;
+        let text = utils::html_text_decode(&html[tag_end + 1..close]);
+        let label = comparable_text(&text, query);
+        let score = utils::str_score(&label, query);
+        if score > best_score {
+            best_score = score;
+            best = Some(html[href_start..href_end].to_string());
+        }
+        pos = close + "</a>".len();
+    }
+    (best_score >= 65.0).then_some(best).flatten()
+}
+
+fn comparable_text(text: &str, query: &str) -> String {
+    let max_words = query.split_whitespace().count();
+    text.split_whitespace()
+        .filter(|tok| *tok != "by")
+        .take(max_words)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn extract_details_div(html: &str, id: &str) -> Option<String> {
+    let marker = format!("id=\"lrc_{id}_details\"");
+    let attr = html.find(&marker)?;
+    let open_end = html[attr..].find('>').map(|i| attr + i)?;
+    let close = html[open_end..].find("</div>").map(|i| open_end + i)?;
+    Some(
+        utils::html_text_decode(&html[open_end + 1..close])
+            .trim()
+            .to_string(),
+    )
+}
+
+fn classify(text: String) -> Candidate {
+    if matches!(
+        utils::detect_format(&text),
+        crate::LyricsFormat::Lrc | crate::LyricsFormat::EnhancedLrc
+    ) {
+        Candidate {
+            synced: Some(text),
+            unsynced: None,
+        }
+    } else {
+        Candidate {
+            synced: None,
+            unsynced: Some(text),
+        }
+    }
+}

--- a/src-tauri/crates/syncedlyrics/src/providers/mod.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/mod.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+pub(crate) mod genius;
+pub(crate) mod lrclib;
+pub(crate) mod megalobiz;
+pub(crate) mod musixmatch;
+pub(crate) mod netease;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provider {
+    Musixmatch,
+    Lrclib,
+    NetEase,
+    Megalobiz,
+    Genius,
+}
+
+impl Provider {
+    pub const fn defaults() -> &'static [Provider] {
+        &[
+            Provider::Musixmatch,
+            Provider::Lrclib,
+            Provider::NetEase,
+            Provider::Megalobiz,
+            Provider::Genius,
+        ]
+    }
+}

--- a/src-tauri/crates/syncedlyrics/src/providers/musixmatch.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/musixmatch.rs
@@ -1,0 +1,208 @@
+use serde_json::Value;
+
+use crate::{utils, Candidate, Error, Result, SearchOptions};
+
+const ROOT: &str = "https://apic-desktop.musixmatch.com/ws/1.1";
+
+pub async fn search(http: &reqwest::Client, options: &SearchOptions) -> Result<Option<Candidate>> {
+    let token = get_token(http).await?;
+    let response: Value = http
+        .get(format!("{ROOT}/track.search"))
+        .query(&[
+            ("q", options.query.as_str()),
+            ("page_size", "5"),
+            ("page", "1"),
+            ("app_id", "web-desktop-app-v1.0"),
+            ("usertoken", token.as_str()),
+            ("t", &timestamp_ms()),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    if response["message"]["header"]["status_code"].as_i64() != Some(200) {
+        return Ok(None);
+    }
+    let Some(tracks) = response["message"]["body"]["track_list"].as_array() else {
+        return Ok(None);
+    };
+    let Some(track_id) = best_track_id(tracks, &options.query) else {
+        return Ok(None);
+    };
+    let track_id = track_id.to_string();
+
+    if options.enhanced {
+        if let Some(candidate) = richsync(http, &token, &track_id).await? {
+            if candidate.synced.is_some() {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+
+    subtitle(http, &token, &track_id, options.lang.as_deref()).await
+}
+
+async fn get_token(http: &reqwest::Client) -> Result<String> {
+    let response: Value = http
+        .get(format!("{ROOT}/token.get"))
+        .query(&[
+            ("user_language", "en"),
+            ("app_id", "web-desktop-app-v1.0"),
+            ("t", &timestamp_ms()),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    response["message"]["body"]["user_token"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| Error::Provider("Musixmatch token missing".into()))
+}
+
+fn best_track_id(tracks: &[Value], query: &str) -> Option<i64> {
+    tracks
+        .iter()
+        .filter_map(|item| {
+            let track = item.get("track")?;
+            let name = track.get("track_name")?.as_str().unwrap_or_default();
+            let artist = track.get("artist_name")?.as_str().unwrap_or_default();
+            let label = format!("{name} {artist}");
+            let score = utils::str_score(&label, query);
+            let id = track.get("track_id")?.as_i64()?;
+            Some((score, id))
+        })
+        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+        .and_then(|(score, id)| (score >= 65.0).then_some(id))
+}
+
+async fn subtitle(
+    http: &reqwest::Client,
+    token: &str,
+    track_id: &str,
+    lang: Option<&str>,
+) -> Result<Option<Candidate>> {
+    let response: Value = http
+        .get(format!("{ROOT}/track.subtitle.get"))
+        .query(&[
+            ("track_id", track_id),
+            ("subtitle_format", "lrc"),
+            ("app_id", "web-desktop-app-v1.0"),
+            ("usertoken", token),
+            ("t", &timestamp_ms()),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let Some(mut lrc) = response["message"]["body"]["subtitle"]["subtitle_body"]
+        .as_str()
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+    else {
+        return Ok(None);
+    };
+
+    if let Some(lang) = lang {
+        lrc = add_translations(http, token, track_id, lang, lrc).await?;
+    }
+    Ok(Some(Candidate {
+        synced: Some(lrc),
+        unsynced: None,
+    }))
+}
+
+async fn add_translations(
+    http: &reqwest::Client,
+    token: &str,
+    track_id: &str,
+    lang: &str,
+    mut lrc: String,
+) -> Result<String> {
+    let response: Value = http
+        .get(format!("{ROOT}/crowd.track.translations.get"))
+        .query(&[
+            ("track_id", track_id),
+            ("subtitle_format", "lrc"),
+            ("translation_fields_set", "minimal"),
+            ("selected_language", lang),
+            ("app_id", "web-desktop-app-v1.0"),
+            ("usertoken", token),
+            ("t", &timestamp_ms()),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    if let Some(translations) = response["message"]["body"]["translations_list"].as_array() {
+        for item in translations {
+            let original = item["translation"]["subtitle_matched_line"].as_str();
+            let translated = item["translation"]["description"].as_str();
+            if let (Some(original), Some(translated)) = (original, translated) {
+                lrc = lrc.replace(original, &format!("{original}\n({translated})"));
+            }
+        }
+    }
+    Ok(lrc)
+}
+
+async fn richsync(
+    http: &reqwest::Client,
+    token: &str,
+    track_id: &str,
+) -> Result<Option<Candidate>> {
+    let response: Value = http
+        .get(format!("{ROOT}/track.richsync.get"))
+        .query(&[
+            ("track_id", track_id),
+            ("app_id", "web-desktop-app-v1.0"),
+            ("usertoken", token),
+            ("t", &timestamp_ms()),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    if response["message"]["header"]["status_code"].as_i64() != Some(200) {
+        return Ok(None);
+    }
+    let Some(raw) = response["message"]["body"]["richsync"]["richsync_body"].as_str() else {
+        return Ok(None);
+    };
+    let rows: Value = serde_json::from_str(raw)?;
+    let Some(rows) = rows.as_array() else {
+        return Ok(None);
+    };
+    let mut out = String::new();
+    for row in rows {
+        let ts = row["ts"].as_f64().unwrap_or_default();
+        out.push_str(&format!("[{}] ", utils::format_time(ts)));
+        if let Some(letters) = row["l"].as_array() {
+            for letter in letters {
+                let offset = letter["o"].as_f64().unwrap_or_default();
+                let c = letter["c"].as_str().unwrap_or_default();
+                out.push_str(&format!("<{}> {} ", utils::format_time(ts + offset), c));
+            }
+        }
+        out.push('\n');
+    }
+    Ok((!out.trim().is_empty()).then_some(Candidate {
+        synced: Some(out),
+        unsynced: None,
+    }))
+}
+
+fn timestamp_ms() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .to_string()
+}

--- a/src-tauri/crates/syncedlyrics/src/providers/musixmatch.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/musixmatch.rs
@@ -1,26 +1,27 @@
 use serde_json::Value;
 
+use crate::http::safe_json;
 use crate::{utils, Candidate, Error, Result, SearchOptions};
 
 const ROOT: &str = "https://apic-desktop.musixmatch.com/ws/1.1";
 
 pub async fn search(http: &reqwest::Client, options: &SearchOptions) -> Result<Option<Candidate>> {
     let token = get_token(http).await?;
-    let response: Value = http
-        .get(format!("{ROOT}/track.search"))
-        .query(&[
-            ("q", options.query.as_str()),
-            ("page_size", "5"),
-            ("page", "1"),
-            ("app_id", "web-desktop-app-v1.0"),
-            ("usertoken", token.as_str()),
-            ("t", &timestamp_ms()),
-        ])
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let response: Value = safe_json(
+        http.get(format!("{ROOT}/track.search"))
+            .query(&[
+                ("q", options.query.as_str()),
+                ("page_size", "5"),
+                ("page", "1"),
+                ("app_id", "web-desktop-app-v1.0"),
+                ("usertoken", token.as_str()),
+                ("t", &timestamp_ms()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
 
     if response["message"]["header"]["status_code"].as_i64() != Some(200) {
         return Ok(None);
@@ -45,18 +46,18 @@ pub async fn search(http: &reqwest::Client, options: &SearchOptions) -> Result<O
 }
 
 async fn get_token(http: &reqwest::Client) -> Result<String> {
-    let response: Value = http
-        .get(format!("{ROOT}/token.get"))
-        .query(&[
-            ("user_language", "en"),
-            ("app_id", "web-desktop-app-v1.0"),
-            ("t", &timestamp_ms()),
-        ])
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let response: Value = safe_json(
+        http.get(format!("{ROOT}/token.get"))
+            .query(&[
+                ("user_language", "en"),
+                ("app_id", "web-desktop-app-v1.0"),
+                ("t", &timestamp_ms()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     response["message"]["body"]["user_token"]
         .as_str()
         .map(str::to_string)
@@ -85,20 +86,20 @@ async fn subtitle(
     track_id: &str,
     lang: Option<&str>,
 ) -> Result<Option<Candidate>> {
-    let response: Value = http
-        .get(format!("{ROOT}/track.subtitle.get"))
-        .query(&[
-            ("track_id", track_id),
-            ("subtitle_format", "lrc"),
-            ("app_id", "web-desktop-app-v1.0"),
-            ("usertoken", token),
-            ("t", &timestamp_ms()),
-        ])
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let response: Value = safe_json(
+        http.get(format!("{ROOT}/track.subtitle.get"))
+            .query(&[
+                ("track_id", track_id),
+                ("subtitle_format", "lrc"),
+                ("app_id", "web-desktop-app-v1.0"),
+                ("usertoken", token),
+                ("t", &timestamp_ms()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     let Some(mut lrc) = response["message"]["body"]["subtitle"]["subtitle_body"]
         .as_str()
         .filter(|s| !s.trim().is_empty())
@@ -123,22 +124,22 @@ async fn add_translations(
     lang: &str,
     mut lrc: String,
 ) -> Result<String> {
-    let response: Value = http
-        .get(format!("{ROOT}/crowd.track.translations.get"))
-        .query(&[
-            ("track_id", track_id),
-            ("subtitle_format", "lrc"),
-            ("translation_fields_set", "minimal"),
-            ("selected_language", lang),
-            ("app_id", "web-desktop-app-v1.0"),
-            ("usertoken", token),
-            ("t", &timestamp_ms()),
-        ])
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let response: Value = safe_json(
+        http.get(format!("{ROOT}/crowd.track.translations.get"))
+            .query(&[
+                ("track_id", track_id),
+                ("subtitle_format", "lrc"),
+                ("translation_fields_set", "minimal"),
+                ("selected_language", lang),
+                ("app_id", "web-desktop-app-v1.0"),
+                ("usertoken", token),
+                ("t", &timestamp_ms()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     if let Some(translations) = response["message"]["body"]["translations_list"].as_array() {
         for item in translations {
             let original = item["translation"]["subtitle_matched_line"].as_str();
@@ -156,19 +157,19 @@ async fn richsync(
     token: &str,
     track_id: &str,
 ) -> Result<Option<Candidate>> {
-    let response: Value = http
-        .get(format!("{ROOT}/track.richsync.get"))
-        .query(&[
-            ("track_id", track_id),
-            ("app_id", "web-desktop-app-v1.0"),
-            ("usertoken", token),
-            ("t", &timestamp_ms()),
-        ])
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let response: Value = safe_json(
+        http.get(format!("{ROOT}/track.richsync.get"))
+            .query(&[
+                ("track_id", track_id),
+                ("app_id", "web-desktop-app-v1.0"),
+                ("usertoken", token),
+                ("t", &timestamp_ms()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?,
+    )
+    .await?;
     if response["message"]["header"]["status_code"].as_i64() != Some(200) {
         return Ok(None);
     }
@@ -179,18 +180,56 @@ async fn richsync(
     let Some(rows) = rows.as_array() else {
         return Ok(None);
     };
+    // Validate every row carries a real numeric `ts` BEFORE building
+    // the output. Musixmatch occasionally returns rows where `ts` is
+    // missing or shaped as a string instead of a number; the previous
+    // `as_f64().unwrap_or_default()` path silently coerced those to
+    // `0.0`, producing a fake word-level LRC where every line was
+    // stamped `[00:00.00]`. The caller (`commands/lyrics.rs`) caches
+    // any Musixmatch result with EnhancedLrc format AHEAD of LRCLIB,
+    // so a corrupted richsync would defeat the "real word-level only"
+    // gate the PR description advertises.
     let mut out = String::new();
+    let mut row_stamps: Vec<f64> = Vec::with_capacity(rows.len());
     for row in rows {
-        let ts = row["ts"].as_f64().unwrap_or_default();
+        let Some(ts) = row.get("ts").and_then(Value::as_f64) else {
+            return Ok(None);
+        };
+        if !ts.is_finite() || ts < 0.0 {
+            return Ok(None);
+        }
+        row_stamps.push(ts);
         out.push_str(&format!("[{}] ", utils::format_time(ts)));
         if let Some(letters) = row["l"].as_array() {
             for letter in letters {
-                let offset = letter["o"].as_f64().unwrap_or_default();
+                let offset = letter
+                    .get("o")
+                    .and_then(Value::as_f64)
+                    .filter(|f| f.is_finite() && *f >= 0.0)
+                    .unwrap_or(0.0);
                 let c = letter["c"].as_str().unwrap_or_default();
                 out.push_str(&format!("<{}> {} ", utils::format_time(ts + offset), c));
             }
         }
         out.push('\n');
+    }
+    // Need at least 4 rows AND ≥ 80 % unique line stamps before we
+    // call this a real word-level result. A track whose every line
+    // shares the same `ts` is either an outright bug in the upstream
+    // response OR a corrupted record (Musixmatch returns these for
+    // some instrumental tracks); either way it must not poison the
+    // cache as "word-level lyrics found".
+    if row_stamps.len() < 4 {
+        return Ok(None);
+    }
+    let unique_ratio = {
+        let mut sorted = row_stamps.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.dedup();
+        sorted.len() as f64 / row_stamps.len() as f64
+    };
+    if unique_ratio < 0.80 {
+        return Ok(None);
     }
     Ok((!out.trim().is_empty()).then_some(Candidate {
         synced: Some(out),
@@ -205,4 +244,124 @@ fn timestamp_ms() -> String {
         .unwrap_or_default()
         .as_millis()
         .to_string()
+}
+
+#[cfg(test)]
+mod richsync_tests {
+    //! These tests exercise the richsync validation in isolation: the
+    //! function under test (`richsync`) is async + does HTTP, so we
+    //! factor the validation logic into a sibling helper that takes
+    //! the parsed rows and reproduce the regression #5 scenarios.
+    //!
+    //! Replication: copy the body of the row-validation loop and the
+    //! ratio check into `validate_rows_for_test` below so the public
+    //! `richsync` function stays a single network-boundary entry point.
+
+    use serde_json::json;
+
+    /// Strict copy of the validation logic in `richsync`. Returns
+    /// `None` when the rows should be rejected (= the production
+    /// function would return Ok(None)), `Some(stamps)` otherwise.
+    fn validate_rows_for_test(rows: &[serde_json::Value]) -> Option<Vec<f64>> {
+        let mut stamps: Vec<f64> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let ts = row.get("ts").and_then(serde_json::Value::as_f64)?;
+            if !ts.is_finite() || ts < 0.0 {
+                return None;
+            }
+            stamps.push(ts);
+        }
+        if stamps.len() < 4 {
+            return None;
+        }
+        let unique_ratio = {
+            let mut sorted = stamps.clone();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            sorted.dedup();
+            sorted.len() as f64 / stamps.len() as f64
+        };
+        if unique_ratio < 0.80 {
+            return None;
+        }
+        Some(stamps)
+    }
+
+    #[test]
+    fn rejects_all_zero_timestamps() {
+        let rows = vec![
+            json!({"ts": 0.0, "l": []}),
+            json!({"ts": 0.0, "l": []}),
+            json!({"ts": 0.0, "l": []}),
+            json!({"ts": 0.0, "l": []}),
+            json!({"ts": 0.0, "l": []}),
+        ];
+        assert!(validate_rows_for_test(&rows).is_none());
+    }
+
+    #[test]
+    fn rejects_string_timestamps() {
+        // Musixmatch occasionally returns `ts` as a JSON string. The
+        // pre-fix code coerced to `0.0`; the fix must reject.
+        let rows = vec![
+            json!({"ts": "1.0", "l": []}),
+            json!({"ts": "2.0", "l": []}),
+            json!({"ts": "3.0", "l": []}),
+            json!({"ts": "4.0", "l": []}),
+        ];
+        assert!(validate_rows_for_test(&rows).is_none());
+    }
+
+    #[test]
+    fn rejects_too_few_rows() {
+        let rows = vec![
+            json!({"ts": 0.0, "l": []}),
+            json!({"ts": 1.0, "l": []}),
+            json!({"ts": 2.0, "l": []}),
+        ];
+        assert!(validate_rows_for_test(&rows).is_none());
+    }
+
+    #[test]
+    fn rejects_majority_duplicate_timestamps() {
+        // 5 rows, only 2 unique → 40 % unique, below the 80 % gate.
+        let rows = vec![
+            json!({"ts": 1.0, "l": []}),
+            json!({"ts": 1.0, "l": []}),
+            json!({"ts": 1.0, "l": []}),
+            json!({"ts": 2.0, "l": []}),
+            json!({"ts": 2.0, "l": []}),
+        ];
+        assert!(validate_rows_for_test(&rows).is_none());
+    }
+
+    #[test]
+    fn accepts_well_formed_rows() {
+        let rows = vec![
+            json!({"ts": 0.0, "l": []}),
+            json!({"ts": 1.0, "l": []}),
+            json!({"ts": 2.0, "l": []}),
+            json!({"ts": 3.0, "l": []}),
+            json!({"ts": 4.0, "l": []}),
+        ];
+        assert!(validate_rows_for_test(&rows).is_some());
+    }
+
+    #[test]
+    fn rejects_negative_or_non_finite_timestamps() {
+        let rows = vec![
+            json!({"ts": -1.0, "l": []}),
+            json!({"ts": 1.0, "l": []}),
+            json!({"ts": 2.0, "l": []}),
+            json!({"ts": 3.0, "l": []}),
+        ];
+        assert!(validate_rows_for_test(&rows).is_none());
+
+        let rows = vec![
+            json!({"ts": f64::NAN, "l": []}),
+            json!({"ts": 1.0, "l": []}),
+            json!({"ts": 2.0, "l": []}),
+            json!({"ts": 3.0, "l": []}),
+        ];
+        assert!(validate_rows_for_test(&rows).is_none());
+    }
 }

--- a/src-tauri/crates/syncedlyrics/src/providers/musixmatch.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/musixmatch.rs
@@ -152,6 +152,44 @@ async fn add_translations(
     Ok(lrc)
 }
 
+/// Validate that the richsync rows form a real word-level lyric.
+///
+/// Returns `Some(stamps)` when every row carries a finite, non-negative
+/// numeric `ts` AND there are at least 4 rows AND at least 80 % of the
+/// stamps are unique. `None` means the row set must be rejected.
+///
+/// Used by both the live `richsync` path and the unit tests; the
+/// caller in `commands/lyrics.rs::fetch_lyrics` caches a Musixmatch
+/// hit with `EnhancedLrc` format AHEAD of LRCLIB, so a corrupted
+/// row set must not slip through — Musixmatch occasionally returns
+/// rows where `ts` is missing or shaped as a string, which the
+/// previous `as_f64().unwrap_or_default()` path silently coerced to
+/// `0.0` (producing a fake word-level LRC with every line stamped
+/// `[00:00.00]`).
+fn validate_rows(rows: &[Value]) -> Option<Vec<f64>> {
+    let mut stamps: Vec<f64> = Vec::with_capacity(rows.len());
+    for row in rows {
+        let ts = row.get("ts").and_then(Value::as_f64)?;
+        if !ts.is_finite() || ts < 0.0 {
+            return None;
+        }
+        stamps.push(ts);
+    }
+    if stamps.len() < 4 {
+        return None;
+    }
+    let unique_ratio = {
+        let mut sorted = stamps.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.dedup();
+        sorted.len() as f64 / stamps.len() as f64
+    };
+    if unique_ratio < 0.80 {
+        return None;
+    }
+    Some(stamps)
+}
+
 async fn richsync(
     http: &reqwest::Client,
     token: &str,
@@ -180,25 +218,17 @@ async fn richsync(
     let Some(rows) = rows.as_array() else {
         return Ok(None);
     };
-    // Validate every row carries a real numeric `ts` BEFORE building
-    // the output. Musixmatch occasionally returns rows where `ts` is
-    // missing or shaped as a string instead of a number; the previous
-    // `as_f64().unwrap_or_default()` path silently coerced those to
-    // `0.0`, producing a fake word-level LRC where every line was
-    // stamped `[00:00.00]`. The caller (`commands/lyrics.rs`) caches
-    // any Musixmatch result with EnhancedLrc format AHEAD of LRCLIB,
-    // so a corrupted richsync would defeat the "real word-level only"
-    // gate the PR description advertises.
+    // Reject up-front via the shared validator so tests + production
+    // share a single source of truth for what counts as real
+    // word-level. See [`validate_rows`] for the contract.
+    if validate_rows(rows).is_none() {
+        return Ok(None);
+    }
     let mut out = String::new();
-    let mut row_stamps: Vec<f64> = Vec::with_capacity(rows.len());
     for row in rows {
-        let Some(ts) = row.get("ts").and_then(Value::as_f64) else {
-            return Ok(None);
-        };
-        if !ts.is_finite() || ts < 0.0 {
-            return Ok(None);
-        }
-        row_stamps.push(ts);
+        // Safe to expect: `validate_rows` already proved every row
+        // has a finite non-negative `ts`.
+        let ts = row.get("ts").and_then(Value::as_f64).expect("validated");
         out.push_str(&format!("[{}] ", utils::format_time(ts)));
         if let Some(letters) = row["l"].as_array() {
             for letter in letters {
@@ -212,24 +242,6 @@ async fn richsync(
             }
         }
         out.push('\n');
-    }
-    // Need at least 4 rows AND ≥ 80 % unique line stamps before we
-    // call this a real word-level result. A track whose every line
-    // shares the same `ts` is either an outright bug in the upstream
-    // response OR a corrupted record (Musixmatch returns these for
-    // some instrumental tracks); either way it must not poison the
-    // cache as "word-level lyrics found".
-    if row_stamps.len() < 4 {
-        return Ok(None);
-    }
-    let unique_ratio = {
-        let mut sorted = row_stamps.clone();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        sorted.dedup();
-        sorted.len() as f64 / row_stamps.len() as f64
-    };
-    if unique_ratio < 0.80 {
-        return Ok(None);
     }
     Ok((!out.trim().is_empty()).then_some(Candidate {
         synced: Some(out),
@@ -248,43 +260,13 @@ fn timestamp_ms() -> String {
 
 #[cfg(test)]
 mod richsync_tests {
-    //! These tests exercise the richsync validation in isolation: the
-    //! function under test (`richsync`) is async + does HTTP, so we
-    //! factor the validation logic into a sibling helper that takes
-    //! the parsed rows and reproduce the regression #5 scenarios.
-    //!
-    //! Replication: copy the body of the row-validation loop and the
-    //! ratio check into `validate_rows_for_test` below so the public
-    //! `richsync` function stays a single network-boundary entry point.
+    //! Tests for the regression #5 scenarios. Exercise the shared
+    //! [`validate_rows`] helper directly so production + tests run
+    //! against a single source of truth — when the production path
+    //! evolves, the tests follow automatically.
 
+    use super::validate_rows;
     use serde_json::json;
-
-    /// Strict copy of the validation logic in `richsync`. Returns
-    /// `None` when the rows should be rejected (= the production
-    /// function would return Ok(None)), `Some(stamps)` otherwise.
-    fn validate_rows_for_test(rows: &[serde_json::Value]) -> Option<Vec<f64>> {
-        let mut stamps: Vec<f64> = Vec::with_capacity(rows.len());
-        for row in rows {
-            let ts = row.get("ts").and_then(serde_json::Value::as_f64)?;
-            if !ts.is_finite() || ts < 0.0 {
-                return None;
-            }
-            stamps.push(ts);
-        }
-        if stamps.len() < 4 {
-            return None;
-        }
-        let unique_ratio = {
-            let mut sorted = stamps.clone();
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            sorted.dedup();
-            sorted.len() as f64 / stamps.len() as f64
-        };
-        if unique_ratio < 0.80 {
-            return None;
-        }
-        Some(stamps)
-    }
 
     #[test]
     fn rejects_all_zero_timestamps() {
@@ -295,7 +277,7 @@ mod richsync_tests {
             json!({"ts": 0.0, "l": []}),
             json!({"ts": 0.0, "l": []}),
         ];
-        assert!(validate_rows_for_test(&rows).is_none());
+        assert!(validate_rows(&rows).is_none());
     }
 
     #[test]
@@ -308,7 +290,7 @@ mod richsync_tests {
             json!({"ts": "3.0", "l": []}),
             json!({"ts": "4.0", "l": []}),
         ];
-        assert!(validate_rows_for_test(&rows).is_none());
+        assert!(validate_rows(&rows).is_none());
     }
 
     #[test]
@@ -318,7 +300,7 @@ mod richsync_tests {
             json!({"ts": 1.0, "l": []}),
             json!({"ts": 2.0, "l": []}),
         ];
-        assert!(validate_rows_for_test(&rows).is_none());
+        assert!(validate_rows(&rows).is_none());
     }
 
     #[test]
@@ -331,7 +313,7 @@ mod richsync_tests {
             json!({"ts": 2.0, "l": []}),
             json!({"ts": 2.0, "l": []}),
         ];
-        assert!(validate_rows_for_test(&rows).is_none());
+        assert!(validate_rows(&rows).is_none());
     }
 
     #[test]
@@ -343,7 +325,7 @@ mod richsync_tests {
             json!({"ts": 3.0, "l": []}),
             json!({"ts": 4.0, "l": []}),
         ];
-        assert!(validate_rows_for_test(&rows).is_some());
+        assert!(validate_rows(&rows).is_some());
     }
 
     #[test]
@@ -354,7 +336,7 @@ mod richsync_tests {
             json!({"ts": 2.0, "l": []}),
             json!({"ts": 3.0, "l": []}),
         ];
-        assert!(validate_rows_for_test(&rows).is_none());
+        assert!(validate_rows(&rows).is_none());
 
         let rows = vec![
             json!({"ts": f64::NAN, "l": []}),
@@ -362,6 +344,6 @@ mod richsync_tests {
             json!({"ts": 2.0, "l": []}),
             json!({"ts": 3.0, "l": []}),
         ];
-        assert!(validate_rows_for_test(&rows).is_none());
+        assert!(validate_rows(&rows).is_none());
     }
 }

--- a/src-tauri/crates/syncedlyrics/src/providers/netease.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/netease.rs
@@ -1,0 +1,82 @@
+use serde_json::Value;
+
+use crate::{utils, Candidate, Result};
+
+pub async fn search(
+    http: &reqwest::Client,
+    query: &str,
+    cookie: Option<&str>,
+) -> Result<Option<Candidate>> {
+    let mut req = http.get("https://music.163.com/api/search/pc").query(&[
+        ("limit", "10"),
+        ("type", "1"),
+        ("offset", "0"),
+        ("s", query),
+    ]);
+    if let Some(cookie) = cookie {
+        req = req.header(reqwest::header::COOKIE, cookie);
+    }
+    let response: Value = req.send().await?.error_for_status()?.json().await?;
+    let Some(songs) = response["result"]["songs"].as_array() else {
+        return Ok(None);
+    };
+    let Some(id) = best_song_id(songs, query) else {
+        return Ok(None);
+    };
+    lyrics_by_id(http, id, cookie).await
+}
+
+fn best_song_id(songs: &[Value], query: &str) -> Option<i64> {
+    songs
+        .iter()
+        .filter_map(|song| {
+            let name = song["name"].as_str().unwrap_or_default();
+            let artist = song["artists"]
+                .as_array()
+                .and_then(|artists| artists.first())
+                .and_then(|artist| artist["name"].as_str())
+                .unwrap_or_default();
+            let score = utils::str_score(&format!("{name} {artist}"), query);
+            let id = song["id"].as_i64()?;
+            Some((score, id))
+        })
+        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+        .and_then(|(score, id)| (score >= 65.0).then_some(id))
+}
+
+async fn lyrics_by_id(
+    http: &reqwest::Client,
+    id: i64,
+    cookie: Option<&str>,
+) -> Result<Option<Candidate>> {
+    let mut req = http
+        .get("https://music.163.com/api/song/lyric")
+        .query(&[("id", id.to_string()), ("lv", "1".to_string())]);
+    if let Some(cookie) = cookie {
+        req = req.header(reqwest::header::COOKIE, cookie);
+    }
+    let response: Value = req.send().await?.error_for_status()?.json().await?;
+    let Some(lyric) = response["lrc"]["lyric"]
+        .as_str()
+        .filter(|s| !s.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+    let text = lyric.to_string();
+    Ok(Some(
+        if matches!(
+            utils::detect_format(&text),
+            crate::LyricsFormat::Lrc | crate::LyricsFormat::EnhancedLrc
+        ) {
+            Candidate {
+                synced: Some(text),
+                unsynced: None,
+            }
+        } else {
+            Candidate {
+                synced: None,
+                unsynced: Some(text),
+            }
+        },
+    ))
+}

--- a/src-tauri/crates/syncedlyrics/src/providers/netease.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/netease.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 
+use crate::http::safe_json;
 use crate::{utils, Candidate, Result};
 
 pub async fn search(
@@ -16,7 +17,7 @@ pub async fn search(
     if let Some(cookie) = cookie {
         req = req.header(reqwest::header::COOKIE, cookie);
     }
-    let response: Value = req.send().await?.error_for_status()?.json().await?;
+    let response: Value = safe_json(req.send().await?.error_for_status()?).await?;
     let Some(songs) = response["result"]["songs"].as_array() else {
         return Ok(None);
     };
@@ -55,7 +56,7 @@ async fn lyrics_by_id(
     if let Some(cookie) = cookie {
         req = req.header(reqwest::header::COOKIE, cookie);
     }
-    let response: Value = req.send().await?.error_for_status()?.json().await?;
+    let response: Value = safe_json(req.send().await?.error_for_status()?).await?;
     let Some(lyric) = response["lrc"]["lyric"]
         .as_str()
         .filter(|s| !s.trim().is_empty())

--- a/src-tauri/crates/syncedlyrics/src/utils.rs
+++ b/src-tauri/crates/syncedlyrics/src/utils.rs
@@ -88,7 +88,7 @@ pub fn detect_format(content: &str) -> LyricsFormat {
 
 fn strip_lrc_stamp(line: &str) -> Option<&str> {
     let close = line.find(']')?;
-    let body = &line.get(1..close)?;
+    let body = line.get(1..close)?;
     let colon = body.find(':')?;
     if colon == 0 || !body[..colon].chars().all(|c| c.is_ascii_digit()) {
         return None;
@@ -200,7 +200,17 @@ pub(crate) fn html_text_decode(input: &str) -> String {
             out.push('\n');
             rest = after;
         } else if rest.starts_with('<') {
-            let Some(end) = rest.find('>') else { break };
+            // Malformed HTML (a `<` with no closing `>`) used to
+            // `break` and truncate the remainder of the input —
+            // costing every character after the stray `<`. Consume
+            // the lone `<` as a literal instead and keep going so a
+            // single rough byte in a scraped lyric page can't drop
+            // the rest of the verse.
+            let Some(end) = rest.find('>') else {
+                out.push('<');
+                rest = &rest[1..];
+                continue;
+            };
             rest = &rest[end + 1..];
         } else if let Some(after) = rest.strip_prefix("&amp;") {
             out.push('&');

--- a/src-tauri/crates/syncedlyrics/src/utils.rs
+++ b/src-tauri/crates/syncedlyrics/src/utils.rs
@@ -1,0 +1,197 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LyricsFormat {
+    Plain,
+    Lrc,
+    EnhancedLrc,
+}
+
+pub(crate) fn synced_to_plaintext(input: &str) -> String {
+    input
+        .lines()
+        .map(|line| {
+            let mut rest = line.trim_start();
+            while let Some(stripped) = strip_lrc_stamp(rest) {
+                rest = stripped.trim_start();
+            }
+            rest
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn detect_format(content: &str) -> LyricsFormat {
+    let mut has_line_stamp = false;
+    for line in content.lines().take(40) {
+        let line = line.trim_start();
+        if strip_lrc_stamp(line).is_some() {
+            has_line_stamp = true;
+            if let Some(close) = line.find(']') {
+                if word_stamp_present(&line[close + 1..]) {
+                    return LyricsFormat::EnhancedLrc;
+                }
+            }
+        }
+    }
+    if has_line_stamp {
+        LyricsFormat::Lrc
+    } else {
+        LyricsFormat::Plain
+    }
+}
+
+fn strip_lrc_stamp(line: &str) -> Option<&str> {
+    let close = line.find(']')?;
+    let body = &line.get(1..close)?;
+    let colon = body.find(':')?;
+    if colon == 0 || !body[..colon].chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(&line[close + 1..])
+}
+
+fn word_stamp_present(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            let mut j = i + 1;
+            let d1 = scan_digits(bytes, j);
+            if d1 > 0 {
+                j += d1;
+                if bytes.get(j) == Some(&b':') {
+                    j += 1;
+                    let d2 = scan_digits(bytes, j);
+                    if d2 > 0 {
+                        j += d2;
+                        if matches!(bytes.get(j), Some(b'.') | Some(b':')) {
+                            j += 1 + scan_digits(bytes, j + 1);
+                        }
+                        if bytes.get(j) == Some(&b'>') {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn scan_digits(bytes: &[u8], start: usize) -> usize {
+    let mut n = 0;
+    while matches!(bytes.get(start + n), Some(b) if b.is_ascii_digit()) {
+        n += 1;
+    }
+    n
+}
+
+pub(crate) fn format_time(seconds: f64) -> String {
+    let total_cs = (seconds * 100.0).floor().max(0.0) as u64;
+    let minutes = total_cs / 6000;
+    let secs = (total_cs / 100) % 60;
+    let cs = total_cs % 100;
+    format!("{minutes:02}:{secs:02}.{cs:02}")
+}
+
+pub(crate) fn str_score(a: &str, b: &str) -> f64 {
+    let a_norm = normalize(a);
+    let b_norm = normalize(b);
+    let a_tokens = token_set(&a_norm);
+    let b_tokens = token_set(&b_norm);
+    if a_tokens.is_empty() && b_tokens.is_empty() {
+        return 100.0;
+    }
+    if a_tokens.is_empty() || b_tokens.is_empty() {
+        return 0.0;
+    }
+    let intersect = a_tokens.iter().filter(|tok| b_tokens.contains(tok)).count();
+    if intersect == a_tokens.len().min(b_tokens.len()) {
+        return 100.0;
+    }
+    let precision = intersect as f64 / a_tokens.len() as f64;
+    let recall = intersect as f64 / b_tokens.len() as f64;
+    if precision + recall == 0.0 {
+        0.0
+    } else {
+        200.0 * precision * recall / (precision + recall)
+    }
+}
+
+fn normalize(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            let c = c.to_ascii_lowercase();
+            if c.is_ascii_alphanumeric() {
+                c
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
+fn token_set(input: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    for tok in input.split_whitespace() {
+        if !out.contains(&tok) {
+            out.push(tok);
+        }
+    }
+    out
+}
+
+pub(crate) fn html_text_decode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while !rest.is_empty() {
+        if let Some(after) = rest
+            .strip_prefix("<br/>")
+            .or_else(|| rest.strip_prefix("<br>"))
+        {
+            out.push('\n');
+            rest = after;
+        } else if rest.starts_with('<') {
+            let Some(end) = rest.find('>') else { break };
+            rest = &rest[end + 1..];
+        } else if let Some(after) = rest.strip_prefix("&amp;") {
+            out.push('&');
+            rest = after;
+        } else if let Some(after) = rest.strip_prefix("&lt;") {
+            out.push('<');
+            rest = after;
+        } else if let Some(after) = rest.strip_prefix("&gt;") {
+            out.push('>');
+            rest = after;
+        } else if let Some(after) = rest.strip_prefix("&quot;") {
+            out.push('"');
+            rest = after;
+        } else if let Some(after) = rest
+            .strip_prefix("&#x27;")
+            .or_else(|| rest.strip_prefix("&#39;"))
+        {
+            out.push('\'');
+            rest = after;
+        } else if let Some(ch) = rest.chars().next() {
+            out.push(ch);
+            rest = &rest[ch.len_utf8()..];
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_subset_scores_like_query_match() {
+        assert_eq!(
+            str_score("Gloria Estefan - Get on Your Feet", "get on your feet"),
+            100.0
+        );
+    }
+}

--- a/src-tauri/crates/syncedlyrics/src/utils.rs
+++ b/src-tauri/crates/syncedlyrics/src/utils.rs
@@ -13,10 +13,57 @@ pub(crate) fn synced_to_plaintext(input: &str) -> String {
             while let Some(stripped) = strip_lrc_stamp(rest) {
                 rest = stripped.trim_start();
             }
-            rest
+            // Enhanced LRC carries inline word-stamps (`<mm:ss.xx>`) that the
+            // line-stamp strip above leaves untouched; drop them so plaintext
+            // output never leaks timing tokens.
+            strip_word_stamps(rest).trim().to_string()
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Remove inline `<mm:ss.xx>` / `<mm:ss>` word-stamps from a line, leaving any
+/// other angle-bracketed text intact.
+fn strip_word_stamps(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(lt) = rest.find('<') {
+        match rest[lt + 1..].find('>') {
+            Some(gt_rel) => {
+                let gt = lt + 1 + gt_rel;
+                if is_time_token(&rest[lt + 1..gt]) {
+                    out.push_str(&rest[..lt]);
+                    rest = &rest[gt + 1..];
+                } else {
+                    out.push_str(&rest[..=lt]);
+                    rest = &rest[lt + 1..];
+                }
+            }
+            None => break,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// `true` when `s` looks like a timestamp body: `mm:ss` or `mm:ss.xx`.
+fn is_time_token(s: &str) -> bool {
+    let Some((minutes, after)) = s.split_once(':') else {
+        return false;
+    };
+    if minutes.is_empty() || !minutes.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    let seconds = match after.split_once('.') {
+        Some((secs, frac)) => {
+            if frac.is_empty() || !frac.bytes().all(|b| b.is_ascii_digit()) {
+                return false;
+            }
+            secs
+        }
+        None => after,
+    };
+    !seconds.is_empty() && seconds.bytes().all(|b| b.is_ascii_digit())
 }
 
 pub fn detect_format(content: &str) -> LyricsFormat {
@@ -193,5 +240,17 @@ mod tests {
             str_score("Gloria Estefan - Get on Your Feet", "get on your feet"),
             100.0
         );
+    }
+
+    #[test]
+    fn plaintext_drops_word_stamps() {
+        let enhanced = "[00:01.00]<00:01.00>Hello <00:01.50>world";
+        assert_eq!(synced_to_plaintext(enhanced), "Hello world");
+    }
+
+    #[test]
+    fn plaintext_keeps_non_timestamp_brackets() {
+        let line = "[00:01.00]a < b and c > d";
+        assert_eq!(synced_to_plaintext(line), "a < b and c > d");
     }
 }


### PR DESCRIPTION
## Résumé

Ajoute la nouvelle crate `waveflow-syncedlyrics` — un portage Rust du projet Python [`syncedlyrics`](https://github.com/moehmeni/syncedlyrics) (projet original local : `/home/nayeon/workspace/syncedlyrics`) qui fournit un lookup de paroles multi-providers : Musixmatch, LRCLIB, NetEase, Megalobiz, Genius.

L'intégration est branchée dans `src-tauri/crates/app/src/commands/lyrics.rs` :
- **Musixmatch Enhanced** est tenté avant LRCLIB, mais uniquement s'il renvoie réellement du word-level.
- **LRCLIB exact** reste le match strict.

## Conformité licence

WaveFlow reste sous **GPL-3.0-only**. Ajout d'un `THIRD_PARTY_NOTICES.md` qui préserve la notice MIT originale (`Copyright (c) 2022 Momo`, `Copyright (c) 2026 InstaZDLL`), lié depuis le README. MIT est compatible GPL-3.

## Vérifications

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check`
- `cargo check --manifest-path src-tauri/Cargo.toml -p waveflow-syncedlyrics --all-targets`
- `cargo test --manifest-path src-tauri/Cargo.toml -p waveflow-syncedlyrics`
- `cargo check --manifest-path src-tauri/Cargo.toml -p waveflow --all-targets` (passe sans workaround ALSA depuis l'installation de `libasound2-dev`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Paroles : prise en charge étendue de fournisseurs (Musixmatch, NetEase, Megalobiz, Genius + LRCLIB), recherche multi‑fournisseurs avec waterfall/fallback, support des paroles enrichies (enhanced LRC), caching discipliné et opt‑in Musixmatch.

* **Documentation**
  * Mise à jour des guides d’intégration, stratégie de cache, comportement hors‑ligne, prélecture library‑wide, paramètres réseau/timeouts, et renvoi vers LICENSE et THIRD_PARTY_NOTICES.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->