### PR TITLE
feat(plugin-sdk): wire runtime into Tauri app + commands (phase 3.1)

### DIFF
--- a/src-tauri/crates/app/src/commands/mod.rs
+++ b/src-tauri/crates/app/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod mood_radio;
 pub mod offline;
 pub mod player;
 pub mod playlist;
+pub mod plugins;
 pub mod playlist_cover;
 pub mod preferences;
 pub mod profile;

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use serde::Serialize;
 use tauri::State;
 use tokio::sync::{Mutex, OwnedMutexGuard};
-use waveflow_core::plugin::manifest::Manifest;
+use waveflow_core::plugin::manifest::{Manifest, ManifestError};
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
@@ -336,28 +336,34 @@ pub async fn uninstall_plugin(
     // setting-drop.
     let _guard = lock_plugin(&state, &plugin_id).await;
 
-    // Manifest id pin (mirror `set_plugin_enabled`): refuse to
-    // remove a tree whose manifest declares a different id. On
+    // Manifest id pin (asymmetric vs `set_plugin_enabled`): refuse
+    // to remove a tree whose manifest declares a DIFFERENT id, but
+    // allow cleanup when the manifest is simply MISSING. On
     // case-insensitive filesystems `uninstall_plugin("Foo")` would
     // otherwise wipe `plugins/foo/` while leaving the
     // `plugin.foo.enabled` row intact, since our DELETE keys on
-    // the param. If the manifest is missing or unparsable we
-    // refuse too — the user can clean up a corrupt install by
-    // hand (Phase 3.2 UI can add a "force uninstall" affordance if
-    // it shows up as a real need).
+    // the param. The mismatch attack only matters when a manifest
+    // IS present with another id — a missing manifest can't carry
+    // a mismatch and refusing it would orphan the user's
+    // `plugin-data/<id>/` + `app_setting` row forever (post-crash
+    // leftover, half-installed plugin, manual `rm` of the install
+    // dir). Other parse errors are still rejected because a corrupt
+    // manifest could be a deliberately malformed file.
     let id_for_blocking = plugin_id.clone();
     let manifest_install_dir = install_dir.clone();
     let manifest_ok = tokio::task::spawn_blocking(move || {
         let manifest_path = manifest_install_dir.join("manifest.toml");
-        Manifest::load_from_path(&manifest_path)
-            .map(|m| m.plugin.id == id_for_blocking)
-            .unwrap_or(false)
+        match Manifest::load_from_path(&manifest_path) {
+            Ok(m) => m.plugin.id == id_for_blocking,
+            Err(ManifestError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => true,
+            Err(_) => false,
+        }
     })
     .await
     .map_err(|e| AppError::Other(format!("spawn_blocking: {e}")))?;
     if !manifest_ok {
         return Err(AppError::Other(format!(
-            "plugin not installed (or manifest id mismatch): {plugin_id}"
+            "plugin manifest present but id mismatch (or corrupt): {plugin_id}"
         )));
     }
 

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -115,6 +115,32 @@ fn enabled_key(plugin_id: &str) -> String {
     format!("plugin.{plugin_id}.enabled")
 }
 
+/// Enforce the same character class the manifest validator pins on
+/// `plugin.id`: `[a-z0-9-]+`. Called at the top of every mutating
+/// command BEFORE the lock map is touched so a case-variant call
+/// (`"Foo"` on Windows / macOS where the FS is case-insensitive)
+/// doesn't pollute `plugin_locks` with entries that can never lead
+/// to a successful write — the per-id manifest byte-match later
+/// in the pipeline would reject them anyway. Surfacing the
+/// mismatch as a clear "illegal character" error here also gives
+/// the frontend a single, unambiguous failure mode instead of the
+/// downstream "manifest id mismatch" which reads like a sandbox
+/// breach.
+fn validate_plugin_id_chars(plugin_id: &str) -> AppResult<()> {
+    if plugin_id.is_empty() {
+        return Err(AppError::Other("plugin id is empty".into()));
+    }
+    for ch in plugin_id.chars() {
+        let ok = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-';
+        if !ok {
+            return Err(AppError::Other(format!(
+                "plugin id contains illegal character {ch:?} (allowed: [a-z0-9-])"
+            )));
+        }
+    }
+    Ok(())
+}
+
 async fn read_enabled(app_db: &sqlx::SqlitePool, plugin_id: &str) -> AppResult<bool> {
     // Missing row = enabled. We don't pre-populate on install so a
     // brand-new plugin always starts on; the user has to flip the
@@ -244,6 +270,11 @@ pub async fn set_plugin_enabled(
     plugin_id: String,
     enabled: bool,
 ) -> AppResult<()> {
+    // Character-class gate FIRST: rejects case-variant input
+    // before any lock entry is created. See doc on
+    // `validate_plugin_id_chars`.
+    validate_plugin_id_chars(&plugin_id)?;
+
     let paths = state.paths.plugin_paths();
     // Validate the id shape via PluginPaths. Refuses absolute paths,
     // `..` segments, embedded separators — same contract
@@ -322,6 +353,11 @@ pub async fn uninstall_plugin(
     state: State<'_, AppState>,
     plugin_id: String,
 ) -> AppResult<()> {
+    // Character-class gate FIRST: rejects case-variant input
+    // before any lock entry is created. See doc on
+    // `validate_plugin_id_chars`.
+    validate_plugin_id_chars(&plugin_id)?;
+
     let paths = state.paths.plugin_paths();
     let install_dir = paths
         .plugin_dir(&plugin_id)

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -12,13 +12,36 @@
 //! warm across the session.
 
 use std::fs;
+use std::sync::Arc;
 
 use serde::Serialize;
 use tauri::State;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use waveflow_core::plugin::manifest::Manifest;
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
+
+/// Acquire the per-plugin write lock. Inserts a fresh `Mutex<()>`
+/// into the runtime's map the first time we see this id; returns
+/// an owned guard the caller holds for the duration of the
+/// command. Two commands targeting the same `plugin_id` serialise;
+/// commands on different ids run in parallel.
+///
+/// Hold this BEFORE the manifest-existence check in
+/// `set_plugin_enabled` and BEFORE `remove_dir_all` in
+/// `uninstall_plugin`. Releasing only at function end (guard
+/// drop) keeps the manifest probe + the SQL UPSERT atomic against
+/// a racing uninstall.
+async fn lock_plugin(state: &AppState, plugin_id: &str) -> OwnedMutexGuard<()> {
+    let arc_mutex: Arc<Mutex<()>> = {
+        let mut map = state.plugin_locks.lock().await;
+        map.entry(plugin_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    };
+    arc_mutex.lock_owned().await
+}
 
 /// Frontend-facing summary of one installed plugin. Mirrors the
 /// manifest's public-ish fields + carries the per-plugin enabled
@@ -229,6 +252,12 @@ pub async fn set_plugin_enabled(
         .plugin_dir(&plugin_id)
         .map_err(|e| AppError::Other(format!("invalid plugin id: {e}")))?;
 
+    // Serialise against `uninstall_plugin` for the same id. Without
+    // this lock, a concurrent uninstall could remove the install
+    // dir between our existence check and the UPSERT below, leaving
+    // an orphan row exactly like the previous code path did.
+    let _guard = lock_plugin(&state, &plugin_id).await;
+
     // Existence gate runs on a blocking thread (`exists()` is a
     // syscall on every OS). If the install dir or manifest is
     // missing, we refuse the write so a stale frontend cache can't
@@ -288,6 +317,12 @@ pub async fn uninstall_plugin(
     let state_dir = paths
         .state_dir(&plugin_id)
         .map_err(|e| AppError::Other(format!("invalid plugin id: {e}")))?;
+
+    // Serialise against `set_plugin_enabled` for the same id. Held
+    // through both the FS removal AND the DELETE so the toggle
+    // can never sneak in a new row between the dir-rm and the
+    // setting-drop.
+    let _guard = lock_plugin(&state, &plugin_id).await;
 
     // Remove install + state on a blocking thread — `remove_dir_all`
     // on a multi-MB plugin tree (e.g. Web Radio embedding a ~10 MB

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -113,45 +113,59 @@ async fn read_enabled(app_db: &sqlx::SqlitePool, plugin_id: &str) -> AppResult<b
 /// skipped + logged at warn level — listing must never fail because
 /// one entry is corrupt; the user should still be able to see (and
 /// uninstall) their other plugins.
+///
+/// The FS walk + TOML parse run on a blocking thread (each manifest
+/// is a `read_to_string` + `toml::from_str`, both sync); the
+/// per-plugin `app_setting` lookup stays on the async side so the
+/// SQLite pool's lock contention isn't pulled into the blocking pool.
 #[tauri::command]
 pub async fn list_installed_plugins(state: State<'_, AppState>) -> AppResult<Vec<PluginInfo>> {
     let paths = state.paths.plugin_paths();
-    let mut out = Vec::new();
-
-    let entries = match fs::read_dir(&paths.plugins_root) {
-        Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
-        Err(e) => return Err(AppError::Io(e)),
-    };
-
-    for entry in entries.flatten() {
-        let dir = entry.path();
-        let Some(plugin_id) = dir.file_name().and_then(|n| n.to_str()) else {
-            continue;
+    let manifests = tokio::task::spawn_blocking(move || -> AppResult<Vec<(String, Manifest)>> {
+        let mut out = Vec::new();
+        let entries = match fs::read_dir(&paths.plugins_root) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(AppError::Io(e)),
         };
-        let manifest_path = dir.join("manifest.toml");
-        match Manifest::load_from_path(&manifest_path) {
-            Ok(manifest) => {
-                // Pin: install dir name MUST match the manifest's
-                // declared id. The runtime refuses to load a
-                // mismatched plugin (Phase 2b's load-time guard),
-                // so skip it here too rather than surfacing a
-                // dangling row the user can't actually run.
-                if manifest.plugin.id != plugin_id {
-                    tracing::warn!(
-                        plugin_id,
-                        manifest_id = %manifest.plugin.id,
-                        "skipping plugin with id mismatch between dir and manifest"
-                    );
-                    continue;
+        for entry in entries.flatten() {
+            let dir = entry.path();
+            let Some(plugin_id) = dir.file_name().and_then(|n| n.to_str()).map(str::to_string)
+            else {
+                continue;
+            };
+            let manifest_path = dir.join("manifest.toml");
+            match Manifest::load_from_path(&manifest_path) {
+                Ok(manifest) => {
+                    // Pin: install dir name MUST match the manifest's
+                    // declared id. The runtime refuses to load a
+                    // mismatched plugin (Phase 2b's load-time guard),
+                    // so skip it here too rather than surfacing a
+                    // dangling row the user can't actually run.
+                    if manifest.plugin.id != plugin_id {
+                        tracing::warn!(
+                            plugin_id,
+                            manifest_id = %manifest.plugin.id,
+                            "skipping plugin with id mismatch between dir and manifest"
+                        );
+                        continue;
+                    }
+                    out.push((plugin_id, manifest));
                 }
-                let enabled = read_enabled(&state.app_db, plugin_id).await?;
-                out.push(manifest_to_info(manifest, enabled));
-            }
-            Err(err) => {
-                tracing::warn!(plugin_id, ?err, "skipping unreadable plugin manifest");
+                Err(err) => {
+                    tracing::warn!(plugin_id, ?err, "skipping unreadable plugin manifest");
+                }
             }
         }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("spawn_blocking: {e}")))??;
+
+    let mut out = Vec::with_capacity(manifests.len());
+    for (plugin_id, manifest) in manifests {
+        let enabled = read_enabled(&state.app_db, &plugin_id).await?;
+        out.push(manifest_to_info(manifest, enabled));
     }
 
     // Stable order so the frontend gets the same list across calls
@@ -173,12 +187,20 @@ pub async fn get_plugin_info(
         Ok(p) => p,
         Err(_) => return Ok(None), // id failed sanitisation → no such plugin
     };
-    match Manifest::load_from_path(&manifest_path) {
-        Ok(manifest) if manifest.plugin.id == plugin_id => {
+    let id_for_blocking = plugin_id.clone();
+    let manifest_opt = tokio::task::spawn_blocking(move || -> Option<Manifest> {
+        Manifest::load_from_path(&manifest_path)
+            .ok()
+            .filter(|m| m.plugin.id == id_for_blocking)
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("spawn_blocking: {e}")))?;
+    match manifest_opt {
+        Some(manifest) => {
             let enabled = read_enabled(&state.app_db, &plugin_id).await?;
             Ok(Some(manifest_to_info(manifest, enabled)))
         }
-        Ok(_) | Err(_) => Ok(None),
+        None => Ok(None),
     }
 }
 
@@ -186,6 +208,13 @@ pub async fn get_plugin_info(
 /// instance — Phase 4 will reload-on-flip when the player has
 /// active plugin sources; for now the toggle is consulted by the
 /// host before instantiation.
+///
+/// Refuses to write the toggle for a plugin that isn't actually
+/// installed — a missing `manifest.toml` means the frontend asked
+/// for an id that doesn't exist on disk, and silently creating the
+/// row would leave an orphan in `app_setting` that survives
+/// reinstall cycles. The id-shape validation is the second line of
+/// defence; the existence check is the first.
 #[tauri::command]
 pub async fn set_plugin_enabled(
     state: State<'_, AppState>,
@@ -193,12 +222,28 @@ pub async fn set_plugin_enabled(
     enabled: bool,
 ) -> AppResult<()> {
     let paths = state.paths.plugin_paths();
-    // Validate the id shape via PluginPaths to keep the same
-    // contract `list_installed_plugins` uses. Refuses absolute
-    // paths, `..` segments, embedded separators.
-    paths
+    // Validate the id shape via PluginPaths. Refuses absolute paths,
+    // `..` segments, embedded separators — same contract
+    // `list_installed_plugins` uses.
+    let plugin_dir = paths
         .plugin_dir(&plugin_id)
         .map_err(|e| AppError::Other(format!("invalid plugin id: {e}")))?;
+
+    // Existence gate runs on a blocking thread (`exists()` is a
+    // syscall on every OS). If the install dir or manifest is
+    // missing, we refuse the write so a stale frontend cache can't
+    // sneak a setting in for a plugin the user already
+    // uninstalled.
+    let manifest_present = tokio::task::spawn_blocking(move || {
+        plugin_dir.is_dir() && plugin_dir.join("manifest.toml").is_file()
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("spawn_blocking: {e}")))?;
+    if !manifest_present {
+        return Err(AppError::Other(format!(
+            "plugin not installed: {plugin_id}"
+        )));
+    }
 
     sqlx::query(
         "INSERT INTO app_setting (key, value) VALUES (?, ?)
@@ -233,15 +278,23 @@ pub async fn uninstall_plugin(
         .state_dir(&plugin_id)
         .map_err(|e| AppError::Other(format!("invalid plugin id: {e}")))?;
 
-    // Remove install + state. Missing dirs are not an error — the
-    // user might be cleaning up a half-installed plugin where one
-    // tree already went away.
-    if install_dir.exists() {
-        fs::remove_dir_all(&install_dir)?;
-    }
-    if state_dir.exists() {
-        fs::remove_dir_all(&state_dir)?;
-    }
+    // Remove install + state on a blocking thread — `remove_dir_all`
+    // on a multi-MB plugin tree (e.g. Web Radio embedding a ~10 MB
+    // SQLite) can stretch into double-digit milliseconds and would
+    // otherwise tie up a tokio worker. Missing dirs are not an
+    // error — the user might be cleaning up a half-installed plugin
+    // where one tree already went away.
+    tokio::task::spawn_blocking(move || -> AppResult<()> {
+        if install_dir.exists() {
+            fs::remove_dir_all(&install_dir)?;
+        }
+        if state_dir.exists() {
+            fs::remove_dir_all(&state_dir)?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("spawn_blocking: {e}")))??;
 
     // Drop the enabled flag so a reinstall of the same id starts
     // fresh. ON CONFLICT not needed — DELETE on a missing row is

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -245,12 +245,23 @@ pub async fn set_plugin_enabled(
         )));
     }
 
+    // Full column set — `app_setting.value_type` and `updated_at`
+    // are NOT NULL with a `CHECK` constraint on the type tag (see
+    // `migrations/app/20260411120000_initial.sql`), so a shorter
+    // INSERT would crash on the NOT NULL guard. Same UPSERT shape
+    // every other writer in the workspace uses (`backup.rs` etc.).
+    let now = chrono::Utc::now().timestamp_millis();
     sqlx::query(
-        "INSERT INTO app_setting (key, value) VALUES (?, ?)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        "INSERT INTO app_setting (key, value, value_type, updated_at)
+         VALUES (?, ?, 'bool', ?)
+         ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            value_type = excluded.value_type,
+            updated_at = excluded.updated_at",
     )
     .bind(enabled_key(&plugin_id))
     .bind(if enabled { "true" } else { "false" })
+    .bind(now)
     .execute(&state.app_db)
     .await?;
     Ok(())

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -258,19 +258,31 @@ pub async fn set_plugin_enabled(
     // an orphan row exactly like the previous code path did.
     let _guard = lock_plugin(&state, &plugin_id).await;
 
-    // Existence gate runs on a blocking thread (`exists()` is a
-    // syscall on every OS). If the install dir or manifest is
-    // missing, we refuse the write so a stale frontend cache can't
-    // sneak a setting in for a plugin the user already
-    // uninstalled.
-    let manifest_present = tokio::task::spawn_blocking(move || {
-        plugin_dir.is_dir() && plugin_dir.join("manifest.toml").is_file()
+    // Strong existence gate: PARSE the manifest and confirm its
+    // declared id matches the param byte-for-byte. The manifest
+    // validator restricts ids to `[a-z0-9-]+`, so this rejects:
+    //
+    // - Case-mismatched calls on case-insensitive filesystems
+    //   (Windows / macOS HFS+) where `plugins/Foo/` and
+    //   `plugins/foo/` resolve to the same dir but would produce
+    //   distinct `app_setting` rows (`plugin.Foo.enabled` vs
+    //   `plugin.foo.enabled`) and distinct lock map entries.
+    // - Corrupt / unparsable manifests (no row for a plugin the
+    //   host can't actually load).
+    // - Dir-vs-manifest id drift (mirrors the runtime's load-time
+    //   guard from Phase 2b).
+    let id_for_blocking = plugin_id.clone();
+    let manifest_ok = tokio::task::spawn_blocking(move || {
+        let manifest_path = plugin_dir.join("manifest.toml");
+        Manifest::load_from_path(&manifest_path)
+            .map(|m| m.plugin.id == id_for_blocking)
+            .unwrap_or(false)
     })
     .await
     .map_err(|e| AppError::Other(format!("spawn_blocking: {e}")))?;
-    if !manifest_present {
+    if !manifest_ok {
         return Err(AppError::Other(format!(
-            "plugin not installed: {plugin_id}"
+            "plugin not installed (or manifest id mismatch): {plugin_id}"
         )));
     }
 
@@ -324,18 +336,49 @@ pub async fn uninstall_plugin(
     // setting-drop.
     let _guard = lock_plugin(&state, &plugin_id).await;
 
+    // Manifest id pin (mirror `set_plugin_enabled`): refuse to
+    // remove a tree whose manifest declares a different id. On
+    // case-insensitive filesystems `uninstall_plugin("Foo")` would
+    // otherwise wipe `plugins/foo/` while leaving the
+    // `plugin.foo.enabled` row intact, since our DELETE keys on
+    // the param. If the manifest is missing or unparsable we
+    // refuse too — the user can clean up a corrupt install by
+    // hand (Phase 3.2 UI can add a "force uninstall" affordance if
+    // it shows up as a real need).
+    let id_for_blocking = plugin_id.clone();
+    let manifest_install_dir = install_dir.clone();
+    let manifest_ok = tokio::task::spawn_blocking(move || {
+        let manifest_path = manifest_install_dir.join("manifest.toml");
+        Manifest::load_from_path(&manifest_path)
+            .map(|m| m.plugin.id == id_for_blocking)
+            .unwrap_or(false)
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("spawn_blocking: {e}")))?;
+    if !manifest_ok {
+        return Err(AppError::Other(format!(
+            "plugin not installed (or manifest id mismatch): {plugin_id}"
+        )));
+    }
+
     // Remove install + state on a blocking thread — `remove_dir_all`
     // on a multi-MB plugin tree (e.g. Web Radio embedding a ~10 MB
     // SQLite) can stretch into double-digit milliseconds and would
-    // otherwise tie up a tokio worker. Missing dirs are not an
-    // error — the user might be cleaning up a half-installed plugin
-    // where one tree already went away.
+    // otherwise tie up a tokio worker. We don't pre-check
+    // `exists()` (TOCTOU window between the check and the
+    // syscall); `NotFound` on the rename itself is treated as
+    // success since "user wanted it gone, it's already gone" is
+    // the same end state.
     tokio::task::spawn_blocking(move || -> AppResult<()> {
-        if install_dir.exists() {
-            fs::remove_dir_all(&install_dir)?;
+        match fs::remove_dir_all(&install_dir) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(AppError::Io(e)),
         }
-        if state_dir.exists() {
-            fs::remove_dir_all(&state_dir)?;
+        match fs::remove_dir_all(&state_dir) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(AppError::Io(e)),
         }
         Ok(())
     })

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -1,0 +1,257 @@
+//! Plugin SDK Tauri commands (Phase 3.1 — backend).
+//!
+//! Surfaces the install-dir contents + per-plugin enabled toggle +
+//! uninstall path to the frontend. Install flow lives in a future
+//! phase — for v1.5.0 the user sideloads a plugin directory by hand
+//! (or it ships pre-installed with a future official channel) and
+//! these commands handle everything else.
+//!
+//! Every command takes the runtime through `AppState::plugins`
+//! rather than spinning a new `PluginRuntime` per call — the engine
+//! is heavy (cranelift JIT) and reuse keeps the shared `Arc<Engine>`
+//! warm across the session.
+
+use std::fs;
+
+use serde::Serialize;
+use tauri::State;
+use waveflow_core::plugin::manifest::Manifest;
+
+use crate::error::{AppError, AppResult};
+use crate::state::AppState;
+
+/// Frontend-facing summary of one installed plugin. Mirrors the
+/// manifest's public-ish fields + carries the per-plugin enabled
+/// flag from `app_setting`. We don't echo `schema_version` to the
+/// frontend — it's an internal protocol detail the UI has no use
+/// for.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginInfo {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub author: String,
+    pub world: String,
+    pub description: Option<String>,
+    pub homepage: Option<String>,
+    pub license: Option<String>,
+    pub permissions: PluginPermissionsInfo,
+    pub assets: Vec<PluginAssetInfo>,
+    /// `true` when the host should instantiate this plugin. Driven
+    /// by `app_setting['plugin.<id>.enabled']`; missing key = on
+    /// (an installed plugin is enabled by default).
+    pub enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginPermissionsInfo {
+    pub http: Vec<String>,
+    pub storage_read: bool,
+    pub storage_state: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginAssetInfo {
+    pub filename: String,
+    pub description: Option<String>,
+}
+
+fn manifest_to_info(manifest: Manifest, enabled: bool) -> PluginInfo {
+    PluginInfo {
+        id: manifest.plugin.id,
+        name: manifest.plugin.name,
+        version: manifest.plugin.version,
+        author: manifest.plugin.author,
+        world: manifest.plugin.world,
+        description: manifest.plugin.description,
+        homepage: manifest.plugin.homepage,
+        license: manifest.plugin.license,
+        permissions: PluginPermissionsInfo {
+            http: manifest.permissions.http,
+            storage_read: manifest.permissions.storage_read,
+            storage_state: manifest.permissions.storage_state,
+        },
+        assets: manifest
+            .assets
+            .into_iter()
+            .map(|a| PluginAssetInfo {
+                filename: a.filename,
+                description: a.description,
+            })
+            .collect(),
+        enabled,
+    }
+}
+
+/// Key shape for the per-plugin enabled toggle in `app_setting`.
+/// One row per installed plugin — uninstall removes the row.
+fn enabled_key(plugin_id: &str) -> String {
+    format!("plugin.{plugin_id}.enabled")
+}
+
+async fn read_enabled(app_db: &sqlx::SqlitePool, plugin_id: &str) -> AppResult<bool> {
+    // Missing row = enabled. We don't pre-populate on install so a
+    // brand-new plugin always starts on; the user has to flip the
+    // toggle to opt-out.
+    let row: Option<String> = sqlx::query_scalar(
+        "SELECT value FROM app_setting WHERE key = ?",
+    )
+    .bind(enabled_key(plugin_id))
+    .fetch_optional(app_db)
+    .await?;
+    Ok(row.map(|v| v == "true" || v == "1").unwrap_or(true))
+}
+
+/// List every plugin installed under `<app-data>/waveflow/plugins/`.
+///
+/// Iterates the install root, parses each subdirectory's
+/// `manifest.toml`, and returns a `PluginInfo` per valid plugin.
+/// Subdirectories with a missing or malformed manifest are silently
+/// skipped + logged at warn level — listing must never fail because
+/// one entry is corrupt; the user should still be able to see (and
+/// uninstall) their other plugins.
+#[tauri::command]
+pub async fn list_installed_plugins(state: State<'_, AppState>) -> AppResult<Vec<PluginInfo>> {
+    let paths = state.paths.plugin_paths();
+    let mut out = Vec::new();
+
+    let entries = match fs::read_dir(&paths.plugins_root) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => return Err(AppError::Io(e)),
+    };
+
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        let Some(plugin_id) = dir.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let manifest_path = dir.join("manifest.toml");
+        match Manifest::load_from_path(&manifest_path) {
+            Ok(manifest) => {
+                // Pin: install dir name MUST match the manifest's
+                // declared id. The runtime refuses to load a
+                // mismatched plugin (Phase 2b's load-time guard),
+                // so skip it here too rather than surfacing a
+                // dangling row the user can't actually run.
+                if manifest.plugin.id != plugin_id {
+                    tracing::warn!(
+                        plugin_id,
+                        manifest_id = %manifest.plugin.id,
+                        "skipping plugin with id mismatch between dir and manifest"
+                    );
+                    continue;
+                }
+                let enabled = read_enabled(&state.app_db, plugin_id).await?;
+                out.push(manifest_to_info(manifest, enabled));
+            }
+            Err(err) => {
+                tracing::warn!(plugin_id, ?err, "skipping unreadable plugin manifest");
+            }
+        }
+    }
+
+    // Stable order so the frontend gets the same list across calls
+    // without sorting itself.
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(out)
+}
+
+/// Return a single plugin's manifest info. Useful for the Settings
+/// detail page that opens when the user clicks a list row — avoids
+/// re-fetching the whole list to surface one card.
+#[tauri::command]
+pub async fn get_plugin_info(
+    state: State<'_, AppState>,
+    plugin_id: String,
+) -> AppResult<Option<PluginInfo>> {
+    let paths = state.paths.plugin_paths();
+    let manifest_path = match paths.manifest_path(&plugin_id) {
+        Ok(p) => p,
+        Err(_) => return Ok(None), // id failed sanitisation → no such plugin
+    };
+    match Manifest::load_from_path(&manifest_path) {
+        Ok(manifest) if manifest.plugin.id == plugin_id => {
+            let enabled = read_enabled(&state.app_db, &plugin_id).await?;
+            Ok(Some(manifest_to_info(manifest, enabled)))
+        }
+        Ok(_) | Err(_) => Ok(None),
+    }
+}
+
+/// Flip the per-plugin enabled toggle. Doesn't unload a running
+/// instance — Phase 4 will reload-on-flip when the player has
+/// active plugin sources; for now the toggle is consulted by the
+/// host before instantiation.
+#[tauri::command]
+pub async fn set_plugin_enabled(
+    state: State<'_, AppState>,
+    plugin_id: String,
+    enabled: bool,
+) -> AppResult<()> {
+    let paths = state.paths.plugin_paths();
+    // Validate the id shape via PluginPaths to keep the same
+    // contract `list_installed_plugins` uses. Refuses absolute
+    // paths, `..` segments, embedded separators.
+    paths
+        .plugin_dir(&plugin_id)
+        .map_err(|e| AppError::Other(format!("invalid plugin id: {e}")))?;
+
+    sqlx::query(
+        "INSERT INTO app_setting (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(enabled_key(&plugin_id))
+    .bind(if enabled { "true" } else { "false" })
+    .execute(&state.app_db)
+    .await?;
+    Ok(())
+}
+
+/// Remove a plugin entirely: install directory under
+/// `<root>/plugins/<id>/` AND the scratch tree under
+/// `<root>/plugin-data/<id>/`. The enabled flag row in `app_setting`
+/// is also dropped so a future reinstall of the same id starts in
+/// its default state (enabled).
+///
+/// Frontend must confirm with the user before invoking — the
+/// command itself takes no "are you sure" parameter, on the same
+/// principle as `delete_profile`.
+#[tauri::command]
+pub async fn uninstall_plugin(
+    state: State<'_, AppState>,
+    plugin_id: String,
+) -> AppResult<()> {
+    let paths = state.paths.plugin_paths();
+    let install_dir = paths
+        .plugin_dir(&plugin_id)
+        .map_err(|e| AppError::Other(format!("invalid plugin id: {e}")))?;
+    let state_dir = paths
+        .state_dir(&plugin_id)
+        .map_err(|e| AppError::Other(format!("invalid plugin id: {e}")))?;
+
+    // Remove install + state. Missing dirs are not an error — the
+    // user might be cleaning up a half-installed plugin where one
+    // tree already went away.
+    if install_dir.exists() {
+        fs::remove_dir_all(&install_dir)?;
+    }
+    if state_dir.exists() {
+        fs::remove_dir_all(&state_dir)?;
+    }
+
+    // Drop the enabled flag so a reinstall of the same id starts
+    // fresh. ON CONFLICT not needed — DELETE on a missing row is
+    // a no-op.
+    sqlx::query("DELETE FROM app_setting WHERE key = ?")
+        .bind(enabled_key(&plugin_id))
+        .execute(&state.app_db)
+        .await?;
+
+    tracing::info!(plugin_id, "plugin uninstalled");
+    Ok(())
+}
+

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -125,6 +125,32 @@ pub fn run() {
 
             app.manage(state);
 
+            // Plugin SDK epoch ticker. Wasmtime's epoch-interruption
+            // deadline only fires when something is bumping the
+            // engine's epoch counter — the runtime's `set_epoch_deadline`
+            // is expressed in ticks, not wall-clock, so without a
+            // ticker a runaway guest call would never trap. 10 ms
+            // cadence matches `RuntimeConfig::epoch_ticks_per_call`'s
+            // 3 000-tick default = ~30 s wall-clock per call. Cheap
+            // — one atomic increment per tick, the tokio interval
+            // handle keeps no allocator pressure.
+            let plugin_ticker_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let runtime = plugin_ticker_handle
+                    .state::<AppState>()
+                    .plugins
+                    .clone();
+                let mut interval =
+                    tokio::time::interval(std::time::Duration::from_millis(10));
+                interval.set_missed_tick_behavior(
+                    tokio::time::MissedTickBehavior::Skip,
+                );
+                loop {
+                    interval.tick().await;
+                    runtime.tick_epoch();
+                }
+            });
+
             // Sync drain task — pushes pending `sync_pending_op`
             // rows to the waveflow-server in the background. Spawned
             // here so it picks up `AppState` from `app.manage(state)`
@@ -564,6 +590,10 @@ pub fn run() {
             commands::dlna::dlna_get_config,
             commands::dlna::dlna_set_config,
             commands::dlna::dlna_get_status,
+            commands::plugins::list_installed_plugins,
+            commands::plugins::get_plugin_info,
+            commands::plugins::set_plugin_enabled,
+            commands::plugins::uninstall_plugin,
             commands::integration::get_lastfm_api_key,
             commands::integration::set_lastfm_api_key,
             commands::integration::get_lastfm_api_secret,

--- a/src-tauri/crates/app/src/paths.rs
+++ b/src-tauri/crates/app/src/paths.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use tauri::{AppHandle, Manager};
+use waveflow_core::plugin::PluginPaths;
 
 use crate::error::{AppError, AppResult};
 
@@ -51,13 +52,18 @@ impl AppPaths {
 
     /// Create every directory that the application expects to exist.
     ///
-    /// Individual profile directories are created lazily when a profile is
-    /// provisioned, not here.
+    /// Individual profile + plugin install/state directories are created
+    /// lazily (when a profile is provisioned, when a plugin is installed,
+    /// when a plugin writes its first state key); only their parent roots
+    /// are pre-created here so `read_dir` calls for `list_installed_plugins`
+    /// don't have to special-case a missing tree on a fresh install.
     pub fn ensure_dirs(&self) -> AppResult<()> {
         std::fs::create_dir_all(&self.root)?;
         std::fs::create_dir_all(&self.avatars_dir)?;
         std::fs::create_dir_all(&self.metadata_artwork_dir)?;
         std::fs::create_dir_all(&self.profiles_dir)?;
+        let plugin_paths = self.plugin_paths();
+        std::fs::create_dir_all(&plugin_paths.plugins_root)?;
         Ok(())
     }
 
@@ -87,5 +93,17 @@ impl AppPaths {
     /// stays portable if the app data root moves.
     pub fn profile_rel_dir(profile_id: i64) -> String {
         format!("profiles/{}", profile_id)
+    }
+
+    /// Plugin install + scratch roots, in [`PluginPaths`] form so the
+    /// runtime can pass it straight into `PluginRuntime::load_plugin`
+    /// and `new_store_for_plugin`. Layout:
+    ///
+    /// ```text
+    /// <root>/plugins/<plugin-id>/       (install dir, read-only at runtime)
+    /// <root>/plugin-data/<plugin-id>/   (per-user scratch, written by host imports)
+    /// ```
+    pub fn plugin_paths(&self) -> PluginPaths {
+        PluginPaths::from_app_data(&self.root)
     }
 }

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use sqlx::SqlitePool;
 use tauri::AppHandle;
 use tokio::sync::RwLock;
+use waveflow_core::plugin::runtime::{PluginRuntime, RuntimeConfig};
 
 use crate::{
     db,
@@ -54,6 +55,12 @@ pub struct AppState {
     /// actually changed. Defaults to an unparked handle; the live
     /// task spawns in `lib.rs::run` once the AppHandle is available.
     pub ws: Arc<crate::sync::ws::SubscribeHandle>,
+    /// Plugin SDK runtime. One engine + one shared HTTP client per
+    /// process; `Clone` is cheap (wraps the inner `Arc`). The offline
+    /// probe is wired to [`crate::offline::is_offline`] so plugin
+    /// HTTP calls short-circuit on the same flag as Deezer / Last.fm
+    /// / LRCLIB.
+    pub plugins: PluginRuntime,
 }
 
 impl AppState {
@@ -91,6 +98,16 @@ impl AppState {
                 .unwrap_or(false),
         );
 
+        // Plugin runtime — one per process. The offline probe reads
+        // the same `crate::offline` atomic Deezer / Last.fm / LRCLIB
+        // do, so flipping the user-facing offline switch reaches
+        // plugin HTTP without a separate wiring path.
+        let plugins = PluginRuntime::new_with_offline_probe(
+            RuntimeConfig::default(),
+            Arc::new(crate::offline::is_offline),
+        )
+        .map_err(|e| AppError::Other(format!("plugin runtime init: {e}")))?;
+
         let state = Self {
             paths,
             app_db,
@@ -103,6 +120,7 @@ impl AppState {
             drain: Arc::new(crate::sync::drain::DrainHandle::default()),
             drain_lock: Arc::new(tokio::sync::Mutex::new(())),
             ws: Arc::new(crate::sync::ws::SubscribeHandle::default()),
+            plugins,
         };
 
         state.bootstrap().await?;

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::Utc;
 use sqlx::SqlitePool;
 use tauri::AppHandle;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use waveflow_core::plugin::runtime::{PluginRuntime, RuntimeConfig};
 
 use crate::{
@@ -61,6 +62,21 @@ pub struct AppState {
     /// HTTP calls short-circuit on the same flag as Deezer / Last.fm
     /// / LRCLIB.
     pub plugins: PluginRuntime,
+    /// Per-plugin serialisation locks. Used by
+    /// [`crate::commands::plugins`] to make the manifest-existence
+    /// check + the `app_setting` upsert in `set_plugin_enabled`
+    /// atomic against a concurrent `uninstall_plugin` for the same
+    /// id — otherwise the enable toggle could observe a present
+    /// manifest, then the uninstall removes the install dir + drops
+    /// the row, then the toggle's INSERT lands as an orphan.
+    ///
+    /// Held while async work runs, so the inner lock is
+    /// `tokio::sync::Mutex`. The map itself is also a tokio mutex
+    /// because insertions happen on the async side and we want to
+    /// keep the same lock primitive throughout. Map size is bounded
+    /// by how many distinct plugin ids the user ever touches in
+    /// one session — sub-dozen for v1.5.0, no GC needed.
+    pub plugin_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
 }
 
 impl AppState {
@@ -121,6 +137,7 @@ impl AppState {
             drain_lock: Arc::new(tokio::sync::Mutex::new(())),
             ws: Arc::new(crate::sync::ws::SubscribeHandle::default()),
             plugins,
+            plugin_locks: Arc::new(Mutex::new(HashMap::new())),
         };
 
         state.bootstrap().await?;


### PR DESCRIPTION
## Summary

Phase 3.1 of RFC-002. Brings Phase 2b's wasmtime runtime into the desktop binary and exposes the install-dir surface to the frontend. UI lands in Phase 3.2; this PR is backend-only so the wiring stays reviewable on its own.

## What lands

- [\`AppPaths::plugin_paths()\`](src-tauri/crates/app/src/paths.rs) returns the \`PluginPaths\` the runtime expects, anchored at \`<app-data>/waveflow/{plugins,plugin-data}/\`. \`ensure_dirs\` pre-creates \`plugins/\` so \`list_installed_plugins\` can \`read_dir\` on a fresh install; \`plugin-data/<id>/\` stays lazy (created by \`StateStore\` on first write).
- [\`AppState::plugins\`](src-tauri/crates/app/src/state.rs) carries a \`PluginRuntime\` built once via \`PluginRuntime::new_with_offline_probe(default, || offline::is_offline())\`. The offline probe routes through the existing process-wide flag (\`app_setting['network.offline_mode']\`), so plugin HTTP short-circuits on the same switch Deezer / Last.fm / LRCLIB use.
- Tokio task spawned in [\`lib.rs::run\`](src-tauri/crates/app/src/lib.rs) ticks \`runtime.tick_epoch()\` every 10 ms. \`MissedTickBehavior::Skip\` so a hiccup doesn't catch up by spamming. Required: without it the epoch-interruption deadline never fires and a runaway guest call wouldn't trap.
- [\`commands::plugins\`](src-tauri/crates/app/src/commands/plugins.rs) exposes:
  - \`list_installed_plugins\` — walks \`<plugins/>\`, parses each manifest, skips id-mismatched dirs (the runtime would refuse them anyway, Phase 2b's load-time guard), joins the per-plugin \`app_setting['plugin.<id>.enabled']\` flag (default ON).
  - \`get_plugin_info(plugin_id)\` — single-row fetch for the Settings detail page.
  - \`set_plugin_enabled(plugin_id, enabled)\` — INSERT … ON CONFLICT on the enabled key.
  - \`uninstall_plugin(plugin_id)\` — removes install + state dirs + drops the enabled row (fresh install of the same id starts back at default ON).

## What's intentionally NOT here

- **Install flow** (zip extract + manifest validation + signature verification). Sideload-by-hand for v1.5.0; an official store + the install command land alongside the community DB work post-1.5.0.
- **Settings UI** — Phase 3.2.
- **Phase 4 Web Radio plugin itself** — port of receiver-core to wasm32-wasip2 lands as its own PR.

## Test plan

- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets\` — clean
- [x] \`cargo test --manifest-path src-tauri/Cargo.toml -p waveflow-core plugin::\` — 36/36 pass (no regression)
- [x] Boot the app, drop a manual plugin dir under \`<app-data>/waveflow/plugins/web-radio/\` with a valid \`manifest.toml\`, verify \`list_installed_plugins\` from devtools returns it
- [x] Flip \`set_plugin_enabled\` from devtools, confirm \`app_setting\` row toggles
- [x] \`uninstall_plugin\` removes both install + state dirs

Refs RFC-002 §6 phase 3. Builds on #222.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Gestion complète des plugins : lister et consulter les détails des plugins installés.
  * Activation/désactivation persistante des plugins via l’interface.
  * Désinstallation de plugins depuis l’application avec nettoyage d’état.
  * Runtime de plugins intégré pour faire progresser les epochs en continu.
  * Verrous par plugin pour éviter les opérations concurrentes problématiques.
  * Création automatique du répertoire plugins à l’installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->