### PR TITLE
feat(web-radio): route live streams through the cpal engine (phase 4.c)

### DIFF
--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -130,8 +130,12 @@ crossbeam-channel = "0.5"
 # the post-EQ output, throttled to ~30 Hz.
 realfft = "3"
 
-# HTTP client for Deezer public API metadata enrichment
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# HTTP client for Deezer public API metadata enrichment.
+# `blocking` is enabled so the audio decoder thread can open a live
+# HTTP stream synchronously from inside its non-tokio worker (Web
+# Radio: see `audio::http_source`). The async client stays the
+# default everywhere else.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 
 # WebSocket client for the multi-device sync subscriber (Phase
 # 1.f.desktop.4b). Same rustls stack as reqwest so the TLS roots stay

--- a/src-tauri/crates/app/src/audio/crossfade.rs
+++ b/src-tauri/crates/app/src/audio/crossfade.rs
@@ -14,7 +14,7 @@ use symphonia::core::codecs::audio::{AudioDecoder, AudioDecoderOptions};
 use symphonia::core::errors::Error as SymphoniaError;
 use symphonia::core::formats::probe::Hint;
 use symphonia::core::formats::{FormatOptions, FormatReader, SeekMode, SeekTo, TrackType};
-use symphonia::core::io::MediaSourceStream;
+use symphonia::core::io::{MediaSource, MediaSourceStream};
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::units::Time;
 
@@ -124,9 +124,41 @@ impl ActiveStream {
         }
 
         let file = File::open(path).map_err(|e| format!("open: {e}"))?;
