### PR TITLE
feat(plugin-sdk): settings panel for installed plugins (phase 3.2)

### DIFF
--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -41,8 +41,10 @@ import {
   Database,
   Keyboard,
   Stethoscope,
+  Puzzle,
 } from "lucide-react";
 import { ServerAccountCard } from "./settings/ServerAccountCard";
+import { PluginsCard } from "./settings/PluginsCard";
 import { useTheme } from "../../hooks/useTheme";
 import { THEME_PRESETS } from "../../lib/themes";
 import { getProfileSetting, setProfileSetting } from "../../lib/tauri/profile";
@@ -153,6 +155,7 @@ type SettingsCategory =
   | "integrations"
   | "appearance"
   | "data"
+  | "plugins"
   | "shortcuts"
   | "diagnostics";
 
@@ -174,6 +177,7 @@ const SETTINGS_CATEGORIES: ReadonlyArray<{
     Icon: Palette,
   },
   { id: "data", labelKey: "settings.sections.data", Icon: Database },
+  { id: "plugins", labelKey: "settings.sections.plugins", Icon: Puzzle },
   {
     id: "shortcuts",
     labelKey: "settings.sections.shortcuts",
@@ -3071,6 +3075,26 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
                 <span>{t("settings.reset.action")}</span>
               </button>
             </div>
+          </div>
+        </section>
+      )}
+
+      {/* Plugins category — list / toggle / uninstall installed plugins. */}
+      {activeCategory === "plugins" && (
+        <section
+          role="tabpanel"
+          id="settings-panel-plugins"
+          aria-labelledby="settings-tab-plugins"
+          tabIndex={0}
+        >
+          <h2
+            id="settings-plugins-section-heading"
+            className="text-[10px] font-bold tracking-widest text-zinc-400 mb-4 px-4 uppercase"
+          >
+            {t("settings.sections.plugins")}
+          </h2>
+          <div className="px-4">
+            <PluginsCard />
           </div>
         </section>
       )}

