### PR TITLE
fix(audio): negotiate WASAPI Exclusive format chain S24/S16 (#174)

### DIFF
--- a/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
+++ b/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
@@ -148,6 +148,79 @@ fn output_thread_main(
     tracing::debug!("wasapi exclusive output thread exiting");
 }
 
+/// Bit depth + container layout actually accepted by the device in
+/// exclusive mode. Returned from the negotiation in
+/// [`open_exclusive_session`] so the hot path knows how to pack
+/// `f32` samples into the byte buffer wasapi consumes (#174).
+///
+/// Order in [`FORMAT_FALLBACK_CHAIN`] is high-quality → low-quality:
+/// most audiophile DACs accept Float32 natively; Realtek ALC and
+/// many integrated codecs only honor PCM in exclusive mode and
+/// reject Float32 outright with `AUDCLNT_E_UNSUPPORTED_FORMAT`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExclusiveSampleFormat {
+    /// `wBitsPerSample = 32`, `KSDATAFORMAT_SUBTYPE_IEEE_FLOAT`.
+    /// Native cpal-style pipeline — zero conversion at the boundary.
+    Float32,
+    /// `wBitsPerSample = 24`, container 24, PCM. Three bytes per
+    /// sample, no padding. Compact wire format favored by USB
+    /// class-1 / class-2 DACs.
+    Pcm24Packed,
+    /// `wBitsPerSample = 32`, valid bits 24, PCM. Four bytes per
+    /// sample, high byte is the LSB of a sign-extended i32. Most
+    /// integrated codecs that "support 24-bit" really want this
+    /// layout in exclusive mode.
+    Pcm24Padded,
+    /// `wBitsPerSample = 16`, PCM. Two bytes per sample. Universal
+    /// fallback for ancient or driver-limited hardware.
+    Pcm16,
+}
+
+impl ExclusiveSampleFormat {
+    /// Bytes per sample on the wire (per single channel).
+    fn bytes_per_sample(self) -> usize {
+        match self {
+            Self::Float32 | Self::Pcm24Padded => 4,
+            Self::Pcm24Packed => 3,
+            Self::Pcm16 => 2,
+        }
+    }
+
+    /// Build the WaveFormat the wasapi crate hands to WASAPI.
+    /// `valid_bits` matches the actual precision, `bits_per_sample`
+    /// matches the container size — the two differ for Pcm24Padded.
+    fn to_wave_format(self, sample_rate: usize, channels: usize) -> WaveFormat {
+        let (bits, valid, ty) = match self {
+            Self::Float32 => (32, 32, SampleType::Float),
+            Self::Pcm24Packed => (24, 24, SampleType::Int),
+            Self::Pcm24Padded => (32, 24, SampleType::Int),
+            Self::Pcm16 => (16, 16, SampleType::Int),
+        };
+        WaveFormat::new(bits, valid, &ty, sample_rate, channels, None)
+    }
+
+    /// Short label for the diagnostics log line.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Float32 => "F32",
+            Self::Pcm24Packed => "S24_3LE",
+            Self::Pcm24Padded => "S24_4LE",
+            Self::Pcm16 => "S16_LE",
+        }
+    }
+}
+
+/// Order tried by [`open_exclusive_session`]. Float first (zero
+/// conversion cost), then PCM 24-bit packed / padded, then PCM 16
+/// as the universal last resort. Falling all the way through
+/// triggers the cpal shared-mode fallback at the caller.
+const FORMAT_FALLBACK_CHAIN: [ExclusiveSampleFormat; 4] = [
+    ExclusiveSampleFormat::Float32,
+    ExclusiveSampleFormat::Pcm24Packed,
+    ExclusiveSampleFormat::Pcm24Padded,
+    ExclusiveSampleFormat::Pcm16,
+];
+
 /// Bundle of everything the event loop needs after a successful init.
 /// Kept private so callers can't misuse the wasapi handles outside
 /// the thread that owns the COM apartment.
@@ -158,67 +231,126 @@ struct ExclusiveSession {
     sample_rate: u32,
     channels: u16,
     buffer_frames: u32,
+    /// Format the device actually accepted. Drives the f32 → bytes
+    /// conversion inside `run_event_loop`.
+    format: ExclusiveSampleFormat,
 }
 
