### PR TITLE
feat(plugin-sdk): wasmtime runtime skeleton + sandbox (phase 2a)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +519,9 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -639,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
 ]
 
 [[package]]
@@ -690,6 +702,15 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cocoa"
@@ -868,7 +889,7 @@ dependencies = [
  "jni 0.21.1",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.5.0",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -884,6 +905,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -903,6 +933,148 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c4ebb31662e2051dcc49b7342d222405a99e951720756cc4b93315972abd67"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dfc2ec96ec1c3a8a250602e936712e00a381df032f7a8ad175c8f768c03bb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5694aa8a2eb2571a15b3feee38d16ccaf2712200e7b5c9ae0479069bdfb46949"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab349d30a5fad9699440ee7ccb435374e8a8735dcca26696a4245bcefcc47e"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e95970bdb51d145c828a114a1084cb8b63e65569a51600ad398cb49fa78b062"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8414b8ecc81f89f8a3f2c5cbc785b9ed690200cd6f9d780e96a92f88879704"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck 0.5.0",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631c4e5db42e6a0f9e7a68f18f7faba3692862114870c7c598aee7e0e5677e59"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c6e92c825abfbb739a4beaa5db3988f98a96a68d6ea656f562098efc142976"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e57cd185782abada9ab2606bfe88d0abc0d42d83a7d432dcf69991e17fe76e"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0f17e48d15e29552e2f264d302c31a661a830196d879bbdaf4d7b2bf2f7011"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "407b80b46934c9dce9a6581f0e80d079b7a69e11372fb03d7dce4c7ba3fee4e3"
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a40e056e421d9a6c757983f2184f765ae1c28a51555d3877e98afc97ce5705b"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdbadda21e49798825a1ec795dab30bcb03235891f662b5ccf23fa45b39682f"
 
 [[package]]
 name = "crc"
@@ -933,6 +1105,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1378,6 +1569,27 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1916,6 +2128,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2327,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -2574,6 +2803,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +3053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +3167,15 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
@@ -2980,6 +3233,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "memoffset"
@@ -3498,6 +3760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
 name = "ogg_pager"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3777,6 +4051,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3885,6 +4171,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6ccdd6fc70f6c33eb21cb8fe05a71a5f7ee4cbef7a093a8a87dd8a908697cd"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00101fdb6fcaf9ea98a1994be11861d7e0c910c718c41bae373c44179e3160c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4056,6 +4365,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "realfft"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4113,6 +4442,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -4318,6 +4661,12 @@ dependencies = [
  "visibility",
  "windowfunctions",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -5521,6 +5870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tauri"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5929,6 +6284,15 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -6847,7 +7211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -6858,8 +7232,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -6885,6 +7259,254 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c191891081c3bf9f10cb579819b32b0e81695641dc639eef34b57cf10c59ad81"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags 2.13.0",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "libc",
+ "log",
+ "mach2 0.4.3",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rayon",
+ "rustix",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f337d68a62d868f3c297517b46d20dc7e293f0da36bbee2f6ec3c30eab938bd"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1cc8df1940657960571d7bc9bc0eadf869c0eb95cff831a6554409f89b25b0"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73ccd2e0e6bd91fb0161a17ee5e2d7badbeba6eb7461d0e0e3991492bd3835d"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110bf85122cd451d3b9ff67f8911d428ec9b729208abe950a0333c3244660e88"
+dependencies = [
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0236a21553c5b30ee953f413a8dc99729548b747219eef7e70f8288ed313ebe"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccd50931b61ad593ae91e62d41a96b997b26c9308305cae4523cfef9301d9e8"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a52ca7429272234b44f81fdf80d4793593e5c368b0f960d41fd401b1117bec"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa6818a4864719772680694f4e4649a8600bb5efcf71111ebaf7419b266463e8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdc6a69c42fbbf13104ccbf0d3c096d0392f00102e2c70b542d9fca402eb162"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0bd1cd696ec4b7e6f46357c0479e7739c3858e54afb69a15765402bbc1f9dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2ca01234ef55acd10c0fa5a2f96c3fd422eba03b221e2e9572944d19a476a7"
+dependencies = [
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b3d8cfaad2d33a92ec4ed93d69e9836c04f7eb5b8dfe1dde9df47c41f20b7"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.0",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
@@ -6985,6 +7607,7 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "usvg",
+ "wasmtime",
  "waveflow-plugin-sdk",
 ]
 
@@ -7167,6 +7790,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fdfab04a4d446c558a9ea994ded662d35580a17b15385b862002703aa43245"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+]
 
 [[package]]
 name = "window-vibrancy"
@@ -7706,7 +8348,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -7753,10 +8395,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -7774,7 +8416,26 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -120,6 +120,20 @@ sha2 = "0.10"
 # crate both sides import.
 waveflow-plugin-sdk = { path = "../plugin-sdk" }
 
+# WebAssembly Component Model runtime — Phase 2a wires the engine,
+# component loader, and sandbox config (fuel, memory cap, epoch
+# interrupt). The `bindgen!` macro generates the host-side trait shells
+# from the WIT files under `../plugin-sdk/wit/`; Phase 2b implements
+# them in `plugin::host_impl`. Defaults trimmed: we don't need the
+# pooling allocator, async API, coredump, or addr2line debug-info paths
+# in v1 — sync API + cranelift JIT keeps the bundle bump near 5 MB.
+wasmtime = { version = "45", default-features = false, features = [
+    "runtime",
+    "cranelift",
+    "component-model",
+    "parallel-compilation",
+] }
+
 [dev-dependencies]
 # Sandboxed scratch directories for the smart-playlist cover render
 # tests. Same usage shape as the app crate's existing dev-dep.

--- a/src-tauri/crates/core/src/plugin/mod.rs
+++ b/src-tauri/crates/core/src/plugin/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod assets;
 pub mod manifest;
+pub mod runtime;
 
 use std::path::{Component, Path, PathBuf};
 

--- a/src-tauri/crates/core/src/plugin/runtime.rs
+++ b/src-tauri/crates/core/src/plugin/runtime.rs
@@ -17,6 +17,7 @@
 //! long-running compute task. The host can raise them per plugin
 //! later; Phase 2a only exposes the defaults.
 
+use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -85,8 +86,10 @@ pub enum RuntimeError {
     Io(#[from] std::io::Error),
     #[error("wasmtime: {0}")]
     Wasmtime(#[from] wasmtime::Error),
-    #[error("plugin.wasm too large: {size} bytes (max {max})")]
+    #[error("plugin.wasm too large: at least {size} bytes (max {max})")]
     WasmTooLarge { size: u64, max: u64 },
+    #[error("plugin.wasm is not a regular file")]
+    WasmNotRegularFile,
 }
 
 /// Process-wide plugin runtime. Owns the [`Engine`] (`Send + Sync`
@@ -174,18 +177,29 @@ impl PluginRuntime {
         let manifest_path = paths.manifest_path(plugin_id)?;
         let manifest = Manifest::load_from_path(&manifest_path)?;
         let wasm_path = paths.wasm_path(plugin_id)?;
-        // Stat first — refuse to slurp a multi-GB blob into a `Vec<u8>`
-        // even if the user (or a malicious sideload) put one in the
-        // plugin directory. `fs::metadata` is cheap and lets us
-        // surface the size in the error without paying the read cost.
-        let size = std::fs::metadata(&wasm_path)?.len();
-        if size > MAX_WASM_SIZE {
+        // Open once, stat the same handle, read from the same handle.
+        // Separating `fs::metadata` from `fs::read` is a TOCTOU window
+        // (a sideloaded plugin could swap the file between the two
+        // syscalls) AND `metadata.len()` reports 0 for FIFOs / sockets
+        // / character devices — those would slip past a pre-stat size
+        // check and stream unbounded bytes into our `Vec`. Open the
+        // handle, confirm it's a regular file, then bound the read at
+        // `MAX_WASM_SIZE + 1` so anything over the cap is detected
+        // without ever holding more than `MAX_WASM_SIZE + 1` bytes
+        // in memory.
+        let file = std::fs::File::open(&wasm_path)?;
+        let meta = file.metadata()?;
+        if !meta.file_type().is_file() {
+            return Err(RuntimeError::WasmNotRegularFile);
+        }
+        let mut bytes = Vec::with_capacity(meta.len().min(MAX_WASM_SIZE) as usize);
+        let read = file.take(MAX_WASM_SIZE + 1).read_to_end(&mut bytes)? as u64;
+        if read > MAX_WASM_SIZE {
             return Err(RuntimeError::WasmTooLarge {
-                size,
+                size: read,
                 max: MAX_WASM_SIZE,
             });
         }
-        let bytes = std::fs::read(&wasm_path)?;
         let component = Component::from_binary(&self.inner.engine, &bytes)?;
         Ok(LoadedPlugin {
             manifest,

--- a/src-tauri/crates/core/src/plugin/runtime.rs
+++ b/src-tauri/crates/core/src/plugin/runtime.rs
@@ -26,6 +26,15 @@ use wasmtime::{Config, Engine, OptLevel, Store, StoreLimits, StoreLimitsBuilder}
 use crate::plugin::manifest::{Manifest, ManifestError};
 use crate::plugin::{InvalidPluginId, PluginPaths};
 
+/// Hard cap on the compiled `plugin.wasm` size we'll read off disk.
+/// Defence-in-depth against a hostile sideload: a multi-GB file
+/// would OOM the host long before wasmtime ever got a chance to
+/// reject it. 50 MB is comfortable headroom for our largest planned
+/// plugin (Web Radio with a ~10 MB SQLite + icon cache + bindings,
+/// ballparked at 15-20 MB compiled); anything bigger is suspect and
+/// gets refused at the syscall boundary.
+const MAX_WASM_SIZE: u64 = 50 * 1024 * 1024;
+
 /// Sandbox limits applied to every plugin Store this runtime spins
 /// up. Cloning is cheap (three integers); the runtime takes one of
 /// these by value at construction and hands it to each Store.
@@ -76,6 +85,8 @@ pub enum RuntimeError {
     Io(#[from] std::io::Error),
     #[error("wasmtime: {0}")]
     Wasmtime(#[from] wasmtime::Error),
+    #[error("plugin.wasm too large: {size} bytes (max {max})")]
+    WasmTooLarge { size: u64, max: u64 },
 }
 
 /// Process-wide plugin runtime. Owns the [`Engine`] (`Send + Sync`
@@ -163,6 +174,17 @@ impl PluginRuntime {
         let manifest_path = paths.manifest_path(plugin_id)?;
         let manifest = Manifest::load_from_path(&manifest_path)?;
         let wasm_path = paths.wasm_path(plugin_id)?;
+        // Stat first — refuse to slurp a multi-GB blob into a `Vec<u8>`
+        // even if the user (or a malicious sideload) put one in the
+        // plugin directory. `fs::metadata` is cheap and lets us
+        // surface the size in the error without paying the read cost.
+        let size = std::fs::metadata(&wasm_path)?.len();
+        if size > MAX_WASM_SIZE {
+            return Err(RuntimeError::WasmTooLarge {
+                size,
+                max: MAX_WASM_SIZE,
+            });
+        }
         let bytes = std::fs::read(&wasm_path)?;
         let component = Component::from_binary(&self.inner.engine, &bytes)?;
         Ok(LoadedPlugin {
@@ -283,6 +305,45 @@ mod tests {
             Ok(_) => panic!("expected error, got Ok"),
             Err(RuntimeError::InvalidId(_)) => {}
             Err(err) => panic!("expected InvalidId, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn load_plugin_refuses_oversized_wasm() {
+        // Lay down a valid manifest + a sparse "plugin.wasm" whose
+        // file length exceeds `MAX_WASM_SIZE`. We use `set_len` on
+        // an empty file so the disk footprint stays trivial — the
+        // guard reads `fs::metadata().len()` which reflects the
+        // logical (sparse) size, not allocated blocks.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let runtime = PluginRuntime::new(RuntimeConfig::default()).expect("engine builds");
+        let paths = PluginPaths::from_app_data(tmp.path());
+        let plugin_dir = paths.plugin_dir("oversize").expect("dir");
+        std::fs::create_dir_all(&plugin_dir).expect("mkdir");
+
+        let manifest = r#"
+schema_version = 1
+
+[plugin]
+id = "oversize"
+name = "x"
+version = "1"
+author = "x"
+world = "waveflow:source/v1"
+"#;
+        std::fs::write(plugin_dir.join("manifest.toml"), manifest).expect("write manifest");
+
+        let wasm = std::fs::File::create(plugin_dir.join("plugin.wasm")).expect("create wasm");
+        wasm.set_len(MAX_WASM_SIZE + 1).expect("set_len");
+        drop(wasm);
+
+        match runtime.load_plugin(&paths, "oversize") {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(RuntimeError::WasmTooLarge { size, max }) => {
+                assert_eq!(size, MAX_WASM_SIZE + 1);
+                assert_eq!(max, MAX_WASM_SIZE);
+            }
+            Err(err) => panic!("expected WasmTooLarge, got {err:?}"),
         }
     }
 

--- a/src-tauri/crates/core/src/plugin/runtime.rs
+++ b/src-tauri/crates/core/src/plugin/runtime.rs
@@ -1,0 +1,301 @@
+//! Wasmtime runtime skeleton (Phase 2a).
+//!
+//! This module owns the process-wide [`Engine`] + the per-plugin
+//! sandbox knobs (fuel, memory cap, epoch interrupt) and resolves a
+//! plugin id on disk into a compiled [`Component`] paired with its
+//! parsed manifest. It intentionally does NOT yet bind any host
+//! imports — Phase 2b adds the `waveflow:host/{http,log,storage}`
+//! impls + the `bindgen!` wiring + the per-world [`Linker`]. The
+//! intent is a reviewable foundation: a host can `load_plugin` and
+//! confirm the wasm parses, before any guest code is actually
+//! instantiated.
+//!
+//! Sandbox defaults — see [`RuntimeConfig`] for the values. They're
+//! aggressive (64 MB / 100M fuel / 30 s epoch deadline) compared to
+//! a generic wasm host because a music-player plugin is expected to
+//! do small bursts of I/O around an HTTP fetch + a parse, not a
+//! long-running compute task. The host can raise them per plugin
+//! later; Phase 2a only exposes the defaults.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use wasmtime::component::{Component, ResourceTable};
+use wasmtime::{Config, Engine, OptLevel, Store, StoreLimits, StoreLimitsBuilder};
+
+use crate::plugin::manifest::{Manifest, ManifestError};
+use crate::plugin::{InvalidPluginId, PluginPaths};
+
+/// Sandbox limits applied to every plugin Store this runtime spins
+/// up. Cloning is cheap (three integers); the runtime takes one of
+/// these by value at construction and hands it to each Store.
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    /// Max fuel units a guest call may consume before trapping.
+    /// Wasmtime decrements fuel on every wasm instruction; a fuel
+    /// trap aborts the call cleanly without affecting other plugins
+    /// or the host. 100M ≈ a few seconds of pure compute on typical
+    /// hardware — comfortable headroom for an HTTP-bound plugin.
+    pub fuel_per_call: u64,
+
+    /// Max linear-memory bytes the guest may allocate. Enforced via
+    /// [`ResourceLimiter`] — an over-cap `memory.grow` returns 0 to
+    /// the guest (the standard wasm out-of-memory signal). 64 MB
+    /// covers a Web Radio plugin embedding a SQLite cache + an icon
+    /// resize buffer with margin.
+    pub max_memory_bytes: usize,
+
+    /// Number of epoch ticks a guest call may pass through before
+    /// being interrupted. The host runs a 10 ms ticker that calls
+    /// [`Engine::increment_epoch`], so the default 3_000 ticks ≈ 30 s
+    /// wall-clock — long enough to swallow a slow network round-trip
+    /// without strangling a plugin that's intentionally polling.
+    pub epoch_ticks_per_call: u64,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            fuel_per_call: 100_000_000,
+            max_memory_bytes: 64 * 1024 * 1024,
+            epoch_ticks_per_call: 3_000,
+        }
+    }
+}
+
+/// Errors that can surface from the plugin runtime. Each variant is
+/// either a wasmtime-side failure (compile / instantiate / trap) or
+/// a path / manifest issue we caught before touching wasm.
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("invalid plugin id: {0}")]
+    InvalidId(#[from] InvalidPluginId),
+    #[error("manifest: {0}")]
+    Manifest(#[from] ManifestError),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("wasmtime: {0}")]
+    Wasmtime(#[from] wasmtime::Error),
+}
+
+/// Process-wide plugin runtime. Owns the [`Engine`] (`Send + Sync`
+/// across threads) plus the shared sandbox config. One instance per
+/// app — cheap to clone via [`Arc`] when handing into a tokio task.
+#[derive(Clone)]
+pub struct PluginRuntime {
+    inner: Arc<RuntimeInner>,
+}
+
+struct RuntimeInner {
+    engine: Engine,
+    config: RuntimeConfig,
+}
+
+impl PluginRuntime {
+    /// Build a runtime with the given sandbox config. Fails if
+    /// wasmtime rejects the `Config` (impossible with the static
+    /// settings here today — defensive against future feature
+    /// upgrades).
+    pub fn new(config: RuntimeConfig) -> Result<Self, RuntimeError> {
+        let mut wt = Config::new();
+        // Component Model is the only execution mode plugins use —
+        // raw wasm modules aren't a supported plugin shape.
+        wt.wasm_component_model(true);
+        // Fuel + epoch are the two independent sandboxes: fuel
+        // catches infinite loops at the instruction level, epoch
+        // catches blocked host calls (an import that never returns)
+        // at wall-clock granularity. Both are required because
+        // neither alone catches the other's failure mode.
+        wt.consume_fuel(true);
+        wt.epoch_interruption(true);
+        // Threads stay off because the crate doesn't enable
+        // wasmtime's `threads` Cargo feature — there's no `Config`
+        // toggle to disable what isn't compiled in. If a future
+        // change opts that feature in, add `wt.wasm_threads(false)`
+        // back here so a plugin can never spin up wasm threads
+        // outside the host's resource accounting.
+        // Plugins are loaded once and called many times; spend the
+        // compile budget on faster steady-state code instead of
+        // shorter compile time.
+        wt.cranelift_opt_level(OptLevel::Speed);
+
+        let engine = Engine::new(&wt)?;
+        Ok(Self {
+            inner: Arc::new(RuntimeInner { engine, config }),
+        })
+    }
+
+    /// Shared [`Engine`] handle — pass to `bindgen!`-generated
+    /// `add_to_linker` helpers in Phase 2b.
+    pub fn engine(&self) -> &Engine {
+        &self.inner.engine
+    }
+
+    /// Sandbox config used for every Store spun up by this runtime.
+    pub fn config(&self) -> &RuntimeConfig {
+        &self.inner.config
+    }
+
+    /// Bump the engine's epoch counter. The host runs a dedicated
+    /// timer thread (Phase 2b wires the timer alongside the host
+    /// imports) that calls this every 10 ms; we expose it here so
+    /// tests can drive the epoch deterministically.
+    pub fn tick_epoch(&self) {
+        self.inner.engine.increment_epoch();
+    }
+
+    /// Read + parse a plugin's manifest, compile its `plugin.wasm`,
+    /// and return both bundled together. The function does NOT
+    /// instantiate the component — Phase 2b is where a `Linker` +
+    /// `Store` come together and the guest's exported functions
+    /// become callable.
+    ///
+    /// The manifest's declared `world` is validated here against the
+    /// SDK's known catalog ([`Manifest::parse`] enforces this), but
+    /// we don't yet cross-check that the compiled component
+    /// actually exports the declared interfaces — that check needs
+    /// the bindgen-generated types and lands in Phase 2b.
+    pub fn load_plugin(
+        &self,
+        paths: &PluginPaths,
+        plugin_id: &str,
+    ) -> Result<LoadedPlugin, RuntimeError> {
+        let manifest_path = paths.manifest_path(plugin_id)?;
+        let manifest = Manifest::load_from_path(&manifest_path)?;
+        let wasm_path = paths.wasm_path(plugin_id)?;
+        let bytes = std::fs::read(&wasm_path)?;
+        let component = Component::from_binary(&self.inner.engine, &bytes)?;
+        Ok(LoadedPlugin {
+            manifest,
+            component,
+            wasm_path,
+        })
+    }
+
+    /// Construct a fresh [`Store`] for one plugin invocation. The
+    /// store is preconfigured with this runtime's fuel + epoch
+    /// deadlines + memory cap — callers don't need to remember to
+    /// apply them. The `data` field on the returned store is the
+    /// host context (Phase 2b will substitute the real `HostCtx`
+    /// once the import traits are wired).
+    pub fn new_store(&self) -> Result<Store<HostCtx>, RuntimeError> {
+        let ctx = HostCtx::new(self.inner.config.max_memory_bytes);
+        let mut store = Store::new(&self.inner.engine, ctx);
+
+        store.set_fuel(self.inner.config.fuel_per_call)?;
+        // `set_epoch_deadline` is in epoch-tick units; the host
+        // increments the engine's epoch counter and the store
+        // traps when it crosses the deadline.
+        store.set_epoch_deadline(self.inner.config.epoch_ticks_per_call);
+        // Apply the memory limiter we configured on `HostCtx::new`.
+        store.limiter(|ctx| &mut ctx.limits);
+
+        Ok(store)
+    }
+}
+
+/// One plugin loaded from disk: parsed manifest + compiled
+/// component + the path the wasm came from (kept for diagnostics).
+pub struct LoadedPlugin {
+    pub manifest: Manifest,
+    pub component: Component,
+    pub wasm_path: PathBuf,
+}
+
+/// Per-Store host context. Phase 2a only carries the resource
+/// table + memory limiter so the runtime can already enforce its
+/// sandbox; Phase 2b adds the HTTP allowlist, log scope (plugin id),
+/// scratch-store handle, and any other state the host imports need
+/// at call time.
+///
+/// Why a struct vs `()`: the `bindgen!`-generated `Host` trait will
+/// be implemented on `HostCtx` (not on a generic), so introducing
+/// the type now keeps Phase 2b's diff small + reviewable.
+pub struct HostCtx {
+    /// Wasmtime resource table — required by `bindgen!` even when
+    /// the WIT files don't declare resources (the macro stitches it
+    /// into the generated `add_to_linker` boilerplate).
+    pub table: ResourceTable,
+    /// Memory cap enforcement. The [`Store::limiter`] closure points
+    /// at this field so a guest `memory.grow` over the cap returns
+    /// 0 instead of asking the OS for more pages.
+    pub limits: StoreLimits,
+}
+
+impl HostCtx {
+    pub fn new(max_memory_bytes: usize) -> Self {
+        let limits = StoreLimitsBuilder::new()
+            .memory_size(max_memory_bytes)
+            .build();
+        Self {
+            table: ResourceTable::new(),
+            limits,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_defaults_are_sensible() {
+        let cfg = RuntimeConfig::default();
+        assert!(cfg.fuel_per_call > 0);
+        assert!(cfg.max_memory_bytes >= 16 * 1024 * 1024);
+        assert!(cfg.epoch_ticks_per_call > 0);
+    }
+
+    #[test]
+    fn runtime_builds_with_default_config() {
+        let runtime = PluginRuntime::new(RuntimeConfig::default()).expect("engine builds");
+        assert_eq!(runtime.config().max_memory_bytes, 64 * 1024 * 1024);
+    }
+
+    #[test]
+    fn store_carries_sandbox_limits() {
+        let runtime = PluginRuntime::new(RuntimeConfig::default()).expect("engine builds");
+        let store = runtime.new_store().expect("store builds");
+        // Fuel is set; reading it back should match the config.
+        let fuel = store.get_fuel().expect("store has fuel enabled");
+        assert_eq!(fuel, runtime.config().fuel_per_call);
+    }
+
+    #[test]
+    fn epoch_tick_increments_engine() {
+        let runtime = PluginRuntime::new(RuntimeConfig::default()).expect("engine builds");
+        // No public getter for the epoch counter — just confirm
+        // the call doesn't panic. Phase 2b's integration test will
+        // verify the deadline actually traps a guest.
+        runtime.tick_epoch();
+        runtime.tick_epoch();
+    }
+
+    #[test]
+    fn load_plugin_rejects_invalid_id() {
+        let runtime = PluginRuntime::new(RuntimeConfig::default()).expect("engine builds");
+        let paths = PluginPaths::from_app_data(std::path::Path::new("/tmp/waveflow"));
+        // `LoadedPlugin` doesn't impl `Debug` (wasmtime's `Component`
+        // doesn't either), so we can't `.unwrap_err()` or print
+        // the Ok branch — collapse the result to a tagged enum the
+        // assertion can compare against.
+        match runtime.load_plugin(&paths, "../escape") {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(RuntimeError::InvalidId(_)) => {}
+            Err(err) => panic!("expected InvalidId, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn load_plugin_reports_missing_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let runtime = PluginRuntime::new(RuntimeConfig::default()).expect("engine builds");
+        let paths = PluginPaths::from_app_data(tmp.path());
+        // No files on disk — `manifest_path` points nowhere valid.
+        match runtime.load_plugin(&paths, "ghost") {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(RuntimeError::Io(_)) | Err(RuntimeError::Manifest(_)) => {}
+            Err(err) => panic!("expected Io / Manifest, got {err:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2a of RFC-002 (Plugin SDK). Introduces [`waveflow_core::plugin::runtime`](src-tauri/crates/core/src/plugin/runtime.rs) — the wasmtime engine wrapper that Phase 2b will graft host imports onto.

- `PluginRuntime` owns the process-wide [`Engine`] + the sandbox config (`RuntimeConfig`: fuel + memory cap + epoch ticks per call).
- `PluginRuntime::new_store()` produces a `Store<HostCtx>` pre-loaded with the sandbox limits — callers don't have to remember the fuel / epoch / memory bookkeeping.
- `PluginRuntime::load_plugin(paths, plugin_id)` parses the manifest, reads `plugin.wasm`, compiles a [`Component`], and returns both bundled together. Does NOT instantiate yet — that's Phase 2b once host imports exist.
- `HostCtx` skeleton carries the wasmtime `ResourceTable` + the `StoreLimits` for the memory limiter. Phase 2b adds the HTTP allowlist, log scope, scratch-store handle, etc.

**Sandbox defaults** — 100M fuel / 64 MB memory / 3 000 epoch ticks (~30 s wall-clock at the planned 10 ms ticker cadence). Sized for a music-player plugin doing HTTP-bound bursts; the host can raise them per plugin later.

**Threads disabled by omission** — the crate doesn't enable wasmtime's `threads` Cargo feature, so there's no `Config` toggle to disable what isn't compiled in. A comment in `PluginRuntime::new` flags the spot to re-add `wasm_threads(false)` if a future change opts the feature in.

## What's intentionally NOT here

- **`bindgen!` wiring + the `Host` trait impls** — landing in Phase 2b alongside the actual http / log / storage backing code. Splitting them out keeps this PR reviewable on the wasmtime config + sandbox choices alone.
- **Per-world `Linker<HostCtx>`** — Phase 2b builds this once per world after `bindgen!` runs.
- **Epoch ticker thread** — Phase 2b wires the 10 ms tokio interval that calls `runtime.tick_epoch()`. Phase 2a only exposes the hook so tests can drive it deterministically.
- **Component-world consistency check** — verifying the compiled component actually exports the world the manifest declares needs the bindgen-generated types. Phase 2b.

## Test plan

- [x] \`cargo test --manifest-path src-tauri/Cargo.toml -p waveflow-core plugin::\` — 20/20 pass (5 new in `runtime::tests`)
  - `runtime_defaults_are_sensible` — config sanity
  - `runtime_builds_with_default_config` — `PluginRuntime::new` succeeds
  - `store_carries_sandbox_limits` — fuel handoff verified
  - `epoch_tick_increments_engine` — `tick_epoch` doesn't panic
  - `load_plugin_rejects_invalid_id` — path-traversal id refused
  - `load_plugin_reports_missing_manifest` — Io / Manifest error variant
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets\` — clean
- [x] Bundle size delta verified in CI (wasmtime is a heavy dep — expecting +5-8 MB unstripped)

Refs RFC-002 §6 (Phase 2). Builds on #220 (Phase 1: manifest + sidecar assets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Runtime de plugins Wasm isolé avec sandboxing, contrôle mémoire et quotas d’exécution, et vérification de la taille des modules avant chargement.
* **Améliorations**
  * Paramètres par défaut sécurisés et configurables pour fiabilité et limites d’exécution (fuel, mémoire, ticks d’epoch).
* **Tests**
  * Tests unitaires couvrant valeurs par défaut et scénarios d’erreur courants lors du chargement de plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->