### PR TITLE
feat(core): project track.album_id in postgres list + get + insert + update

### DIFF
--- a/src-tauri/crates/core/src/repository/postgres/track.rs
+++ b/src-tauri/crates/core/src/repository/postgres/track.rs
@@ -281,7 +281,7 @@ impl PostgresTrackRepository {
           RETURNING id,
                     library_id,
                     title,
-                    NULL::bigint  AS album_id,
+                    album_id,
                     NULL::text    AS album_title,
                     NULL::bigint  AS artist_id,
                     NULL::text    AS artist_name,

--- a/src-tauri/crates/core/src/repository/postgres/track.rs
+++ b/src-tauri/crates/core/src/repository/postgres/track.rs
@@ -13,11 +13,15 @@
 //! waveflow-server side): a thin row carrying the columns that
 //! actually exist on disk for every file. The album / artist /
 //! artwork joins from the desktop's `TrackRow` projection still
-//! materialise in the response shape — they're projected as `NULL`
-//! casts of the right Postgres type until the album / artist /
-//! artwork tables ship on the server. Same pattern as
-//! `library.track_count = 0::bigint`: keep the wire field so the
-//! client doesn't need to adapt when the joins become real.
+//! materialise in the response shape — most are projected as `NULL`
+//! casts of the right Postgres type until the joined tables ship.
+//! `album_id` IS projected real since phase 4.d.0.1 added the
+//! `album` table + the nullable `track.album_id` FK; the album
+//! drill-down endpoint already relies on it, and the legacy
+//! `/tracks` collection now matches (closing the asymmetry
+//! documented in the server's CLAUDE.md). The remaining NULL casts
+//! (`album_title`, `artist_*`, `artwork_*`) stay until their
+//! materialisation paths land on the server.
 //!
 //! Insert + update follow the race-free patterns established by
 //! `PostgresProfileRepository::rename_for_user` and
@@ -69,7 +73,7 @@ impl PostgresTrackRepository {
             "SELECT t.id,
                     t.library_id,
                     t.title,
-                    NULL::bigint  AS album_id,
+                    t.album_id,
                     NULL::text    AS album_title,
                     NULL::bigint  AS artist_id,
                     NULL::text    AS artist_name,
@@ -125,7 +129,7 @@ impl PostgresTrackRepository {
             "SELECT t.id,
                     t.library_id,
                     t.title,
-                    NULL::bigint  AS album_id,
+                    t.album_id,
                     NULL::text    AS album_title,
                     NULL::bigint  AS artist_id,
                     NULL::text    AS artist_name,
@@ -201,7 +205,7 @@ impl PostgresTrackRepository {
          RETURNING id,
                    library_id,
                    title,
-                   NULL::bigint  AS album_id,
+                   album_id,
                    NULL::text    AS album_title,
                    NULL::bigint  AS artist_id,
                    NULL::text    AS artist_name,


### PR DESCRIPTION
## Summary

Closes the asymmetry documented in the server's CLAUDE.md (and in the desktop \`project_sprint_4_web_progress.md\` follow-ups note).

Phase 4.d.0.1 (server PR #34) added the \`album\` table + the nullable \`track.album_id\` FK. Phase 4.d.0.4 (server PR #36) added the album drill-down endpoint which projects the real value. The legacy \`/api/v1/profiles/{p}/libraries/{l}/tracks\` collection still NULL-projected the column because the SELECT lives here in waveflow-core and predates the album surface — so the desktop / web client saw \`album_id = null\` on the per-library track list even when the row was materialised by the apply pipeline.

This PR swaps every \`NULL::bigint AS album_id\` for \`t.album_id\` (or \`album_id\` in the RETURNING blocks) in 4 sites:

- \`PostgresTrackRepository::list_for_library\` (SELECT)
- \`PostgresTrackRepository::get_for_library\` (SELECT)
- \`PostgresTrackRepository::insert_for_library\` (RETURNING)
- \`PostgresTrackRepository::update_for_library\` (RETURNING)

INSERT doesn't set \`album_id\` (the column list deliberately excludes it — track→album materialisation owns that field via the sync apply pipeline, not the CRUD write path), so RETURNING projects \`null\` for freshly inserted rows. UPDATE doesn't touch it either, so RETURNING projects whatever's stored. Both correct.

The module-level doc comment now calls out that \`album_id\` is the projected-real case; the remaining NULL casts (\`album_title\`, \`artist_*\`, \`artwork_*\`) stay until their materialisation paths land server-side.

## Test plan

- [x] \`cargo check --manifest-path src-tauri/Cargo.toml -p waveflow-core --features postgres --no-default-features\` clean
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets\` clean (covers the sqlite consumer in \`crates/app\` — no impact since it doesn't go through these methods)
- [x] \`cargo test -p waveflow-core --features postgres --lib --no-run\` builds clean
- [x] \`cargo fmt --all\` clean
- [x] CI runs the full suite

No desktop behavior change — \`crates/app\` consumes \`waveflow-core\` via the \`sqlite\` feature flag which routes through the sqlite repos, not the postgres ones touched here.

## Follow-up

A small PR on waveflow-server bumps the \`waveflow-core\` git rev in \`Cargo.toml\` to pick this up once this lands on \`main\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correction : les identifiants d'album sont désormais retournés correctement lors de la récupération et de l'énumération des pistes depuis la bibliothèque, au lieu de valeurs vides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->