--- a/src/components/views/settings/PluginsCard.tsx
+++ b/src/components/views/settings/PluginsCard.tsx
@@ -1,0 +1,328 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Puzzle, Trash2, Globe, Database, FileText } from "lucide-react";
+
+import {
+  listInstalledPlugins,
+  setPluginEnabled,
+  uninstallPlugin,
+  type PluginInfo,
+} from "../../../lib/tauri/plugins";
+
+/**
+ * Settings → Plugins panel (Phase 3.2). Lists every plugin
+ * installed under `<app-data>/waveflow/plugins/`, surfaces its
+ * manifest metadata + permissions, and exposes the enable toggle +
+ * uninstall flow.
+ *
+ * Empty state is the normal case for v1.5.0 because the only
+ * supported install path is sideload (drop a directory under
+ * `<app-data>/waveflow/plugins/<id>/`). Phase 4 ships Web Radio
+ * pre-installed; an official store + the install flow land
+ * post-1.5.0.
+ *
+ * Uninstall uses an inline confirm (a second click on the same
+ * row's button) rather than a modal — Settings is already a
+ * focused surface, a modal would feel heavy for a per-row action.
+ */
+export function PluginsCard() {
+  const { t } = useTranslation();
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingUninstall, setConfirmingUninstall] = useState<string | null>(
+    null,
+  );
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    // `.then`-style instead of an `await` inside an IIFE because
+    // `react-hooks/set-state-in-effect` traces synchronous
+    // setState calls through awaits + IIFEs, and reads `.then`
+    // callbacks as the external-subscription shape the rule
+    // accepts. `cancelled` guards against a stale callback
+    // landing setState after the component unmounted.
+    let cancelled = false;
+    listInstalledPlugins().then(
+      (list) => {
+        if (cancelled) return;
+        setPlugins(list);
+        setError(null);
+        setLoading(false);
+      },
+      (e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onToggle = useCallback(
+    async (plugin: PluginInfo) => {
+      setBusyId(plugin.id);
+      // Optimistic flip — revert on backend error.
+      setPlugins((prev) =>
+        prev.map((p) =>
+          p.id === plugin.id ? { ...p, enabled: !p.enabled } : p,
+        ),
+      );
+      try {
+        await setPluginEnabled(plugin.id, !plugin.enabled);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setPlugins((prev) =>
+          prev.map((p) =>
+            p.id === plugin.id ? { ...p, enabled: plugin.enabled } : p,
+          ),
+        );
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [],
+  );
+
+  const onUninstall = useCallback(
+    async (pluginId: string) => {
+      setBusyId(pluginId);
+      try {
+        await uninstallPlugin(pluginId);
+        setPlugins((prev) => prev.filter((p) => p.id !== pluginId));
+        setConfirmingUninstall(null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [],
+  );
+
+  return (
+    <section
+      aria-labelledby="settings-plugins-heading"
+      className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden"
+    >
+      <header className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-800 flex items-start gap-3">
+        <Puzzle
+          size={20}
+          className="text-zinc-400 mt-0.5 shrink-0"
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <h3
+            id="settings-plugins-heading"
+            className="text-sm font-medium text-zinc-900 dark:text-white"
+          >
+            {t("settings.plugins.title")}
+          </h3>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed mt-0.5">
+            {t("settings.plugins.subtitle")}
+          </p>
+        </div>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="px-4 py-2 bg-red-50 dark:bg-red-950/30 text-xs text-red-700 dark:text-red-300 border-b border-red-200 dark:border-red-900"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="px-4 py-6 text-xs text-zinc-500 dark:text-zinc-400 text-center">
+          {t("settings.plugins.loading")}
+        </div>
+      ) : plugins.length === 0 ? (
+        <div className="px-4 py-8 text-center">
+          <Puzzle
+            size={32}
+            className="mx-auto text-zinc-300 dark:text-zinc-700 mb-2"
+            aria-hidden="true"
+          />
+          <p className="text-sm text-zinc-600 dark:text-zinc-300">
+            {t("settings.plugins.emptyTitle")}
+          </p>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">
+            {t("settings.plugins.emptyHint")}
+          </p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
+          {plugins.map((plugin) => {
+            const isBusy = busyId === plugin.id;
+            const isConfirming = confirmingUninstall === plugin.id;
+            return (
+              <li key={plugin.id} className="px-4 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-zinc-900 dark:text-white truncate">
+                        {plugin.name}
+                      </span>
+                      <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                        v{plugin.version}
+                      </span>
+                      <WorldBadge world={plugin.world} />
+                    </div>
+                    <div className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 truncate">
+                      {t("settings.plugins.byAuthor", { author: plugin.author })}
+                    </div>
+                    {plugin.description && (
+                      <p className="text-xs text-zinc-600 dark:text-zinc-300 mt-1 leading-relaxed">
+                        {plugin.description}
+                      </p>
+                    )}
+                    <PermissionsRow
+                      permissions={plugin.permissions}
+                      assetsCount={plugin.assets.length}
+                    />
+                  </div>
+                  <div className="flex flex-col items-end gap-2 shrink-0">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {plugin.enabled
+                          ? t("settings.plugins.enabled")
+                          : t("settings.plugins.disabled")}
+                      </span>
+                      <input
+                        type="checkbox"
+                        checked={plugin.enabled}
+                        disabled={isBusy}
+                        onChange={() => {
+                          void onToggle(plugin);
+                        }}
+                        className="w-4 h-4 accent-emerald-500 cursor-pointer disabled:opacity-50"
+                        aria-label={t("settings.plugins.toggleAria", {
+                          name: plugin.name,
+                        })}
+                      />
+                    </label>
+                    {isConfirming ? (
+                      <div
+                        role="group"
+                        aria-label={t("settings.plugins.confirmUninstall", {
+                          name: plugin.name,
+                        })}
+                        className="flex items-center gap-1"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void onUninstall(plugin.id);
+                          }}
+                          disabled={isBusy}
+                          className="px-2 py-1 text-xs font-medium text-white bg-red-600 hover:bg-red-700 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                        >
+                          {t("settings.plugins.confirmYes")}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingUninstall(null)}
+                          disabled={isBusy}
+                          className="px-2 py-1 text-xs font-medium text-zinc-700 dark:text-zinc-200 bg-zinc-100 hover:bg-zinc-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+                        >
+                          {t("settings.plugins.confirmNo")}
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => setConfirmingUninstall(plugin.id)}
+                        disabled={isBusy}
+                        className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                        aria-label={t("settings.plugins.uninstallAria", {
+                          name: plugin.name,
+                        })}
+                      >
+                        <Trash2 size={14} aria-hidden="true" />
+                        <span>{t("settings.plugins.uninstall")}</span>
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function WorldBadge({ world }: { world: string }) {
+  const { t } = useTranslation();
+  // Map the WIT world label to a short user-facing role.
+  const label = world.startsWith("waveflow:source")
+    ? t("settings.plugins.worlds.source")
+    : world.startsWith("waveflow:metadata")
+      ? t("settings.plugins.worlds.metadata")
+      : world.startsWith("waveflow:ui")
+        ? t("settings.plugins.worlds.ui")
+        : world;
+  return (
+    <span className="text-[10px] uppercase tracking-wide font-medium px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
+      {label}
+    </span>
+  );
+}
+
+function PermissionsRow({
+  permissions,
+  assetsCount,
+}: {
+  permissions: PluginInfo["permissions"];
+  assetsCount: number;
+}) {
+  const { t } = useTranslation();
+  const chips: { key: string; icon: typeof Globe; label: string }[] = [];
+  if (permissions.http.length > 0) {
+    chips.push({
+      key: "http",
+      icon: Globe,
+      label: t("settings.plugins.permissions.http", {
+        count: permissions.http.length,
+      }),
+    });
+  }
+  if (permissions.storageState) {
+    chips.push({
+      key: "state",
+      icon: Database,
+      label: t("settings.plugins.permissions.storageState"),
+    });
+  }
+  if (assetsCount > 0 || permissions.storageRead) {
+    chips.push({
+      key: "assets",
+      icon: FileText,
+      label: t("settings.plugins.permissions.assets", { count: assetsCount }),
+    });
+  }
+  if (chips.length === 0) {
+    return (
+      <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5 italic">
+        {t("settings.plugins.permissions.none")}
+      </p>
+    );
+  }
+  return (
+    <ul className="flex flex-wrap gap-1.5 mt-1.5">
+      {chips.map(({ key, icon: Icon, label }) => (
+        <li
+          key={key}
+          className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+        >
+          <Icon size={11} aria-hidden="true" />
+          <span>{label}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/views/settings/PluginsCard.tsx
+++ b/src/components/views/settings/PluginsCard.tsx
@@ -298,7 +298,21 @@ function PermissionsRow({
       label: t("settings.plugins.permissions.storageState"),
     });
   }
-  if (assetsCount > 0 || permissions.storageRead) {
+  // `storage.read` (permission to read bundled assets) and the
+  // declared asset count are independent surfaces — a plugin can
+  // request the permission without shipping assets (forward-compat)
+  // and a plugin can ship assets without asking for the
+  // permission (manifest oversight). Surface them as separate
+  // chips so the user sees the truth on each axis instead of an
+  // "Assets (0)" chip when only the permission is set.
+  if (permissions.storageRead) {
+    chips.push({
+      key: "storageRead",
+      icon: FileText,
+      label: t("settings.plugins.permissions.storageRead"),
+    });
+  }
+  if (assetsCount > 0) {
     chips.push({
       key: "assets",
       icon: FileText,

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1267,6 +1267,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "تخزين المستخدم",
+        "storageRead": "قراءة الموارد",
         "assets": "الموارد ({{count}})",
         "none": "لا توجد أذونات مطلوبة"
       }

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1267,7 +1267,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "تخزين المستخدم",
-        "storageRead": "قراءة الموارد",
+        "storageRead": "قراءة التخزين",
         "assets": "الموارد ({{count}})",
         "none": "لا توجد أذونات مطلوبة"
       }

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1240,8 +1240,36 @@
       "appearance": "المظهر",
       "storage": "التخزين والبيانات",
       "data": "البيانات",
+      "plugins": "الإضافات",
       "shortcuts": "اختصارات لوحة المفاتيح",
       "diagnostics": "التشخيص"
+    },
+    "plugins": {
+      "title": "الإضافات المثبتة",
+      "subtitle": "أدر الامتدادات التي تضيف مصادر أو بيانات وصفية أو طرق عرض إلى WaveFlow.",
+      "loading": "جارٍ التحميل…",
+      "emptyTitle": "لا توجد إضافات مثبتة",
+      "emptyHint": "التثبيت اليدوي: ضع مجلدًا تحت <data>/waveflow/plugins/. سيتوفر متجر رسمي قريبًا.",
+      "byAuthor": "بواسطة {{author}}",
+      "enabled": "مفعّل",
+      "disabled": "معطّل",
+      "toggleAria": "تفعيل أو تعطيل {{name}}",
+      "uninstall": "إلغاء التثبيت",
+      "uninstallAria": "إلغاء تثبيت {{name}}",
+      "confirmUninstall": "تأكيد إلغاء تثبيت {{name}}",
+      "confirmYes": "تأكيد",
+      "confirmNo": "إلغاء",
+      "worlds": {
+        "source": "مصدر",
+        "metadata": "بيانات وصفية",
+        "ui": "واجهة"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "تخزين المستخدم",
+        "assets": "الموارد ({{count}})",
+        "none": "لا توجد أذونات مطلوبة"
+      }
     },
     "shortcuts": {
       "subtitle": "انقر على اختصار ثم اضغط على تركيبة المفاتيح المطلوبة. Backspace للمسح، Esc للإلغاء.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Nutzerspeicher",
+        "storageRead": "Ressourcenlesen",
         "assets": "Ressourcen ({{count}})",
         "none": "Keine Berechtigungen angefordert"
       }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Nutzerspeicher",
-        "storageRead": "Ressourcenlesen",
+        "storageRead": "Speicherlesen",
         "assets": "Ressourcen ({{count}})",
         "none": "Keine Berechtigungen angefordert"
       }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1236,8 +1236,36 @@
       "appearance": "Aussehen",
       "storage": "Speicher & Daten",
       "data": "Daten",
+      "plugins": "Plugins",
       "shortcuts": "Tastenkürzel",
       "diagnostics": "Diagnose"
+    },
+    "plugins": {
+      "title": "Installierte Plugins",
+      "subtitle": "Verwalte Erweiterungen, die WaveFlow Quellen, Metadaten oder Ansichten hinzufügen.",
+      "loading": "Lädt…",
+      "emptyTitle": "Keine Plugins installiert",
+      "emptyHint": "Manuelle Installation: Ordner in <data>/waveflow/plugins/ ablegen. Ein offizieller Store folgt.",
+      "byAuthor": "Von {{author}}",
+      "enabled": "Aktiviert",
+      "disabled": "Deaktiviert",
+      "toggleAria": "{{name}} aktivieren oder deaktivieren",
+      "uninstall": "Deinstallieren",
+      "uninstallAria": "{{name}} deinstallieren",
+      "confirmUninstall": "Deinstallation von {{name}} bestätigen",
+      "confirmYes": "Bestätigen",
+      "confirmNo": "Abbrechen",
+      "worlds": {
+        "source": "Quelle",
+        "metadata": "Metadaten",
+        "ui": "Oberfläche"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Nutzerspeicher",
+        "assets": "Ressourcen ({{count}})",
+        "none": "Keine Berechtigungen angefordert"
+      }
     },
     "shortcuts": {
       "subtitle": "Klicke auf ein Tastenkürzel und drücke dann die gewünschte Tastenkombination. Rücktaste zum Löschen, Esc zum Abbrechen.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "User storage",
-        "storageRead": "Asset read",
+        "storageRead": "Storage read",
         "assets": "Assets ({{count}})",
         "none": "No permission requested"
       }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1236,8 +1236,36 @@
       "appearance": "Appearance",
       "storage": "Storage & data",
       "data": "Data",
+      "plugins": "Plugins",
       "shortcuts": "Keyboard shortcuts",
       "diagnostics": "Diagnostics"
+    },
+    "plugins": {
+      "title": "Installed plugins",
+      "subtitle": "Manage extensions that add sources, metadata, or views to WaveFlow.",
+      "loading": "Loading…",
+      "emptyTitle": "No plugins installed",
+      "emptyHint": "Manual install: drop a directory under <data>/waveflow/plugins/. An official store is coming.",
+      "byAuthor": "By {{author}}",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "toggleAria": "Enable or disable {{name}}",
+      "uninstall": "Uninstall",
+      "uninstallAria": "Uninstall {{name}}",
+      "confirmUninstall": "Confirm uninstalling {{name}}",
+      "confirmYes": "Confirm",
+      "confirmNo": "Cancel",
+      "worlds": {
+        "source": "Source",
+        "metadata": "Metadata",
+        "ui": "UI"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "User storage",
+        "assets": "Assets ({{count}})",
+        "none": "No permission requested"
+      }
     },
     "shortcuts": {
       "subtitle": "Click a shortcut then press the key combination you want. Backspace to clear, Escape to cancel.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "User storage",
+        "storageRead": "Asset read",
         "assets": "Assets ({{count}})",
         "none": "No permission requested"
       }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Almacenamiento del usuario",
+        "storageRead": "Lectura de recursos",
         "assets": "Recursos ({{count}})",
         "none": "Sin permisos solicitados"
       }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Almacenamiento del usuario",
-        "storageRead": "Lectura de recursos",
+        "storageRead": "Lectura de almacenamiento",
         "assets": "Recursos ({{count}})",
         "none": "Sin permisos solicitados"
       }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1236,8 +1236,36 @@
       "appearance": "Apariencia",
       "storage": "Almacenamiento y datos",
       "data": "Datos",
+      "plugins": "Complementos",
       "shortcuts": "Atajos de teclado",
       "diagnostics": "Diagnóstico"
+    },
+    "plugins": {
+      "title": "Complementos instalados",
+      "subtitle": "Gestiona las extensiones que añaden fuentes, metadatos o vistas a WaveFlow.",
+      "loading": "Cargando…",
+      "emptyTitle": "No hay complementos instalados",
+      "emptyHint": "Instalación manual: deja una carpeta en <data>/waveflow/plugins/. Próximamente una tienda oficial.",
+      "byAuthor": "Por {{author}}",
+      "enabled": "Activado",
+      "disabled": "Desactivado",
+      "toggleAria": "Activar o desactivar {{name}}",
+      "uninstall": "Desinstalar",
+      "uninstallAria": "Desinstalar {{name}}",
+      "confirmUninstall": "Confirmar la desinstalación de {{name}}",
+      "confirmYes": "Confirmar",
+      "confirmNo": "Cancelar",
+      "worlds": {
+        "source": "Fuente",
+        "metadata": "Metadatos",
+        "ui": "Interfaz"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Almacenamiento del usuario",
+        "assets": "Recursos ({{count}})",
+        "none": "Sin permisos solicitados"
+      }
     },
     "shortcuts": {
       "subtitle": "Haz clic en un atajo y pulsa la combinación de teclas que quieras. Retroceso para borrar, Esc para cancelar.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1236,8 +1236,36 @@
       "appearance": "Apparence",
       "storage": "Stockage & Données",
       "data": "Données",
+      "plugins": "Plugins",
       "shortcuts": "Raccourcis clavier",
       "diagnostics": "Diagnostics"
+    },
+    "plugins": {
+      "title": "Plugins installés",
+      "subtitle": "Gérez les extensions qui ajoutent des sources, des métadonnées ou des vues à WaveFlow.",
+      "loading": "Chargement…",
+      "emptyTitle": "Aucun plugin installé",
+      "emptyHint": "L'installation manuelle se fait en déposant un dossier sous <data>/waveflow/plugins/. Un magasin officiel suivra.",
+      "byAuthor": "Par {{author}}",
+      "enabled": "Activé",
+      "disabled": "Désactivé",
+      "toggleAria": "Activer ou désactiver {{name}}",
+      "uninstall": "Désinstaller",
+      "uninstallAria": "Désinstaller {{name}}",
+      "confirmUninstall": "Confirmer la désinstallation de {{name}}",
+      "confirmYes": "Confirmer",
+      "confirmNo": "Annuler",
+      "worlds": {
+        "source": "Source",
+        "metadata": "Métadonnées",
+        "ui": "Interface"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Stockage utilisateur",
+        "assets": "Ressources ({{count}})",
+        "none": "Aucune permission demandée"
+      }
     },
     "categoryNavLabel": "Catégories des paramètres",
     "appearance": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Stockage utilisateur",
-        "storageRead": "Lecture des ressources",
+        "storageRead": "Lecture du stockage",
         "assets": "Ressources ({{count}})",
         "none": "Aucune permission demandée"
       }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Stockage utilisateur",
+        "storageRead": "Lecture des ressources",
         "assets": "Ressources ({{count}})",
         "none": "Aucune permission demandée"
       }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "उपयोगकर्ता संग्रहण",
-        "storageRead": "संपत्ति पढ़ना",
+        "storageRead": "संग्रहण पढ़ना",
         "assets": "संपत्तियाँ ({{count}})",
         "none": "कोई अनुमति अनुरोधित नहीं"
       }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "उपयोगकर्ता संग्रहण",
+        "storageRead": "संपत्ति पढ़ना",
         "assets": "संपत्तियाँ ({{count}})",
         "none": "कोई अनुमति अनुरोधित नहीं"
       }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1236,8 +1236,36 @@
       "appearance": "रूप",
       "storage": "भंडारण और डेटा",
       "data": "डेटा",
+      "plugins": "प्लगइन्स",
       "diagnostics": "निदान",
       "shortcuts": "कीबोर्ड शॉर्टकट"
+    },
+    "plugins": {
+      "title": "इंस्टॉल किए गए प्लगइन्स",
+      "subtitle": "WaveFlow में स्रोत, मेटाडेटा या दृश्य जोड़ने वाले एक्सटेंशन प्रबंधित करें।",
+      "loading": "लोड हो रहा है…",
+      "emptyTitle": "कोई प्लगइन इंस्टॉल नहीं है",
+      "emptyHint": "मैन्युअल इंस्टॉल: <data>/waveflow/plugins/ के अंतर्गत एक फ़ोल्डर रखें। आधिकारिक स्टोर जल्द आ रहा है।",
+      "byAuthor": "{{author}} द्वारा",
+      "enabled": "सक्षम",
+      "disabled": "अक्षम",
+      "toggleAria": "{{name}} सक्षम या अक्षम करें",
+      "uninstall": "अनइंस्टॉल",
+      "uninstallAria": "{{name}} अनइंस्टॉल करें",
+      "confirmUninstall": "{{name}} अनइंस्टॉल करने की पुष्टि करें",
+      "confirmYes": "पुष्टि करें",
+      "confirmNo": "रद्द करें",
+      "worlds": {
+        "source": "स्रोत",
+        "metadata": "मेटाडेटा",
+        "ui": "UI"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "उपयोगकर्ता संग्रहण",
+        "assets": "संपत्तियाँ ({{count}})",
+        "none": "कोई अनुमति अनुरोधित नहीं"
+      }
     },
     "shortcuts": {
       "subtitle": "किसी शॉर्टकट पर क्लिक करें फिर अपनी इच्छित कुंजी संयोजन दबाएँ। साफ़ करने के लिए Backspace, रद्द करने के लिए Escape।",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1236,8 +1236,36 @@
       "appearance": "Tampilan",
       "storage": "Penyimpanan & data",
       "data": "Data",
+      "plugins": "Plugin",
       "shortcuts": "Pintasan keyboard",
       "diagnostics": "Diagnostik"
+    },
+    "plugins": {
+      "title": "Plugin terpasang",
+      "subtitle": "Kelola ekstensi yang menambahkan sumber, metadata, atau tampilan ke WaveFlow.",
+      "loading": "Memuat…",
+      "emptyTitle": "Tidak ada plugin terpasang",
+      "emptyHint": "Pemasangan manual: letakkan folder di <data>/waveflow/plugins/. Toko resmi segera hadir.",
+      "byAuthor": "Oleh {{author}}",
+      "enabled": "Aktif",
+      "disabled": "Nonaktif",
+      "toggleAria": "Aktifkan atau nonaktifkan {{name}}",
+      "uninstall": "Hapus",
+      "uninstallAria": "Hapus {{name}}",
+      "confirmUninstall": "Konfirmasi penghapusan {{name}}",
+      "confirmYes": "Konfirmasi",
+      "confirmNo": "Batal",
+      "worlds": {
+        "source": "Sumber",
+        "metadata": "Metadata",
+        "ui": "Antarmuka"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Penyimpanan pengguna",
+        "assets": "Aset ({{count}})",
+        "none": "Tidak ada izin diminta"
+      }
     },
     "shortcuts": {
       "subtitle": "Klik sebuah pintasan lalu tekan kombinasi tombol yang kamu inginkan. Backspace untuk menghapus, Esc untuk membatalkan.",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Penyimpanan pengguna",
-        "storageRead": "Baca aset",
+        "storageRead": "Baca penyimpanan",
         "assets": "Aset ({{count}})",
         "none": "Tidak ada izin diminta"
       }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Penyimpanan pengguna",
+        "storageRead": "Baca aset",
         "assets": "Aset ({{count}})",
         "none": "Tidak ada izin diminta"
       }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Archivio utente",
-        "storageRead": "Lettura risorse",
+        "storageRead": "Lettura archivio",
         "assets": "Risorse ({{count}})",
         "none": "Nessun permesso richiesto"
       }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1236,8 +1236,36 @@
       "appearance": "Aspetto",
       "storage": "Archiviazione e dati",
       "data": "Dati",
+      "plugins": "Plugin",
       "shortcuts": "Scorciatoie da tastiera",
       "diagnostics": "Diagnostica"
+    },
+    "plugins": {
+      "title": "Plugin installati",
+      "subtitle": "Gestisci le estensioni che aggiungono sorgenti, metadati o viste a WaveFlow.",
+      "loading": "Caricamento…",
+      "emptyTitle": "Nessun plugin installato",
+      "emptyHint": "Installazione manuale: lascia una cartella in <data>/waveflow/plugins/. Uno store ufficiale è in arrivo.",
+      "byAuthor": "Di {{author}}",
+      "enabled": "Attivo",
+      "disabled": "Disattivato",
+      "toggleAria": "Attiva o disattiva {{name}}",
+      "uninstall": "Disinstalla",
+      "uninstallAria": "Disinstalla {{name}}",
+      "confirmUninstall": "Conferma la disinstallazione di {{name}}",
+      "confirmYes": "Conferma",
+      "confirmNo": "Annulla",
+      "worlds": {
+        "source": "Sorgente",
+        "metadata": "Metadati",
+        "ui": "Interfaccia"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Archivio utente",
+        "assets": "Risorse ({{count}})",
+        "none": "Nessun permesso richiesto"
+      }
     },
     "shortcuts": {
       "subtitle": "Clicca su una scorciatoia e premi la combinazione di tasti desiderata. Backspace per cancellare, Esc per annullare.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Archivio utente",
+        "storageRead": "Lettura risorse",
         "assets": "Risorse ({{count}})",
         "none": "Nessun permesso richiesto"
       }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "ユーザーストレージ",
-        "storageRead": "アセット読み取り",
+        "storageRead": "ストレージ読み取り",
         "assets": "アセット ({{count}})",
         "none": "要求された権限はありません"
       }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "ユーザーストレージ",
