### PR TITLE
feat(sync): rfc-003 phase a.3 — desktop sqlite HLC columns + digest table

### DIFF
--- a/src-tauri/crates/app/src/db/mod.rs
+++ b/src-tauri/crates/app/src/db/mod.rs
@@ -9,3 +9,6 @@ pub mod app_db;
 pub mod migration_heal;
 pub mod profile_db;
 pub mod profile_meta;
+
+#[cfg(test)]
+mod rfc003_hlc_tests;

--- a/src-tauri/crates/app/src/db/rfc003_hlc_tests.rs
+++ b/src-tauri/crates/app/src/db/rfc003_hlc_tests.rs
@@ -1,0 +1,167 @@
+//! Smoke tests for the RFC-003 §3.1 HLC migrations (Phase A.3).
+//!
+//! Runs the compiled-in migrators against fresh in-memory SQLite DBs
+//! and asserts that every entity row has the four HLC columns and that
+//! `metadata_digest_version` is seeded with the expected entity names.
+//!
+//! Catches three regression classes the dual-shape ingest on the
+//! server side relies on:
+//!
+//! - Column NAMES match the server schema (`hlc_wall`, `hlc_logical`,
+//!   `origin_device_id`, `payload_hash`). The A.4 emit path will read
+//!   these by name; a typo here only surfaces at run-time otherwise.
+//! - Columns are present on every entity the desktop pushes today
+//!   (`library` / `track` / `playlist` / `playlist_track` /
+//!   `liked_track` per profile DB + `profile` in app.db). The
+//!   `track` row also carries a `rating_` mirror because rating is a
+//!   column on `track` rather than a sibling table.
+//! - `metadata_digest_version` is seeded with the right entity names
+//!   so the A.4 bump can `INSERT ... ON CONFLICT DO UPDATE` without
+//!   needing a separate provisioning step.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{Row, SqlitePool};
+use std::str::FromStr;
+
+/// HLC + payload_hash quartet the migration adds to every synced entity.
+const HLC_COLUMNS: &[(&str, &str, i64)] = &[
+    ("hlc_wall", "INTEGER", 1),
+    ("hlc_logical", "INTEGER", 1),
+    ("origin_device_id", "TEXT", 0),
+    ("payload_hash", "BLOB", 0),
+];
+
+async fn fresh_pool() -> SqlitePool {
+    let opts = SqliteConnectOptions::from_str(":memory:")
+        .unwrap()
+        .foreign_keys(true);
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(opts)
+        .await
+        .unwrap()
+}
+
+async fn column_info(pool: &SqlitePool, table: &str, column: &str) -> Option<(String, i64)> {
+    let stmt = format!("PRAGMA table_info({table})");
+    let rows = sqlx::query(sqlx::AssertSqlSafe(stmt))
+        .fetch_all(pool)
+        .await
+        .unwrap();
+    for row in rows {
+        let name: String = row.get("name");
+        if name == column {
+            let ty: String = row.get("type");
+            let notnull: i64 = row.get("notnull");
+            return Some((ty, notnull));
+        }
+    }
+    None
+}
+
+async fn assert_hlc_quartet(pool: &SqlitePool, table: &str) {
+    for (col, ty, notnull) in HLC_COLUMNS {
+        let info = column_info(pool, table, col)
+            .await
+            .unwrap_or_else(|| panic!("missing column {table}.{col}"));
+        assert_eq!(info.0.to_uppercase(), *ty, "{table}.{col} type mismatch");
+        assert_eq!(info.1, *notnull, "{table}.{col} notnull flag mismatch");
+    }
+}
+
+#[tokio::test]
+async fn profile_migrations_apply_hlc_quartet_to_every_entity() {
+    let pool = fresh_pool().await;
+    sqlx::migrate!("../../migrations/profile")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    for table in [
+        "library",
+        "track",
+        "playlist",
+        "playlist_track",
+        "liked_track",
+    ] {
+        assert_hlc_quartet(&pool, table).await;
+    }
+
+    // Rating mirror lives on `track` because rating is a column.
+    for col in [
+        "rating_hlc_wall",
+        "rating_hlc_logical",
+        "rating_origin_device_id",
+        "rating_payload_hash",
+    ] {
+        assert!(
+            column_info(&pool, "track", col).await.is_some(),
+            "missing track.{col}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn profile_migrations_seed_metadata_digest_version() {
+    let pool = fresh_pool().await;
+    sqlx::migrate!("../../migrations/profile")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    let mut entities: Vec<String> =
+        sqlx::query_scalar("SELECT entity FROM metadata_digest_version ORDER BY entity")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    entities.sort();
+
+    let mut expected: Vec<String> = [
+        "library",
+        "liked_track",
+        "playlist",
+        "playlist_track",
+        "track",
+        "track_rating",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    expected.sort();
+
+    assert_eq!(entities, expected);
+
+    // Versions all start at 0 so the first bump lands at 1.
+    let versions: Vec<i64> = sqlx::query_scalar("SELECT version FROM metadata_digest_version")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert!(versions.iter().all(|v| *v == 0));
+}
+
+#[tokio::test]
+async fn app_migrations_apply_hlc_quartet_to_profile() {
+    let pool = fresh_pool().await;
+    sqlx::migrate!("../../migrations/app")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    assert_hlc_quartet(&pool, "profile").await;
+}
+
+#[tokio::test]
+async fn app_migrations_seed_metadata_digest_version_with_profile_only() {
+    let pool = fresh_pool().await;
+    sqlx::migrate!("../../migrations/app")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    let entities: Vec<String> =
+        sqlx::query_scalar("SELECT entity FROM metadata_digest_version ORDER BY entity")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(entities, vec!["profile".to_string()]);
+}

--- a/src-tauri/migrations/app/20260615000000_rfc003_hlc.sql
+++ b/src-tauri/migrations/app/20260615000000_rfc003_hlc.sql
@@ -1,0 +1,45 @@
+-- RFC-003 §3.1 — desktop app-wide HLC columns. Phase A.3.
+--
+-- Sibling of `migrations/profile/20260615000000_rfc003_hlc.sql`.
+-- The `profile` registry row lives in `app.db` (shared cross-
+-- profile) so its HLC + digest version live here, while every other
+-- synced entity (`library` / `track` / `playlist` / `playlist_track`
+-- / `liked_track` / `track_rating`) lives per-profile and its
+-- HLC columns ship in the profile-side migration of the same date.
+--
+-- Mirrors the server-side schema landed in waveflow-server #51 (the
+-- `profile` table addition) plus #53 (`user_metadata_digest_version`
+-- which on desktop collapses into the same shape since the per-DB
+-- scope already disambiguates tenants).
+--
+-- ## Scope
+--
+-- ALTER + DEFAULT only. Existing rows backfill to `(0, 0, NULL,
+-- NULL)`; no emit-side code change ships here (A.4 owns the v2
+-- wire format and the `payload_hash` move into `waveflow-core`).
+
+-- =============================================================================
+-- 1. profile registry HLC columns (mirror waveflow-server #51 §1)
+-- =============================================================================
+
+ALTER TABLE profile ADD COLUMN hlc_wall         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE profile ADD COLUMN hlc_logical      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE profile ADD COLUMN origin_device_id TEXT;
+ALTER TABLE profile ADD COLUMN payload_hash     BLOB;
+
+-- =============================================================================
+-- 2. App-wide entity digest version (mirror waveflow-server #51 §2)
+-- =============================================================================
+--
+-- Only the `profile` entity lives in `app.db`, so this counter has a
+-- single seeded row. We keep the same `(entity, version)` schema as
+-- the per-profile sibling table so the digest endpoint client can
+-- query both with identical SQL.
+
+CREATE TABLE metadata_digest_version (
+    entity      TEXT PRIMARY KEY,
+    version     INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO metadata_digest_version (entity, version) VALUES
+    ('profile', 0);

--- a/src-tauri/migrations/profile/20260615000000_rfc003_hlc.sql
+++ b/src-tauri/migrations/profile/20260615000000_rfc003_hlc.sql
@@ -1,0 +1,127 @@
+-- RFC-003 §3.1 — desktop per-profile HLC columns. Phase A.3.
+--
+-- Mirror of the server-side schema landed in waveflow-server #51
+-- (migration `20260613000000_entity_hlc.sql`). Every entity row this
+-- desktop emits or could re-emit through the sync pipeline grows
+-- four columns:
+--
+--   * `hlc_wall`            BIGINT, Unix epoch milliseconds of the
+--                           Hybrid Logical Clock the apply pipeline
+--                           stamped on the most-recently-accepted op.
+--                           Server-side BIGINT NOT NULL DEFAULT 0; we
+--                           match the wire shape with SQLite INTEGER
+--                           (which is a 64-bit signed value here).
+--   * `hlc_logical`         INTEGER, the i32-range logical counter
+--                           paired with `hlc_wall` (§2 total order
+--                           sorts by `(wall, logical, origin_device_id)`).
+--   * `origin_device_id`    TEXT (UUIDv4-shaped), identifies the device
+--                           whose op produced the current state. NULL
+--                           when the row predates v2 (Lamport-era)
+--                           and the origin is unknown.
+--   * `payload_hash`        BLOB, BLAKE3-256 of the canonical wire
+--                           form (§4). NULL pre-v2; populated by the
+--                           A.4 emit path once we ship it.
+--
+-- ## Scope on A.3
+--
+-- This migration ONLY widens the schema. The desktop produces ops
+-- but is not yet a consumer of the v2 wire shape — that ships in
+-- Phase A.4 alongside the `payload_hash` helper move from
+-- `waveflow-server` into `waveflow-core`. Until then every column
+-- stays at its DEFAULT (`0` / `NULL`) and round-trips against the
+-- server without behavioural change. The server treats absent v2
+-- fields on inbound ops as a legacy push (dual-shape ingest landed
+-- in #52) so existing 1.f drains keep working untouched.
+--
+-- ## Rating is a column on `track`, not a sibling table
+--
+-- The server splits `user_track_rating` into its own table (different
+-- tenant scoping — rating is user-scoped, the track row itself is
+-- profile-scoped). On desktop the per-profile DB IS the user scope,
+-- so we keep `track.rating` as a column and co-locate the rating's
+-- HLC + payload_hash on the same row under a `rating_` prefix. Same
+-- physical row, two logical sync entities (`track` vs
+-- `track_rating`), independent HLCs. This matches the emit-time
+-- distinction already in `commands/track.rs` where the
+-- `entity: "track_rating"` op carries `track.file_hash` as
+-- `entity_id` while metadata-edit ops carry `entity: "track"`.
+--
+-- ## Backfill policy
+--
+-- Existing rows get `(0, 0, NULL, NULL)` via the DEFAULTs. That maps
+-- 1:1 to the server's "row predates v2" state — when the desktop
+-- starts emitting v2 in A.4, its first push for any pre-A.4 entity
+-- carries fresh HLC values derived from the local lamport counter
+-- (server-side dual-shape ingest in #52 does the rest).
+
+-- =============================================================================
+-- 1. Profile-scoped entities (mirror waveflow-server #51 §1)
+-- =============================================================================
+
+ALTER TABLE library ADD COLUMN hlc_wall         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE library ADD COLUMN hlc_logical      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE library ADD COLUMN origin_device_id TEXT;
+ALTER TABLE library ADD COLUMN payload_hash     BLOB;
+
+ALTER TABLE track ADD COLUMN hlc_wall         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE track ADD COLUMN hlc_logical      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE track ADD COLUMN origin_device_id TEXT;
+ALTER TABLE track ADD COLUMN payload_hash     BLOB;
+
+-- Rating sub-entity on the same `track` row. Independent HLC because
+-- a metadata edit and a rating change are separate ops that ship at
+-- different times — without separate HLC fields one would clobber the
+-- other's stamping on read-modify-write.
+ALTER TABLE track ADD COLUMN rating_hlc_wall         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE track ADD COLUMN rating_hlc_logical      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE track ADD COLUMN rating_origin_device_id TEXT;
+ALTER TABLE track ADD COLUMN rating_payload_hash     BLOB;
+
+ALTER TABLE playlist ADD COLUMN hlc_wall         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE playlist ADD COLUMN hlc_logical      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE playlist ADD COLUMN origin_device_id TEXT;
+ALTER TABLE playlist ADD COLUMN payload_hash     BLOB;
+
+ALTER TABLE playlist_track ADD COLUMN hlc_wall         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE playlist_track ADD COLUMN hlc_logical      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE playlist_track ADD COLUMN origin_device_id TEXT;
+ALTER TABLE playlist_track ADD COLUMN payload_hash     BLOB;
+
+ALTER TABLE liked_track ADD COLUMN hlc_wall         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE liked_track ADD COLUMN hlc_logical      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE liked_track ADD COLUMN origin_device_id TEXT;
+ALTER TABLE liked_track ADD COLUMN payload_hash     BLOB;
+
+-- =============================================================================
+-- 2. Per-entity digest version (mirror waveflow-server #51 §2 +
+--    #53 user_metadata_digest_version)
+-- =============================================================================
+--
+-- One row per synced entity name. `version` is bumped in the same
+-- transaction as every op-derived write whose `payload_hash`
+-- actually changes (§invariant: bump iff hash differs). The digest
+-- endpoint (server #56) joins this counter with the per-entity
+-- members hash to give two devices a cheap "are we in sync?" check.
+--
+-- On the server this is split in two tables (one keyed by
+-- `profile_id`, one keyed by `user_id`) because a single Postgres
+-- DB hosts every tenant. On desktop the per-profile `data.db`
+-- already IS the profile/user scope, so a single keyed-by-entity
+-- table covers both `library` / `track` / `playlist` /
+-- `playlist_track` (profile-scoped server-side) AND `liked_track` /
+-- `track_rating` (user-scoped server-side) without further splitting.
+-- The `profile` entity's digest lives in `app.db` (see the matching
+-- migration there) because the row itself lives in `app.db`.
+
+CREATE TABLE metadata_digest_version (
+    entity      TEXT PRIMARY KEY,
+    version     INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO metadata_digest_version (entity, version) VALUES
+    ('library',        0),
+    ('track',          0),
+    ('playlist',       0),
+    ('playlist_track', 0),
+    ('liked_track',    0),
+    ('track_rating',   0);


### PR DESCRIPTION
## Summary

Phase A.3 of RFC-003 sync v2 — mirror the server-side HLC + digest
schema (waveflow-server #51 + #53) on the desktop side. Every entity
row that the desktop sync pipeline emits today gains the four-column
HLC quartet (`hlc_wall` / `hlc_logical` / `origin_device_id` /
`payload_hash`), and a per-DB `metadata_digest_version` counter table
seeds the rows the A.4 emit path will bump in-tx with every accepted
write.

ALTER + DEFAULT only — no emit-side code change ships here. The
server's dual-shape ingest (waveflow-server #52) treats absent v2
fields on inbound ops as a legacy push, so existing 1.f drains keep
working untouched until A.4 lights up the v2 wire format.

## Migration

### `migrations/profile/20260615000000_rfc003_hlc.sql`

- `library` / `track` / `playlist` / `playlist_track` / `liked_track`
  gain `hlc_wall` (INTEGER NOT NULL DEFAULT 0), `hlc_logical` (INTEGER
  NOT NULL DEFAULT 0), `origin_device_id` (TEXT), `payload_hash` (BLOB).
- `track` gains an additional `rating_`-prefixed quartet because rating
  lives as a column on `track` (vs the server's sibling
  `user_track_rating` table). Independent HLC so metadata + rating
  changes don't clobber each other's stamping.
- New `metadata_digest_version (entity TEXT PRIMARY KEY, version INTEGER
  NOT NULL DEFAULT 0)` seeded with the 6 profile-scoped entities.

### `migrations/app/20260615000000_rfc003_hlc.sql`

- `profile` gains the same HLC quartet.
- New `metadata_digest_version` table with one seeded row (`profile`).

## What this does NOT do

- ❌ Émission v2 wire shape côté desktop → Phase A.4
- ❌ Déplacement de `payload_hash` du server vers `waveflow-core` → A.4
- ❌ Apply pipeline desktop → desktop est producteur, pas consumer

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` — 237 tests pass
- [x] 4 nouveaux smoke tests `db::rfc003_hlc_tests::*` :
  - `profile_migrations_apply_hlc_quartet_to_every_entity` — vérifie via PRAGMA table_info que les 4 colonnes existent avec le bon type sur chaque table profile-scoped, et que `track` a aussi le mirror `rating_`
  - `profile_migrations_seed_metadata_digest_version` — vérifie le seed et que toutes les versions partent à 0
  - `app_migrations_apply_hlc_quartet_to_profile` — équivalent pour `profile` dans app.db
  - `app_migrations_seed_metadata_digest_version_with_profile_only` — vérifie qu'app.db ne seed que `profile`
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean

## Refs

- RFC-003 §3.1 (HLC fields)
- waveflow-server #51 (server entity tables HLC + metadata_digest_version)
- waveflow-server #53 (server user_metadata_digest_version)
- waveflow-server #56 (server payload_hash bind + digest bump + endpoint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Tests**
  * Ajout de tests de migrations pour valider l'intégrité des modifications de schéma.

* **Infrastructure**
  * Amélioration des capacités de synchronisation multi-appareils avec ajout de métadonnées de versioning et suivi des modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->