-/// Resolve the device, build a candidate WaveFormat, verify it's
-/// supported in exclusive mode, then initialize the client. On any
-/// fatal mismatch we return Err so the engine falls back to shared
-/// mode rather than launching a broken stream.
+/// Resolve the device, then walk the format fallback chain
+/// (#174). For each candidate we acquire a fresh `IAudioClient`,
+/// check the format is supported in exclusive mode, and try to
+/// initialize. Many consumer DACs (Realtek ALC, Conexant CX, some
+/// USB codecs) reject `IEEE_FLOAT` outright with
+/// `AUDCLNT_E_UNSUPPORTED_FORMAT` (0x88890008) but accept PCM at
+/// 24-bit or 16-bit — without this chain those users got bumped to
+/// cpal shared mode and never reached bit-perfect playback even
+/// with the WASAPI Exclusive toggle on.
+///
+/// A fresh `IAudioClient` per attempt is deliberate: once an
+/// `IAudioClient` has been initialized it can't be re-initialized,
+/// and an `is_supported` rejection still leaves the COM object in
+/// a "you initialized me with the wrong shape" state on some
+/// drivers. Acquiring a new one is cheap and reliable.
 fn open_exclusive_session(
     device_name: &Option<String>,
     shared: &Arc<SharedPlayback>,
 ) -> AppResult<ExclusiveSession> {
-    // 1. Resolve device — explicit name first, OS default as fallback.
     let device = pick_device(device_name)?;
 
-    // 2. Audio client.
-    let mut client = device
+    // Mix format gives us the device's native (sample rate,
+    // channel count). It doesn't tell us the supported bit depth
+    // in exclusive mode — that's what the chain below probes.
+    let probe_client = device
         .get_iaudioclient()
-        .map_err(|e| AppError::Audio(format!("get IAudioClient: {e:?}")))?;
-
-    // 3. Build WaveFormat. We anchor on the device's mix format so
-    //    the chosen sample rate matches what the user picked in the
-    //    Windows Sound control panel. Exclusive mode rejects formats
-    //    the device hardware can't run natively — `is_supported`
-    //    tells us before we commit.
-    let mix_format = client
+        .map_err(|e| AppError::Audio(format!("get IAudioClient (probe): {e:?}")))?;
+    let mix_format = probe_client
         .get_mixformat()
         .map_err(|e| AppError::Audio(format!("get_mixformat: {e:?}")))?;
     let sample_rate = mix_format.get_samplespersec() as usize;
     let channels = mix_format.get_nchannels() as usize;
+    drop(probe_client);
 
-    // 32-bit float stereo (downmix happens upstream in the decoder
-    // when the source is multichannel). Float is the most widely
-    // supported exclusive-mode format on consumer DACs.
-    let desired = WaveFormat::new(32, 32, &SampleType::Float, sample_rate, channels, None);
+    let mut last_err: Option<AppError> = None;
+    for &format in FORMAT_FALLBACK_CHAIN.iter() {
+        match try_open_with_format(&device, format, sample_rate, channels) {
+            Ok((client, render, event, buffer_frames)) => {
+                tracing::info!(
+                    sample_rate = sample_rate as u32,
+                    channels = channels as u16,
+                    format = format.label(),
+                    "wasapi exclusive negotiation succeeded"
+                );
+                shared
+                    .sample_rate
+                    .store(sample_rate as u32, Ordering::Release);
+                shared.channels.store(channels as u16, Ordering::Release);
+                return Ok(ExclusiveSession {
+                    client,
+                    render,
+                    event,
+                    sample_rate: sample_rate as u32,
+                    channels: channels as u16,
+                    buffer_frames,
+                    format,
+                });
+            }
+            Err(err) => {
+                tracing::debug!(
+                    format = format.label(),
+                    %err,
+                    "wasapi exclusive format rejected; trying next in chain"
+                );
+                last_err = Some(err);
+            }
+        }
+    }
 
-    // 4. Check the format is supported in exclusive mode. The wasapi
-    //    crate returns `Ok(None)` here on success — Err on rejection.
-    //    Surface the rejection so the engine falls back to shared.
-    client
-        .is_supported(&desired, &ShareMode::Exclusive)
-        .map_err(|e| {
-            AppError::Audio(format!(
-                "device does not support 32-bit float in exclusive mode: {e:?}"
-            ))
-        })?;
+    Err(last_err.unwrap_or_else(|| {
+        AppError::Audio(
+            "wasapi exclusive: every format in the fallback chain was rejected".into(),
+        )
+    }))
+}
 