+        "storageRead": "アセット読み取り",
         "assets": "アセット ({{count}})",
         "none": "要求された権限はありません"
       }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1236,8 +1236,36 @@
       "appearance": "外観",
       "storage": "ストレージとデータ",
       "data": "データ",
+      "plugins": "プラグイン",
       "diagnostics": "診断",
       "shortcuts": "キーボードショートカット"
+    },
+    "plugins": {
+      "title": "インストール済みプラグイン",
+      "subtitle": "WaveFlow にソース、メタデータ、ビューを追加する拡張機能を管理します。",
+      "loading": "読み込み中…",
+      "emptyTitle": "プラグインがインストールされていません",
+      "emptyHint": "手動インストール: <data>/waveflow/plugins/ 内にフォルダを置きます。公式ストアは近日公開予定です。",
+      "byAuthor": "作者: {{author}}",
+      "enabled": "有効",
+      "disabled": "無効",
+      "toggleAria": "{{name}} を有効または無効にする",
+      "uninstall": "アンインストール",
+      "uninstallAria": "{{name}} をアンインストール",
+      "confirmUninstall": "{{name}} のアンインストールを確認",
+      "confirmYes": "確認",
+      "confirmNo": "キャンセル",
+      "worlds": {
+        "source": "ソース",
+        "metadata": "メタデータ",
+        "ui": "UI"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "ユーザーストレージ",
+        "assets": "アセット ({{count}})",
+        "none": "要求された権限はありません"
+      }
     },
     "integrations": {
       "lastfm": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "사용자 저장소",
+        "storageRead": "자산 읽기",
         "assets": "자산 ({{count}})",
         "none": "요청된 권한 없음"
       }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1236,8 +1236,36 @@
       "appearance": "외관",
       "storage": "저장소 및 데이터",
       "data": "데이터",
