### PR TITLE
feat(plugin-sdk): manifest + sidecar assets foundation (RFC-002 phase 1)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6976,13 +6976,23 @@ dependencies = [
  "resvg",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sqlx",
  "symphonia",
  "tempfile",
  "thiserror 2.0.18",
  "tiny-skia",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "usvg",
+ "waveflow-plugin-sdk",
+]
+
+[[package]]
+name = "waveflow-plugin-sdk"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/core", "crates/app"]
+members = ["crates/core", "crates/app", "crates/plugin-sdk"]
 
 # The actual package definitions live in `crates/core/Cargo.toml` and
 # `crates/app/Cargo.toml`. The workspace root is virtual: it owns the

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -107,6 +107,19 @@ lofty = "0.24"
 # parses it via the lower-level `id3` crate.
 id3 = "1"
 
+# Plugin manifest parsing (`crate::plugin::manifest`). TOML over
+# JSON because authors write these by hand — TOML reads cleaner.
+toml = "0.9"
+# Plugin sidecar asset hashing (`crate::plugin::assets`). Standard
+# SHA-256 hex digest so a third-party tool can verify the file
+# without depending on us. Re-uses the same `sha2` codegen the
+# rest of the workspace already pulls in transitively.
+sha2 = "0.10"
+# Shared plugin contract (manifest schema version + WIT world / permission
+# catalog). The SDK crate doesn't depend on us — it's a flat constants
+# crate both sides import.
+waveflow-plugin-sdk = { path = "../plugin-sdk" }
+
 [dev-dependencies]
 # Sandboxed scratch directories for the smart-playlist cover render
 # tests. Same usage shape as the app crate's existing dev-dep.

--- a/src-tauri/crates/core/src/lib.rs
+++ b/src-tauri/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod audio_format;
 pub mod domain;
 pub mod error;
 pub mod metadata;
+pub mod plugin;
 pub mod repository;
 pub mod scanner;
 pub mod smart_playlists;

--- a/src-tauri/crates/core/src/plugin/assets.rs
+++ b/src-tauri/crates/core/src/plugin/assets.rs
@@ -1,0 +1,210 @@
+//! Sidecar asset resolver (option B from the plugin SDK design).
+//!
+//! Plugins bundle large read-only data files (the 10 MB SQLite
+//! catalogue for Web Radio, lyric databases, language models) under
+//! `assets/` next to `manifest.toml`. The wasm component never sees
+//! the host filesystem directly — when a plugin calls
+//! `waveflow:host/storage.read-asset(path)`, that call lands here.
+//!
+//! Defence-in-depth: the manifest already validates that asset
+//! filenames don't contain `..`, but the host re-checks at every
+//! read because a manifest is just a string the user dropped on
+//! disk and we don't want a single missed validation to escape the
+//! plugin directory.
+//!
+//! Asset SHA-256 verification (when declared in the manifest) is
+//! also performed here; a verified mismatch returns an error and
+//! the read does NOT succeed — drive-by tampering is detectable
+//! without a full signing chain.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::manifest::Manifest;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AssetError {
+    #[error("asset io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("asset not declared in manifest: {0}")]
+    NotDeclared(String),
+    #[error("asset path tries to escape sandbox: {0}")]
+    PathEscape(String),
+    #[error("asset hash mismatch (expected {expected}, got {got})")]
+    HashMismatch { expected: String, got: String },
+}
+
+/// Resolves [`waveflow:host/storage.read-asset(path)`](../wit/waveflow-host.wit)
+/// calls against the plugin's bundled `assets/` directory.
+///
+/// Constructed once per plugin instantiation. Holds a snapshot of
+/// the manifest's allow-list so the host can pin "what the user
+/// installed" against "what the plugin is asking for" — a manifest
+/// edited mid-session won't be re-read until the host reloads the
+/// plugin.
+pub struct AssetResolver {
+    /// `<plugin-dir>/assets/` — root for every read.
+    assets_root: PathBuf,
+    /// Declared assets (filename → optional sha256). Reads against
+    /// any other path return [`AssetError::NotDeclared`].
+    declared: std::collections::HashMap<String, Option<String>>,
+}
+
+impl AssetResolver {
+    /// Build a resolver from a parsed manifest + the plugin's
+    /// on-disk root directory. The manifest's `[[assets]]` table
+    /// drives the allow-list; the directory is the prefix we
+    /// resolve against.
+    pub fn new(plugin_dir: &Path, manifest: &Manifest) -> Self {
+        let declared = manifest
+            .assets
+            .iter()
+            .map(|a| (a.filename.clone(), a.sha256.clone()))
+            .collect();
+        Self {
+            assets_root: plugin_dir.join("assets"),
+            declared,
+        }
+    }
+
+    /// Read one asset. `path` is what the plugin passed to the
+    /// host import — relative to `assets/`, no leading `/`, no
+    /// `..` segments.
+    pub fn read(&self, path: &str) -> Result<Vec<u8>, AssetError> {
+        let expected_hash = self
+            .declared
+            .get(path)
+            .ok_or_else(|| AssetError::NotDeclared(path.into()))?
+            .clone();
+
+        // Re-check `..` even though the manifest validator catches
+        // it — defence in depth. Reject anything other than
+        // forward path components, no `..`, no absolute root.
+        if path.is_empty() {
+            return Err(AssetError::PathEscape(path.into()));
+        }
+        let candidate = self.assets_root.join(path);
+        // Canonicalise both sides so a symlink under `assets/`
+        // can't escape — `canonicalize` resolves the link AND
+        // ensures the target exists.
+        let canon_root = self
+            .assets_root
+            .canonicalize()
+            .unwrap_or_else(|_| self.assets_root.clone());
+        let canon_candidate = candidate.canonicalize()?;
+        if !canon_candidate.starts_with(&canon_root) {
+            return Err(AssetError::PathEscape(path.into()));
+        }
+
+        let bytes = fs::read(&canon_candidate)?;
+
+        if let Some(expected) = expected_hash {
+            let got = sha256_hex(&bytes);
+            if !constant_time_eq(expected.as_bytes(), got.as_bytes()) {
+                return Err(AssetError::HashMismatch { expected, got });
+            }
+        }
+
+        Ok(bytes)
+    }
+}
+
+/// Lower-case hex SHA-256. Pulled in via the existing `blake3`
+/// dependency tree's transitive `sha2` would be nice but we already
+/// take `sha2` directly through `metadata::lastfm`'s signing, so
+/// reuse it.
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Constant-time slice equality so a malicious sidecar can't be
+/// timing-probed for its expected hash.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut acc = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::manifest::{AssetDecl, Manifest, PluginMetadata};
+
+    fn make_manifest(assets: Vec<AssetDecl>) -> Manifest {
+        // Build via the public types rather than parse — we only
+        // care about the resolver's behaviour here, not the
+        // manifest validator.
+        Manifest {
+            schema_version: 1,
+            plugin: PluginMetadata {
+                id: "test".into(),
+                name: "Test".into(),
+                version: "1.0.0".into(),
+                author: "x".into(),
+                world: waveflow_plugin_sdk::worlds::SOURCE_V1.into(),
+                description: None,
+                homepage: None,
+                license: None,
+            },
+            permissions: Default::default(),
+            assets,
+        }
+    }
+
+    #[test]
+    fn rejects_undeclared_asset() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("assets")).unwrap();
+        std::fs::write(tmp.path().join("assets").join("hello.txt"), b"hi").unwrap();
+        let manifest = make_manifest(vec![]); // no assets declared
+        let r = AssetResolver::new(tmp.path(), &manifest);
+        let err = r.read("hello.txt").unwrap_err();
+        assert!(matches!(err, AssetError::NotDeclared(_)));
+    }
+
+    #[test]
+    fn reads_declared_asset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let assets = tmp.path().join("assets");
+        std::fs::create_dir_all(&assets).unwrap();
+        std::fs::write(assets.join("stations.db"), b"sqlite-bytes").unwrap();
+        let manifest = make_manifest(vec![AssetDecl {
+            filename: "stations.db".into(),
+            description: None,
+            sha256: None,
+        }]);
+        let r = AssetResolver::new(tmp.path(), &manifest);
+        let bytes = r.read("stations.db").expect("declared asset");
+        assert_eq!(bytes, b"sqlite-bytes");
+    }
+
+    #[test]
+    fn detects_sha256_tampering() {
+        let tmp = tempfile::tempdir().unwrap();
+        let assets = tmp.path().join("assets");
+        std::fs::create_dir_all(&assets).unwrap();
+        std::fs::write(assets.join("file"), b"original").unwrap();
+        // Hash of "tampered", not "original".
+        let bogus_hash =
+            "0c8f0c79c8f7b6e0f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9".to_string();
+        let manifest = make_manifest(vec![AssetDecl {
+            filename: "file".into(),
+            description: None,
+            sha256: Some(bogus_hash),
+        }]);
+        let r = AssetResolver::new(tmp.path(), &manifest);
+        let err = r.read("file").unwrap_err();
+        assert!(matches!(err, AssetError::HashMismatch { .. }));
+    }
+}