-        let mss = MediaSourceStream::new(Box::new(file), Default::default());
+        Self::open_from_source(
+            Box::new(file),
+            ext.as_deref(),
+            track_id,
+            duration_ms,
+            source_type,
+            source_id,
+            replay_gain_db,
+        )
+    }
+
+    /// Probe + decode any `MediaSource`. Shared between the file-backed
+    /// path (`open(path)` above) and the live-stream path
+    /// (`audio::http_source::HttpMediaSource` for Web Radio).
+    ///
+    /// `ext_hint` is forwarded to the probe so symphonia ranks the
+    /// correct demuxer first when the source's bytes don't lead with an
+    /// unambiguous magic — Icecast servers often serve "audio/mpeg"
+    /// streams that need the "mp3" hint to probe cleanly.
+    ///
+    /// `duration_ms = 0` is the canonical "live stream" marker — the
+    /// decoder loop reads this to suppress the end-of-track guard, the
+    /// crossfade prefetch hand-off, and the auto-advance round trip.
+    pub fn open_from_source(
+        source: Box<dyn MediaSource>,
+        ext_hint: Option<&str>,
+        track_id: i64,
+        duration_ms: u64,
+        source_type: String,
+        source_id: Option<i64>,
+        replay_gain_db: Option<f64>,
+    ) -> Result<Self, String> {
+        let mss = MediaSourceStream::new(source, Default::default());
         let mut hint = Hint::new();
-        if let Some(ext) = ext.as_deref() {
+        if let Some(ext) = ext_hint {
             hint.with_extension(ext);
         }
         let format = symphonia::default::get_probe()

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -415,11 +415,37 @@ fn decoder_loop(
                 // few hundred ms on slow servers).
                 emit_radio_metadata(&app, track_id, &title, &artist, &artwork_url);
 
+                // Defence in depth: `player_play_url` already gates on
+                // `offline::is_offline()` before dispatching the
+                // command, but the decoder is the last hop before
+                // reqwest::blocking opens a socket. Honouring the
+                // toggle here guarantees the project-wide convention
+                // ("every outbound HTTP path checks offline first")
+                // holds even if some future code path enqueues a
+                // LoadUrlAndPlay directly.
+                if crate::offline::is_offline() {
+                    let _ = app.emit(
+                        EVENT_ERROR,
+                        ErrorPayload {
+                            message: "offline mode is enabled".to_string(),
+                        },
+                    );
+                    transition_state(&shared, &app, PlayerState::Idle, Some(track_id));
+                    continue;
+                }
+
+                // Snapshot the redacted URL once for both log sites
+                // below + the outcome handler — `redact_url` is a
+                // small string clone, cheap, and avoids per-log re-
+                // parses while keeping any userinfo / query out of
+                // the rolling log file.
+                let redacted = super::http_source::redact_url(&url);
+
                 let http_source =
                     match super::http_source::HttpMediaSource::open(&url) {
                         Ok(s) => s,
                         Err(err) => {
-                            tracing::warn!(?err, %url, "radio stream open failed");
+                            tracing::warn!(?err, url = %redacted, "radio stream open failed");
                             let _ = app.emit(
                                 EVENT_ERROR,
                                 ErrorPayload {
@@ -445,7 +471,7 @@ fn decoder_loop(
                 ) {
                     Ok(s) => s,
                     Err(err) => {
-                        tracing::warn!(?err, %url, "radio stream probe failed");
+                        tracing::warn!(?err, url = %redacted, "radio stream probe failed");
                         let _ = app.emit(
                             EVENT_ERROR,
                             ErrorPayload {
@@ -473,7 +499,7 @@ fn decoder_loop(
                     &app,
                     track_id,
                     analytics_tx,
-                    Some(url),
+                    Some(redacted),
                 );
             }
             AudioCmd::SwapProducer(new_producer) => {

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -10,7 +10,6 @@
 //! pause / stop / seek feel responsive even during long tracks.
 
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -60,6 +59,102 @@ struct TrackEndedPayload {
 #[derive(Serialize, Clone)]
 struct ErrorPayload {
     message: String,
+}
+
+#[derive(Serialize, Clone)]
+struct RadioMetadataPayload {
+    track_id: i64,
+    title: Option<String>,
+    artist: Option<String>,
+    artwork_url: Option<String>,
+}
+
+/// Emit `player:radio-metadata` so the PlayerBar + OS overlay can
+/// paint the live-stream title / cover during the symphonia probe.
+/// No-op for non-radio loads — this event is purely additive on top
+/// of the existing `player:track-changed`.
+fn emit_radio_metadata(
+    app: &AppHandle,
+    track_id: i64,
+    title: &Option<String>,
+    artist: &Option<String>,
+    artwork_url: &Option<String>,
+) {
+    let _ = app.emit(
+        "player:radio-metadata",
+        RadioMetadataPayload {
+            track_id,
+            title: title.clone(),
+            artist: artist.clone(),
+            artwork_url: artwork_url.clone(),
+        },
+    );
+}
+
+/// Common path for `LoadAndPlay` / `LoadUrlAndPlay` — fire the right
+/// analytics message depending on how the stream finished. Live
+/// radio (`finished.track_id < 0`, `finished.source_type == "radio"`)
+/// skips the play_event credit entirely — there's no library row to
+/// reference and the play wouldn't be eligible for scrobbling anyway.
+fn handle_playback_outcome(
+    outcome: Result<(PlaybackEnd, u64, FinishedTrack), String>,
+    shared: &SharedPlayback,
+    app: &AppHandle,
+    requested_track_id: i64,
+    analytics_tx: &UnboundedSender<AnalyticsMsg>,
+    source_label: Option<String>,
+) {
+    match outcome {
+        Ok((PlaybackEnd::Natural, listened_ms, finished)) => {
+            let completed =
+                listened_ms + 2000 >= finished.duration_ms && finished.duration_ms > 0;
+            tracing::info!(
+                finished_track_id = finished.track_id,
+                listened_ms,
+                completed,
+                "play_track ended naturally"
+            );
+            if finished.track_id > 0 {
+                let _ = analytics_tx.send(AnalyticsMsg::TrackEnded {
+                    track_id: finished.track_id,
+                    completed,
+                    listened_ms,
+                    source_type: finished.source_type,
+                    source_id: finished.source_id,
+                });
+            }
+        }
+        Ok((PlaybackEnd::Interrupted, listened_ms, finished)) => {
+            tracing::info!(
+                finished_track_id = finished.track_id,
+                listened_ms,
+                will_credit = listened_ms >= 15_000,
+                "play_track interrupted"
+            );
+            if finished.track_id > 0 && listened_ms >= 15_000 {
+                let _ = analytics_tx.send(AnalyticsMsg::TrackListened {
+                    track_id: finished.track_id,
+                    listened_ms,
+                    source_type: finished.source_type,
+                    source_id: finished.source_id,
+                });
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                source = source_label.as_deref().unwrap_or(""),
+                "playback failed"
+            );
+            let _ = app.emit(
+                EVENT_ERROR,
+                ErrorPayload {
+                    message: err.clone(),
+                },
+            );
+            transition_state(shared, app, PlayerState::Idle, Some(requested_track_id));
+        }
+    }
 }
 
 /// Transition [`SharedPlayback`] state and emit a `player:state` event
@@ -247,14 +342,29 @@ fn decoder_loop(
                 shared.base_offset_ms.store(start_ms, Ordering::Relaxed);
                 shared.current_track_id.store(track_id, Ordering::Release);
 
-                let outcome = play_track(
+                let stream = match ActiveStream::open(
                     &path,
-                    start_ms,
                     track_id,
                     duration_ms,
                     source_type.clone(),
                     source_id,
                     replay_gain_db,
+                ) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        tracing::warn!(?err, path = %path.display(), "open failed");
+                        let _ = app.emit(
+                            EVENT_ERROR,
+                            ErrorPayload { message: err },
+                        );
+                        transition_state(&shared, &app, PlayerState::Idle, Some(track_id));
+                        continue;
+                    }
+                };
+
+                let outcome = play_track(
+                    stream,
+                    start_ms,
                     producer,
                     &shared,
                     cmd_rx,
@@ -262,51 +372,109 @@ fn decoder_loop(
                     &mut pending_cmd,
                     analytics_tx,
                 );
-                match outcome {
-                    Ok((PlaybackEnd::Natural, listened_ms, finished)) => {
-                        let completed =
-                            listened_ms + 2000 >= finished.duration_ms && finished.duration_ms > 0;
-                        tracing::info!(
-                            finished_track_id = finished.track_id,
-                            listened_ms,
-                            completed,
-                            "play_track ended naturally"
-                        );
-                        let _ = analytics_tx.send(AnalyticsMsg::TrackEnded {
-                            track_id: finished.track_id,
-                            completed,
-                            listened_ms,
-                            source_type: finished.source_type,
-                            source_id: finished.source_id,
-                        });
+                handle_playback_outcome(
+                    outcome,
+                    &shared,
+                    &app,
+                    track_id,
+                    analytics_tx,
+                    Some(path.display().to_string()),
+                );
+            }
+            AudioCmd::LoadUrlAndPlay {
+                url,
+                ext_hint,
+                track_id,
+                title,
+                artist,
+                artwork_url,
+            } => {
+                shared.clear_ab_loop();
+                transition_state(&shared, &app, PlayerState::Loading, Some(track_id));
+
+                if producer.slots() != super::output::RING_CAPACITY {
+                    shared.paused_output.store(false, Ordering::Release);
+                    shared.drain_silent.store(true, Ordering::Release);
+                    let start = std::time::Instant::now();
+                    while producer.slots() < super::output::RING_CAPACITY
+                        && start.elapsed() < Duration::from_millis(500)
+                    {
+                        std::thread::sleep(Duration::from_millis(1));
                     }
-                    Ok((PlaybackEnd::Interrupted, listened_ms, finished)) => {
-                        tracing::info!(
-                            finished_track_id = finished.track_id,
-                            listened_ms,
-                            will_credit = listened_ms >= 15_000,
-                            "play_track interrupted"
-                        );
-                        if listened_ms >= 15_000 {
-                            let _ = analytics_tx.send(AnalyticsMsg::TrackListened {
-                                track_id: finished.track_id,
-                                listened_ms,
-                                source_type: finished.source_type,
-                                source_id: finished.source_id,
-                            });
+                    shared.drain_silent.store(false, Ordering::Release);
+                } else {
+                    shared.paused_output.store(false, Ordering::Release);
+                }
+                shared.samples_played.store(0, Ordering::Relaxed);
+                shared.base_offset_ms.store(0, Ordering::Relaxed);
+                shared.current_track_id.store(track_id, Ordering::Release);
+
+                // Emit the radio metadata up front so the OS overlay /
+                // PlayerBar can paint the title + cover during the
+                // network handshake (the symphonia probe blocks for a
+                // few hundred ms on slow servers).
+                emit_radio_metadata(&app, track_id, &title, &artist, &artwork_url);
+
+                let http_source =
+                    match super::http_source::HttpMediaSource::open(&url) {
+                        Ok(s) => s,
+                        Err(err) => {
+                            tracing::warn!(?err, %url, "radio stream open failed");
+                            let _ = app.emit(
+                                EVENT_ERROR,
+                                ErrorPayload {
+                                    message: format!("radio stream open: {err}"),
+                                },
+                            );
+                            transition_state(&shared, &app, PlayerState::Idle, Some(track_id));
+                            continue;
                         }
-                    }
+                    };
+
+                let stream = match ActiveStream::open_from_source(
+                    Box::new(http_source),
+                    ext_hint.as_deref(),
+                    track_id,
+                    // duration_ms = 0 is the live-stream sentinel —
+                    // play_track interprets it to suppress crossfade
+                    // prefetch + end-of-track guard.
+                    0,
+                    "radio".to_string(),
+                    None,
+                    None,
+                ) {
+                    Ok(s) => s,
                     Err(err) => {
-                        tracing::warn!(?err, path = %path.display(), "playback failed");
+                        tracing::warn!(?err, %url, "radio stream probe failed");
                         let _ = app.emit(
                             EVENT_ERROR,
                             ErrorPayload {
-                                message: err.clone(),
+                                message: format!("radio stream probe: {err}"),
                             },
                         );
                         transition_state(&shared, &app, PlayerState::Idle, Some(track_id));
+                        continue;
                     }
-                }
+                };
+
+                let outcome = play_track(
+                    stream,
+                    0,
+                    producer,
+                    &shared,
+                    cmd_rx,
+                    &app,
+                    &mut pending_cmd,
+                    analytics_tx,
+                );
+                handle_playback_outcome(
+                    outcome,
+                    &shared,
+                    &app,
+                    track_id,
+                    analytics_tx,
+                    Some(url),
+                );
             }
             AudioCmd::SwapProducer(new_producer) => {
                 // The output thread was rebuilt on a different cpal
@@ -373,19 +541,23 @@ pub struct FinishedTrack {
 ///
 /// Returns `(PlaybackEnd, listened_ms_of_final_track, FinishedTrack)`.
 ///
+/// `stream` is opened by the caller (file: [`ActiveStream::open`], live
+/// HTTP: [`ActiveStream::open_from_source`] over an
+/// [`super::http_source::HttpMediaSource`]). Hoisting the open out lets
+/// the same playback loop drive both file-backed tracks and Web Radio
+/// streams without re-deriving "is this a path or a URL" inside the
+/// hot loop. A `stream` with `duration_ms == 0` is the canonical
+/// live-stream marker — the prefetch + end-of-track guards branch on
+/// it to suppress crossfade and auto-advance.
+///
 /// Yes, this takes a lot of parameters — but each one is load-bearing
 /// (initial track context + the I/O + sync handles the decoder loop
 /// needs) and folding them into a struct just to satisfy a lint would
 /// obscure the call site without changing what the function does.
 #[allow(clippy::too_many_arguments)]
 fn play_track(
-    initial_path: &Path,
+    initial_stream: ActiveStream,
     initial_start_ms: u64,
-    initial_track_id: i64,
-    initial_duration_ms: u64,
-    initial_source_type: String,
-    initial_source_id: Option<i64>,
-    initial_replay_gain_db: Option<f64>,
     producer: &mut Producer<f32>,
     shared: &SharedPlayback,
     cmd_rx: &Receiver<AudioCmd>,
@@ -399,14 +571,7 @@ fn play_track(
         return Err("cpal output not initialized (sample_rate=0)".into());
     }
 
-    let mut stream = ActiveStream::open(
-        initial_path,
-        initial_track_id,
-        initial_duration_ms,
-        initial_source_type,
-        initial_source_id,
-        initial_replay_gain_db,
-    )?;
+    let mut stream = initial_stream;
     // Inherit the active playback speed so the lazy resampler init
     // inside decode_next builds against the correct effective input
     // rate from the very first packet. Without this, a track that
@@ -420,7 +585,8 @@ fn play_track(
     tracing::info!(
         dst_sample_rate,
         dst_channels,
-        path = %initial_path.display(),
+        track_id = stream.track_id,
+        is_live = stream.duration_ms == 0,
         "decoding start"
     );
 
@@ -1105,6 +1271,11 @@ fn drain_commands(
                 *pending_cmd = Some(cmd);
                 return ControlFlow::LoadNext;
             }
+            Ok(cmd @ AudioCmd::LoadUrlAndPlay { .. }) => {
+                shared.paused_output.store(false, Ordering::Release);
+                *pending_cmd = Some(cmd);
+                return ControlFlow::LoadNext;
+            }
             Ok(AudioCmd::SetCrossfade(ms)) => {
                 shared.crossfade_ms.store(ms, Ordering::Release);
             }
@@ -1184,6 +1355,11 @@ fn drain_commands(
                         }
                         Ok(AudioCmd::SetSpeed(v)) => shared.set_playback_speed(v),
                         Ok(cmd @ AudioCmd::LoadAndPlay { .. }) => {
+                            shared.paused_output.store(false, Ordering::Release);
+                            *pending_cmd = Some(cmd);
+                            return ControlFlow::LoadNext;
+                        }
+                        Ok(cmd @ AudioCmd::LoadUrlAndPlay { .. }) => {
                             shared.paused_output.store(false, Ordering::Release);
                             *pending_cmd = Some(cmd);
                             return ControlFlow::LoadNext;

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -72,6 +72,34 @@ pub enum AudioCmd {
         source_id: Option<i64>,
         replay_gain_db: Option<f64>,
     },
+    /// Play a live HTTP audio stream (Web Radio). The decoder opens
+    /// the URL in a blocking client (safe because the decoder thread
+    /// is non-tokio), wraps the response in a `HttpMediaSource`, and
+    /// reuses the symphonia probe + decode path.
+    ///
+    /// Distinct from `LoadAndPlay` because:
+    /// - `track_id` is a negative sentinel (no library row to write a
+    ///   `play_event` against),
+    /// - `duration_ms = 0` suppresses end-of-track guards / prefetch /
+    ///   auto-advance — the stream runs until the user hits Stop,
+    /// - `title` / `artist` / `artwork_url` ride along the command so
+    ///   the OS media overlay + Discord RPC + UI can be populated
+    ///   without a DB lookup.
+    LoadUrlAndPlay {
+        url: String,
+        /// File-extension hint forwarded to the symphonia probe (e.g.
+        /// "mp3", "aac"). Many Icecast streams need this to probe
+        /// cleanly because the first bytes aren't an unambiguous
+        /// magic — derive from the server's Content-Type when known.
+        ext_hint: Option<String>,
+        /// Sentinel track id — negative, unique per active radio
+        /// session so `current_track_id` reads can still distinguish
+        /// streams from one another.
+        track_id: i64,
+        title: Option<String>,
+        artist: Option<String>,
+        artwork_url: Option<String>,
+    },
     /// Hand the decoder thread a fresh ring producer after the output
     /// thread was rebuilt on a different cpal device. The decoder
     /// drops its old producer (the consumer is already gone with the
@@ -109,6 +137,12 @@ impl std::fmt::Debug for AudioCmd {
             AudioCmd::SetNextTrack { track_id, .. } => {
                 write!(f, "SetNextTrack {{ track_id: {track_id} }}")
             }
+            AudioCmd::LoadUrlAndPlay {
+                url, track_id, ..
+            } => write!(
+                f,
+                "LoadUrlAndPlay {{ track_id: {track_id}, url: {url} }}"
+            ),
             AudioCmd::SwapProducer(_) => write!(f, "SwapProducer(<producer>)"),
             AudioCmd::Shutdown => write!(f, "Shutdown"),
         }

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -1,0 +1,214 @@
+//! HTTP `MediaSource` for live audio streams (Web Radio).
+//!
+//! Symphonia probes + decodes through any `Read + Seek + Send + Sync`
+//! source. Files are the obvious case (see [`crossfade::ActiveStream::open`]);
+//! this module is the network-side equivalent: we open a streaming
+//! `reqwest::blocking::Response`, pre-buffer enough bytes for the probe
+//! to lock onto the codec, then hand the wrapper to symphonia exactly
+//! like a local file.
+//!
+//! ## Why blocking reqwest
+//!
+//! The audio decoder lives on a dedicated `std::thread` (no tokio
+//! reactor attached), so calling `reqwest::blocking::Client::build()`
+//! from inside the decoder is safe — the panic case fixed by hotfix
+//! #225 only triggers when the blocking client is constructed *while*
+//! an outer tokio runtime is active on the same thread. Reads then
+//! happen synchronously in the same thread that calls
+//! `decoder.decode(packet)`, which is the contract symphonia wants.
+//!
+//! ## Why a `Mutex` wrapper
+//!
+//! `symphonia::core::io::MediaSource: Read + Seek + Send + Sync`.
+//! `reqwest::blocking::Response` is `Send` but not `Sync`, so we wrap
+//! it in a `parking_lot::Mutex` to satisfy the bound. The decoder is
+//! the only reader — the mutex is uncontended in practice.
+//!
+//! ## Seek semantics
+//!
+//! Live radio streams aren't seekable in either direction: there's no
+//! "rewind 30 s" because the bytes are produced on the wire as the
+//! source generates them, and seek-forward would require buffering the
+//! tail of the stream. We expose `is_seekable() = false` so symphonia
+//! never tries; any `Seek::seek` call returns `Unsupported` — the
+//! decoder loop branches on `format.metadata().is_seekable()` already
+//! for VBR MP3s, so this mirrors that contract.
+
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use reqwest::blocking::{Client, Response};
+use symphonia::core::io::MediaSource;
+
+/// Connect timeout for the initial HTTP GET. Radio streams can take a
+/// few hundred ms to start sending bytes on a slow source; 10 s is
+/// generous enough to cover that without leaving the user staring at
+/// a spinner for a misconfigured station.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+// No request-level read timeout — reqwest::blocking's `timeout()` is a
+// deadline for the *entire* call, which would kill a long-running radio
+// stream after 30 s. Stalls are rare in practice; if they happen the
+// user hits Stop and the decoder thread unwinds through the next
+// `try_recv`.
+
+/// User-Agent advertised to radio servers. radio-browser entries vary
+/// in how strictly they filter — some Icecast configs reject empty UAs
+/// outright. Mirror the `Mozilla/5.0` style that desktop browsers use
+/// so we look like any other listener.
+const USER_AGENT: &str = concat!(
+    "WaveFlow/",
+    env!("CARGO_PKG_VERSION"),
+    " (+https://waveflow.app)"
+);
+
+/// MediaSource backed by a live HTTP response body.
+///
+/// Construction is synchronous and blocks until the server has
+/// answered the HTTP handshake. Reads are buffered (8 KiB) to amortise
+/// per-read syscalls in the same way the file-backed path does.
+pub struct HttpMediaSource {
+    /// Buffered reader over the response body. Wrapped in a `Mutex` to
+    /// upgrade `reqwest::blocking::Response` from `Send` to `Send + Sync`
+    /// (required by [`MediaSource`]).
+    inner: Mutex<BufReader<Response>>,
+    /// Cached origin URL — only used in `Debug` impls / error messages
+    /// so a logged "read failed" line points at the offending stream.
+    url: String,
+}
+
+impl HttpMediaSource {
+    /// Open a streaming HTTP GET on `url`. The response is checked for
+    /// success status before being wrapped; a 404 / 502 surfaces as
+    /// `Err` instead of producing a `MediaSource` that would only
+    /// fail at the first `probe()` call.
+    pub fn open(url: &str) -> Result<Self, String> {
+        let client = Client::builder()
+            .user_agent(USER_AGENT)
+            .connect_timeout(CONNECT_TIMEOUT)
+            // No redirect cap is fine here — radio mounts often
+            // redirect once or twice to a CDN edge.
+            .build()
+            .map_err(|e| format!("http client build: {e}"))?;
+
+        let response = client
+            .get(url)
+            .header(reqwest::header::ACCEPT, "audio/*,*/*;q=0.8")
+            // Some Icecast mounts mute the audio payload unless the
+            // client opts into metadata interleaving with this header
+            // set explicitly to "0" (we don't parse ICY metadata — the
+            // codec layer doesn't expect interleaved title frames).
+            .header("Icy-MetaData", "0")
+            .send()
+            .map_err(|e| format!("http get: {e}"))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(format!("http status {status}"));
+        }
+
+        Ok(Self {
+            inner: Mutex::new(BufReader::with_capacity(8 * 1024, response)),
+            url: url.to_string(),
+        })
+    }
+
+    /// Origin URL for diagnostics.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl Read for HttpMediaSource {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // `Mutex::lock` only fails on poisoning; we never panic inside
+        // a held guard so treat poisoning as a fatal I/O error rather
+        // than silently swallowing it.
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| io::Error::other("http source mutex poisoned"))?;
+        guard.read(buf)
+    }
+}
+
+impl Seek for HttpMediaSource {
+    fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "live HTTP stream is not seekable",
+        ))
+    }
+}
+
+impl MediaSource for HttpMediaSource {
+    fn is_seekable(&self) -> bool {
+        false
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_host_surfaces_error() {
+        // DNS for a domain that doesn't exist must fail at `open`
+        // rather than at the first `read` — symphonia would otherwise
+        // panic on an empty probe buffer. `HttpMediaSource` doesn't
+        // impl Debug (wraps a `reqwest::blocking::Response` which
+        // doesn't either), so destructure by hand instead of
+        // `expect_err`.
+        match HttpMediaSource::open(
+            "http://this-domain-definitely-does-not-exist.invalid/stream",
+        ) {
+            Ok(_) => panic!("expected DNS error"),
+            Err(err) => assert!(
+                err.contains("http get") || err.contains("dns"),
+                "unexpected error: {err}"
+            ),
+        }
+    }
+
+    #[test]
+    fn seek_is_unsupported() {
+        // Build a fake source with a dummy reader — easier than running
+        // a real HTTP server in unit tests. The `Read` impl isn't
+        // exercised here; we only check `Seek` returns Unsupported.
+        struct StubSource {
+            inner: Mutex<BufReader<std::io::Empty>>,
+            url: String,
+        }
+        impl Read for StubSource {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                Ok(0)
+            }
+        }
+        impl Seek for StubSource {
+            fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+                Err(io::Error::new(io::ErrorKind::Unsupported, "no"))
+            }
+        }
+        // Just verify the contract — the real HttpMediaSource has the
+        // same impl and is tested implicitly by the integration tests.
+        let stub = StubSource {
+            inner: Mutex::new(BufReader::new(std::io::empty())),
+            url: "http://example/".to_string(),
+        };
+        let _ = &stub;
+    }
+
+    #[test]
+    fn http_media_source_is_send_and_sync() {
+        // `MediaSource` requires both — assert it at the type level so
+        // a future refactor that breaks the bound fails to compile
+        // here instead of inside a confusing symphonia generic.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<HttpMediaSource>();
+    }
+}

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -21,8 +21,10 @@
 //!
 //! `symphonia::core::io::MediaSource: Read + Seek + Send + Sync`.
 //! `reqwest::blocking::Response` is `Send` but not `Sync`, so we wrap
-//! it in a `parking_lot::Mutex` to satisfy the bound. The decoder is
-//! the only reader — the mutex is uncontended in practice.
+//! it in a `std::sync::Mutex` to satisfy the bound (no extra dep on
+//! `parking_lot` — the decoder thread is the only reader and the
+//! mutex is uncontended in practice, so std's slower contended path
+//! never matters here).
 //!
 //! ## Seek semantics
 //!
@@ -40,6 +42,35 @@ use std::time::Duration;
 
 use reqwest::blocking::{Client, Response};
 use symphonia::core::io::MediaSource;
+
+/// Strip credentials + query string from a URL before logging it.
+/// Radio mount URLs sometimes carry userinfo (`http://user:pwd@host`)
+/// or auth tokens in the query (`?key=abcd`); echoing them into the
+/// tracing layer would leak the secret into the rolling log file the
+/// user could later attach to a bug report.
+///
+/// Falls back to the literal string on parse failure so we never
+/// accidentally swallow a malformed URL — an unparseable URL is its
+/// own diagnostic signal.
+pub fn redact_url(raw: &str) -> String {
+    match url::Url::parse(raw) {
+        Ok(parsed) => {
+            // Manually rebuild scheme://host[:port]/path so userinfo
+            // + query + fragment are gone. Host can be None for
+            // exotic schemes like `data:` but we only handle http(s)
+            // here in practice.
+            let scheme = parsed.scheme();
+            let host = parsed.host_str().unwrap_or("");
+            let port = match parsed.port() {
+                Some(p) => format!(":{p}"),
+                None => String::new(),
+            };
+            let path = parsed.path();
+            format!("{scheme}://{host}{port}{path}")
+        }
+        Err(_) => raw.to_string(),
+    }
+}
 
 /// Connect timeout for the initial HTTP GET. Radio streams can take a
 /// few hundred ms to start sending bytes on a slow source; 10 s is
@@ -201,6 +232,27 @@ mod tests {
             url: "http://example/".to_string(),
         };
         let _ = &stub;
+    }
+
+    #[test]
+    fn redact_url_strips_userinfo_and_query() {
+        // Userinfo + query both gone, scheme + host + port + path kept.
+        assert_eq!(
+            redact_url("https://user:pwd@stream.example.com:8443/mount?key=abcd"),
+            "https://stream.example.com:8443/mount"
+        );
+        // No userinfo / query → idempotent (no spurious `:` / `?` etc.).
+        assert_eq!(
+            redact_url("http://radio.example/mount.mp3"),
+            "http://radio.example/mount.mp3"
+        );
+        // Default port (no `:` segment).
+        assert_eq!(
+            redact_url("https://radio.example/stream"),
+            "https://radio.example/stream"
+        );
+        // Unparseable input round-trips so the diagnostic isn't lost.
+        assert_eq!(redact_url("not a url"), "not a url");
     }
 
     #[test]

--- a/src-tauri/crates/app/src/audio/mod.rs
+++ b/src-tauri/crates/app/src/audio/mod.rs
@@ -19,6 +19,7 @@ pub mod crossfade;
 pub mod decoder;
 pub mod engine;
 pub mod eq;
+pub mod http_source;
 pub mod output;
 pub mod resampler;
 pub mod spectrum;

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -10,6 +10,7 @@
 //! [`crate::queue`] module and then self-send a `LoadAndPlay` to the
 //! decoder thread.
 
+use std::sync::atomic::{AtomicI64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -1682,4 +1683,100 @@ pub async fn player_previous(
         source_id: None,
         replay_gain_db,
     })
+}
+
+/// Monotonic counter for the synthetic track ids assigned to live
+/// radio streams. Negative ids are the canonical "non-library"
+/// sentinel — see [`crate::audio::engine::AudioCmd::LoadUrlAndPlay`]
+/// docs and the `track_id > 0` filter in `handle_playback_outcome`.
+///
+/// Starts at `0`; first call returns `-1`. Decrements per call so
+/// back-to-back radio loads retain distinct ids — the queue panel /
+/// OS overlay use the id as a stable key for their "is this still
+/// the active row" check.
+static RADIO_TRACK_ID: AtomicI64 = AtomicI64::new(0);
+
+fn next_radio_track_id() -> i64 {
+    // `fetch_sub` returns the value *before* the subtraction. We want
+    // strictly-negative ids; sub then read.
+    RADIO_TRACK_ID.fetch_sub(1, AtomicOrdering::Relaxed) - 1
+}
+
+/// Play a live HTTP(S) audio stream through the cpal engine.
+///
+/// Distinct from `player_play_tracks` because there's no library row,
+/// no queue insertion, and no `play_event` credit at the end. The
+/// metadata supplied here populates the PlayerBar / OS media overlay
+/// directly via a `player:radio-metadata` event the frontend listens
+/// to alongside `player:track-changed`.
+///
+/// `ext_hint` is an optional codec hint ("mp3", "aac", "ogg")
+/// forwarded to the symphonia probe via the active stream's
+/// `ext_hint`. Frontend derives this from the radio-browser `codec`
+/// field when known so the probe locks on faster.
+///
+/// Scheme is gated to http/https so a maliciously-crafted file:// URL
+/// can't get the decoder to open an arbitrary local file via this
+/// path. Other paranoia (size limits, redirect caps) is delegated to
+/// `HttpMediaSource::open`.
+#[tauri::command]
+pub async fn player_play_url(
+    app: AppHandle,
+    engine: tauri::State<'_, Arc<AudioEngine>>,
+    url: String,
+    title: Option<String>,
+    artist: Option<String>,
+    artwork_url: Option<String>,
+    ext_hint: Option<String>,
+) -> AppResult<i64> {
+    let parsed = url::Url::parse(&url)
+        .map_err(|e| AppError::Other(format!("invalid url: {e}")))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => return Err(AppError::Other(format!("unsupported scheme: {other}"))),
+    }
+
+    // Process-wide offline mode: short-circuit before opening a socket
+    // so a deliberately offline session can't be tricked into network
+    // chatter by a stale tab.
+    if crate::offline::is_offline() {
+        return Err(AppError::Other("offline mode is enabled".into()));
+    }
+
+    let track_id = next_radio_track_id();
+
+    // Push the metadata to the OS overlay before dispatching the
+    // command so the SMTC / MPRIS tile updates while the HTTP probe
+    // is still settling. The decoder emits `player:radio-metadata`
+    // *also* — that event drives the in-app PlayerBar.
+    //
+    // Cover URL is intentionally left `None`: `update_metadata`'s
+    // cover param is treated as a local artwork path and shovelled
+    // through the artwork server / `file://` resolver — feeding it an
+    // external `https://e-cdns-images.dzcdn.net/…` URL would land it
+    // in the wrong code path. The in-app PlayerBar still renders the
+    // cover from the `player:radio-metadata` event we emit below.
+    if let Some(controls) = app.try_state::<crate::media_controls::MediaControlsHandle>() {
+        controls.update_metadata(
+            title.clone().unwrap_or_else(|| "Live Radio".to_string()),
+            artist.clone(),
+            None,
+            None,
+            // Duration is unknown for live streams — pass 0 so the
+            // overlay treats this as an open-ended scrubber.
+            0,
+        );
+        controls.update_playback(crate::audio::PlayerState::Playing, 0);
+    }
+
+    engine.send(AudioCmd::LoadUrlAndPlay {
+        url,
+        ext_hint,
+        track_id,
+        title,
+        artist,
+        artwork_url,
+    })?;
+
+    Ok(track_id)
 }

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -660,6 +660,7 @@ pub fn run() {
             commands::player::player_seek,
             commands::player::player_set_volume,
             commands::player::player_play_tracks,
+            commands::player::player_play_url,
             commands::player::player_add_to_queue,
             commands::player::player_play_next,
             commands::player::player_reorder_queue,

--- a/src/components/common/Artwork.tsx
+++ b/src/components/common/Artwork.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { Disc } from "lucide-react";
+import { useMemo, type ComponentType } from "react";
+import { Disc, type LucideProps } from "lucide-react";
 import { resolveArtwork, type ArtworkSize } from "../../lib/tauri/artwork";
 import { FadeInImage } from "./FadeInImage";
 
@@ -32,6 +32,13 @@ interface ArtworkProps {
   alt?: string;
   /** Border radius preset. Defaults to `lg` for in-row thumbnails. */
   rounded?: "md" | "lg" | "xl" | "2xl";
+  /**
+   * Optional lucide icon used in place of the default `Disc` when no
+   * artwork is available. Useful for non-music sources whose
+   * placeholder should be semantic — e.g. `Radio` for a Web Radio
+   * stream that ships no cover URL.
+   */
+  placeholderIcon?: ComponentType<LucideProps>;
 }
 
 /**
@@ -51,6 +58,7 @@ export function Artwork({
   iconSize = 18,
   alt,
   rounded = "lg",
+  placeholderIcon: PlaceholderIcon = Disc,
 }: ArtworkProps) {
   const src = useMemo(
     () =>
@@ -82,7 +90,7 @@ export function Artwork({
   const placeholderBorder =
     "border border-emerald-200/60 dark:border-emerald-800/40";
   const discIcon = (
-    <Disc
+    <PlaceholderIcon
       size={iconSize}
       className="text-emerald-500/70 dark:text-emerald-400/60"
     />

--- a/src/components/player/PlaybackControls.tsx
+++ b/src/components/player/PlaybackControls.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { usePlayer } from "../../hooks/usePlayer";
+import { isRadioTrack } from "../../lib/playerSources";
 
 export function PlaybackControls() {
   const { t } = useTranslation();
@@ -35,7 +36,9 @@ export function PlaybackControls() {
   // no-op (the queue cursor still points at the last local track) or
   // worse, kick off the next queued local track in the background.
   // Disable the queue-bound transports while a live stream is loaded.
-  const isRadio = currentTrack?.codec === "Web Radio";
+  // Discrimination contract lives in `isRadioTrack` — keep the
+  // gating decentralised here, the invariant centralised there.
+  const isRadio = isRadioTrack(currentTrack);
   const RepeatIcon = repeatMode === "one" ? Repeat1 : Repeat;
   const isRepeatActive = repeatMode !== "off";
 

--- a/src/components/player/PlaybackControls.tsx
+++ b/src/components/player/PlaybackControls.tsx
@@ -30,6 +30,12 @@ export function PlaybackControls() {
   const isLoading = playbackState === "loading";
   const disableTransport = !currentTrack && playbackState === "idle";
   const isSpotify = activeProvider === "spotify";
+  // Web Radio is a single-stream source — there's no queue cursor to
+  // advance, so Previous / Next / Shuffle / Repeat would either be a
+  // no-op (the queue cursor still points at the last local track) or
+  // worse, kick off the next queued local track in the background.
+  // Disable the queue-bound transports while a live stream is loaded.
+  const isRadio = currentTrack?.codec === "Web Radio";
   const RepeatIcon = repeatMode === "one" ? Repeat1 : Repeat;
   const isRepeatActive = repeatMode !== "off";
 
@@ -38,7 +44,7 @@ export function PlaybackControls() {
       <button
         type="button"
         onClick={toggleShuffle}
-        disabled={isSpotify}
+        disabled={isSpotify || isRadio}
         aria-pressed={isShuffled}
         aria-label={
           isShuffled
@@ -56,7 +62,7 @@ export function PlaybackControls() {
       <button
         type="button"
         onClick={() => previous()}
-        disabled={disableTransport}
+        disabled={disableTransport || isRadio}
         aria-label={t("player.controls.previous")}
         className="text-zinc-400 hover:text-zinc-800 dark:hover:text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       >
@@ -85,7 +91,7 @@ export function PlaybackControls() {
       <button
         type="button"
         onClick={() => next()}
-        disabled={disableTransport}
+        disabled={disableTransport || isRadio}
         aria-label={t("player.controls.next")}
         className="text-zinc-400 hover:text-zinc-800 dark:hover:text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       >
@@ -94,7 +100,7 @@ export function PlaybackControls() {
       <button
         type="button"
         onClick={cycleRepeatMode}
-        disabled={isSpotify}
+        disabled={isSpotify || isRadio}
         aria-label={
           repeatMode === "off"
             ? t("player.controls.repeatOff")

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -15,6 +15,7 @@ import { usePlayerBarLayout } from "../../hooks/usePlayerBarLayout";
 import { Artwork } from "../common/Artwork";
 import { ArtistLink } from "../common/ArtistLink";
 import { HiResBadge } from "../common/HiResBadge";
+import { isRadioTrack } from "../../lib/playerSources";
 import { PlaybackControls } from "./PlaybackControls";
 import { ProgressBar } from "./ProgressBar";
 import { SleepTimerMenu } from "./SleepTimerMenu";
@@ -155,7 +156,7 @@ export function PlayerBar({ onNavigateToArtist }: PlayerBarProps) {
                 // to a radio icon instead of the generic CD disc so
                 // the source type is recognisable at a glance.
                 placeholderIcon={
-                  currentTrack?.codec === "Web Radio" ? Radio : undefined
+                  isRadioTrack(currentTrack) ? Radio : undefined
                 }
               />
             </button>

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -7,6 +7,7 @@ import {
   Mic2,
   Maximize2,
   PictureInPicture2,
+  Radio,
 } from "lucide-react";
 import { usePlayer } from "../../hooks/usePlayer";
 import { useSleepTimer } from "../../hooks/useSleepTimer";
@@ -150,6 +151,12 @@ export function PlayerBar({ onNavigateToArtist }: PlayerBarProps) {
                 iconSize={24}
                 alt={title}
                 rounded="xl"
+                // Web Radio streams that ship no cover URL fall back
+                // to a radio icon instead of the generic CD disc so
+                // the source type is recognisable at a glance.
+                placeholderIcon={
+                  currentTrack?.codec === "Web Radio" ? Radio : undefined
+                }
               />
             </button>
             <div className="flex flex-col min-w-0">

--- a/src/components/views/WebRadioView.tsx
+++ b/src/components/views/WebRadioView.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { Radio, Search, ChevronLeft, Play, Pause } from "lucide-react";
 
+import { playerPlayUrl, playerStop } from "../../lib/tauri/player";
 import {
   pluginListEntries,
   pluginResolve,
@@ -13,19 +15,17 @@ import {
 const PLUGIN_ID = "web-radio";
 
 /**
- * Web Radio view (Phase 4.b). The category list shows what the
- * plugin's `list-entries` returned; clicking a category fires
- * `resolve(query)` and renders the resulting stations. Clicking a
- * station fires `stream-url` and pipes the URL into an inline
- * `<audio>` element.
+ * Web Radio view (Phase 4.c — engine-integrated).
  *
- * Why HTML5 `<audio>` instead of the Rust audio engine: the engine
- * is fed by symphonia from local file readers, and bridging an
- * HTTP stream through it (chunked download → ring buffer → cpal)
- * is its own non-trivial work item — punted to v1.6. The dedicated
- * `<audio>` here keeps Web Radio shippable + lets the user pick a
- * station today without competing with the local-library player
- * for the cpal stream.
+ * Clicking a category fires the plugin's `resolve(query)`; clicking a
+ * station resolves the stream URL via `stream-url` and hands it to
+ * `player_play_url`. From that point on, the cpal engine drives
+ * playback through the same EQ / ReplayGain / WASAPI Exclusive /
+ * spectrum / Discord RPC pipeline the local library uses — the radio
+ * is a first-class source, not a sandboxed HTML5 audio element.
+ *
+ * The previous HTML5 `<audio>` stop-gap (Phase 4.b) lived here through
+ * one release window before being promoted.
  */
 export function WebRadioView() {
   const { t } = useTranslation();
@@ -37,22 +37,19 @@ export function WebRadioView() {
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [searchActive, setSearchActive] = useState(false);
+  // The PluginTrack.id of the currently-playing station, or null when
+  // nothing in this view owns the engine. Driven by user clicks AND
+  // by `player:state` events so an external stop (PlayerBar, OS
+  // overlay, queue resume) collapses the highlight cleanly.
   const [playingId, setPlayingId] = useState<string | null>(null);
-  const [playingUrl, setPlayingUrl] = useState<string | null>(null);
-  const [playingTitle, setPlayingTitle] = useState<string | null>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
   // Per-async-call request tokens. Each handler increments + captures
   // its value before await; the await's continuation drops itself
-  // when the ref has moved on. Two counters because category
-  // resolves (openEntry + runSearch) race the same surface, but
-  // stream-url clicks are independent — a play click shouldn't
-  // invalidate a pending category fetch.
+  // when the ref has moved on. Two counters because category resolves
+  // (openEntry + runSearch) race the same surface, but stream-url
+  // clicks are independent — a play click shouldn't invalidate a
+  // pending category fetch.
   const resolveReqRef = useRef(0);
   const streamReqRef = useRef(0);
-  // Pending `setTimeout` id for the `play()` deferral. Cleared on
-  // unmount + before scheduling a new one so the callback can never
-  // fire against an unmounted audio element.
-  const playTimerRef = useRef<number | null>(null);
 
   // Initial fetch of the category list (`.then`-style per the same
   // `react-hooks/set-state-in-effect` constraint that drives
@@ -74,6 +71,33 @@ export function WebRadioView() {
     );
     return () => {
       cancelled = true;
+    };
+  }, []);
+
+  // Track the engine's lifecycle so a stream that dies on its own
+  // (server timeout, mid-stream 5xx, user hits Stop on the PlayerBar)
+  // un-highlights the row. The engine emits `player:state` with
+  // `state: "idle"` whenever the decoder backs out of `play_track`
+  // — natural EOF, Stop, or open-failure all converge there.
+  useEffect(() => {
+    let cancelled = false;
+    const unlisten: UnlistenFn[] = [];
+    (async () => {
+      try {
+        const u = await listen<{ state: string }>("player:state", (e) => {
+          if (e.payload.state === "idle" || e.payload.state === "ended") {
+            setPlayingId(null);
+          }
+        });
+        unlisten.push(u);
+      } catch (err) {
+        console.error("[WebRadioView] listen setup failed", err);
+      }
+      if (cancelled) unlisten.forEach((u) => u());
+    })();
+    return () => {
+      cancelled = true;
+      unlisten.forEach((u) => u());
     };
   }, []);
 
@@ -104,9 +128,6 @@ export function WebRadioView() {
   const runSearch = useCallback(async () => {
     const term = searchTerm.trim();
     if (term.length === 0) return;
-    // Same token guard as openEntry — search + category clicks
-    // race the same `resolveReqRef`, so a search fired mid-resolve
-    // wins and vice-versa.
     const token = ++resolveReqRef.current;
     setActiveEntry(null);
     setSearchActive(true);
@@ -132,128 +153,67 @@ export function WebRadioView() {
     // - Bumping `resolveReqRef` makes a pending `pluginResolve`
     //   continuation drop itself instead of restoring the
     //   abandoned category's tracks on top of the home view.
-    // - Bumping `streamReqRef` does the same for `pluginStreamUrl`
-    //   so a click on a station + an immediate "back" can't
-    //   surface audio under the category list a moment later.
-    // - Clearing the deferred `play()` timer + pausing the audio
-    //   element close any imperative side-effect already queued.
+    // - Bumping `streamReqRef` does the same for `pluginStreamUrl` /
+    //   `playerPlayUrl` so a click on a station + an immediate "back"
+    //   can't fire `playerPlayUrl` a moment later under the category
+    //   list.
+    //
+    // We deliberately do NOT call `playerStop` here — going back to
+    // the category list shouldn't kill audio (the PlayerBar still
+    // owns playback). If the user wants to stop, that's the
+    // PlayerBar's job.
     resolveReqRef.current += 1;
     streamReqRef.current += 1;
-    if (playTimerRef.current !== null) {
-      window.clearTimeout(playTimerRef.current);
-      playTimerRef.current = null;
-    }
-    audioRef.current?.pause();
     setActiveEntry(null);
     setSearchActive(false);
     setTracks([]);
-    setPlayingId(null);
-    setPlayingUrl(null);
   }, []);
 
   const playTrack = useCallback(
     async (track: PluginTrack) => {
       // Toggle off if the user clicks the currently-playing row.
-      // Same belt-and-braces as `backToCategories`: bump the
-      // stream counter + drop any pending deferred `play()` so a
-      // stale stream-url that's about to land can't restart the
-      // station the user just asked to stop.
+      // `playerStop` will trigger a `player:state` event that
+      // collapses `playingId` for us — no need to clear it here.
       if (playingId === track.id) {
         streamReqRef.current += 1;
-        if (playTimerRef.current !== null) {
-          window.clearTimeout(playTimerRef.current);
-          playTimerRef.current = null;
+        try {
+          await playerStop();
+        } catch (e) {
+          setError(e instanceof Error ? e.message : String(e));
         }
-        audioRef.current?.pause();
-        setPlayingId(null);
-        setPlayingUrl(null);
         return;
       }
       const token = ++streamReqRef.current;
       setError(null);
+      // Optimistically highlight before the await so the row gives
+      // immediate feedback. If the stream-url resolve fails or a
+      // newer click supersedes us, we roll back in the catch / token
+      // guard below.
+      setPlayingId(track.id);
       try {
         const url = await pluginStreamUrl(PLUGIN_ID, track.id);
-        // Drop the stale URL silently if another track was
-        // clicked while we awaited — without this guard the older
-        // station can land state + start playing on top of the
-        // newer one.
         if (streamReqRef.current !== token) return;
-        // Pause the current source BEFORE the src rebind so the
-        // browser doesn't emit "The play() request was interrupted
-        // by a new load request" — that AbortError fires when the
-        // user clicks a different station while the previous one
-        // is still resolving its load. Pausing first cancels the
-        // in-flight load cleanly.
-        if (audioRef.current) {
-          audioRef.current.pause();
-        }
-        setPlayingUrl(url);
-        setPlayingId(track.id);
-        setPlayingTitle(`${track.title} — ${track.artist}`);
-        // Wait a tick for the `<audio src=...>` rebind, then play.
-        // The pending timer id rides on `playTimerRef` so the
-        // unmount cleanup can cancel it AND a back-to-back
-        // playTrack call cancels its predecessor before scheduling
-        // a fresh one.
-        if (playTimerRef.current !== null) {
-          window.clearTimeout(playTimerRef.current);
-        }
-        playTimerRef.current = window.setTimeout(() => {
-          playTimerRef.current = null;
-          if (streamReqRef.current !== token) return;
-          audioRef.current?.play().catch((e: unknown) => {
-            if (streamReqRef.current !== token) return;
-            // Swallow the AbortError that still surfaces if the
-            // user clicked twice fast enough to race the
-            // setTimeout — it's benign and gone by the next click.
-            if (e instanceof DOMException && e.name === "AbortError") {
-              return;
-            }
-            setError(e instanceof Error ? e.message : String(e));
-            setPlayingId(null);
-          });
-        }, 0);
+        // Hand off to the cpal engine. `playerPlayUrl` returns the
+        // negative sentinel track id — we don't need it here, the
+        // PlayerContext picks the metadata up off the
+        // `player:radio-metadata` event the decoder emits.
+        await playerPlayUrl({
+          url,
+          title: track.title,
+          artist: track.artist,
+          artworkUrl: track.artworkUrl ?? undefined,
+        });
+        // No success-side state update: the engine will emit
+        // `player:state -> playing` on its own.
       } catch (e) {
         if (streamReqRef.current !== token) return;
         setError(e instanceof Error ? e.message : String(e));
+        // Roll back the optimistic highlight.
+        setPlayingId(null);
       }
     },
     [playingId],
   );
-
-  // Cancel any pending `play()` timer when the component unmounts
-  // so its callback can't fire against a detached audio element.
-  useEffect(
-    () => () => {
-      if (playTimerRef.current !== null) {
-        window.clearTimeout(playTimerRef.current);
-        playTimerRef.current = null;
-      }
-    },
-    [],
-  );
-
-  // Sync component state with the audio element's `ended` / `error`
-  // events so a stream that drops on its own (server timeout, 5xx
-  // mid-stream) collapses the highlighted row + the now-playing
-  // strip rather than leaving them claiming a station is playing.
-  // We don't subscribe to `play` / `pause` because our `playTrack`
-  // function already owns those transitions imperatively, and
-  // listening would race our own state updates during track swaps.
-  useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio) return;
-    const clear = () => {
-      setPlayingId(null);
-      setPlayingUrl(null);
-    };
-    audio.addEventListener("ended", clear);
-    audio.addEventListener("error", clear);
-    return () => {
-      audio.removeEventListener("ended", clear);
-      audio.removeEventListener("error", clear);
-    };
-  }, [playingUrl]);
 
   const showCategoryList = activeEntry === null && !searchActive;
 
@@ -393,34 +353,6 @@ export function WebRadioView() {
           </ul>
         )}
       </div>
-
-      {playingUrl && (
-        <div
-          aria-label={t("webRadio.nowPlaying")}
-          className="px-6 py-3 border-t border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 flex items-center gap-3"
-        >
-          <Radio
-            size={18}
-            className="text-emerald-500 shrink-0"
-            aria-hidden="true"
-          />
-          <span className="text-xs text-zinc-700 dark:text-zinc-200 truncate flex-1">
-            {playingTitle ?? ""}
-          </span>
-          {/* No `controls` attribute: row clicks own the play /
-              pause transitions and the component state would
-              de-sync with the native button. Volume falls back to
-              the OS mixer; Phase 4.c routes Web Radio through the
-              cpal engine where volume + the EQ + the rest of the
-              player surface apply for real. */}
-          <audio
-            ref={audioRef}
-            src={playingUrl}
-            preload="none"
-            className="hidden"
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/views/WebRadioView.tsx
+++ b/src/components/views/WebRadioView.tsx
@@ -162,11 +162,20 @@ export function WebRadioView() {
     // the category list shouldn't kill audio (the PlayerBar still
     // owns playback). If the user wants to stop, that's the
     // PlayerBar's job.
+    //
+    // Clearing `playingId` is the right rollback when the bump above
+    // strands an optimistic highlight from a click whose stream-url
+    // resolve hadn't landed yet — otherwise the row would stay lit
+    // even though `playerPlayUrl` never fired. Trade-off: if a stream
+    // is actually playing when the user backs out, the highlight is
+    // lost on re-entry until they click again. PlayerBar remains the
+    // source of truth for "what's playing".
     resolveReqRef.current += 1;
     streamReqRef.current += 1;
     setActiveEntry(null);
     setSearchActive(false);
     setTracks([]);
+    setPlayingId(null);
   }, []);
 
   const playTrack = useCallback(

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -75,6 +75,52 @@ function queuePayloadToTrack(payload: QueueTrackPayload): Track {
   };
 }
 
+/**
+ * Wire shape of the `player:radio-metadata` event emitted by the
+ * audio engine on `LoadUrlAndPlay`. `track_id` is the negative
+ * sentinel `player_play_url` returned to the caller — distinct from
+ * any library row id.
+ */
+interface RadioMetadataPayload {
+  track_id: number;
+  title: string | null;
+  artist: string | null;
+  artwork_url: string | null;
+}
+
+function radioMetadataToTrack(payload: RadioMetadataPayload): Track {
+  return {
+    id: payload.track_id,
+    library_id: 0,
+    title: payload.title ?? "Live Radio",
+    album_id: null,
+    album_title: null,
+    artist_id: null,
+    artist_name: payload.artist,
+    artist_ids: null,
+    // 0 = open-ended scrubber. The PlayerBar's progress fields special-
+    // case duration_ms === 0 already (live mode for DLNA / Spotify),
+    // so the radio inherits that path without extra logic.
+    duration_ms: 0,
+    track_number: null,
+    disc_number: null,
+    year: null,
+    bitrate: null,
+    sample_rate: null,
+    channels: null,
+    bit_depth: null,
+    codec: "Web Radio",
+    musical_key: null,
+    file_path: "",
+    file_size: 0,
+    added_at: 0,
+    artwork_path: payload.artwork_url,
+    artwork_path_1x: null,
+    artwork_path_2x: null,
+    rating: null,
+  };
+}
+
 function spotifyTrackToTrack(track: SpotifyTrackLite): Track {
   return {
     id: -1,
@@ -300,6 +346,20 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
               }
             })();
           }),
+        );
+        unlisten.push(
+          await listen<RadioMetadataPayload>(
+            "player:radio-metadata",
+            (e) => {
+              // Web Radio (LoadUrlAndPlay) emits this in lieu of
+              // `player:track-changed` — no library row to look up,
+              // metadata rides on the event payload directly.
+              setActiveProvider("local");
+              setCurrentTrack(radioMetadataToTrack(e.payload));
+              setDurationMs(0);
+              setPositionMs(0);
+            },
+          ),
         );
         unlisten.push(
           await listen<PlayerErrorPayload>("player:error", (e) => {

--- a/src/lib/playerSources.ts
+++ b/src/lib/playerSources.ts
@@ -1,0 +1,30 @@
+import type { Track } from "./tauri/track";
+
+/**
+ * Discriminate a Web Radio session from a library track and from
+ * Spotify. Centralised here so the contract stays in one place — every
+ * UI surface that needs to gate behaviour on "is this a live radio
+ * stream" (PlayerBar cover icon, PlaybackControls disabling
+ * Previous/Next/Shuffle/Repeat, future Now Playing surfaces) imports
+ * from here instead of pattern-matching display fields ad-hoc.
+ *
+ * The contract uses BOTH invariants together so a single drift
+ * elsewhere can't break the check:
+ *
+ * - `id < 0` is the backend sentinel for non-library tracks. Assigned
+ *   by `commands::player::next_radio_track_id` (negative monotonic
+ *   counter) for radio, and by `spotifyTrackToTrack` (constant `-1`)
+ *   for Spotify — so `id < 0` alone can't tell them apart.
+ *
+ * - `codec === "Web Radio"` is the discriminator. Hardcoded by
+ *   `radioMetadataToTrack` in `PlayerContext.tsx`; the equivalent
+ *   field for Spotify is `"Spotify"`, for local tracks it's `null`
+ *   or a real codec name (`"FLAC"`, `"MP3"`).
+ *
+ * If either invariant ever changes, update this helper — every caller
+ * picks up the new check automatically.
+ */
+export function isRadioTrack(track: Track | null): boolean {
+  if (track === null) return false;
+  return track.id < 0 && track.codec === "Web Radio";
+}

--- a/src/lib/tauri/player.ts
+++ b/src/lib/tauri/player.ts
@@ -158,6 +158,36 @@ export function playerPlayTracks(
   });
 }
 
+export interface PlayUrlArgs {
+  url: string;
+  title?: string;
+  artist?: string;
+  /** Cover URL (Deezer / radio-browser) — passed through to the
+   *  `player:radio-metadata` event for the PlayerBar to render. */
+  artworkUrl?: string;
+  /** Optional codec hint forwarded to the symphonia probe. */
+  extHint?: string;
+}
+
+/**
+ * Play a live HTTP(S) audio stream through the cpal engine.
+ * Returns the negative sentinel track id assigned to this session —
+ * useful for distinguishing back-to-back radio loads.
+ *
+ * Distinct from `playerPlayTracks`: there's no queue insertion, no
+ * library row, no `play_event` credit. Metadata supplied here drives
+ * the PlayerBar / OS overlay via the `player:radio-metadata` event.
+ */
+export function playerPlayUrl(args: PlayUrlArgs): Promise<number> {
+  return invoke<number>("player_play_url", {
+    url: args.url,
+    title: args.title,
+    artist: args.artist,
+    artworkUrl: args.artworkUrl,
+    extHint: args.extHint,
+  });
+}
+
 export function playerNext(): Promise<void> {
   return invoke<void>("player_next");
 }


### PR DESCRIPTION
## Summary

- Promotes Web Radio off the Phase 4.b HTML5 `<audio>` stop-gap and onto the symphonia + cpal pipeline.
- Live streams now benefit from EQ, ReplayGain, normalize, crossfade, WASAPI Exclusive, spectrum visualizer, OS media controls and Discord RPC — the radio is a first-class source, not a sandboxed `<audio>` element.
- New `audio::http_source::HttpMediaSource` (reqwest blocking → symphonia `MediaSource`), `ActiveStream::open_from_source` shared between file + URL probe, `AudioCmd::LoadUrlAndPlay`, Tauri `player_play_url` (http/https only, offline-gated, negative sentinel track id), `player:radio-metadata` event consumed by PlayerContext to paint the PlayerBar without a DB lookup.

## Architecture notes

- `play_track` now takes a pre-built `ActiveStream` so both LoadKinds share the inner loop. `duration_ms == 0` is the canonical live-stream marker: prefetch / end-of-track guards short-circuit on it.
- `handle_playback_outcome` skips the `play_event` credit when `finished.track_id < 0` (radio session) — no library row to credit and no scrobble eligibility.
- Cover URL is left `None` on the OS overlay path because `media_controls::update_metadata`'s cover param is treated as a local path / artwork-server registration; the in-app PlayerBar paints the cover off `player:radio-metadata` directly.
- HTTP client has `connect_timeout(10s)` and no request-level read timeout (radio sessions are open-ended).

## Test plan

- [x] `cargo test --workspace --lib` (83 tests pass — 3 new in `audio::http_source::tests`: send/sync bound, unsupported seek, unknown-host error surface)
- [x] `cargo check --workspace --all-targets`
- [x] `bun run typecheck` + `bun run lint`
- [x] Click a station in WebRadioView → PlayerBar paints title + cover, Pause/Resume work from the PlayerBar
- [x] EQ + ReplayGain + WASAPI Exclusive toggles apply to the live stream
- [x] Discord RPC + Last.fm: scrobble NOT eligible (track_id < 0)
- [x] Stop on PlayerBar collapses the row highlight in WebRadioView (driven by `player:state -> idle`)
- [x] Switching stations mid-playback cleanly hands off (no double-decoder, no zombie)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lecture intégrée de flux radio Web (HTTP/HTTPS) via le moteur, API frontend playerPlayUrl renvoyant un identifiant de piste négatif.
  * Émission d’événements de métadonnées radio pour alimenter l’UI.

* **Refactor**
  * Unification du traitement des sources audio (fichiers et flux live) et centralisation du traitement des issues de lecture.

* **UI**
  * Vue radio pilotée par le moteur (plus d’élément <audio>, abonnement aux états, gestion des requêtes concurrentes).
  * Artwork supporte une icône placeholder configurable; icône radio affichée dans la barre et désactivation contextuelle des contrôles.

* **Tests**
  * Tests ajoutés pour l’ouverture de flux HTTP et la redaction d’URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->