### PR TITLE
feat(web-radio): add internet radio playback

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4158,7 +4158,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -131,7 +131,7 @@ crossbeam-channel = "0.5"
 realfft = "3"
 
 # HTTP client for Deezer public API metadata enrichment
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 # WebSocket client for the multi-device sync subscriber (Phase
 # 1.f.desktop.4b). Same rustls stack as reqwest so the TLS roots stay

--- a/src-tauri/crates/app/src/audio/crossfade.rs
+++ b/src-tauri/crates/app/src/audio/crossfade.rs
@@ -7,14 +7,16 @@
 //! re-implementing the symphonia init dance twice.
 
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{self, Read, Seek, SeekFrom};
 use std::path::Path;
+use std::sync::Mutex;
+use std::time::Duration;
 
 use symphonia::core::codecs::audio::{AudioDecoder, AudioDecoderOptions};
 use symphonia::core::errors::Error as SymphoniaError;
 use symphonia::core::formats::probe::Hint;
 use symphonia::core::formats::{FormatOptions, FormatReader, SeekMode, SeekTo, TrackType};
-use symphonia::core::io::MediaSourceStream;
+use symphonia::core::io::{MediaSource, MediaSourceStream};
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::units::Time;
 
@@ -88,6 +90,54 @@ pub struct ActiveStream {
 /// 64 KiB ≈ 23 ms of DSD64 stereo, comfortably below the SPSC ring
 /// capacity but large enough to amortise the FIR convolution cost.
 const DSD_READ_CHUNK: usize = 64 * 1024;
+
+struct HttpMediaSource {
+    inner: Mutex<reqwest::blocking::Response>,
+}
+
+impl HttpMediaSource {
+    fn open(url: &str) -> Result<Self, String> {
+        let client = reqwest::blocking::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .user_agent("WaveFlow/1.0 web-radio")
+            .build()
+            .map_err(|e| format!("http client: {e}"))?;
+        let response = client
+            .get(url)
+            .send()
+            .and_then(|res| res.error_for_status())
+            .map_err(|e| format!("stream request: {e}"))?;
+        Ok(Self {
+            inner: Mutex::new(response),
+        })
+    }
+}
+
+impl Read for HttpMediaSource {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut response = self
+            .inner
+            .lock()
+            .map_err(|_| io::Error::other("radio stream mutex poisoned"))?;
+        response.read(buf)
+    }
+}
+
+impl Seek for HttpMediaSource {
+    fn seek(&mut self, _: SeekFrom) -> io::Result<u64> {
+        Err(io::Error::other("radio streams are not seekable"))
+    }
+}
+
+impl MediaSource for HttpMediaSource {
+    fn is_seekable(&self) -> bool {
+        false
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        None
+    }
+}
 
 impl ActiveStream {
     /// Open `path`, probe + build the codec, and stash everything
@@ -167,6 +217,60 @@ impl ActiveStream {
             source_type,
             source_id,
             replay_gain_linear: replay_gain_db_to_linear(replay_gain_db),
+            src_sample_rate: 0,
+            playback_speed: 1.0,
+        })
+    }
+
+    pub fn open_url(
+        url: &str,
+        codec_hint: Option<&str>,
+        track_id: i64,
+        source_type: String,
+        source_id: Option<i64>,
+    ) -> Result<Self, String> {
+        let source = HttpMediaSource::open(url)?;
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+        let mut hint = Hint::new();
+        if let Some(ext) = codec_hint {
+            hint.with_extension(ext);
+        }
+        let format = symphonia::default::get_probe()
+            .probe(
+                &hint,
+                mss,
+                FormatOptions::default(),
+                MetadataOptions::default(),
+            )
+            .map_err(|e| format!("probe: {e}"))?;
+        let track_symphonia = format
+            .default_track(TrackType::Audio)
+            .ok_or_else(|| "no decodable stream".to_string())?;
+        let symphonia_track_id = track_symphonia.id;
+        let audio_params = track_symphonia
+            .codec_params
+            .as_ref()
+            .and_then(|p| p.audio())
+            .ok_or_else(|| "stream has no audio codec params".to_string())?;
+        let decoder = symphonia::default::get_codecs()
+            .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
+            .map_err(|e| format!("codec init: {e}"))?;
+
+        Ok(Self {
+            backend: StreamBackend::Symphonia {
+                format,
+                decoder,
+                decoded_interleaved: Vec::new(),
+                symphonia_track_id,
+                spec_captured: false,
+            },
+            resampler: Resampler::Passthrough,
+            src_channels: 0,
+            track_id,
+            duration_ms: 0,
+            source_type,
+            source_id,
+            replay_gain_linear: 1.0,
             src_sample_rate: 0,
             playback_speed: 1.0,
         })

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -248,7 +248,7 @@ fn decoder_loop(
                 shared.current_track_id.store(track_id, Ordering::Release);
 
                 let outcome = play_track(
-                    &path,
+                    InitialAudioSource::Local(&path),
                     start_ms,
                     track_id,
                     duration_ms,
@@ -298,6 +298,77 @@ fn decoder_loop(
                     }
                     Err(err) => {
                         tracing::warn!(?err, path = %path.display(), "playback failed");
+                        let _ = app.emit(
+                            EVENT_ERROR,
+                            ErrorPayload {
+                                message: err.clone(),
+                            },
+                        );
+                        transition_state(&shared, &app, PlayerState::Idle, Some(track_id));
+                    }
+                }
+            }
+            AudioCmd::LoadUrlAndPlay {
+                url,
+                codec_hint,
+                track_id,
+                source_type,
+                source_id,
+            } => {
+                shared.clear_ab_loop();
+                transition_state(&shared, &app, PlayerState::Loading, Some(track_id));
+                if producer.slots() != super::output::RING_CAPACITY {
+                    shared.paused_output.store(false, Ordering::Release);
+                    shared.drain_silent.store(true, Ordering::Release);
+                    let start = std::time::Instant::now();
+                    while producer.slots() < super::output::RING_CAPACITY
+                        && start.elapsed() < Duration::from_millis(500)
+                    {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    shared.drain_silent.store(false, Ordering::Release);
+                } else {
+                    shared.paused_output.store(false, Ordering::Release);
+                }
+                shared.samples_played.store(0, Ordering::Relaxed);
+                shared.base_offset_ms.store(0, Ordering::Relaxed);
+                shared.current_track_id.store(track_id, Ordering::Release);
+
+                let outcome = play_track(
+                    InitialAudioSource::RemoteUrl {
+                        url: &url,
+                        codec_hint: codec_hint.as_deref(),
+                    },
+                    0,
+                    track_id,
+                    0,
+                    source_type,
+                    source_id,
+                    None,
+                    producer,
+                    &shared,
+                    cmd_rx,
+                    &app,
+                    &mut pending_cmd,
+                    analytics_tx,
+                );
+                match outcome {
+                    Ok((PlaybackEnd::Natural, listened_ms, finished)) => {
+                        tracing::info!(
+                            finished_track_id = finished.track_id,
+                            listened_ms,
+                            "web radio stream ended"
+                        );
+                    }
+                    Ok((PlaybackEnd::Interrupted, listened_ms, finished)) => {
+                        tracing::info!(
+                            finished_track_id = finished.track_id,
+                            listened_ms,
+                            "web radio stream interrupted"
+                        );
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, url, "web radio playback failed");
                         let _ = app.emit(
                             EVENT_ERROR,
                             ErrorPayload {
@@ -363,6 +434,14 @@ pub struct FinishedTrack {
     pub source_id: Option<i64>,
 }
 
+enum InitialAudioSource<'a> {
+    Local(&'a Path),
+    RemoteUrl {
+        url: &'a str,
+        codec_hint: Option<&'a str>,
+    },
+}
+
 /// Decode tracks until either an interruption or a track ends naturally.
 /// Honors crossfade: if `shared.crossfade_ms > 0` and there's a pending
 /// next track (delivered by `AudioCmd::SetNextTrack`), this function
@@ -379,7 +458,7 @@ pub struct FinishedTrack {
 /// obscure the call site without changing what the function does.
 #[allow(clippy::too_many_arguments)]
 fn play_track(
-    initial_path: &Path,
+    initial_source: InitialAudioSource<'_>,
     initial_start_ms: u64,
     initial_track_id: i64,
     initial_duration_ms: u64,
@@ -399,14 +478,23 @@ fn play_track(
         return Err("cpal output not initialized (sample_rate=0)".into());
     }
 
-    let mut stream = ActiveStream::open(
-        initial_path,
-        initial_track_id,
-        initial_duration_ms,
-        initial_source_type,
-        initial_source_id,
-        initial_replay_gain_db,
-    )?;
+    let mut stream = match initial_source {
+        InitialAudioSource::Local(path) => ActiveStream::open(
+            path,
+            initial_track_id,
+            initial_duration_ms,
+            initial_source_type,
+            initial_source_id,
+            initial_replay_gain_db,
+        )?,
+        InitialAudioSource::RemoteUrl { url, codec_hint } => ActiveStream::open_url(
+            url,
+            codec_hint,
+            initial_track_id,
+            initial_source_type,
+            initial_source_id,
+        )?,
+    };
     // Inherit the active playback speed so the lazy resampler init
     // inside decode_next builds against the correct effective input
     // rate from the very first packet. Without this, a track that
@@ -420,7 +508,7 @@ fn play_track(
     tracing::info!(
         dst_sample_rate,
         dst_channels,
-        path = %initial_path.display(),
+        source = %stream.source_type,
         "decoding start"
     );
 
@@ -1049,7 +1137,7 @@ fn drain_commands(
             Ok(AudioCmd::Shutdown) => return ControlFlow::Shutdown,
             Ok(AudioCmd::Stop) => return ControlFlow::Break,
             Ok(AudioCmd::Seek(ms)) => return ControlFlow::Seek(ms),
-            Ok(cmd @ AudioCmd::LoadAndPlay { .. }) => {
+            Ok(cmd @ (AudioCmd::LoadAndPlay { .. } | AudioCmd::LoadUrlAndPlay { .. })) => {
                 shared.paused_output.store(false, Ordering::Release);
                 *pending_cmd = Some(cmd);
                 return ControlFlow::LoadNext;
@@ -1132,7 +1220,9 @@ fn drain_commands(
                             shared.gapless_enabled.store(on, Ordering::Release)
                         }
                         Ok(AudioCmd::SetSpeed(v)) => shared.set_playback_speed(v),
-                        Ok(cmd @ AudioCmd::LoadAndPlay { .. }) => {
+                        Ok(
+                            cmd @ (AudioCmd::LoadAndPlay { .. } | AudioCmd::LoadUrlAndPlay { .. }),
+                        ) => {
                             shared.paused_output.store(false, Ordering::Release);
                             *pending_cmd = Some(cmd);
                             return ControlFlow::LoadNext;

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -41,6 +41,13 @@ pub enum AudioCmd {
         /// stays out of the SQLite path.
         replay_gain_db: Option<f64>,
     },
+    LoadUrlAndPlay {
+        url: String,
+        codec_hint: Option<String>,
+        track_id: i64,
+        source_type: String,
+        source_id: Option<i64>,
+    },
     Pause,
     Resume,
     Stop,
@@ -94,6 +101,9 @@ impl std::fmt::Debug for AudioCmd {
                 f,
                 "LoadAndPlay {{ track_id: {track_id}, start_ms: {start_ms} }}"
             ),
+            AudioCmd::LoadUrlAndPlay { track_id, url, .. } => {
+                write!(f, "LoadUrlAndPlay {{ track_id: {track_id}, url: {url} }}")
+            }
             AudioCmd::Pause => write!(f, "Pause"),
             AudioCmd::Resume => write!(f, "Resume"),
             AudioCmd::Stop => write!(f, "Stop"),

--- a/src-tauri/crates/app/src/commands/mod.rs
+++ b/src-tauri/crates/app/src/commands/mod.rs
@@ -36,4 +36,5 @@ pub mod stats;
 pub mod sync;
 pub mod track;
 pub mod tray;
+pub mod web_radio;
 pub mod wrapped;

--- a/src-tauri/crates/app/src/commands/web_radio.rs
+++ b/src-tauri/crates/app/src/commands/web_radio.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::{
+    audio::{engine::AudioCmd, AudioEngine},
+    commands::player::QueueTrackPayload,
+    error::{AppError, AppResult},
+};
+
+#[derive(Debug, Clone, Copy)]
+struct StationDef {
+    id: i64,
+    slug: &'static str,
+    name: &'static str,
+    tagline: &'static str,
+    genre: &'static str,
+    stream_url: &'static str,
+    codec_hint: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WebRadioStation {
+    pub id: i64,
+    pub slug: String,
+    pub name: String,
+    pub tagline: String,
+    pub genre: String,
+    pub codec: String,
+}
+
+const STATIONS: &[StationDef] = &[
+    StationDef {
+        id: 1,
+        slug: "groove-salad",
+        name: "Groove Salad",
+        tagline: "Ambient and downtempo beats",
+        genre: "Chillout",
+        stream_url: "https://ice5.somafm.com/groovesalad-128-mp3",
+        codec_hint: "mp3",
+    },
+    StationDef {
+        id: 2,
+        slug: "drone-zone",
+        name: "Drone Zone",
+        tagline: "Atmospheric textures for deep focus",
+        genre: "Ambient",
+        stream_url: "https://ice5.somafm.com/dronezone-128-mp3",
+        codec_hint: "mp3",
+    },
+    StationDef {
+        id: 3,
+        slug: "beat-blender",
+        name: "Beat Blender",
+        tagline: "Late-night downtempo and instrumental grooves",
+        genre: "Electronic",
+        stream_url: "https://ice5.somafm.com/beatblender-128-mp3",
+        codec_hint: "mp3",
+    },
+    StationDef {
+        id: 4,
+        slug: "def-con-radio",
+        name: "DEF CON Radio",
+        tagline: "Hacker culture beats and dark electronics",
+        genre: "Electronic",
+        stream_url: "https://ice5.somafm.com/defcon-128-mp3",
+        codec_hint: "mp3",
+    },
+    StationDef {
+        id: 5,
+        slug: "secret-agent",
+        name: "Secret Agent",
+        tagline: "The soundtrack for stylish missions",
+        genre: "Lounge",
+        stream_url: "https://ice5.somafm.com/secretagent-128-mp3",
+        codec_hint: "mp3",
+    },
+];
+
+#[tauri::command]
+pub fn web_radio_list_stations() -> Vec<WebRadioStation> {
+    STATIONS.iter().map(station_to_payload).collect()
+}
+
+#[tauri::command]
+pub fn web_radio_play_station(
+    app: AppHandle,
+    engine: tauri::State<'_, Arc<AudioEngine>>,
+    station_id: i64,
+) -> AppResult<()> {
+    let station = STATIONS
+        .iter()
+        .find(|station| station.id == station_id)
+        .ok_or_else(|| AppError::Other(format!("unknown web radio station {station_id}")))?;
+    let track_id = synthetic_track_id(station.id);
+    let payload = QueueTrackPayload {
+        id: track_id,
+        title: station.name.to_string(),
+        artist_id: None,
+        artist_name: Some("Web Radio".to_string()),
+        artist_ids: None,
+        album_title: Some(station.genre.to_string()),
+        duration_ms: 0,
+        file_path: station.stream_url.to_string(),
+        artwork_path: None,
+        artwork_path_1x: None,
+        artwork_path_2x: None,
+        bitrate: Some(128_000),
+        sample_rate: None,
+        channels: None,
+        bit_depth: None,
+        codec: Some("MP3 stream".to_string()),
+        file_size: 0,
+    };
+
+    let _ = app.emit("player:track-changed", payload.clone());
+    if let Some(tray) = app.tray_by_id("waveflow") {
+        let _ = tray.set_tooltip(Some(format!("{} - Web Radio", station.name)));
+    }
+    if let Some(controls) = app.try_state::<crate::media_controls::MediaControlsHandle>() {
+        controls.update_metadata(
+            payload.title,
+            payload.artist_name,
+            payload.album_title,
+            None,
+            0,
+        );
+    }
+
+    engine.send(AudioCmd::LoadUrlAndPlay {
+        url: station.stream_url.to_string(),
+        codec_hint: Some(station.codec_hint.to_string()),
+        track_id,
+        source_type: "web-radio".to_string(),
+        source_id: Some(station.id),
+    })
+}
+
+fn station_to_payload(station: &StationDef) -> WebRadioStation {
+    WebRadioStation {
+        id: station.id,
+        slug: station.slug.to_string(),
+        name: station.name.to_string(),
+        tagline: station.tagline.to_string(),
+        genre: station.genre.to_string(),
+        codec: station.codec_hint.to_uppercase(),
+    }
+}
+
+fn synthetic_track_id(station_id: i64) -> i64 {
+    -10_000 - station_id
+}

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -658,6 +658,8 @@ pub fn run() {
             commands::player::player_list_output_devices,
             commands::player::player_set_output_device,
             commands::player::player_set_wasapi_exclusive,
+            commands::web_radio::web_radio_list_stations,
+            commands::web_radio::web_radio_play_station,
             commands::player::player_get_wasapi_exclusive,
             commands::stats::stats_overview,
             commands::stats::stats_top_tracks,

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -51,6 +51,11 @@ const SpotifyView = lazy(() =>
     default: module.SpotifyView,
   })),
 );
+const WebRadioView = lazy(() =>
+  import("../views/WebRadioView").then((module) => ({
+    default: module.WebRadioView,
+  })),
+);
 const AboutView = lazy(() =>
   import("../views/AboutView").then((module) => ({
     default: module.AboutView,
@@ -117,6 +122,7 @@ type HistoryEntry =
   | { id: "statistics" }
   | { id: "liked" }
   | { id: "recent" }
+  | { id: "web-radio" }
   | { id: "wrapped"; year?: number | null }
   | { id: "playlist"; playlistId?: number | null }
   | { id: "album-detail"; albumId?: number | null }
@@ -205,6 +211,7 @@ export function AppLayout() {
       void import("../views/WrappedView");
       void import("../views/SettingsView");
       void import("../views/SpotifyView");
+      void import("../views/WebRadioView");
       void import("../views/AboutView");
       void import("../views/FeedbackView");
     };
@@ -411,6 +418,8 @@ export function AppLayout() {
         return <SettingsView onNavigate={setActiveView} />;
       case "spotify":
         return <SpotifyView onNavigate={setActiveView} />;
+      case "web-radio":
+        return <WebRadioView />;
       case "about":
         return <AboutView onNavigate={setActiveView} />;
       case "feedback":

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Upload,
   Sparkles,
   Headphones,
+  Radio,
 } from "lucide-react";
 import type { ViewId, LibraryTab } from "../../types";
 import { NavItem } from "../common/NavItem";
@@ -275,6 +276,12 @@ export function Sidebar({
             onClick={() => setActiveView("spotify")}
           />
         )}
+        <NavItem
+          icon={<Radio size={18} />}
+          label={t("sidebar.nav.webRadio", "Web Radio")}
+          active={activeView === "web-radio"}
+          onClick={() => setActiveView("web-radio")}
+        />
       </div>
 
       {/* Single scroll surface for everything below the pinned nav so

--- a/src/components/views/WebRadioView.tsx
+++ b/src/components/views/WebRadioView.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2, Play, Radio, Signal, Volume2 } from "lucide-react";
+import { usePlayer } from "../../hooks/usePlayer";
+import {
+  webRadioListStations,
+  webRadioPlayStation,
+  type WebRadioStation,
+} from "../../lib/tauri/webRadio";
+
+const ACCENTS = [
+  "from-emerald-500 to-cyan-500",
+  "from-indigo-500 to-sky-500",
+  "from-rose-500 to-orange-500",
+  "from-violet-500 to-fuchsia-500",
+  "from-amber-500 to-lime-500",
+];
+
+export function WebRadioView() {
+  const { t } = useTranslation();
+  const { currentTrack, playbackState } = usePlayer();
+  const [stations, setStations] = useState<WebRadioStation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [playingStationId, setPlayingStationId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    webRadioListStations()
+      .then((rows) => {
+        if (!cancelled) setStations(rows);
+      })
+      .catch((err) => {
+        console.error("[WebRadioView] list stations failed", err);
+        if (!cancelled) {
+          setError(
+            t("webRadio.errors.load", "Unable to load web radio stations."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const activeStationSlug = useMemo(() => {
+    if (!currentTrack || currentTrack.id >= -10_000) return null;
+    return stations.find((station) => currentTrack.id === -10_000 - station.id)
+      ?.slug;
+  }, [currentTrack, stations]);
+
+  const handlePlay = useCallback(
+    async (station: WebRadioStation) => {
+      if (playingStationId != null) return;
+      setError(null);
+      setPlayingStationId(station.id);
+      try {
+        await webRadioPlayStation(station.id);
+      } catch (err) {
+        console.error("[WebRadioView] play station failed", err);
+        setError(
+          t("webRadio.errors.play", "Unable to start {{station}}.", {
+            station: station.name,
+          }),
+        );
+      } finally {
+        setPlayingStationId(null);
+      }
+    },
+    [playingStationId, t],
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-2">
+          <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">
+            <Signal size={14} />
+            <span>{t("webRadio.eyebrow", "Live streams")}</span>
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-zinc-950 dark:text-white">
+              {t("webRadio.title", "Web Radio")}
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+              {t(
+                "webRadio.subtitle",
+                "Tune into curated internet radio stations without adding anything to your local library.",
+              )}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs font-medium text-zinc-600 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+          <Radio size={15} />
+          <span>
+            {t("webRadio.stationCount", "{{count}} stations", {
+              count: stations.length,
+            })}
+          </span>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex min-h-72 items-center justify-center">
+          <Loader2 size={28} className="animate-spin text-emerald-500" />
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {stations.map((station, index) => {
+            const isActive =
+              activeStationSlug === station.slug && playbackState !== "idle";
+            const isStarting = playingStationId === station.id;
+            return (
+              <button
+                key={station.slug}
+                type="button"
+                onClick={() => handlePlay(station)}
+                disabled={isStarting}
+                className={`group flex min-h-44 flex-col justify-between rounded-lg border p-4 text-left shadow-sm transition ${
+                  isActive
+                    ? "border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/30"
+                    : "border-zinc-200 bg-white hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
+                } disabled:opacity-70`}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div
+                    className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br ${ACCENTS[index % ACCENTS.length]} text-white shadow-sm`}
+                  >
+                    <Radio size={22} />
+                  </div>
+                  <div className="flex items-center gap-2 rounded-md bg-zinc-100 px-2 py-1 text-[11px] font-semibold uppercase text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+                    {station.codec}
+                  </div>
+                </div>
+
+                <div className="mt-5 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h2 className="truncate text-lg font-semibold text-zinc-950 dark:text-white">
+                      {station.name}
+                    </h2>
+                    {isActive && (
+                      <Volume2
+                        size={16}
+                        className="shrink-0 text-emerald-600 dark:text-emerald-400"
+                      />
+                    )}
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-sm leading-5 text-zinc-600 dark:text-zinc-400">
+                    {station.tagline}
+                  </p>
+                </div>
+
+                <div className="mt-5 flex items-center justify-between gap-3">
+                  <span className="truncate text-xs font-medium text-zinc-500 dark:text-zinc-500">
+                    {station.genre}
+                  </span>
+                  <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-zinc-950 text-white transition group-hover:bg-emerald-600 dark:bg-white dark:text-zinc-950 dark:group-hover:bg-emerald-400">
+                    {isStarting ? (
+                      <Loader2 size={16} className="animate-spin" />
+                    ) : (
+                      <Play size={16} className="ml-0.5 fill-current" />
+                    )}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -124,7 +124,8 @@
   "sidebar": {
     "nav": {
       "home": "Home",
-      "spotify": "Spotify"
+      "spotify": "Spotify",
+      "webRadio": "Web Radio"
     },
     "sections": {
       "open": "Open",
@@ -189,6 +190,18 @@
       "playlistSubtext_zero": "0 tracks",
       "playlistSubtext_one": "{{count}} track",
       "playlistSubtext_other": "{{count}} tracks"
+    }
+  },
+  "webRadio": {
+    "eyebrow": "Live streams",
+    "title": "Web Radio",
+    "subtitle": "Tune into curated internet radio stations without adding anything to your local library.",
+    "stationCount_zero": "0 stations",
+    "stationCount_one": "{{count}} station",
+    "stationCount_other": "{{count}} stations",
+    "errors": {
+      "load": "Unable to load web radio stations.",
+      "play": "Unable to start {{station}}."
     }
   },
   "topbar": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -124,7 +124,8 @@
   "sidebar": {
     "nav": {
       "home": "Accueil",
-      "spotify": "Spotify"
+      "spotify": "Spotify",
+      "webRadio": "Web Radio"
     },
     "sections": {
       "open": "Ouvrir",
@@ -189,6 +190,18 @@
       "playlistSubtext_zero": "0 titre",
       "playlistSubtext_one": "{{count}} titre",
       "playlistSubtext_other": "{{count}} titres"
+    }
+  },
+  "webRadio": {
+    "eyebrow": "Flux en direct",
+    "title": "Web Radio",
+    "subtitle": "Écoutez des stations de radio internet sélectionnées sans rien ajouter à votre bibliothèque locale.",
+    "stationCount_zero": "0 station",
+    "stationCount_one": "{{count}} station",
+    "stationCount_other": "{{count}} stations",
+    "errors": {
+      "load": "Impossible de charger les stations web radio.",
+      "play": "Impossible de lancer {{station}}."
     }
   },
   "topbar": {

--- a/src/lib/tauri/webRadio.ts
+++ b/src/lib/tauri/webRadio.ts
@@ -1,0 +1,18 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface WebRadioStation {
+  id: number;
+  slug: string;
+  name: string;
+  tagline: string;
+  genre: string;
+  codec: string;
+}
+
+export function webRadioListStations(): Promise<WebRadioStation[]> {
+  return invoke<WebRadioStation[]>("web_radio_list_stations");
+}
+
+export function webRadioPlayStation(stationId: number): Promise<void> {
+  return invoke<void>("web_radio_play_station", { stationId });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export type ViewId =
   | "statistics"
   | "liked"
   | "recent"
+  | "web-radio"
   | "spotify"
   | "wrapped"
   | "album-detail"


### PR DESCRIPTION
## Summary
- add backend support for non-seekable HTTP MP3 streams in the audio engine
- expose a curated Web Radio station catalog through Tauri commands
- add a Web Radio view and sidebar navigation entry with EN/FR labels

## Verification
- bun run typecheck
- bun run lint
- cargo check --manifest-path src-tauri/Cargo.toml --all-targets
- git diff --check
- verified the bundled station URLs respond as audio/mpeg streams


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Ajout d'une section Web Radio permettant de parcourir et de lancer des stations de radio en direct
  * Support du streaming HTTP pour la lecture de flux audio en continu

* **Chores**
  * Mise à jour des dépendances pour le support du streaming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->