+      "plugins": "플러그인",
       "diagnostics": "진단",
       "shortcuts": "키보드 단축키"
+    },
+    "plugins": {
+      "title": "설치된 플러그인",
+      "subtitle": "WaveFlow에 소스, 메타데이터 또는 뷰를 추가하는 확장 기능을 관리합니다.",
+      "loading": "로드 중…",
+      "emptyTitle": "설치된 플러그인이 없습니다",
+      "emptyHint": "수동 설치: <data>/waveflow/plugins/에 폴더를 넣으세요. 공식 스토어가 곧 출시됩니다.",
+      "byAuthor": "{{author}} 작성",
+      "enabled": "활성화됨",
+      "disabled": "비활성화됨",
+      "toggleAria": "{{name}} 활성화 또는 비활성화",
+      "uninstall": "제거",
+      "uninstallAria": "{{name}} 제거",
+      "confirmUninstall": "{{name}} 제거 확인",
+      "confirmYes": "확인",
+      "confirmNo": "취소",
+      "worlds": {
+        "source": "소스",
+        "metadata": "메타데이터",
+        "ui": "UI"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "사용자 저장소",
+        "assets": "자산 ({{count}})",
+        "none": "요청된 권한 없음"
+      }
     },
     "shortcuts": {
       "subtitle": "단축키를 클릭한 후 원하는 키 조합을 누르세요. 지우려면 Backspace, 취소하려면 Escape를 누르세요.",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "사용자 저장소",
-        "storageRead": "자산 읽기",
+        "storageRead": "스토리지 읽기",
         "assets": "자산 ({{count}})",
         "none": "요청된 권한 없음"
       }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Gebruikersopslag",