--- a/src-tauri/crates/core/src/plugin/assets.rs
+++ b/src-tauri/crates/core/src/plugin/assets.rs
@@ -207,4 +207,31 @@ mod tests {
         let err = r.read("file").unwrap_err();
         assert!(matches!(err, AssetError::HashMismatch { .. }));
     }
+
+    #[test]
+    fn rejects_path_traversal_at_runtime() {
+        // Belt-and-suspenders: the manifest validator already rejects
+        // ".." segments in asset filenames, but `AssetResolver::read`
+        // is callable directly from the host import boundary with
+        // whatever string the wasm plugin chose to pass at runtime.
+        // A plugin asking for "../secret.txt" must hit the
+        // not-declared branch (the manifest never listed it) and not
+        // the canonicalisation fallback below.
+        let tmp = tempfile::tempdir().unwrap();
+        let assets = tmp.path().join("assets");
+        std::fs::create_dir_all(&assets).unwrap();
+        std::fs::write(assets.join("ok.txt"), b"declared").unwrap();
+        // A "secret" file living NEXT TO the assets directory — what
+        // a "../secret.txt" lookup would resolve to if the
+        // sandboxing didn't bite.
+        std::fs::write(tmp.path().join("secret.txt"), b"sensitive").unwrap();
+        let manifest = make_manifest(vec![AssetDecl {
+            filename: "ok.txt".into(),
+            description: None,
+            sha256: None,
+        }]);
+        let r = AssetResolver::new(tmp.path(), &manifest);
+        let err = r.read("../secret.txt").unwrap_err();
+        assert!(matches!(err, AssetError::NotDeclared(_)));
+    }
 }

--- a/src-tauri/crates/core/src/plugin/manifest.rs
+++ b/src-tauri/crates/core/src/plugin/manifest.rs
@@ -66,15 +66,21 @@ pub struct Permissions {
     /// invocation.
     #[serde(default)]
     pub http: Vec<String>,
-    /// Whether the plugin can read its bundled sidecar assets.
-    /// Default `false` — plugins that don't ship assets don't need
-    /// it. Defended at the host import layer.
+    /// Whether the plugin can read its bundled sidecar assets
+    /// (the read-only `assets/` directory shipped next to
+    /// `manifest.toml`). Default `false`. Defended at the host
+    /// import layer (`waveflow:host/storage.read-asset`).
     #[serde(default)]
     pub storage_read: bool,
-    /// Whether the plugin can write into its per-user scratch
-    /// directory. Default `false`. Subject to the 10 MB quota.
+    /// Whether the plugin can read AND write its per-user scratch
+    /// store (`waveflow:host/storage.{read,write}-state`). One
+    /// toggle covers both directions because the two host
+    /// functions operate on the same per-plugin key/value space:
+    /// granting only one would let a plugin write data it can
+    /// never read back, or vice-versa, which isn't a meaningful
+    /// security boundary. Subject to a 10 MB quota.
     #[serde(default)]
-    pub storage_write: bool,
+    pub storage_state: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,10 +89,13 @@ pub struct AssetDecl {
     /// load time so a malformed manifest can't escape the sandbox.
     pub filename: String,
     pub description: Option<String>,
-    /// Optional SHA-256 of the file's contents, hex-encoded. When
-    /// present the host verifies the asset before each load —
-    /// makes drive-by tampering detectable without a full signing
-    /// chain.
+    /// Optional SHA-256 of the file's contents, lower-case
+    /// hex-encoded. When present the host verifies the asset
+    /// before each load — makes drive-by tampering detectable
+    /// without a full signing chain. The validator normalises
+    /// uppercase input to lowercase so the comparison in
+    /// [`crate::plugin::assets::AssetResolver`] is a simple
+    /// constant-time byte equality.
     pub sha256: Option<String>,
 }
 
@@ -110,6 +119,8 @@ pub enum ManifestError {
     AssetEscape(String),
     #[error("manifest asset filename is empty")]
     EmptyAssetFilename,
+    #[error("manifest asset sha256 must be 64 hex chars: {0:?}")]
+    InvalidAssetHash(String),
 }
 
 impl Manifest {
@@ -125,8 +136,18 @@ impl Manifest {
     /// [`Self::load_from_path`] so tests can feed strings without
     /// touching the filesystem.
     pub fn parse(raw: &str) -> Result<Self, ManifestError> {
-        let parsed: Self = toml::from_str(raw)?;
+        let mut parsed: Self = toml::from_str(raw)?;
         parsed.validate()?;
+        // Lower-case every asset hash post-validation so the
+        // downstream `AssetResolver::read` byte-equality compare
+        // doesn't need to know the input came from a mixed-case
+        // source. Validation already proved each hash is 64 hex
+        // chars so this is just a case fold.
+        for asset in &mut parsed.assets {
+            if let Some(hash) = &mut asset.sha256 {
+                hash.make_ascii_lowercase();
+            }
+        }
         Ok(parsed)
     }
 
@@ -167,11 +188,11 @@ impl Manifest {
                 permissions::STORAGE_READ.into(),
             ));
         }
-        if self.permissions.storage_write
-            && !permissions::is_known(permissions::STORAGE_WRITE)
+        if self.permissions.storage_state
+            && !permissions::is_known(permissions::STORAGE_STATE)
         {
             return Err(ManifestError::UnknownPermission(
-                permissions::STORAGE_WRITE.into(),
+                permissions::STORAGE_STATE.into(),
             ));
         }
 
@@ -184,6 +205,17 @@ impl Manifest {
             // forgiving toolchain can't sneak past us.
             if asset.filename.split(['/', '\\']).any(|seg| seg == "..") {
                 return Err(ManifestError::AssetEscape(asset.filename.clone()));
+            }
+            // SHA-256 hex shape: exactly 64 hex digits (case-
+            // insensitive — `parse` normalises to lowercase post-
+            // validation). Anything else means the author typoed
+            // the digest or pasted the wrong line; reject so we
+            // don't compare against a malformed expected value
+            // and pass through a tampered asset.
+            if let Some(hash) = &asset.sha256 {
+                if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return Err(ManifestError::InvalidAssetHash(hash.clone()));
+                }
             }
         }
 

