### PR TITLE
fix(server-auth): render OAuth callback page as HTML

### DIFF
--- a/src-tauri/crates/app/src/commands/loopback.rs
+++ b/src-tauri/crates/app/src/commands/loopback.rs
@@ -1,0 +1,29 @@
+//! Shared helpers for the loopback OAuth callback flows.
+//!
+//! Both [`server_auth`](crate::commands::server_auth) (Better Auth
+//! handshake against `waveflow-server`) and [`spotify`](crate::commands::spotify)
+//! spin up a one-shot `tiny_http` server on a local port to capture
+//! the redirect from the system browser. Each one renders a small
+//! HTML confirmation page so the user knows it's safe to close the
+//! tab. The plumbing diverges (different callback URLs, different
+//! query-string shapes, different state validation), but the
+//! "render a `text/html` response" step is identical — extracting it
+//! here keeps a single source of truth and makes sure a future fix
+//! ships to both flows at once.
+
+use tiny_http::{Header, Response};
+
+/// Wrap a static HTML body in a `tiny_http` response with the right
+/// `Content-Type` header.
+///
+/// `tiny_http::Response::from_string` does NOT stamp a Content-Type
+/// of its own; the receiving browser falls back to `text/plain` and
+/// renders the raw HTML markup as literal text. That broke both the
+/// Better Auth and Spotify confirmation pages until this helper
+/// landed.
+pub(crate) fn html_response(body: &'static str) -> Response<std::io::Cursor<Vec<u8>>> {
+    Response::from_string(body).with_header(
+        Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
+            .expect("static html content-type header is well-formed"),
+    )
+}

--- a/src-tauri/crates/app/src/commands/mod.rs
+++ b/src-tauri/crates/app/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod duplicates;
 pub mod edit;
 pub mod integration;
 pub mod library;
+pub mod loopback;
 pub mod lyrics;
 pub mod maintenance;
 pub mod mood_radio;