-        "storageRead": "Resources lezen",
+        "storageRead": "Opslag lezen",
         "assets": "Resources ({{count}})",
         "none": "Geen rechten gevraagd"
       }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1236,8 +1236,36 @@
       "appearance": "Weergave",
       "storage": "Opslag en gegevens",
       "data": "Gegevens",
+      "plugins": "Plug-ins",
       "shortcuts": "Sneltoetsen",
       "diagnostics": "Diagnostiek"
+    },
+    "plugins": {
+      "title": "Geïnstalleerde plug-ins",
+      "subtitle": "Beheer uitbreidingen die bronnen, metadata of weergaven aan WaveFlow toevoegen.",
+      "loading": "Laden…",
+      "emptyTitle": "Geen plug-ins geïnstalleerd",
+      "emptyHint": "Handmatige installatie: plaats een map in <data>/waveflow/plugins/. Een officiële store komt eraan.",
+      "byAuthor": "Door {{author}}",
+      "enabled": "Ingeschakeld",
+      "disabled": "Uitgeschakeld",
+      "toggleAria": "{{name}} in- of uitschakelen",
+      "uninstall": "Verwijderen",
+      "uninstallAria": "{{name}} verwijderen",
+      "confirmUninstall": "Bevestig het verwijderen van {{name}}",
+      "confirmYes": "Bevestigen",
+      "confirmNo": "Annuleren",
+      "worlds": {
+        "source": "Bron",
+        "metadata": "Metadata",
+        "ui": "Interface"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Gebruikersopslag",
+        "assets": "Resources ({{count}})",
+        "none": "Geen rechten gevraagd"
+      }
     },
     "shortcuts": {
       "subtitle": "Klik op een sneltoets en druk vervolgens op de gewenste toetscombinatie. Backspace om te wissen, Esc om te annuleren.",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Gebruikersopslag",
+        "storageRead": "Resources lezen",
         "assets": "Resources ({{count}})",
         "none": "Geen rechten gevraagd"
       }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Armazenamento do usuário",
