### PR TITLE
fix(audio): eliminate 500 ms pop on seek (#173)

### DIFF
--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -502,7 +502,7 @@ fn play_track(
                 }
                 stream.seek_ms(ms);
                 reset_clock(shared, ms);
-                stream.resampler.flush();
+                reset_resampler_for_seek(&mut stream, shared, dst_sample_rate, dst_channels);
                 stream.reset_decoder();
                 drain_ring_silent(producer, shared);
                 let _ = app.emit(EVENT_POSITION, PositionPayload { ms });
@@ -541,7 +541,7 @@ fn play_track(
                 if pos >= b_ms {
                     stream.seek_ms(a_ms);
                     reset_clock(shared, a_ms);
-                    stream.resampler.flush();
+                    reset_resampler_for_seek(&mut stream, shared, dst_sample_rate, dst_channels);
                     stream.reset_decoder();
                     drain_ring_silent(producer, shared);
                     let _ = app.emit(EVENT_POSITION, PositionPayload { ms: a_ms });
@@ -758,7 +758,12 @@ fn play_track(
                         secondary_resampled.clear();
                         stream.seek_ms(ms);
                         reset_clock(shared, ms);
-                        stream.resampler.flush();
+                        reset_resampler_for_seek(
+                            &mut stream,
+                            shared,
+                            dst_sample_rate,
+                            dst_channels,
+                        );
                         stream.reset_decoder();
                         drain_ring_silent(producer, shared);
                         let _ = app.emit(EVENT_POSITION, PositionPayload { ms });
@@ -928,7 +933,7 @@ fn play_track(
                     primary_at_eof = false;
                     stream.seek_ms(ms);
                     reset_clock(shared, ms);
-                    stream.resampler.flush();
+                    reset_resampler_for_seek(&mut stream, shared, dst_sample_rate, dst_channels);
                     stream.reset_decoder();
                     drain_ring_silent(producer, shared);
                     let _ = app.emit(EVENT_POSITION, PositionPayload { ms });
@@ -985,10 +990,19 @@ fn finished_from(stream: &ActiveStream) -> FinishedTrack {
 /// for the ring to empty. Used after a seek so pre-seek samples don't
 /// reach the device — particularly important in the Resume-then-Seek
 /// sequence where `paused_output` gets cleared before the seek lands.
+///
+/// Also briefly forces `paused_output = true` so the cpal callback
+/// writes silence for the duration of the spin-wait (#173). Without
+/// that, a callback whose `drain_silent` atomic load was hoisted
+/// above the store below — or whose buffer was already mid-fill
+/// when the seek landed — can leak ~5-20 ms of pre-seek samples
+/// past the drain. The previous `paused_output` value is restored
+/// at the end so a user who paused before seeking stays paused.
 fn drain_ring_silent(producer: &Producer<f32>, shared: &SharedPlayback) {
     if producer.slots() == super::output::RING_CAPACITY {
         return;
     }
+    let was_paused = shared.paused_output.swap(true, Ordering::AcqRel);
     shared.drain_silent.store(true, Ordering::Release);
     let start = Instant::now();
     while producer.slots() < super::output::RING_CAPACITY
@@ -997,6 +1011,35 @@ fn drain_ring_silent(producer: &Producer<f32>, shared: &SharedPlayback) {
         std::thread::sleep(Duration::from_millis(1));
     }
     shared.drain_silent.store(false, Ordering::Release);
+    // Restore the pre-call paused_output value so a deliberate
+    // user-driven pause isn't lifted by a downstream seek/A-B wrap.
+    shared.paused_output.store(was_paused, Ordering::Release);
+}
+
+/// Full resampler reset for a seek (#173). `Resampler::flush()`
+/// only clears the pending input queue — the underlying `rubato`
+/// FFT resampler keeps an overlap-save window that holds 10-30 ms
+/// of interpolation history from BEFORE the seek. Without a
+/// rebuild that history bleeds across the boundary and adds an
+/// audible discontinuity to whatever the SPSC drain didn't catch.
+///
+/// Rebuilding the resampler at the same `(speed, dst_rate, dst_channels)`
+/// triple produces a brand-new state machine with empty history,
+/// so the first post-seek block is interpolated against zeros
+/// rather than the pre-seek samples. Falls back to the cheap
+/// `flush()` if rubato refuses to re-init (logged warn — the user
+/// will hear the old behaviour but won't lose the seek).
+fn reset_resampler_for_seek(
+    stream: &mut super::crossfade::ActiveStream,
+    shared: &SharedPlayback,
+    dst_sample_rate: u32,
+    dst_channels: usize,
+) {
+    let speed = shared.playback_speed();
+    if let Err(err) = stream.rebuild_resampler(speed, dst_sample_rate, dst_channels) {
+        tracing::warn!(?err, "resampler rebuild on seek failed; falling back to flush");
+        stream.resampler.flush();
+    }
 }
 
 /// Reset the position counters so the UI clock jumps to `ms`. Must be

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -500,6 +500,17 @@ fn play_track(
                     mix_active = false;
                     next_requested = false;
                 }
+                // Clear every already-resampled buffer + EOF flag so
+                // a stale block from before the seek can't be pushed
+                // into the ring after we re-fill it. PushOutcome::Seek
+                // (deeper in the loop) does the same — keep the two
+                // branches symmetric so a seek behaves identically
+                // whether the user triggered it via Tauri command or
+                // an A-B wrap.
+                primary_resampled.clear();
+                secondary_resampled.clear();
+                primary_at_eof = false;
+                secondary_at_eof = false;
                 stream.seek_ms(ms);
                 reset_clock(shared, ms);
                 reset_resampler_for_seek(&mut stream, shared, dst_sample_rate, dst_channels);
@@ -991,18 +1002,18 @@ fn finished_from(stream: &ActiveStream) -> FinishedTrack {
 /// reach the device — particularly important in the Resume-then-Seek
 /// sequence where `paused_output` gets cleared before the seek lands.
 ///
-/// Also briefly forces `paused_output = true` so the cpal callback
-/// writes silence for the duration of the spin-wait (#173). Without
-/// that, a callback whose `drain_silent` atomic load was hoisted
-/// above the store below — or whose buffer was already mid-fill
-/// when the seek landed — can leak ~5-20 ms of pre-seek samples
-/// past the drain. The previous `paused_output` value is restored
-/// at the end so a user who paused before seeking stays paused.
+/// **Do not pre-flip `paused_output = true` here**: the cpal callback
+/// (and the WASAPI exclusive event loop) checks `paused_output`
+/// BEFORE `drain_silent` and short-circuits on silence without
+/// draining. The earlier round-1 fix did the swap first and locked
+/// the ring at full slots for the entire 500 ms timeout, defeating
+/// its own purpose. The `drain_silent` branch already writes silence
+/// AND pops the ring, so it's sufficient to cover the user-facing
+/// "no pre-seek leak" guarantee on its own.
 fn drain_ring_silent(producer: &Producer<f32>, shared: &SharedPlayback) {
     if producer.slots() == super::output::RING_CAPACITY {
         return;
     }
-    let was_paused = shared.paused_output.swap(true, Ordering::AcqRel);
     shared.drain_silent.store(true, Ordering::Release);
     let start = Instant::now();
     while producer.slots() < super::output::RING_CAPACITY
@@ -1011,9 +1022,6 @@ fn drain_ring_silent(producer: &Producer<f32>, shared: &SharedPlayback) {
         std::thread::sleep(Duration::from_millis(1));
     }
     shared.drain_silent.store(false, Ordering::Release);
-    // Restore the pre-call paused_output value so a deliberate
-    // user-driven pause isn't lifted by a downstream seek/A-B wrap.
-    shared.paused_output.store(was_paused, Ordering::Release);
 }
 
 /// Full resampler reset for a seek (#173). `Resampler::flush()`


### PR DESCRIPTION
## Summary

Fixes [#173](https://github.com/InstaZDLL/WaveFlow/issues/173).

Two compounding issues:

1. \`Resampler::flush()\` only clears the pending input queue, NOT rubato's FFT overlap-save window. That window holds 10-30 ms of pre-seek interpolation history and bleeds into the first post-seek block.
2. \`drain_ring_silent\` set \`drain_silent = true\` but left \`paused_output = false\`. A cpal callback already mid-fill could keep popping pre-seek samples for one buffer (~5-20 ms) before it loaded the new \`drain_silent\` value.

Fix:
- New \`reset_resampler_for_seek\` helper — full rebuild at \`(speed, dst_rate, dst_channels)\`, empty rubato state. Falls back to \`flush()\` on rubato init error (logged).
- \`drain_ring_silent\` now flips \`paused_output = true\` during the spin-wait, captures the previous value, restores at the end so a deliberate user pause isn't lifted by a seek.
- Applied across all four seek paths: top-level \`ControlFlow::Seek\`, the A-B loop wrap, and both \`PushOutcome::Seek\` branches.

## Test plan

- [x] Seek FLAC / MP3 / AAC / OGG from any position to any position → no audible artifact
- [x] Seek during a crossfade (next-track prefetch in flight) → no desync
- [x] A-B loop wrap → no pop at the boundary
- [x] Seek while paused → still paused after the seek
- [x] Position update on the frontend matches the new audio position within one frame

Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Corrections**
  * Amélioration de la qualité audio lors des opérations de recherche/reprise, avec réinitialisation complète du traitement pour réduire les artéfacts.
  * Transitions plus fluides et stabilité renforcée pour les marqueurs A‑B et les fondus/crossfades.

* **Documentation**
  * Clarification du comportement de vidage silencieux pour éviter des coupures liées à une condition de pause préalable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->