--- a/src-tauri/crates/app/src/commands/server_auth.rs
+++ b/src-tauri/crates/app/src/commands/server_auth.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use serde::Deserialize;
-use tiny_http::{Response, Server};
+use tiny_http::{Header, Response, Server};
 
 use crate::{
     error::{AppError, AppResult},
@@ -200,21 +200,21 @@ fn wait_for_callback(expected_state: &str) -> AppResult<String> {
         // future protocol change — falling through to the error arm
         // below is the safer default.
         (Some(token), None, state_value) if state_value == Some(expected_state) => {
-            let _ = request.respond(Response::from_string(
+            let _ = request.respond(html_response(
                 "<!doctype html><title>WaveFlow</title>\
                  <p>Signed in. You can close this tab and return to WaveFlow.</p>",
             ));
             Ok(token)
         }
         (_, Some(err), _) => {
-            let _ = request.respond(Response::from_string(
+            let _ = request.respond(html_response(
                 "<!doctype html><title>WaveFlow</title>\
                  <p>Sign-in was cancelled or denied.</p>",
             ));
             Err(AppError::Other(format!("sign-in failed: {err}")))
         }
         _ => {
-            let _ = request.respond(Response::from_string(
+            let _ = request.respond(html_response(
                 "<!doctype html><title>WaveFlow</title>\
                  <p>Sign-in failed: state mismatch (possible CSRF). Try again from the desktop.</p>",
             ));
@@ -223,4 +223,15 @@ fn wait_for_callback(expected_state: &str) -> AppResult<String> {
     };
 
     result
+}
+
+/// Build a `tiny_http` response with `Content-Type: text/html; charset=utf-8`
+/// so the browser renders the confirmation page instead of dumping the
+/// raw HTML as plaintext. `tiny_http::Response::from_string` does not
+/// stamp a Content-Type header on its own.
+fn html_response(body: &'static str) -> Response<std::io::Cursor<Vec<u8>>> {
+    Response::from_string(body).with_header(
+        Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
+            .expect("static html content-type header is well-formed"),
+    )
 }

--- a/src-tauri/crates/app/src/commands/server_auth.rs
+++ b/src-tauri/crates/app/src/commands/server_auth.rs
@@ -14,9 +14,10 @@
 use std::time::Duration;
 
 use serde::Deserialize;
-use tiny_http::{Header, Response, Server};
+use tiny_http::Server;
 
 use crate::{
+    commands::loopback::html_response,
     error::{AppError, AppResult},
     server_client::{self, ServerStatus},
     state::AppState,
@@ -223,15 +224,4 @@ fn wait_for_callback(expected_state: &str) -> AppResult<String> {
     };
 
     result
-}
-
-/// Build a `tiny_http` response with `Content-Type: text/html; charset=utf-8`
-/// so the browser renders the confirmation page instead of dumping the
-/// raw HTML as plaintext. `tiny_http::Response::from_string` does not
-/// stamp a Content-Type header on its own.
-fn html_response(body: &'static str) -> Response<std::io::Cursor<Vec<u8>>> {
-    Response::from_string(body).with_header(
-        Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
-            .expect("static html content-type header is well-formed"),
-    )
 }

--- a/src-tauri/crates/app/src/commands/spotify.rs
+++ b/src-tauri/crates/app/src/commands/spotify.rs
@@ -4,10 +4,11 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use tauri::Manager;
-use tiny_http::{Response, Server};
+use tiny_http::Server;
 
 use crate::{
     audio::{engine::AudioCmd, AudioEngine},
+    commands::loopback::html_response,
     error::{AppError, AppResult},
     spotify::{
         self, SpotifyAccessToken, SpotifyPlaylistLite, SpotifySearchResults, SpotifyStatus,
@@ -173,27 +174,21 @@ fn wait_for_callback(expected_state: &str) -> AppResult<String> {
 
     let result = match (parsed.code, parsed.error) {
         (Some(code), _) if parsed.state.as_deref() == Some(expected_state) => {
-            let _ = request.respond(
-                Response::from_string(
-                    "<!doctype html><title>WaveFlow Spotify</title><p>Spotify connected. You can close this tab.</p>",
-                ),
-            );
+            let _ = request.respond(html_response(
+                "<!doctype html><title>WaveFlow Spotify</title><p>Spotify connected. You can close this tab.</p>",
+            ));
             Ok(code)
         }
         (_, Some(err)) => {
-            let _ = request.respond(
-                Response::from_string(
-                    "<!doctype html><title>WaveFlow Spotify</title><p>Spotify login was cancelled or denied.</p>",
-                ),
-            );
+            let _ = request.respond(html_response(
+                "<!doctype html><title>WaveFlow Spotify</title><p>Spotify login was cancelled or denied.</p>",
+            ));
             Err(AppError::Other(format!("Spotify login failed: {err}")))
         }
         _ => {
-            let _ = request.respond(
-                Response::from_string(
-                    "<!doctype html><title>WaveFlow Spotify</title><p>Spotify login failed: invalid state.</p>",
-                ),
-            );
+            let _ = request.respond(html_response(
+                "<!doctype html><title>WaveFlow Spotify</title><p>Spotify login failed: invalid state.</p>",
+            ));
             Err(AppError::Other("Spotify callback state mismatch".into()))
         }
     };


### PR DESCRIPTION
## What

The desktop's OAuth loopback handler ([`server_auth.rs::run_callback_listener`](src-tauri/crates/app/src/commands/server_auth.rs)) responded to the browser with HTML markup but no `Content-Type` header. Chromium-family browsers fall back to `text/plain` rendering, so the user saw raw `<!doctype html>...` text instead of the styled "Signed in. You can close this tab and return to WaveFlow." message.

The sign-in flow itself worked end-to-end — only the confirmation page looked broken.

## How

`tiny_http::Response::from_string` does not stamp a Content-Type on its own. Wrap the three response branches (success / cancel / state mismatch) in a small `html_response` helper that attaches `Content-Type: text/html; charset=utf-8`.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets`
- [x] Manual: sign in via Settings → WaveFlow server → "Sign in with browser" — confirmation page now renders as a styled paragraph instead of raw HTML markup.

## Before
<img width="1492" alt="OAuth callback page rendered as text/plain" src="https://github.com/user-attachments/assets/.placeholder" />

(The user reported observing the raw HTML markup at `http://127.0.0.1:49388/wf/callback?token=...` after a successful sign-in.)

Discovered during the v1.5.0 visual QA pass against the dev stack ([`waveflow-dev-stack`](https://github.com/InstaZDLL/waveflow-dev-stack)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactorisation**
  * Uniformisation de la gestion des pages de callback OAuth : les réponses HTML renvoyées lors de la confirmation, annulation ou erreur utilisent désormais un rendu centralisé garantissant les en‑têtes HTTP corrects.
* **Nouveauté**
  * Ajout d’un utilitaire réutilisable pour générer les réponses HTML de loopback, exposé pour être partagé entre flux d’authentification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->