-        "storageRead": "Leitura de recursos",
+        "storageRead": "Leitura de armazenamento",
         "assets": "Recursos ({{count}})",
         "none": "Nenhuma permissão solicitada"
       }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1236,8 +1236,36 @@
       "appearance": "Aparência",
       "storage": "Armazenamento e dados",
       "data": "Dados",
+      "plugins": "Plugins",
       "diagnostics": "Diagnóstico",
       "shortcuts": "Atalhos de teclado"
+    },
+    "plugins": {
+      "title": "Plugins instalados",
+      "subtitle": "Gerencie as extensões que adicionam fontes, metadados ou visualizações ao WaveFlow.",
+      "loading": "Carregando…",
+      "emptyTitle": "Nenhum plugin instalado",
+      "emptyHint": "Instalação manual: coloque uma pasta em <data>/waveflow/plugins/. Uma loja oficial está chegando.",
+      "byAuthor": "Por {{author}}",
+      "enabled": "Ativado",
+      "disabled": "Desativado",
+      "toggleAria": "Ativar ou desativar {{name}}",
+      "uninstall": "Desinstalar",
+      "uninstallAria": "Desinstalar {{name}}",
+      "confirmUninstall": "Confirmar a desinstalação de {{name}}",
+      "confirmYes": "Confirmar",
+      "confirmNo": "Cancelar",
+      "worlds": {
+        "source": "Fonte",
+        "metadata": "Metadados",
+        "ui": "Interface"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Armazenamento do usuário",
+        "assets": "Recursos ({{count}})",
+        "none": "Nenhuma permissão solicitada"
+      }
     },
     "shortcuts": {
       "subtitle": "Clique em um atalho e pressione a combinação de teclas que você quer. Backspace para limpar, Esc para cancelar.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Armazenamento do usuário",
+        "storageRead": "Leitura de recursos",
         "assets": "Recursos ({{count}})",
         "none": "Nenhuma permissão solicitada"
       }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Armazenamento do utilizador",
+        "storageRead": "Leitura de recursos",
         "assets": "Recursos ({{count}})",
         "none": "Nenhuma permissão pedida"
       }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1236,8 +1236,36 @@
       "appearance": "Aparência",
       "storage": "Armazenamento e dados",
       "data": "Dados",
+      "plugins": "Plugins",
       "diagnostics": "Diagnóstico",
       "shortcuts": "Atalhos de teclado"
+    },
+    "plugins": {
+      "title": "Plugins instalados",
+      "subtitle": "Gere as extensões que adicionam fontes, metadados ou vistas ao WaveFlow.",
+      "loading": "A carregar…",
+      "emptyTitle": "Nenhum plugin instalado",
+      "emptyHint": "Instalação manual: coloque uma pasta em <data>/waveflow/plugins/. Uma loja oficial está a caminho.",
+      "byAuthor": "Por {{author}}",
+      "enabled": "Ativado",
+      "disabled": "Desativado",
+      "toggleAria": "Ativar ou desativar {{name}}",
+      "uninstall": "Desinstalar",
+      "uninstallAria": "Desinstalar {{name}}",
+      "confirmUninstall": "Confirmar a desinstalação de {{name}}",
+      "confirmYes": "Confirmar",
+      "confirmNo": "Cancelar",
+      "worlds": {
+        "source": "Fonte",
+        "metadata": "Metadados",
+        "ui": "Interface"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Armazenamento do utilizador",
+        "assets": "Recursos ({{count}})",
+        "none": "Nenhuma permissão pedida"
+      }
     },
     "shortcuts": {
       "subtitle": "Clica num atalho e prime a combinação de teclas que desejas. Backspace para limpar, Escape para cancelar.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Armazenamento do utilizador",
-        "storageRead": "Leitura de recursos",
+        "storageRead": "Leitura de armazenamento",
         "assets": "Recursos ({{count}})",
         "none": "Nenhuma permissão pedida"
       }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1304,7 +1304,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Хранилище пользователя",
-        "storageRead": "Чтение ресурсов",
+        "storageRead": "Чтение хранилища",
         "assets": "Ресурсы ({{count}})",
         "none": "Права не запрошены"
       }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1277,8 +1277,36 @@
       "appearance": "Внешний вид",
       "storage": "Хранилище и данные",
       "data": "Данные",