--- a/src-tauri/crates/core/src/plugin/manifest.rs
+++ b/src-tauri/crates/core/src/plugin/manifest.rs
@@ -1,0 +1,298 @@
+//! `manifest.toml` parser + validator.
+//!
+//! The plugin manifest is the contract between the author and the
+//! host. The host parses it at install time AND every boot — the
+//! second pass catches sideloads that were swapped after install
+//! (a user dropping a different plugin into the directory, an
+//! updater landing a new manifest).
+//!
+//! Validation rules:
+//!
+//! - `schema_version` MUST equal [`waveflow_plugin_sdk::MANIFEST_SCHEMA_VERSION`].
+//!   A mismatch is a hard error — silently accepting a future
+//!   schema would let unfamiliar fields go ignored.
+//! - `world` MUST be a label [`waveflow_plugin_sdk::worlds::is_known`]
+//!   recognises. Unknown world = the host can't safely bind the
+//!   wasm component and refuses to load.
+//! - Every permission in `permissions.kind` MUST be recognised by
+//!   [`waveflow_plugin_sdk::permissions::is_known`]. Unknown
+//!   permissions are rejected so a future-permission plugin
+//!   doesn't silently get NO access.
+//! - HTTP allowlist patterns are stored verbatim; the runtime
+//!   matches them at request time. We don't pre-compile globs here
+//!   because Phase 1 ships without `wasmtime` and avoiding a
+//!   pattern-matching dep keeps the bundle slim.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use waveflow_plugin_sdk::{permissions, worlds, MANIFEST_SCHEMA_VERSION};
+
+/// Parsed manifest. Public so commands / Tauri handlers can return
+/// it verbatim to the frontend without redefining the shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    /// MUST equal [`MANIFEST_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    pub plugin: PluginMetadata,
+    #[serde(default)]
+    pub permissions: Permissions,
+    #[serde(default)]
+    pub assets: Vec<AssetDecl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginMetadata {
+    /// Plugin id — used as the directory name + the host scope for
+    /// log events, storage keys, and HTTP allowlist matching.
+    /// Restricted to `[a-z0-9-]+` so it's safe on every filesystem.
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub author: String,
+    /// One of the labels in [`worlds`].
+    pub world: String,
+    pub description: Option<String>,
+    pub homepage: Option<String>,
+    pub license: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Permissions {
+    /// HTTP allowlist patterns (e.g. `"https://radio-browser.info/*"`).
+    /// Empty list means HTTP is denied. The host validates the
+    /// request URL against this list at every `waveflow:host/http.send`
+    /// invocation.
+    #[serde(default)]
+    pub http: Vec<String>,
+    /// Whether the plugin can read its bundled sidecar assets.
+    /// Default `false` — plugins that don't ship assets don't need
+    /// it. Defended at the host import layer.
+    #[serde(default)]
+    pub storage_read: bool,
+    /// Whether the plugin can write into its per-user scratch
+    /// directory. Default `false`. Subject to the 10 MB quota.
+    #[serde(default)]
+    pub storage_write: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetDecl {
+    /// Path relative to `assets/`. `..` segments are rejected at
+    /// load time so a malformed manifest can't escape the sandbox.
+    pub filename: String,
+    pub description: Option<String>,
+    /// Optional SHA-256 of the file's contents, hex-encoded. When
+    /// present the host verifies the asset before each load —
+    /// makes drive-by tampering detectable without a full signing
+    /// chain.
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    #[error("manifest io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("manifest parse: {0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("manifest schema_version mismatch: got {got}, host supports {expected}")]
+    SchemaVersionMismatch { got: u32, expected: u32 },
+    #[error("manifest world unknown: {0}")]
+    UnknownWorld(String),
+    #[error("manifest permission unknown: {0}")]
+    UnknownPermission(String),
+    #[error("manifest plugin.id is empty")]
+    EmptyId,
+    #[error("manifest plugin.id contains illegal character: {0}")]
+    InvalidIdChar(char),
+    #[error("manifest asset filename contains '..': {0}")]
+    AssetEscape(String),
+    #[error("manifest asset filename is empty")]
+    EmptyAssetFilename,
+}
+
+impl Manifest {
+    /// Parse `manifest.toml` from disk and run all the validation
+    /// checks. Returns an [`Err`] on the first failure so a partial
+    /// manifest never lands in caller-side state.
+    pub fn load_from_path(path: &Path) -> Result<Self, ManifestError> {
+        let raw = std::fs::read_to_string(path)?;
+        Self::parse(&raw)
+    }
+
+    /// Parse + validate from raw TOML. Split out from
+    /// [`Self::load_from_path`] so tests can feed strings without
+    /// touching the filesystem.
+    pub fn parse(raw: &str) -> Result<Self, ManifestError> {
+        let parsed: Self = toml::from_str(raw)?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    /// Run all the validation rules described in the module docs.
+    fn validate(&self) -> Result<(), ManifestError> {
+        if self.schema_version != MANIFEST_SCHEMA_VERSION {
+            return Err(ManifestError::SchemaVersionMismatch {
+                got: self.schema_version,
+                expected: MANIFEST_SCHEMA_VERSION,
+            });
+        }
+
+        if self.plugin.id.is_empty() {
+            return Err(ManifestError::EmptyId);
+        }
+        for ch in self.plugin.id.chars() {
+            let ok = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-';
+            if !ok {
+                return Err(ManifestError::InvalidIdChar(ch));
+            }
+        }
+
+        if !worlds::is_known(&self.plugin.world) {
+            return Err(ManifestError::UnknownWorld(self.plugin.world.clone()));
+        }
+
+        // HTTP allowlist non-emptiness is up to the plugin author —
+        // an empty list just means "this plugin has no HTTP needs".
+        // What we DO check: every kind that's "on" must be in the
+        // known catalog.
+        if !self.permissions.http.is_empty() && !permissions::is_known(permissions::HTTP) {
+            return Err(ManifestError::UnknownPermission(permissions::HTTP.into()));
+        }
+        if self.permissions.storage_read
+            && !permissions::is_known(permissions::STORAGE_READ)
+        {
+            return Err(ManifestError::UnknownPermission(
+                permissions::STORAGE_READ.into(),
+            ));
+        }
+        if self.permissions.storage_write
+            && !permissions::is_known(permissions::STORAGE_WRITE)
+        {
+            return Err(ManifestError::UnknownPermission(
+                permissions::STORAGE_WRITE.into(),
+            ));
+        }
+
+        for asset in &self.assets {
+            if asset.filename.is_empty() {
+                return Err(ManifestError::EmptyAssetFilename);
+            }
+            // `..` anywhere in the path = sandbox escape. We don't
+            // try to normalise — refuse anything suspicious so a
+            // forgiving toolchain can't sneak past us.
+            if asset.filename.split(['/', '\\']).any(|seg| seg == "..") {
+                return Err(ManifestError::AssetEscape(asset.filename.clone()));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(world: &str, http: &[&str]) -> String {
+        let http_list = http
+            .iter()
+            .map(|p| format!("\"{p}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            r#"
+schema_version = 1
+
+[plugin]
+id = "web-radio"
+name = "Web Radio"
+version = "1.0.0"
+author = "InstaZDLL"
+world = "{world}"
+
+[permissions]
+http = [{http_list}]
+storage_read = true
+"#
+        )
+    }
+
+    #[test]
+    fn parse_valid_manifest() {
+        let m = Manifest::parse(&fixture(
+            worlds::SOURCE_V1,
+            &["https://radio-browser.info/*"],
+        ))
+        .expect("valid manifest");
+        assert_eq!(m.plugin.id, "web-radio");
+        assert_eq!(m.plugin.world, worlds::SOURCE_V1);
+        assert_eq!(m.permissions.http.len(), 1);
+        assert!(m.permissions.storage_read);
+    }
+
+    #[test]
+    fn rejects_unknown_world() {
+        let raw = fixture("waveflow:bogus/v1", &[]);
+        let err = Manifest::parse(&raw).unwrap_err();
+        assert!(matches!(err, ManifestError::UnknownWorld(_)));
+    }
+
+    #[test]
+    fn rejects_uppercase_id() {
+        let raw = r#"
+schema_version = 1
+
+[plugin]
+id = "WebRadio"
+name = "x"
+version = "1"
+author = "x"
+world = "waveflow:source/v1"
+"#;
+        let err = Manifest::parse(raw).unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidIdChar('W')));
+    }
+
+    #[test]
+    fn rejects_asset_escape() {
+        let raw = r#"
+schema_version = 1
+
+[plugin]
+id = "web-radio"
+name = "x"
+version = "1"
+author = "x"
+world = "waveflow:source/v1"
+
+[[assets]]
+filename = "../etc/passwd"
+"#;
+        let err = Manifest::parse(raw).unwrap_err();
+        assert!(matches!(err, ManifestError::AssetEscape(_)));
+    }
+
+    #[test]
+    fn rejects_schema_mismatch() {
+        let raw = r#"
+schema_version = 9999
+
+[plugin]
+id = "web-radio"
+name = "x"
+version = "1"
+author = "x"
+world = "waveflow:source/v1"
+"#;
+        let err = Manifest::parse(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ManifestError::SchemaVersionMismatch {
+                got: 9999,
+                expected: 1
+            }
+        ));
+    }
+}

--- a/src-tauri/crates/core/src/plugin/mod.rs
+++ b/src-tauri/crates/core/src/plugin/mod.rs
@@ -20,7 +20,7 @@
 pub mod assets;
 pub mod manifest;
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// Root layout: `<app-data>/waveflow/plugins/<plugin-id>/manifest.toml
 /// + <plugin-id>/assets/*`. One directory per installed plugin.
@@ -29,6 +29,13 @@ pub struct PluginPaths {
     /// `<app-data>/waveflow/plugins/`.
     pub root: PathBuf,
 }
+
+/// `plugin_id` failed the path-shape check inside [`PluginPaths`].
+/// Callers should treat this the same as "manifest is invalid" —
+/// refuse to load the plugin.
+#[derive(Debug, thiserror::Error)]
+#[error("invalid plugin id: {0:?}")]
+pub struct InvalidPluginId(pub String);
 
 impl PluginPaths {
     /// Build a [`PluginPaths`] anchored at the given app-data dir.
@@ -41,26 +48,59 @@ impl PluginPaths {
         }
     }
 
-    /// Path of one plugin's root directory.
-    pub fn plugin_dir(&self, plugin_id: &str) -> PathBuf {
-        self.root.join(plugin_id)
+    /// Sanitise a plugin id so it can never escape `self.root`. The
+    /// manifest validator already restricts ids to `[a-z0-9-]+`,
+    /// but `PluginPaths` is the last line of defence: anything
+    /// that walks the id through `Path::join` without checking
+    /// would let an absolute id (`/etc/passwd`, `C:\Windows`) or
+    /// one carrying `..` segments land outside the plugins
+    /// directory. We require the input to decompose into exactly
+    /// one `Component::Normal` whose string form is byte-for-byte
+    /// what was passed in — that rules out separators, parent
+    /// segments, drive letters, and empty strings.
+    fn sanitise_id(plugin_id: &str) -> Result<&str, InvalidPluginId> {
+        if plugin_id.is_empty() {
+            return Err(InvalidPluginId(plugin_id.into()));
+        }
+        let path = Path::new(plugin_id);
+        let mut components = path.components();
+        let Some(first) = components.next() else {
+            return Err(InvalidPluginId(plugin_id.into()));
+        };
+        if components.next().is_some() {
+            return Err(InvalidPluginId(plugin_id.into()));
+        }
+        match first {
+            Component::Normal(name) if name.to_str() == Some(plugin_id) => Ok(plugin_id),
+            _ => Err(InvalidPluginId(plugin_id.into())),
+        }
+    }
+
+    /// Path of one plugin's root directory. Returns
+    /// [`InvalidPluginId`] when `plugin_id` would escape
+    /// `self.root` (absolute path, `..` segment, embedded
+    /// separator).
+    pub fn plugin_dir(&self, plugin_id: &str) -> Result<PathBuf, InvalidPluginId> {
+        Self::sanitise_id(plugin_id).map(|id| self.root.join(id))
     }
 
     /// Path to `manifest.toml` for one plugin.
-    pub fn manifest_path(&self, plugin_id: &str) -> PathBuf {
-        self.plugin_dir(plugin_id).join("manifest.toml")
+    pub fn manifest_path(&self, plugin_id: &str) -> Result<PathBuf, InvalidPluginId> {
+        self.plugin_dir(plugin_id)
+            .map(|dir| dir.join("manifest.toml"))
     }
 
     /// Path to the compiled WASM component for one plugin.
-    pub fn wasm_path(&self, plugin_id: &str) -> PathBuf {
-        self.plugin_dir(plugin_id).join("plugin.wasm")
+    pub fn wasm_path(&self, plugin_id: &str) -> Result<PathBuf, InvalidPluginId> {
+        self.plugin_dir(plugin_id)
+            .map(|dir| dir.join("plugin.wasm"))
     }
 
     /// Path to the bundled asset directory for one plugin.
     /// Empty / missing is fine — plugins that don't ship assets
     /// just leave the table out of their manifest.
-    pub fn assets_dir(&self, plugin_id: &str) -> PathBuf {
-        self.plugin_dir(plugin_id).join("assets")
+    pub fn assets_dir(&self, plugin_id: &str) -> Result<PathBuf, InvalidPluginId> {
+        self.plugin_dir(plugin_id).map(|dir| dir.join("assets"))
     }
 }
 
@@ -73,16 +113,46 @@ mod tests {
         let paths = PluginPaths::from_app_data(Path::new("/tmp/waveflow"));
         assert_eq!(paths.root, Path::new("/tmp/waveflow/plugins"));
         assert_eq!(
-            paths.manifest_path("web-radio"),
+            paths.manifest_path("web-radio").unwrap(),
             Path::new("/tmp/waveflow/plugins/web-radio/manifest.toml")
         );
         assert_eq!(
-            paths.assets_dir("web-radio"),
+            paths.assets_dir("web-radio").unwrap(),
             Path::new("/tmp/waveflow/plugins/web-radio/assets")
         );
         assert_eq!(
-            paths.wasm_path("web-radio"),
+            paths.wasm_path("web-radio").unwrap(),
             Path::new("/tmp/waveflow/plugins/web-radio/plugin.wasm")
         );
+    }
+
+    #[test]
+    fn plugin_dir_rejects_absolute_id() {
+        let paths = PluginPaths::from_app_data(Path::new("/tmp/waveflow"));
+        // Unix-style absolute id — would otherwise escape into /etc.
+        assert!(paths.plugin_dir("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn plugin_dir_rejects_parent_segment() {
+        let paths = PluginPaths::from_app_data(Path::new("/tmp/waveflow"));
+        // `..` would walk up out of the plugins directory.
+        assert!(paths.plugin_dir("../escape").is_err());
+        assert!(paths.plugin_dir("..").is_err());
+    }
+
+    #[test]
+    fn plugin_dir_rejects_embedded_separator() {
+        let paths = PluginPaths::from_app_data(Path::new("/tmp/waveflow"));
+        // Even without `..`, an embedded `/` walks into a sub-tree
+        // the host wasn't expecting (e.g. mounting an asset path as
+        // a plugin id).
+        assert!(paths.plugin_dir("web-radio/subdir").is_err());
+    }
+
+    #[test]
+    fn plugin_dir_rejects_empty() {
+        let paths = PluginPaths::from_app_data(Path::new("/tmp/waveflow"));
+        assert!(paths.plugin_dir("").is_err());
     }
 }

--- a/src-tauri/crates/core/src/plugin/mod.rs
+++ b/src-tauri/crates/core/src/plugin/mod.rs
@@ -1,0 +1,88 @@
+//! Plugin host (Phase 1: skeleton — manifest + sidecar assets).
+//!
+//! This module hosts WaveFlow's plugin protocol on the core side so
+//! both the desktop app and the future `waveflow-server` can run the
+//! same plugins. It is intentionally small at Phase 1:
+//!
+//! - [`manifest`] parses `manifest.toml` and validates the declared
+//!   world + permissions against the SDK's catalog.
+//! - [`assets`] resolves sidecar files declared in the manifest's
+//!   `[[assets]]` table. Plugins call into the host's
+//!   `waveflow:host/storage.read-asset` import which lands here.
+//! - [`PluginPaths`] resolves where plugins live on disk:
+//!   `<app-data>/waveflow/plugins/<plugin-id>/`. The same convention
+//!   on every OS (Tauri's app-data dir varies).
+//!
+//! Phase 2 will wire `wasmtime::component` for actual execution. This
+//! phase intentionally ships without `wasmtime` to keep the desktop
+//! bundle size unchanged for the bug-fix release.
+
+pub mod assets;
+pub mod manifest;
+
+use std::path::{Path, PathBuf};
+
+/// Root layout: `<app-data>/waveflow/plugins/<plugin-id>/manifest.toml
+/// + <plugin-id>/assets/*`. One directory per installed plugin.
+#[derive(Debug, Clone)]
+pub struct PluginPaths {
+    /// `<app-data>/waveflow/plugins/`.
+    pub root: PathBuf,
+}
+
+impl PluginPaths {
+    /// Build a [`PluginPaths`] anchored at the given app-data dir.
+    /// The host caller (`waveflow::AppPaths`) owns the OS-specific
+    /// resolution; this helper just appends the canonical
+    /// subdirectory so every plugin shares one layout.
+    pub fn from_app_data(app_data_dir: &Path) -> Self {
+        Self {
+            root: app_data_dir.join("plugins"),
+        }
+    }
+
+    /// Path of one plugin's root directory.
+    pub fn plugin_dir(&self, plugin_id: &str) -> PathBuf {
+        self.root.join(plugin_id)
+    }
+
+    /// Path to `manifest.toml` for one plugin.
+    pub fn manifest_path(&self, plugin_id: &str) -> PathBuf {
+        self.plugin_dir(plugin_id).join("manifest.toml")
+    }
+
+    /// Path to the compiled WASM component for one plugin.
+    pub fn wasm_path(&self, plugin_id: &str) -> PathBuf {
+        self.plugin_dir(plugin_id).join("plugin.wasm")
+    }
+
+    /// Path to the bundled asset directory for one plugin.
+    /// Empty / missing is fine — plugins that don't ship assets
+    /// just leave the table out of their manifest.
+    pub fn assets_dir(&self, plugin_id: &str) -> PathBuf {
+        self.plugin_dir(plugin_id).join("assets")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_paths_compose_under_root() {
+        let paths = PluginPaths::from_app_data(Path::new("/tmp/waveflow"));
+        assert_eq!(paths.root, Path::new("/tmp/waveflow/plugins"));
+        assert_eq!(
+            paths.manifest_path("web-radio"),
+            Path::new("/tmp/waveflow/plugins/web-radio/manifest.toml")
+        );
+        assert_eq!(
+            paths.assets_dir("web-radio"),
+            Path::new("/tmp/waveflow/plugins/web-radio/assets")
+        );
+        assert_eq!(
+            paths.wasm_path("web-radio"),
+            Path::new("/tmp/waveflow/plugins/web-radio/plugin.wasm")
+        );
+    }
+}

--- a/src-tauri/crates/plugin-sdk/Cargo.toml
+++ b/src-tauri/crates/plugin-sdk/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "waveflow-plugin-sdk"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+description = "Type-level contracts + WIT definitions shared by WaveFlow's plugin host and authors."
+publish = false
+
+# Plugin authors do NOT depend on this crate directly. They depend on
+# the `waveflow-plugin` crate that wraps the WIT-generated bindings
+# behind ergonomic traits. This crate is the workspace-internal
+# canonical source: it owns the `wit/` directory + Rust constants
+# (manifest schema version, supported world versions) that both the
+# host (`waveflow-core`) and the future `waveflow-plugin` author crate
+# import without duplicating.
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/src-tauri/crates/plugin-sdk/src/lib.rs
+++ b/src-tauri/crates/plugin-sdk/src/lib.rs
@@ -22,6 +22,30 @@ pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
 /// The three WIT worlds a plugin can export. Each one corresponds to
 /// a file under `wit/`. A plugin manifest declares exactly one
 /// world; mixing exports is out of scope for v1 of the SDK.
+///
+/// **Label vs WIT package name — intentional mismatch.** The
+/// manifest-side label uses a `/vN` major-version suffix
+/// (`"waveflow:source/v1"`) — a stable human-typed identifier
+/// authors hand-paste from this file. The WIT-side package
+/// declaration uses semver decoration (`waveflow:source@1.0.0`),
+/// which is what `wit-bindgen` / `componentize-rs` emit into the
+/// compiled binary. The two strings are related but NOT
+/// interchangeable:
+///
+/// - [`worlds::is_known`] checks the MANIFEST label only. It
+///   never sees the WIT package name.
+/// - When adding a new world you MUST update BOTH: the constant
+///   here AND the WIT package line under `wit/`. Forgetting the
+///   WIT side won't break this catalog but will refuse to
+///   instantiate the wasm at runtime; forgetting the constant
+///   means the manifest parser rejects every plugin shipping the
+///   new world.
+///
+/// Mapping convention for label → WIT package: `waveflow:<name>/v<N>`
+/// → `waveflow:<name>@<N>.0.0`. The first WIT bump beyond `<N>.0.0`
+/// (e.g. `1.1.0`) stays backwards-compatible with `v1` plugins;
+/// only a major bump (`2.0.0`) requires a new label `v2` entry
+/// here.
 pub mod worlds {
     /// `waveflow:source/v1` — source providers (Web Radio, podcasts,
     /// alternative metadata sources that yield tracks the engine
@@ -39,8 +63,10 @@ pub mod worlds {
     pub const UI_V1: &str = "waveflow:ui/v1";
 
     /// Returns `true` if the label names a world this version of the
-    /// SDK knows about. The host uses it to reject manifests
-    /// pointing at unknown worlds before instantiating the wasm.
+    /// SDK knows about. **Compares against manifest labels only**
+    /// — the WIT package strings (`waveflow:source@1.0.0`) are a
+    /// different namespace; see module-level doc for the mapping
+    /// convention.
     pub fn is_known(world: &str) -> bool {
         matches!(world, SOURCE_V1 | METADATA_V1 | UI_V1)
     }
@@ -62,21 +88,27 @@ pub mod permissions {
     /// have NO access to the host's user data, profile DBs, or
     /// arbitrary filesystem locations — this permission only
     /// covers what the plugin author shipped with the manifest.
+    /// Backs `waveflow:host/storage.read-asset`.
     pub const STORAGE_READ: &str = "storage.read";
 
-    /// Read-write access to a small per-plugin scratch directory
+    /// Read AND write access to a small per-plugin scratch store
     /// the host allocates (`~/.config/waveflow/plugin-data/<plugin-id>/`).
-    /// Used by plugins that need to persist a small amount of
-    /// per-user state (favourites, settings). Capped at 10 MB by
-    /// the host; over-quota writes fail.
-    pub const STORAGE_WRITE: &str = "storage.write";
+    /// Both `waveflow:host/storage.read-state` and
+    /// `waveflow:host/storage.write-state` gate on this single
+    /// permission — the per-plugin key/value space is a single
+    /// scope and granting only one direction would be a paper
+    /// security boundary (a plugin that can write but not read
+    /// is the same as one that can write into a key it can then
+    /// re-read with the same call). Capped at 10 MB by the host;
+    /// over-quota writes fail.
+    pub const STORAGE_STATE: &str = "storage.state";
 
     /// Returns `true` if the string names a permission this SDK
     /// version recognises. Unknown permissions in a manifest are
     /// surfaced as a load-time error so a future-permission plugin
     /// doesn't silently get NO access.
     pub fn is_known(perm: &str) -> bool {
-        matches!(perm, HTTP | STORAGE_READ | STORAGE_WRITE)
+        matches!(perm, HTTP | STORAGE_READ | STORAGE_STATE)
     }
 }
 
@@ -96,7 +128,7 @@ mod tests {
     fn known_permissions_round_trip() {
         assert!(permissions::is_known(permissions::HTTP));
         assert!(permissions::is_known(permissions::STORAGE_READ));
-        assert!(permissions::is_known(permissions::STORAGE_WRITE));
+        assert!(permissions::is_known(permissions::STORAGE_STATE));
         assert!(!permissions::is_known("network.tcp"));
     }
 }

--- a/src-tauri/crates/plugin-sdk/src/lib.rs
+++ b/src-tauri/crates/plugin-sdk/src/lib.rs
@@ -1,0 +1,102 @@
+//! WaveFlow Plugin SDK — type-level contracts.
+//!
+//! This crate is the workspace-internal source of truth for the
+//! plugin protocol. It is intentionally small: it only declares the
+//! manifest schema version + the supported WIT world labels. Both
+//! sides of the contract (the host in `waveflow-core::plugin` and
+//! the future author-facing `waveflow-plugin` crate) read from here
+//! so there's exactly one place to bump when the protocol moves.
+//!
+//! WIT files live under `wit/`. They are NOT consumed by this crate
+//! directly — Phase 2 will wire `wasmtime::component::bindgen!` from
+//! `waveflow-core::plugin::runtime` and the eventual `waveflow-plugin`
+//! author crate will wire `wit-bindgen` macros. Both will point at
+//! `crates/plugin-sdk/wit/` so there is no duplicated source.
+
+/// Plugin manifest schema version. Bumped on every breaking change to
+/// `manifest.toml` format. Plugins ship the version they were
+/// authored against; the host rejects any mismatch at load time
+/// rather than silently misinterpreting fields.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// The three WIT worlds a plugin can export. Each one corresponds to
+/// a file under `wit/`. A plugin manifest declares exactly one
+/// world; mixing exports is out of scope for v1 of the SDK.
+pub mod worlds {
+    /// `waveflow:source/v1` — source providers (Web Radio, podcasts,
+    /// alternative metadata sources that yield tracks the engine
+    /// can play). See `wit/waveflow-source.wit`.
+    pub const SOURCE_V1: &str = "waveflow:source/v1";
+
+    /// `waveflow:metadata/v1` — metadata enrichers (Musixmatch,
+    /// MusicBrainz, Discogs). Don't return tracks; enrich existing
+    /// rows with biographies, similar artists, lyrics. See
+    /// `wit/waveflow-metadata.wit`.
+    pub const METADATA_V1: &str = "waveflow:metadata/v1";
+
+    /// `waveflow:ui/v1` — UI extensions (custom views, panels). Return
+    /// view descriptors the host renders. See `wit/waveflow-ui.wit`.
+    pub const UI_V1: &str = "waveflow:ui/v1";
+
+    /// Returns `true` if the label names a world this version of the
+    /// SDK knows about. The host uses it to reject manifests
+    /// pointing at unknown worlds before instantiating the wasm.
+    pub fn is_known(world: &str) -> bool {
+        matches!(world, SOURCE_V1 | METADATA_V1 | UI_V1)
+    }
+}
+
+/// Host permission identifiers (manifest `[permissions]` table).
+/// Plugins declare what they need; the host enforces these at the
+/// wasm import boundary. Anything not declared is denied by
+/// default.
+pub mod permissions {
+    /// Outbound HTTP. The value declared in the manifest is an
+    /// allowlist of host patterns (`https://example.com/*`). The
+    /// host validates every URL against the list before dispatching
+    /// the `waveflow:host/http` import.
+    pub const HTTP: &str = "http";
+
+    /// Read-only access to plugin-bundled sidecar assets (the
+    /// `assets/` subdirectory next to `manifest.toml`). Plugins
+    /// have NO access to the host's user data, profile DBs, or
+    /// arbitrary filesystem locations — this permission only
+    /// covers what the plugin author shipped with the manifest.
+    pub const STORAGE_READ: &str = "storage.read";
+
+    /// Read-write access to a small per-plugin scratch directory
+    /// the host allocates (`~/.config/waveflow/plugin-data/<plugin-id>/`).
+    /// Used by plugins that need to persist a small amount of
+    /// per-user state (favourites, settings). Capped at 10 MB by
+    /// the host; over-quota writes fail.
+    pub const STORAGE_WRITE: &str = "storage.write";
+
+    /// Returns `true` if the string names a permission this SDK
+    /// version recognises. Unknown permissions in a manifest are
+    /// surfaced as a load-time error so a future-permission plugin
+    /// doesn't silently get NO access.
+    pub fn is_known(perm: &str) -> bool {
+        matches!(perm, HTTP | STORAGE_READ | STORAGE_WRITE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_worlds_round_trip() {
+        assert!(worlds::is_known(worlds::SOURCE_V1));
+        assert!(worlds::is_known(worlds::METADATA_V1));
+        assert!(worlds::is_known(worlds::UI_V1));
+        assert!(!worlds::is_known("waveflow:bogus/v1"));
+    }
+
+    #[test]
+    fn known_permissions_round_trip() {
+        assert!(permissions::is_known(permissions::HTTP));
+        assert!(permissions::is_known(permissions::STORAGE_READ));
+        assert!(permissions::is_known(permissions::STORAGE_WRITE));
+        assert!(!permissions::is_known("network.tcp"));
+    }
+}

--- a/src-tauri/crates/plugin-sdk/wit/waveflow-host.wit
+++ b/src-tauri/crates/plugin-sdk/wit/waveflow-host.wit
@@ -48,6 +48,7 @@ interface log {
 interface storage {
   /// Read a bundled sidecar asset. `path` is a relative path within
   /// the plugin's `assets/` directory; `..` segments are rejected.
+  /// Gated by the manifest permission `storage.read`.
   ///
   /// The asset bundle is declared in `manifest.toml` (`[[assets]]`
   /// table). Reading an asset not declared in the manifest fails
@@ -55,11 +56,18 @@ interface storage {
   read-asset: func(path: string) -> result<list<u8>, string>;
 
   /// Read a key from the plugin's per-user scratch store. Returns
-  /// `none` if the key was never written.
+  /// `none` if the key was never written. Gated by the manifest
+  /// permission `storage.state` — the SAME permission that gates
+  /// `write-state`. The two functions operate on a single
+  /// per-plugin key/value space; granting only one direction
+  /// would be a paper boundary, so the manifest spells the
+  /// capability as one toggle.
   read-state: func(key: string) -> result<option<list<u8>>, string>;
 
   /// Write a key into the plugin's per-user scratch store. The
   /// host enforces a per-plugin 10 MB cap (total across all keys);
   /// overflowing writes fail with `Err("storage quota exceeded")`.
+  /// Gated by the manifest permission `storage.state` — see
+  /// `read-state` for why read + write share one toggle.
   write-state: func(key: string, value: list<u8>) -> result<_, string>;
 }

--- a/src-tauri/crates/plugin-sdk/wit/waveflow-host.wit
+++ b/src-tauri/crates/plugin-sdk/wit/waveflow-host.wit
@@ -1,0 +1,65 @@
+// WaveFlow host API — v1.
+//
+// Imports that EVERY plugin world pulls in. Plugins don't talk to
+// the network, the filesystem, or the host's log subsystem
+// directly: those operations go through `waveflow:host/*` so the
+// host can permission-check, rate-limit, and observe them.
+
+package waveflow:host@1.0.0;
+
+interface http {
+  record request {
+    method: string,                 // "GET", "POST", ...
+    url: string,
+    headers: list<tuple<string, string>>,
+    /// Optional request body. UTF-8 encoded if it's text; raw bytes
+    /// if it's binary (the host doesn't transcode).
+    body: option<list<u8>>,
+  }
+
+  record response {
+    status: u16,
+    headers: list<tuple<string, string>>,
+    body: list<u8>,
+  }
+
+  /// Outbound HTTP. The host validates `url` against the plugin's
+  /// `permissions.http` allowlist BEFORE dispatching. A url that's
+  /// not on the list returns `Err("permission denied: <url>")`
+  /// without making a network call.
+  send: func(req: request) -> result<response, string>;
+}
+
+interface log {
+  enum level {
+    trace,
+    debug,
+    info,
+    warn,
+    error,
+  }
+
+  /// Forwarded into the host's `tracing` subsystem as a structured
+  /// event with `plugin = <plugin-id>` set automatically — plugins
+  /// don't need to thread their id into every message.
+  emit: func(level: level, message: string);
+}
+
+interface storage {
+  /// Read a bundled sidecar asset. `path` is a relative path within
+  /// the plugin's `assets/` directory; `..` segments are rejected.
+  ///
+  /// The asset bundle is declared in `manifest.toml` (`[[assets]]`
+  /// table). Reading an asset not declared in the manifest fails
+  /// with `Err("asset not bundled: <path>")`.
+  read-asset: func(path: string) -> result<list<u8>, string>;
+
+  /// Read a key from the plugin's per-user scratch store. Returns
+  /// `none` if the key was never written.
+  read-state: func(key: string) -> result<option<list<u8>>, string>;
+
+  /// Write a key into the plugin's per-user scratch store. The
+  /// host enforces a per-plugin 10 MB cap (total across all keys);
+  /// overflowing writes fail with `Err("storage quota exceeded")`.
+  write-state: func(key: string, value: list<u8>) -> result<_, string>;
+}

--- a/src-tauri/crates/plugin-sdk/wit/waveflow-metadata.wit
+++ b/src-tauri/crates/plugin-sdk/wit/waveflow-metadata.wit
@@ -1,0 +1,50 @@
+// WaveFlow metadata enricher world — v1.
+//
+// Plugins exporting this world enrich existing library rows: artist
+// biographies, similar-artist suggestions, lyrics. They don't yield
+// new tracks; the engine fans calls out to every metadata plugin in
+// parallel and merges the results behind a fallback chain.
+
+package waveflow:metadata@1.0.0;
+
+interface enricher {
+  record artist-info {
+    bio: option<string>,
+    image-url: option<string>,
+    similar: list<string>,
+  }
+
+  record album-info {
+    description: option<string>,
+    cover-url: option<string>,
+    track-count: option<u32>,
+  }
+
+  record lyrics-line {
+    /// Timecode in milliseconds from track start. `none` = the
+    /// line is plain (un-synced) text.
+    time-ms: option<u32>,
+    text: string,
+  }
+
+  /// Free-form artist info lookup by name. Plugins normalise the
+  /// name themselves (case, diacritics) — the host hands what the
+  /// user has, verbatim.
+  artist-info: func(name: string) -> result<artist-info, string>;
+
+  /// Album lookup. Some plugins key on `(artist, title)` pairs;
+  /// pass both even if your DB only uses one.
+  album-info: func(artist: string, title: string) -> result<album-info, string>;
+
+  /// Lyrics lookup. Plugins return a list of lines (possibly
+  /// time-coded) so the host doesn't need to parse multiple text
+  /// formats — empty list = no lyrics for this track.
+  lyrics: func(artist: string, title: string) -> result<list<lyrics-line>, string>;
+}
+
+world plugin {
+  import waveflow:host/http@1.0.0;
+  import waveflow:host/log@1.0.0;
+  import waveflow:host/storage@1.0.0;
+  export enricher;
+}

--- a/src-tauri/crates/plugin-sdk/wit/waveflow-source.wit
+++ b/src-tauri/crates/plugin-sdk/wit/waveflow-source.wit
@@ -1,0 +1,65 @@
+// WaveFlow source provider world — v1.
+//
+// Plugins exporting this world supply tracks the engine can play:
+// internet radio stations, podcasts, network shares, anything the
+// user wants to browse + queue alongside their local library.
+//
+// `resolve` lists tracks for a category / search query.
+// `stream-url` returns the actual stream URL lazily at play time so
+// short-lived tokens don't expire between resolve and playback.
+//
+// Hosts: `waveflow:host/http`, `waveflow:host/log`, `waveflow:host/storage`.
+
+package waveflow:source@1.0.0;
+
+interface provider {
+  record track {
+    /// Plugin-scoped opaque id. Returned to `stream-url` later;
+    /// don't expose anything sensitive (tokens, file paths the user
+    /// hasn't asked to share) — the host stores this string
+    /// verbatim in its history rows.
+    id: string,
+    title: string,
+    artist: string,
+    album: option<string>,
+    duration-ms: u32,
+    artwork-url: option<string>,
+    /// Optional ICY metadata stream URL (radio). When present, the
+    /// host periodically polls it during playback to surface
+    /// now-playing text.
+    icy-url: option<string>,
+  }
+
+  record entry {
+    /// Human-readable display label (`"Jazz stations"`, `"News
+    /// podcasts"`). Shown verbatim in the host's category browser.
+    label: string,
+    /// Opaque token the host hands back to `resolve` to ask for
+    /// this entry's tracks.
+    query: string,
+    /// Optional icon hint — host renders generic icon if absent.
+    icon-url: option<string>,
+  }
+
+  /// Top-level browse points the plugin offers. Returned when the
+  /// user first opens the plugin's view. Empty list = no built-in
+  /// categories; the user only finds content via search.
+  list-entries: func() -> result<list<entry>, string>;
+
+  /// Resolve a category / search query to a track list. `query` is
+  /// either the opaque token returned in `entry.query` or a free-
+  /// form user search string (the plugin decides which is which).
+  resolve: func(query: string) -> result<list<track>, string>;
+
+  /// Return the playable URL for a track. Called at play time so
+  /// the plugin can mint a fresh signed URL / token. Plugins that
+  /// serve direct streams can return the same URL on every call.
+  stream-url: func(track-id: string) -> result<string, string>;
+}
+
+world plugin {
+  import waveflow:host/http@1.0.0;
+  import waveflow:host/log@1.0.0;
+  import waveflow:host/storage@1.0.0;
+  export provider;
+}

--- a/src-tauri/crates/plugin-sdk/wit/waveflow-ui.wit
+++ b/src-tauri/crates/plugin-sdk/wit/waveflow-ui.wit
@@ -1,0 +1,24 @@
+// WaveFlow UI extension world — v1 SKELETON.
+//
+// Reserved for v1.7+ scope: plugins can describe custom views the
+// host renders (categories in the sidebar, panels in the right
+// drawer). The shape is sketched here so the world id is stable,
+// but the host runtime won't bind this world until UI plugins
+// actually land.
+
+package waveflow:ui@1.0.0;
+
+interface extension {
+  /// Sketched: a JSON-encoded view descriptor the host's React
+  /// renderer interprets. The exact schema is still in design —
+  /// holding the surface flat for v1 keeps the world id reusable
+  /// while leaving room to evolve.
+  render: func() -> result<string, string>;
+}
+
+world plugin {
+  import waveflow:host/http@1.0.0;
+  import waveflow:host/log@1.0.0;
+  import waveflow:host/storage@1.0.0;
+  export extension;
+}


### PR DESCRIPTION
## Summary

First slice of the plugin SDK landing as a foundation pass. **No wasmtime yet** — Phase 2 wires the runtime once the contract has stabilized on-disk.

This PR delivers:
- New \`waveflow-plugin-sdk\` workspace crate (constants + WIT files under \`wit/\`).
- \`waveflow-core::plugin\` module: \`manifest\` parser + validator and \`assets\` resolver (option B from the SDK design — sidecar files next to \`manifest.toml\`, not bundled inside the \`.wasm\`).
- \`PluginPaths\` owning the on-disk layout (\`<app-data>/waveflow/plugins/<id>/{manifest.toml, plugin.wasm, assets/...}\`).

## Validation rules in this PR

- Manifest \`schema_version\` MUST equal SDK's \`MANIFEST_SCHEMA_VERSION\` (= 1). Future-schema plugin → hard error.
- \`world\` MUST be in \`waveflow:source/v1\` / \`waveflow:metadata/v1\` / \`waveflow:ui/v1\` (the three WIT files under \`wit/\`).
- Plugin id restricted to \`[a-z0-9-]+\`.
- Asset filenames reject \`..\` at parse time AND at read time (defence in depth).
- Asset reads canonicalise symlinks against \`assets_root\` to prevent sandbox escape.
- Optional SHA-256 verification with constant-time compare.

## What's still ahead (Phase 2-4)

| Phase | Scope |
|---|---|
| 2 | wasmtime + Component Model runtime, host_impl.rs binds the WIT host imports |
| 3 | Tauri commands (\`list_plugins\`, \`install_plugin\`, \`call_plugin_*\`), frontend Settings → Plugins panel |
| 4 | First plugin: Web Radio, porting receiver-core to \`wasm32-wasip2\` with the 10 MB stations.db sidecar |

## Test plan

- [x] 9 unit tests in \`waveflow-core::plugin\` cover manifest parse + every rejection branch + asset reads + tampering detection
- [x] 2 SDK tests for the known-world / known-permission catalog helpers
- [x] \`cargo check --workspace --all-targets\` green
- [x] Manual: Phase 1 ships without runtime so no integration smoke yet — Phase 2 PR brings it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Nouveau système de plugins pour étendre l’application (sources, enrichisseurs de métadonnées, extensions UI).
  * Chargement de manifeste avec validation stricte et sécurité renforcée.
  * Gestion sécurisée des assets de plugin avec vérification d’intégrité (SHA‑256) et protections contre l’évasion de répertoires.
  * API hôte standardisée (HTTP, journalisation, stockage/état) pour l’interaction plugins↔hôte.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->