-    // 5. Pick the minimum supported device period for low latency.
-    //    `get_device_period` returns (default, min) in 100 ns units.
+/// Single attempt with one bit-depth format. Builds a fresh
+/// `IAudioClient`, asks WASAPI to validate the WaveFormat, then
+/// initializes + starts the stream. Pre-fills with silence sized to
+/// the negotiated format so the first device event lands on clean
+/// state.
+fn try_open_with_format(
+    device: &Device,
+    format: ExclusiveSampleFormat,
+    sample_rate: usize,
+    channels: usize,
+) -> AppResult<(AudioClient, AudioRenderClient, Handle, u32)> {
+    let mut client = device
+        .get_iaudioclient()
+        .map_err(|e| AppError::Audio(format!("get IAudioClient ({}): {e:?}", format.label())))?;
+
+    let wave = format.to_wave_format(sample_rate, channels);
+
+    client.is_supported(&wave, &ShareMode::Exclusive).map_err(|e| {
+        AppError::Audio(format!(
+            "is_supported rejected {} in exclusive mode: {e:?}",
+            format.label()
+        ))
+    })?;
+
     let (default_period, min_period) = client
         .get_device_period()
         .map_err(|e| AppError::Audio(format!("get_device_period: {e:?}")))?;
     let period_hns = min_period.max(default_period);
     let mode = StreamMode::EventsExclusive { period_hns };
 
-    // 6. Initialize. `AUDCLNT_E_DEVICE_IN_USE` here means another
-    //    application already owns the device exclusively — we surface
-    //    the error so the engine can fall back gracefully.
     client
-        .initialize_client(&desired, &Direction::Render, &mode)
-        .map_err(|e| AppError::Audio(format!("initialize_client exclusive: {e:?}")))?;
+        .initialize_client(&wave, &Direction::Render, &mode)
+        .map_err(|e| {
+            AppError::Audio(format!(
+                "initialize_client {} exclusive: {e:?}",
+                format.label()
+            ))
+        })?;
 
-    // 7. Register the event handle for the event-driven loop.
     let event = client
         .set_get_eventhandle()
         .map_err(|e| AppError::Audio(format!("set_get_eventhandle: {e:?}")))?;
@@ -231,9 +363,8 @@ fn open_exclusive_session(
         .get_audiorenderclient()
         .map_err(|e| AppError::Audio(format!("get_audiorenderclient: {e:?}")))?;
 
-    // 8. Pre-fill the buffer with silence so the device starts cleanly
-    //    — exclusive mode is strict about the first pass.
-    let silent_bytes = vec![0u8; (buffer_frames as usize) * channels * std::mem::size_of::<f32>()];
+    let silent_bytes =
+        vec![0u8; (buffer_frames as usize) * channels * format.bytes_per_sample()];
     render
         .write_to_device(buffer_frames as usize, &silent_bytes, None)
         .map_err(|e| AppError::Audio(format!("prefill render buffer: {e:?}")))?;
@@ -242,21 +373,7 @@ fn open_exclusive_session(
         .start_stream()
         .map_err(|e| AppError::Audio(format!("start_stream: {e:?}")))?;
 
-    // 9. Stamp the chosen format into SharedPlayback so the decoder
-    //    knows the target sample rate / channel count for its resampler.
-    shared
-        .sample_rate
-        .store(sample_rate as u32, Ordering::Release);
-    shared.channels.store(channels as u16, Ordering::Release);
-
-    Ok(ExclusiveSession {
-        client,
-        render,
-        event,
-        sample_rate: sample_rate as u32,
-        channels: channels as u16,
-        buffer_frames,
-    })
+    Ok((client, render, event, buffer_frames))
 }
 
 fn pick_device(device_name: &Option<String>) -> AppResult<Device> {
@@ -305,13 +422,15 @@ fn run_event_loop(
         event,
         channels,
         buffer_frames,
+        format,
         ..
     } = session;
 
     let channels = channels as usize;
     let need_frames = buffer_frames as usize;
     let need_samples = need_frames * channels;
-    let frame_bytes = channels * std::mem::size_of::<f32>();
+    let sample_bytes = format.bytes_per_sample();
+    let frame_bytes = channels * sample_bytes;
     let buffer_bytes = need_frames * frame_bytes;
 
     // Two reusable scratch buffers: one for the f32 samples we apply
@@ -395,14 +514,11 @@ fn run_event_loop(
                 }
             }
 
-            // Pack f32 samples into the little-endian byte buffer
-            // wasapi expects (KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, 32 bps).
-            for (sample, chunk) in samples
-                .iter()
-                .zip(bytes_scratch.chunks_exact_mut(std::mem::size_of::<f32>()))
-            {
-                chunk.copy_from_slice(&sample.to_le_bytes());
-            }
+            // Pack `samples` into the byte layout the negotiated
+            // exclusive format expects (#174). Hot path: no
+            // allocations, no branches inside the inner loop
+            // beyond the format dispatch above.
+            pack_samples(format, &samples, &mut bytes_scratch);
             &bytes_scratch
         };
 
@@ -427,4 +543,113 @@ fn run_event_loop(
                    // uninit; not strictly required, but tidier under tracing.
     std::thread::sleep(Duration::from_millis(5));
     wasapi::deinitialize();
+}
+
+/// Pack the decoded `f32` sample buffer into the little-endian byte
+/// layout the negotiated exclusive format expects.
+///
+/// Saturation is done by clamping to `[-1.0, 1.0]` before scaling
+/// rather than checking the post-cast i32/i16 — this side-steps the
+/// undefined behaviour C-style casts have on `f32` overflow and
+/// avoids a branch per sample. The decoder upstream applies
+/// `volume * norm_gain` BEFORE this function, so the input is
+/// already at the final analogue amplitude; a clipped sample here
+/// means the upstream chain (EQ, ReplayGain, mono mix) pushed
+/// past 0 dBFS and the user genuinely wants saturation.
+///
+/// All four packing paths are bounded by `samples.len()` and
+/// `bytes.len()` so a mismatched slot count (`samples` short by
+/// one) leaves trailing bytes at their previous values (which the
+/// caller pre-cleared to zero). No panics in the hot path.
+fn pack_samples(format: ExclusiveSampleFormat, samples: &[f32], bytes: &mut [u8]) {
+    match format {
+        ExclusiveSampleFormat::Float32 => {
+            for (sample, chunk) in samples.iter().zip(bytes.chunks_exact_mut(4)) {
+                chunk.copy_from_slice(&sample.to_le_bytes());
+            }
+        }
+        ExclusiveSampleFormat::Pcm24Packed => {
+            // 24-bit signed integer, 3 bytes per sample, little-endian.
+            // i32::MAX for 24-bit is 2^23 - 1 = 8_388_607.
+            for (sample, chunk) in samples.iter().zip(bytes.chunks_exact_mut(3)) {
+                let clamped = sample.clamp(-1.0, 1.0);
+                let v = (clamped * 8_388_607.0) as i32;
+                chunk[0] = (v & 0xFF) as u8;
+                chunk[1] = ((v >> 8) & 0xFF) as u8;
+                chunk[2] = ((v >> 16) & 0xFF) as u8;
+            }
+        }
+        ExclusiveSampleFormat::Pcm24Padded => {
+            // 24-bit valid bits inside a 32-bit container, LE. WASAPI
+            // expects the 24-bit value in the LOW bytes with sign
+            // extension into the high byte (so a positive i32 with
+            // bits 24-30 == 0 is the right shape — left-shift would
+            // be wrong, the container stores the raw signed value).
+            for (sample, chunk) in samples.iter().zip(bytes.chunks_exact_mut(4)) {
+                let clamped = sample.clamp(-1.0, 1.0);
+                let v = (clamped * 8_388_607.0) as i32;
+                chunk.copy_from_slice(&v.to_le_bytes());
+            }
+        }
+        ExclusiveSampleFormat::Pcm16 => {
+            for (sample, chunk) in samples.iter().zip(bytes.chunks_exact_mut(2)) {
+                let clamped = sample.clamp(-1.0, 1.0);
+                let v = (clamped * 32_767.0) as i16;
+                chunk.copy_from_slice(&v.to_le_bytes());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_samples_float32_round_trips() {
+        let samples = [0.0_f32, 1.0, -1.0, 0.5];
+        let mut bytes = vec![0u8; samples.len() * 4];
+        pack_samples(ExclusiveSampleFormat::Float32, &samples, &mut bytes);
+        for (i, sample) in samples.iter().enumerate() {
+            let round = f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap());
+            assert_eq!(round, *sample);
+        }
+    }
+
+    #[test]
+    fn pack_samples_s16_saturates_and_round_trips() {
+        let samples = [0.0_f32, 1.0, -1.0, 0.5, 2.0, -2.0];
+        let mut bytes = vec![0u8; samples.len() * 2];
+        pack_samples(ExclusiveSampleFormat::Pcm16, &samples, &mut bytes);
+        let extract = |i: usize| i16::from_le_bytes(bytes[i * 2..i * 2 + 2].try_into().unwrap());
+        assert_eq!(extract(0), 0);
+        assert_eq!(extract(1), 32_767);
+        assert_eq!(extract(2), -32_767);
+        assert_eq!(extract(3), 16_383); // ~0.5 * 32_767
+        assert_eq!(extract(4), 32_767); // saturated above 1.0
+        assert_eq!(extract(5), -32_767); // saturated below -1.0
+    }
+
+    #[test]
+    fn pack_samples_s24_packed_three_bytes_per_sample() {
+        let samples = [0.0_f32, 1.0, -1.0];
+        let mut bytes = vec![0u8; samples.len() * 3];
+        pack_samples(ExclusiveSampleFormat::Pcm24Packed, &samples, &mut bytes);
+        // 0.0 → 0
+        assert_eq!(&bytes[0..3], &[0, 0, 0]);
+        // 1.0 → 8_388_607 = 0x7F_FF_FF → LE [0xFF, 0xFF, 0x7F]
+        assert_eq!(&bytes[3..6], &[0xFF, 0xFF, 0x7F]);
+        // -1.0 → -8_388_607 = signed i32 0xFF_80_00_01 → low 3 LE bytes
+        let expected = (-8_388_607_i32).to_le_bytes();
+        assert_eq!(&bytes[6..9], &expected[0..3]);
+    }
+
+    #[test]
+    fn pack_samples_s24_padded_four_bytes_per_sample() {
+        let samples = [1.0_f32];
+        let mut bytes = vec![0u8; 4];
+        pack_samples(ExclusiveSampleFormat::Pcm24Padded, &samples, &mut bytes);
+        // 1.0 → 8_388_607 as i32, LE. High byte stays 0 (positive value).
+        assert_eq!(bytes, 8_388_607_i32.to_le_bytes().to_vec());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes [#174](https://github.com/InstaZDLL/WaveFlow/issues/174). Many consumer DACs reject IEEE_FLOAT in exclusive mode and the toggle was silently falling back to cpal shared on every track open.

- `ExclusiveSampleFormat` enum + retry chain F32 → S24_3LE → S24_4LE → S16_LE in \`open_exclusive_session\`.
- Each attempt acquires a fresh \`IAudioClient\` (re-init isn't safe on some drivers).
- \`pack_samples\` adapts the f32 → bytes conversion on the hot path (clamp before scale, no alloc, no branches inside the inner loop).
- Diagnostic INFO logs the chosen format label so users can confirm bit-perfect landed on the right depth.

## Test plan

- [x] Unit tests cover round-trip + saturation for all 4 variants
- [x] Verify on a Realtek ALC1220 or similar — toggle enabled → bit-perfect engaged at native bit depth instead of falling back
- [x] Verify on RME / Focusrite (already accepts F32) — no regression, still picks F32

Closes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de publication

* **Améliorations**
  * Amélioration de la gestion audio en mode WASAPI Exclusive avec support étendu des formats d'échantillons audio. La négociation automatique des formats garantit une meilleure compatibilité et un rendu audio plus fiable sur différentes configurations matérielles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->