+      "plugins": "Плагины",
       "shortcuts": "Сочетания клавиш",
       "diagnostics": "Диагностика"
+    },
+    "plugins": {
+      "title": "Установленные плагины",
+      "subtitle": "Управляйте расширениями, которые добавляют в WaveFlow источники, метаданные или представления.",
+      "loading": "Загрузка…",
+      "emptyTitle": "Плагины не установлены",
+      "emptyHint": "Ручная установка: поместите каталог в <data>/waveflow/plugins/. Официальный магазин скоро будет.",
+      "byAuthor": "От {{author}}",
+      "enabled": "Включено",
+      "disabled": "Отключено",
+      "toggleAria": "Включить или отключить {{name}}",
+      "uninstall": "Удалить",
+      "uninstallAria": "Удалить {{name}}",
+      "confirmUninstall": "Подтвердите удаление {{name}}",
+      "confirmYes": "Подтвердить",
+      "confirmNo": "Отмена",
+      "worlds": {
+        "source": "Источник",
+        "metadata": "Метаданные",
+        "ui": "Интерфейс"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Хранилище пользователя",
+        "assets": "Ресурсы ({{count}})",
+        "none": "Права не запрошены"
+      }
     },
     "shortcuts": {
       "subtitle": "Нажмите на сочетание клавиш, затем введите нужную комбинацию. Backspace — очистить, Esc — отменить.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1304,6 +1304,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Хранилище пользователя",
+        "storageRead": "Чтение ресурсов",
         "assets": "Ресурсы ({{count}})",
         "none": "Права не запрошены"
       }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Kullanıcı deposu",
+        "storageRead": "Varlık okuma",
         "assets": "Varlıklar ({{count}})",
         "none": "İstenen izin yok"
       }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1236,8 +1236,36 @@
       "appearance": "Görünüm",
       "storage": "Depolama ve veriler",
       "data": "Veriler",
+      "plugins": "Eklentiler",
       "shortcuts": "Klavye kısayolları",
       "diagnostics": "Tanılama"
+    },
+    "plugins": {
+      "title": "Yüklü eklentiler",
+      "subtitle": "WaveFlow'a kaynak, üst veri veya görünüm ekleyen uzantıları yönetin.",
+      "loading": "Yükleniyor…",
+      "emptyTitle": "Yüklü eklenti yok",
+      "emptyHint": "Manuel kurulum: <data>/waveflow/plugins/ altına bir klasör bırakın. Resmi mağaza yakında.",
+      "byAuthor": "Yazan: {{author}}",
+      "enabled": "Etkin",
+      "disabled": "Devre dışı",
+      "toggleAria": "{{name}} etkinleştir veya devre dışı bırak",
+      "uninstall": "Kaldır",
+      "uninstallAria": "{{name}} kaldır",
+      "confirmUninstall": "{{name}} kaldırmayı onayla",
+      "confirmYes": "Onayla",
+      "confirmNo": "İptal",
+      "worlds": {
+        "source": "Kaynak",
+        "metadata": "Üst veri",
+        "ui": "Arayüz"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "Kullanıcı deposu",
+        "assets": "Varlıklar ({{count}})",
+        "none": "İstenen izin yok"
+      }
     },
     "shortcuts": {
       "subtitle": "Bir kısayola tıkla ve ardından istediğin tuş kombinasyonuna bas. Silmek için Backspace, iptal için Esc.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "Kullanıcı deposu",
-        "storageRead": "Varlık okuma",
+        "storageRead": "Depolama okuma",
         "assets": "Varlıklar ({{count}})",
         "none": "İstenen izin yok"
       }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "用户存储",
+        "storageRead": "读取资源",
         "assets": "资源 ({{count}})",
         "none": "未请求任何权限"
       }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1236,8 +1236,36 @@
       "appearance": "外观",
       "storage": "存储与数据",
       "data": "数据",
+      "plugins": "插件",
       "diagnostics": "诊断",
       "shortcuts": "键盘快捷键"
+    },
+    "plugins": {
+      "title": "已安装的插件",
+      "subtitle": "管理向 WaveFlow 添加来源、元数据或视图的扩展。",
+      "loading": "加载中…",
+      "emptyTitle": "未安装插件",
+      "emptyHint": "手动安装：将文件夹放在 <data>/waveflow/plugins/ 下。官方商店即将推出。",
+      "byAuthor": "作者：{{author}}",
+      "enabled": "已启用",
+      "disabled": "已禁用",
+      "toggleAria": "启用或禁用 {{name}}",
+      "uninstall": "卸载",
+      "uninstallAria": "卸载 {{name}}",
+      "confirmUninstall": "确认卸载 {{name}}",
+      "confirmYes": "确认",
+      "confirmNo": "取消",
+      "worlds": {
+        "source": "来源",
+        "metadata": "元数据",
+        "ui": "界面"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "用户存储",
+        "assets": "资源 ({{count}})",
+        "none": "未请求任何权限"
+      }
     },
     "integrations": {
       "lastfm": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "用户存储",
-        "storageRead": "读取资源",
+        "storageRead": "读取存储",
         "assets": "资源 ({{count}})",
         "none": "未请求任何权限"
       }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1263,6 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "使用者儲存",
+        "storageRead": "讀取資源",
         "assets": "資源 ({{count}})",
         "none": "未請求任何權限"
       }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1263,7 +1263,7 @@
       "permissions": {
         "http": "HTTP ({{count}})",
         "storageState": "使用者儲存",
-        "storageRead": "讀取資源",
+        "storageRead": "讀取儲存",
         "assets": "資源 ({{count}})",
         "none": "未請求任何權限"
       }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1236,8 +1236,36 @@
       "appearance": "外觀",
       "storage": "儲存與資料",
       "data": "資料",
+      "plugins": "外掛",
       "diagnostics": "診斷",
       "shortcuts": "鍵盤快速鍵"
+    },
+    "plugins": {
+      "title": "已安裝的外掛",
+      "subtitle": "管理為 WaveFlow 新增來源、中繼資料或檢視的擴充功能。",
+      "loading": "載入中…",
+      "emptyTitle": "未安裝任何外掛",
+      "emptyHint": "手動安裝:將資料夾放在 <data>/waveflow/plugins/ 下。官方商店即將推出。",
+      "byAuthor": "作者:{{author}}",
+      "enabled": "已啟用",
+      "disabled": "已停用",
+      "toggleAria": "啟用或停用 {{name}}",
+      "uninstall": "解除安裝",
+      "uninstallAria": "解除安裝 {{name}}",
+      "confirmUninstall": "確認解除安裝 {{name}}",
+      "confirmYes": "確認",
+      "confirmNo": "取消",
+      "worlds": {
+        "source": "來源",
+        "metadata": "中繼資料",
+        "ui": "介面"
+      },
+      "permissions": {
+        "http": "HTTP ({{count}})",
+        "storageState": "使用者儲存",
+        "assets": "資源 ({{count}})",
+        "none": "未請求任何權限"
+      }
     },
     "integrations": {
       "lastfm": {

--- a/src/lib/tauri/plugins.ts
+++ b/src/lib/tauri/plugins.ts
@@ -1,0 +1,82 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Plugin information exposed by the Plugin SDK backend (Phase 3.1).
+ *
+ * Mirrors `commands::plugins::PluginInfo` from the Rust side —
+ * the backend uses `#[serde(rename_all = "camelCase")]` so the
+ * shape matches verbatim. Fields are read-only from the frontend;
+ * mutations go through `setPluginEnabled` / `uninstallPlugin`.
+ */
+export interface PluginInfo {
+  id: string;
+  name: string;
+  version: string;
+  author: string;
+  /** Manifest world label — one of `waveflow:source/v1`,
+   *  `waveflow:metadata/v1`, `waveflow:ui/v1`. */
+  world: string;
+  description: string | null;
+  homepage: string | null;
+  license: string | null;
+  permissions: PluginPermissionsInfo;
+  assets: PluginAssetInfo[];
+  /** Resolved from `app_setting['plugin.<id>.enabled']`. Defaults
+   *  to `true` for a freshly-installed plugin (no setting row). */
+  enabled: boolean;
+}
+
+export interface PluginPermissionsInfo {
+  /** HTTP allowlist patterns, e.g. `https://*.radio-browser.info/**`. */
+  http: string[];
+  storageRead: boolean;
+  storageState: boolean;
+}
+
+export interface PluginAssetInfo {
+  filename: string;
+  description: string | null;
+}
+
+/**
+ * List every plugin installed under `<app-data>/waveflow/plugins/`.
+ * Subdirectories with a missing or malformed manifest are silently
+ * skipped backend-side, so the UI only sees plugins the runtime
+ * could actually load.
+ */
+export async function listInstalledPlugins(): Promise<PluginInfo[]> {
+  return invoke<PluginInfo[]>("list_installed_plugins");
+}
+
+/**
+ * Single-row fetch. Returns `null` when the id doesn't resolve to
+ * a valid plugin (the install dir is gone, the manifest doesn't
+ * parse, or the manifest's declared id doesn't match the param).
+ */
+export async function getPluginInfo(
+  pluginId: string,
+): Promise<PluginInfo | null> {
+  return invoke<PluginInfo | null>("get_plugin_info", { pluginId });
+}
+
+/**
+ * Toggle the per-plugin enabled flag. Backend refuses to write
+ * the setting if the plugin isn't actually installed (missing or
+ * mismatched manifest), so the UI doesn't need to pre-check.
+ */
+export async function setPluginEnabled(
+  pluginId: string,
+  enabled: boolean,
+): Promise<void> {
+  return invoke<void>("set_plugin_enabled", { pluginId, enabled });
+}
+
+/**
+ * Remove the plugin's install dir + scratch dir + the
+ * `app_setting` enabled row. UI MUST confirm with the user before
+ * calling — the command itself takes no "are you sure" parameter,
+ * same convention as `deleteProfile`.
+ */
+export async function uninstallPlugin(pluginId: string): Promise<void> {
+  return invoke<void>("uninstall_plugin", { pluginId });
+}


### PR DESCRIPTION
## Summary

User-facing surface for Phase 3.1's backend wiring (#223). Adds a new Settings → Plugins category that lists every installed plugin, surfaces its manifest metadata + permissions, and exposes the enable toggle + uninstall flow.

## What lands

- [`src/lib/tauri/plugins.ts`](src/lib/tauri/plugins.ts) — typed wrappers around the four Phase 3.1 commands. Types mirror the backend's \`#[serde(rename_all = "camelCase")]\` exactly.
- [`src/components/views/settings/PluginsCard.tsx`](src/components/views/settings/PluginsCard.tsx) — the panel. Empty state on a fresh install, one row per plugin (name + version + author + description + world badge + permission chips), enabled checkbox + uninstall button. Uninstall uses a second-click inline confirm instead of a modal.
- [`SettingsView.tsx`](src/components/views/SettingsView.tsx) — new \`plugins\` entry in \`SettingsCategory\` + table + tabpanel block, slotted between \`data\` and \`shortcuts\`. Lazy mount per the SettingsView convention.
- **i18n**: full \`settings.plugins.*\` block + \`settings.sections.plugins\` label propagated to **all 17 locales** (fr source + native translations for en/es/de/it/nl/pt/pt-BR/ru/tr/id/ja/ko/zh-CN/zh-TW/ar/hi).

## UI behaviour notes

- Initial fetch is inside \`useEffect\` via \`.then\` rather than \`await reload()\` because \`react-hooks/set-state-in-effect\` traces sync setState through awaits + IIFEs; the \`.then\` callback shape reads as an external-subscription which the rule accepts. \`cancelled\` guard for unmount safety.
- Toggle is optimistic — UI flips immediately and reverts on backend error. Uninstall removes the row from the list on success.
- Empty state nudges the user toward the sideload path (\`<data>/waveflow/plugins/\`) until the install command + the official store land post-1.5.0.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] Manual: drop a synthetic plugin dir, verify it shows up + can be toggled + can be uninstalled
- [x] Locale switch: confirm strings render in fr/en/ja (mix of script systems)

Refs RFC-002 §6 phase 3. Builds on #223.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Nouvelle section "Plugins" dans les Paramètres : liste des extensions installées, indicateurs d’origine/permissions, activation/désactivation et désinstallation avec confirmation inline.
  * UI améliorée : états de chargement et liste vide, gestion des erreurs et verrouillage des actions pour éviter interactions concurrentes.
  * Support multilingue étendu pour la gestion des plugins dans 17 langues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->