### PR TITLE
feat(sync): rfc-003 phase a.4.2 — desktop drain emits v2 wire shape

### DIFF
--- a/src-tauri/crates/app/src/db/rfc003_hlc_tests.rs
+++ b/src-tauri/crates/app/src/db/rfc003_hlc_tests.rs
@@ -170,6 +170,71 @@ async fn profile_migrations_seed_metadata_digest_version() {
 }
 
 #[tokio::test]
+async fn profile_migrations_apply_hlc_pair_to_sync_pending_op() {
+    let pool = fresh_pool().await;
+    sqlx::migrate!("../../migrations/profile")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    for (col, ty, notnull, dflt) in [
+        ("hlc_wall", "INTEGER", 1, Some("0")),
+        ("hlc_logical", "INTEGER", 1, Some("0")),
+    ] {
+        let info = column_info(&pool, "sync_pending_op", col)
+            .await
+            .unwrap_or_else(|| panic!("missing column sync_pending_op.{col}"));
+        assert_eq!(info.0.to_uppercase(), ty, "sync_pending_op.{col} type");
+        assert_eq!(info.1, notnull, "sync_pending_op.{col} notnull");
+        assert_eq!(
+            info.2.as_deref(),
+            dflt,
+            "sync_pending_op.{col} default value"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sync_pending_op_check_rejects_logical_outside_i32_range() {
+    // RFC-003 §2 bounds `hlc_logical` to `0..=i32::MAX`. The CHECK
+    // constraint added in 20260616000000 is a defence-in-depth layer
+    // — the bind site in `sync::hlc::next` already refuses overflow,
+    // but a hand-rolled INSERT (test code, manual repair tool, …)
+    // would otherwise plant a poisoned value that fails server-side
+    // at the 23505 path.
+    let pool = fresh_pool().await;
+    sqlx::migrate!("../../migrations/profile")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    let err = sqlx::query(
+        "INSERT INTO sync_pending_op
+            (operation_id, lamport_ts, entity, entity_id, op, created_at,
+             hlc_wall, hlc_logical)
+         VALUES ('op-1', 1, 'playlist', '1', 'set', 0, 0, 2147483648)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap_err();
+    let s = format!("{err}").to_lowercase();
+    assert!(s.contains("check"), "expected CHECK constraint failure: {s}");
+
+    // Negative values get caught too.
+    let err = sqlx::query(
+        "INSERT INTO sync_pending_op
+            (operation_id, lamport_ts, entity, entity_id, op, created_at,
+             hlc_wall, hlc_logical)
+         VALUES ('op-2', 2, 'playlist', '1', 'set', 0, 0, -1)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap_err();
+    let s = format!("{err}").to_lowercase();
+    assert!(s.contains("check"), "expected CHECK constraint failure: {s}");
+}
+
+#[tokio::test]
 async fn app_migrations_apply_hlc_quartet_to_profile() {
     let pool = fresh_pool().await;
     sqlx::migrate!("../../migrations/app")

--- a/src-tauri/crates/app/src/sync/drain.rs
+++ b/src-tauri/crates/app/src/sync/drain.rs
@@ -104,6 +104,17 @@ pub enum DrainOutcome {
 
 // ── Wire shape mirroring waveflow-server's sync types ────────────
 
+/// Mirrors `waveflow_server::sync::Hlc`. RFC-003 v2 pair shipped
+/// under `SyncOpIn.hlc: Option<Hlc>` (waveflow-server #52). The
+/// server-side dual-shape ingest derives `(0, lamport_ts)` for v1
+/// (legacy) rows that omit this key, so the desktop can ship either
+/// form without coordinating a release.
+#[derive(Debug, Serialize)]
+struct WireHlc {
+    wall: i64,
+    logical: i32,
+}
+
 /// Mirrors `waveflow_server::sync::SyncOpIn`.
 #[derive(Debug, Serialize)]
 struct SyncOpInBody {
@@ -122,6 +133,28 @@ struct SyncOpInBody {
     /// a hypothetical future caller wants the legacy shape.
     #[serde(skip_serializing_if = "Option::is_none")]
     profile_canonical_id: Option<String>,
+    /// RFC-003 Phase A.4.2 — v2 wire shape. `Some` when the row in
+    /// `sync_pending_op` was enqueued with a non-zero pair (any
+    /// post-A.4.2 enqueue); `None` for legacy (0, 0) rows where the
+    /// server's dual-shape ingest will derive `(0, lamport_ts)`
+    /// itself. The key is omitted from the JSON when `None` so the
+    /// wire stays bit-identical to the v1 form when there's nothing
+    /// to send.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hlc: Option<WireHlc>,
+}
+
+/// Lift a pending row's `(hlc_wall, hlc_logical)` pair onto the
+/// outbound wire field. Pre-A.4.2 rows backfill to `(0, 0)` via the
+/// migration DEFAULT — `None` rather than `Some(0, 0)` keeps the
+/// JSON identical to the legacy form, so the server picks the v1
+/// dual-shape branch and derives `(0, lamport_ts)` itself.
+fn wire_hlc_from_row(wall: i64, logical: i32) -> Option<WireHlc> {
+    if wall == 0 && logical == 0 {
+        None
+    } else {
+        Some(WireHlc { wall, logical })
+    }
 }
 
 /// Mirrors `waveflow_server::api::sync::PushBatchRequest`.
@@ -251,6 +284,7 @@ pub async fn drain_once(state: &AppState) -> AppResult<DrainOutcome> {
                 op: p.op.clone(),
                 payload: p.payload.clone(),
                 profile_canonical_id: Some(profile_canonical_id.clone()),
+                hlc: wire_hlc_from_row(p.hlc_wall, p.hlc_logical),
             })
             .collect();
         let body = PushBatchRequest {
@@ -380,11 +414,12 @@ mod tests {
     }
 
     #[test]
-    fn push_batch_request_body_matches_server_wire_shape() {
-        // Tightens the contract against waveflow-server's
-        // `SyncOpIn`. A divergence here would surface at the first
-        // real POST, which is far from the test boundary; pinning
-        // the shape locally catches it at compile + serialise time.
+    fn push_batch_request_body_matches_server_wire_shape_v1_legacy() {
+        // Legacy (v1) wire shape — `hlc` field stays absent so the
+        // server's dual-shape ingest derives `(0, lamport_ts)`. The
+        // desktop falls into this branch for rows enqueued before
+        // Phase A.4.2 (DEFAULT 0/0 columns mean
+        // `wire_hlc_from_row` returns `None`).
         let body = PushBatchRequest {
             device_id: "device-a",
             ops: vec![SyncOpInBody {
@@ -396,6 +431,7 @@ mod tests {
                 op: "set".into(),
                 payload: Some(serde_json::json!({ "value": "Soirée" })),
                 profile_canonical_id: Some("11111111-2222-4333-8444-555555555555".into()),
+                hlc: None,
             }],
         };
         let v = serde_json::to_value(&body).unwrap();
@@ -415,6 +451,63 @@ mod tests {
                 }],
             }),
         );
+    }
+
+    #[test]
+    fn push_batch_request_body_carries_hlc_on_v2_wire_shape() {
+        // Phase A.4.2 v2 shape — `hlc: { wall, logical }` rides on
+        // the op. `device_id` doubles as the §2 tiebreaker
+        // `origin_device_id` (UUID-shaped TEXT round-trip per the
+        // A.1.1 server header), so no separate wire key is needed.
+        let body = PushBatchRequest {
+            device_id: "11111111-1111-1111-1111-111111111111",
+            ops: vec![SyncOpInBody {
+                operation_id: "00000000-0000-0000-0000-000000000002".into(),
+                lamport_ts: 5,
+                entity: "playlist".into(),
+                entity_id: "9".into(),
+                field: None,
+                op: "insert".into(),
+                payload: Some(serde_json::json!({ "name": "Mix" })),
+                profile_canonical_id: Some("22222222-3333-4444-8555-666666666666".into()),
+                hlc: Some(WireHlc {
+                    wall: 1_700_000_000_001,
+                    logical: 3,
+                }),
+            }],
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "device_id": "11111111-1111-1111-1111-111111111111",
+                "ops": [{
+                    "operation_id": "00000000-0000-0000-0000-000000000002",
+                    "lamport_ts": 5,
+                    "entity": "playlist",
+                    "entity_id": "9",
+                    "field": null,
+                    "op": "insert",
+                    "payload": { "name": "Mix" },
+                    "profile_canonical_id": "22222222-3333-4444-8555-666666666666",
+                    "hlc": { "wall": 1_700_000_000_001_i64, "logical": 3 },
+                }],
+            }),
+        );
+    }
+
+    #[test]
+    fn wire_hlc_from_row_treats_zero_pair_as_v1() {
+        // The (0, 0) backfill pair maps to None so the wire shape
+        // stays identical to the legacy form. Any non-zero
+        // component flips to the v2 branch.
+        assert!(wire_hlc_from_row(0, 0).is_none());
+        let hlc = wire_hlc_from_row(1, 0).unwrap();
+        assert_eq!((hlc.wall, hlc.logical), (1, 0));
+        let hlc = wire_hlc_from_row(0, 1).unwrap();
+        assert_eq!((hlc.wall, hlc.logical), (0, 1));
+        let hlc = wire_hlc_from_row(123, 456).unwrap();
+        assert_eq!((hlc.wall, hlc.logical), (123, 456));
     }
 
     #[test]

--- a/src-tauri/crates/app/src/sync/drain.rs
+++ b/src-tauri/crates/app/src/sync/drain.rs
@@ -149,8 +149,18 @@ struct SyncOpInBody {
 /// migration DEFAULT — `None` rather than `Some(0, 0)` keeps the
 /// JSON identical to the legacy form, so the server picks the v1
 /// dual-shape branch and derives `(0, lamport_ts)` itself.
+///
+/// The gate is `wall == 0` rather than `wall == 0 && logical == 0`
+/// because `hlc::next_conn` ALWAYS produces a `wall = max(now_ms,
+/// last_wall)` that's strictly greater than zero (epoch-ms in 2026
+/// is ~1.7e12). A row carrying `(0, n > 0)` can only arise from
+/// corruption or a manual edit — emitting it on the wire as a v2
+/// HLC with `wall = 0` (= January 1970) would feed the server's
+/// LWW comparator an ancient pair that loses against every legit
+/// op. Falling back to the v1 shape lets the server derive a
+/// usable `(0, lamport_ts)` from the row's Lamport instead.
 fn wire_hlc_from_row(wall: i64, logical: i32) -> Option<WireHlc> {
-    if wall == 0 && logical == 0 {
+    if wall == 0 {
         None
     } else {
         Some(WireHlc { wall, logical })
@@ -497,15 +507,19 @@ mod tests {
     }
 
     #[test]
-    fn wire_hlc_from_row_treats_zero_pair_as_v1() {
-        // The (0, 0) backfill pair maps to None so the wire shape
-        // stays identical to the legacy form. Any non-zero
-        // component flips to the v2 branch.
+    fn wire_hlc_from_row_gates_on_wall_alone() {
+        // wall == 0 → None: covers both the (0, 0) backfill DEFAULT
+        // and the (0, n > 0) corruption case where emitting a v2
+        // hlc with wall=0 would feed the server an ancient
+        // 1970-epoch pair that loses every LWW comparison.
         assert!(wire_hlc_from_row(0, 0).is_none());
+        assert!(wire_hlc_from_row(0, 1).is_none());
+        assert!(wire_hlc_from_row(0, i32::MAX).is_none());
+        // wall > 0 → Some: the production path (hlc::next_conn
+        // produces wall = max(now_ms, last_wall) so wall is always
+        // ~1.7e12 in 2026).
         let hlc = wire_hlc_from_row(1, 0).unwrap();
         assert_eq!((hlc.wall, hlc.logical), (1, 0));
-        let hlc = wire_hlc_from_row(0, 1).unwrap();
-        assert_eq!((hlc.wall, hlc.logical), (0, 1));
         let hlc = wire_hlc_from_row(123, 456).unwrap();
         assert_eq!((hlc.wall, hlc.logical), (123, 456));
     }

--- a/src-tauri/crates/app/src/sync/hlc.rs
+++ b/src-tauri/crates/app/src/sync/hlc.rs
@@ -1,0 +1,354 @@
+// `next` is the public surface for the enqueue hooks; the diagnostic
+// commands only need `read`. `observe_remote` lands in Phase B's WS
+// subscriber alongside `lamport::observe_remote`, so it's still
+// dead from the desktop side today.
+#![allow(dead_code)]
+
+//! Per-profile Hybrid Logical Clock (RFC-003 §2). Pairs `(wall,
+//! logical)` that strictly increases per draw, the way the §2 total
+//! order needs.
+//!
+//! ## Algorithm — single atomic draw
+//!
+//! Each call to [`next_conn`] runs a single SQLite UPSERT that:
+//!
+//! 1. Reads the persisted `(last_wall, last_logical)` pair.
+//! 2. Picks a candidate wall = `max(now_ms, last_wall)`. This guards
+//!    against wall-clock jumps backwards (NTP sync, manual time
+//!    change, leap seconds): if the system clock rewinds, the HLC
+//!    stays parked on the previous high-water mark instead of
+//!    silently regressing.
+//! 3. Picks a candidate logical:
+//!    - `0` when `now_ms > last_wall` (a fresh wall tick — logical
+//!      counter resets).
+//!    - `last_logical + 1` otherwise (the wall didn't advance, the
+//!      logical takes the slack).
+//! 4. Persists the candidate pair atomically and returns it.
+//!
+//! ## i32 range guard
+//!
+//! `logical` is an `i32` on the wire (waveflow-server A.1.1 bind
+//! site refuses anything outside `0..=i32::MAX`) and the matching
+//! storage column has a CHECK constraint mirroring the bound. The
+//! draw routine refuses to roll past `i32::MAX` — caller gets an
+//! error rather than a silently-truncated value. In practice a user
+//! would need to fire 2³¹ ops within a single epoch-ms tick to hit
+//! this, which is ~2× faster than the fastest CPU can serialise an
+//! `INSERT` to SQLite — physically unreachable, but the guard makes
+//! that explicit instead of "trust me".
+//!
+//! ## Persistence
+//!
+//! Lives in `profile_setting` under two keys so the encode side
+//! doesn't pay to pack a tuple into TEXT and parse it on every
+//! draw. Per-profile because the active Better Auth user changes
+//! every Lamport / HLC space.
+//!
+//! - `sync.hlc.last_wall` — `i64`, last drawn wall (epoch-ms)
+//! - `sync.hlc.last_logical` — `i32`, last drawn logical counter
+
+use chrono::Utc;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::error::{AppError, AppResult};
+
+pub const KEY_WALL: &str = "sync.hlc.last_wall";
+pub const KEY_LOGICAL: &str = "sync.hlc.last_logical";
+
+const LOGICAL_MAX: i64 = i32::MAX as i64;
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+/// Atomic snapshot of the persisted clock as seen at the start of a
+/// draw. Surfaces in tests and diagnostics; production code consumes
+/// it via [`next`] / [`next_conn`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HlcPair {
+    pub wall: i64,
+    pub logical: i32,
+}
+
+impl HlcPair {
+    pub const ZERO: Self = Self { wall: 0, logical: 0 };
+}
+
+/// Draw the next `(wall, logical)` pair on a fresh pool connection.
+/// See [`next_conn`] for the algorithm; this thin wrapper acquires
+/// once and delegates.
+pub async fn next(profile_pool: &SqlitePool) -> AppResult<HlcPair> {
+    let mut conn = profile_pool.acquire().await?;
+    next_conn(&mut conn).await
+}
+
+/// Draw the next `(wall, logical)` pair on a caller-owned
+/// connection. Composes with the entity write + outbox enqueue + the
+/// existing Lamport bump in one atomic commit (see
+/// [`crate::sync::hooks::enqueue_op_in_tx`]).
+///
+/// The draw runs in three round-trips against the same connection:
+///
+/// 1. SELECT the persisted pair (defaults to `(0, 0)` on first
+///    call).
+/// 2. Compute the candidate in Rust (cheap, no SQL trip).
+/// 3. UPSERT the new pair atomically.
+///
+/// The connection serialises every other write under the SQLite
+/// per-connection lock — two concurrent `next_conn` calls on the
+/// same connection are impossible by construction, and two callers
+/// holding separate connections still hit the wall-clock floor
+/// (whichever commits first sets `last_wall`; the other reads it
+/// and either advances or bumps logical).
+pub async fn next_conn(conn: &mut SqliteConnection) -> AppResult<HlcPair> {
+    let last = read_pair_conn(conn).await?;
+    let now = now_ms();
+
+    let (wall, logical) = if now > last.wall {
+        (now, 0)
+    } else {
+        let next_logical = (last.logical as i64) + 1;
+        if next_logical > LOGICAL_MAX {
+            return Err(AppError::Other(format!(
+                "sync HLC logical counter exhausted within wall tick {} (max {})",
+                last.wall, LOGICAL_MAX,
+            )));
+        }
+        (last.wall, next_logical as i32)
+    };
+
+    write_pair_conn(conn, wall, logical).await?;
+
+    Ok(HlcPair { wall, logical })
+}
+
+/// Bump the local clock to at least `remote` so the next [`next`]
+/// call returns a pair strictly greater than it under §2.
+///
+/// Mirror of [`crate::sync::lamport::observe_remote`]. Reserved for
+/// Phase B's WS subscriber (which forwards remote HLCs into the
+/// local floor); shipped here so the apply path can pull it in
+/// without growing the public API surface.
+pub async fn observe_remote(profile_pool: &SqlitePool, remote: HlcPair) -> AppResult<()> {
+    let mut conn = profile_pool.acquire().await?;
+    observe_remote_conn(&mut conn, remote).await
+}
+
+pub async fn observe_remote_conn(conn: &mut SqliteConnection, remote: HlcPair) -> AppResult<()> {
+    if remote == HlcPair::ZERO {
+        return Ok(());
+    }
+    let local = read_pair_conn(conn).await?;
+    // §2 total order — only bump if the remote strictly outranks.
+    if (remote.wall, remote.logical) <= (local.wall, local.logical) {
+        return Ok(());
+    }
+    write_pair_conn(conn, remote.wall, remote.logical).await
+}
+
+/// Read the persisted pair without bumping. Returns `(0, 0)` when
+/// no draw has fired yet.
+pub async fn read(profile_pool: &SqlitePool) -> AppResult<HlcPair> {
+    let mut conn = profile_pool.acquire().await?;
+    read_pair_conn(&mut conn).await
+}
+
+async fn read_pair_conn(conn: &mut SqliteConnection) -> AppResult<HlcPair> {
+    let row: (Option<i64>, Option<i64>) = sqlx::query_as(
+        "SELECT
+            (SELECT CAST(value AS INTEGER) FROM profile_setting WHERE key = ?),
+            (SELECT CAST(value AS INTEGER) FROM profile_setting WHERE key = ?)",
+    )
+    .bind(KEY_WALL)
+    .bind(KEY_LOGICAL)
+    .fetch_one(conn)
+    .await?;
+    let wall = row.0.unwrap_or(0);
+    let logical_raw = row.1.unwrap_or(0);
+    // Defence-in-depth: if a manual edit somehow planted an out-of-
+    // range logical the CHECK on `sync_pending_op` wouldn't have
+    // caught (CHECK only fires on insert into that table, not on
+    // the `profile_setting` row that holds the floor), clamp to the
+    // legal range so the next draw doesn't bind a poisoned value.
+    let logical = logical_raw.clamp(0, LOGICAL_MAX) as i32;
+    Ok(HlcPair { wall, logical })
+}
+
+async fn write_pair_conn(
+    conn: &mut SqliteConnection,
+    wall: i64,
+    logical: i32,
+) -> AppResult<()> {
+    let updated_at = now_ms();
+    // Two separate UPSERTs because the pair lives under two keys.
+    // Same connection = same SQLite per-connection lock, so the
+    // pair appears atomic to every other reader on a different
+    // connection.
+    sqlx::query(
+        "INSERT INTO profile_setting (key, value, value_type, updated_at)
+         VALUES (?, CAST(? AS TEXT), 'int', ?)
+         ON CONFLICT(key) DO UPDATE
+            SET value = excluded.value,
+                value_type = excluded.value_type,
+                updated_at = excluded.updated_at",
+    )
+    .bind(KEY_WALL)
+    .bind(wall)
+    .bind(updated_at)
+    .execute(&mut *conn)
+    .await?;
+    sqlx::query(
+        "INSERT INTO profile_setting (key, value, value_type, updated_at)
+         VALUES (?, CAST(? AS TEXT), 'int', ?)
+         ON CONFLICT(key) DO UPDATE
+            SET value = excluded.value,
+                value_type = excluded.value_type,
+                updated_at = excluded.updated_at",
+    )
+    .bind(KEY_LOGICAL)
+    .bind(logical as i64)
+    .bind(updated_at)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE profile_setting (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                value_type TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn next_starts_with_current_wall_and_logical_zero() {
+        let pool = pool().await;
+        let before = now_ms();
+        let p = next(&pool).await.unwrap();
+        let after = now_ms();
+        assert!(p.wall >= before && p.wall <= after);
+        assert_eq!(p.logical, 0);
+    }
+
+    #[tokio::test]
+    async fn next_advances_logical_within_same_wall_tick() {
+        let pool = pool().await;
+        // Three back-to-back draws inside a single wall ms — logical
+        // should march 0, 1, 2 without the wall changing.
+        let a = next(&pool).await.unwrap();
+        let b = next(&pool).await.unwrap();
+        let c = next(&pool).await.unwrap();
+        // Whether the wall ms ticked between draws is timing-
+        // dependent on a real clock, but the §2 total order rule
+        // is the same either way: the triple must be strictly
+        // increasing.
+        assert!((a.wall, a.logical) < (b.wall, b.logical));
+        assert!((b.wall, b.logical) < (c.wall, c.logical));
+    }
+
+    #[tokio::test]
+    async fn next_resets_logical_when_wall_advances() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        // Seed a pair from "an ms ago" so the next draw sees a
+        // strictly newer `now`. Without seeding the test is
+        // racy under fast clocks.
+        let ms_ago = now_ms() - 100;
+        write_pair_conn(&mut conn, ms_ago, 5).await.unwrap();
+        let p = next_conn(&mut conn).await.unwrap();
+        assert!(p.wall > ms_ago);
+        assert_eq!(p.logical, 0);
+    }
+
+    #[tokio::test]
+    async fn next_refuses_logical_overflow() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        // Plant a future wall so `now_ms()` can't overtake it and
+        // force the draw down the "bump logical" branch.
+        let future_wall = now_ms() + 10_000;
+        write_pair_conn(&mut conn, future_wall, i32::MAX).await.unwrap();
+        let err = next_conn(&mut conn).await.unwrap_err();
+        let s = format!("{err}");
+        assert!(
+            s.contains("logical counter exhausted"),
+            "unexpected error: {s}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_returns_zero_on_fresh_pool() {
+        let pool = pool().await;
+        assert_eq!(read(&pool).await.unwrap(), HlcPair::ZERO);
+    }
+
+    #[tokio::test]
+    async fn observe_remote_bumps_past_local() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let local = next_conn(&mut conn).await.unwrap();
+        let remote = HlcPair {
+            wall: local.wall + 1_000,
+            logical: 7,
+        };
+        observe_remote_conn(&mut conn, remote).await.unwrap();
+        let after = read_pair_conn(&mut conn).await.unwrap();
+        assert_eq!(after, remote);
+    }
+
+    #[tokio::test]
+    async fn observe_remote_never_lowers_local() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let local = next_conn(&mut conn).await.unwrap();
+        let stale = HlcPair { wall: 1, logical: 0 };
+        observe_remote_conn(&mut conn, stale).await.unwrap();
+        let after = read_pair_conn(&mut conn).await.unwrap();
+        // Local stays put.
+        assert_eq!(after, local);
+    }
+
+    #[tokio::test]
+    async fn observe_remote_zero_pair_is_noop() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let before = read_pair_conn(&mut conn).await.unwrap();
+        observe_remote_conn(&mut conn, HlcPair::ZERO).await.unwrap();
+        let after = read_pair_conn(&mut conn).await.unwrap();
+        assert_eq!(after, before);
+    }
+
+    #[tokio::test]
+    async fn read_clamps_poisoned_logical_to_legal_range() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query(
+            "INSERT INTO profile_setting (key, value, value_type, updated_at)
+             VALUES (?, '99999999999', 'int', 0)",
+        )
+        .bind(KEY_LOGICAL)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+        let pair = read_pair_conn(&mut conn).await.unwrap();
+        assert_eq!(pair.logical, i32::MAX);
+    }
+}

--- a/src-tauri/crates/app/src/sync/hlc.rs
+++ b/src-tauri/crates/app/src/sync/hlc.rs
@@ -426,10 +426,12 @@ mod tests {
         // and could return duplicate pairs. The mutex makes the
         // draws strictly ordered, so the returned pairs are
         // distinct under the §2 total order.
-        let pool = pool().await;
-        // Need a pool that can serve > 1 connection so the two
-        // `acquire()` calls inside `next` don't queue at the pool
-        // level (which would mask the actual mutex behaviour).
+        //
+        // Built inline rather than via the shared `pool()` helper
+        // because we need `max_connections > 1` so the two
+        // `acquire()` calls inside concurrent `next` callers don't
+        // queue at the pool level (which would mask the actual
+        // mutex behaviour).
         let multi_pool = SqlitePoolOptions::new()
             .max_connections(4)
             .connect(":memory:")
@@ -446,7 +448,6 @@ mod tests {
         .execute(&multi_pool)
         .await
         .unwrap();
-        drop(pool); // freed; the rest of the test runs on multi_pool
 
         // Fire 8 draws concurrently. The mutex must give each one
         // a distinct triple under §2. We collect them and assert

--- a/src-tauri/crates/app/src/sync/hlc.rs
+++ b/src-tauri/crates/app/src/sync/hlc.rs
@@ -179,38 +179,87 @@ async fn write_pair_conn(
     wall: i64,
     logical: i32,
 ) -> AppResult<()> {
+    // RFC-003 §2 requires the pair to be observed as a unit by any
+    // reader. Two bare UPSERTs auto-commit independently in
+    // autocommit mode — a concurrent reader on a sibling
+    // connection could then observe `wall` bumped while `logical`
+    // still holds the previous value, breaking the total-order
+    // invariant.
+    //
+    // SAVEPOINT wraps the two UPSERTs into a single
+    // observable-as-a-unit step regardless of the caller's tx state:
+    //
+    // - From `enqueue_op_in_tx`, the caller already holds a
+    //   `Transaction<'_, Sqlite>` and the SAVEPOINT nests inside
+    //   it (SQLite supports unlimited nesting of savepoints).
+    //   `RELEASE SAVEPOINT` then defers the durable commit to the
+    //   outer caller's `tx.commit()`.
+    // - From the diagnostic / test path (`next` / `observe_remote`
+    //   wrappers that acquire a fresh pool connection in autocommit
+    //   mode), the SAVEPOINT acts as an implicit transaction —
+    //   `RELEASE` commits both writes atomically.
+    //
+    // Either way `now_ms()` is sampled once so the two rows agree
+    // on `updated_at` (the bare-UPSERT version sampled twice, which
+    // could differ by 1 ms across the round-trip pair).
     let updated_at = now_ms();
-    // Two separate UPSERTs because the pair lives under two keys.
-    // Same connection = same SQLite per-connection lock, so the
-    // pair appears atomic to every other reader on a different
-    // connection.
-    sqlx::query(
-        "INSERT INTO profile_setting (key, value, value_type, updated_at)
-         VALUES (?, CAST(? AS TEXT), 'int', ?)
-         ON CONFLICT(key) DO UPDATE
-            SET value = excluded.value,
-                value_type = excluded.value_type,
-                updated_at = excluded.updated_at",
-    )
-    .bind(KEY_WALL)
-    .bind(wall)
-    .bind(updated_at)
-    .execute(&mut *conn)
-    .await?;
-    sqlx::query(
-        "INSERT INTO profile_setting (key, value, value_type, updated_at)
-         VALUES (?, CAST(? AS TEXT), 'int', ?)
-         ON CONFLICT(key) DO UPDATE
-            SET value = excluded.value,
-                value_type = excluded.value_type,
-                updated_at = excluded.updated_at",
-    )
-    .bind(KEY_LOGICAL)
-    .bind(logical as i64)
-    .bind(updated_at)
-    .execute(&mut *conn)
-    .await?;
-    Ok(())
+    sqlx::query("SAVEPOINT hlc_write")
+        .execute(&mut *conn)
+        .await?;
+
+    let inner = async {
+        sqlx::query(
+            "INSERT INTO profile_setting (key, value, value_type, updated_at)
+             VALUES (?, CAST(? AS TEXT), 'int', ?)
+             ON CONFLICT(key) DO UPDATE
+                SET value = excluded.value,
+                    value_type = excluded.value_type,
+                    updated_at = excluded.updated_at",
+        )
+        .bind(KEY_WALL)
+        .bind(wall)
+        .bind(updated_at)
+        .execute(&mut *conn)
+        .await?;
+        sqlx::query(
+            "INSERT INTO profile_setting (key, value, value_type, updated_at)
+             VALUES (?, CAST(? AS TEXT), 'int', ?)
+             ON CONFLICT(key) DO UPDATE
+                SET value = excluded.value,
+                    value_type = excluded.value_type,
+                    updated_at = excluded.updated_at",
+        )
+        .bind(KEY_LOGICAL)
+        .bind(logical as i64)
+        .bind(updated_at)
+        .execute(&mut *conn)
+        .await?;
+        Ok::<_, AppError>(())
+    }
+    .await;
+
+    match inner {
+        Ok(()) => {
+            sqlx::query("RELEASE SAVEPOINT hlc_write")
+                .execute(&mut *conn)
+                .await?;
+            Ok(())
+        }
+        Err(e) => {
+            // Best-effort rollback to the savepoint — the original
+            // error is the one the caller cares about. `ROLLBACK TO
+            // SAVEPOINT … ; RELEASE SAVEPOINT …` is the SQLite
+            // dance to undo just the inner step without disturbing
+            // an outer transaction.
+            let _ = sqlx::query("ROLLBACK TO SAVEPOINT hlc_write")
+                .execute(&mut *conn)
+                .await;
+            let _ = sqlx::query("RELEASE SAVEPOINT hlc_write")
+                .execute(&mut *conn)
+                .await;
+            Err(e)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -334,6 +383,44 @@ mod tests {
         observe_remote_conn(&mut conn, HlcPair::ZERO).await.unwrap();
         let after = read_pair_conn(&mut conn).await.unwrap();
         assert_eq!(after, before);
+    }
+
+    #[tokio::test]
+    async fn next_conn_composes_with_caller_owned_transaction() {
+        // The hook path (`sync::hooks::enqueue_op_in_tx`) opens its
+        // own tx on the borrowed connection and expects the inner
+        // `next_conn` to nest cleanly. SAVEPOINT inside an active
+        // transaction is the SQLite-supported pattern; verify the
+        // composition end-to-end so a future refactor that swaps
+        // SAVEPOINT for `BEGIN IMMEDIATE` (which would fail with
+        // "cannot start a transaction within a transaction") trips
+        // this test before production.
+        let pool = pool().await;
+        let mut tx = pool.begin().await.unwrap();
+        let pair = next_conn(&mut tx).await.unwrap();
+        // The pair lands on the row even though the outer tx is
+        // still open — same connection, savepoint released, but
+        // the outer tx commit is deferred.
+        tx.commit().await.unwrap();
+        let after = read(&pool).await.unwrap();
+        assert_eq!(after, pair);
+    }
+
+    #[tokio::test]
+    async fn next_conn_two_writes_in_one_outer_tx_round_trip() {
+        // Two consecutive draws inside a single outer transaction
+        // must both land atomically when the outer commits.
+        let pool = pool().await;
+        let mut tx = pool.begin().await.unwrap();
+        let a = next_conn(&mut tx).await.unwrap();
+        let b = next_conn(&mut tx).await.unwrap();
+        assert!((a.wall, a.logical) < (b.wall, b.logical));
+        tx.commit().await.unwrap();
+        // The persisted row holds the LATER pair — the earlier
+        // savepoint was released into the outer tx, so the outer
+        // commit promotes both writes' net effect.
+        let after = read(&pool).await.unwrap();
+        assert_eq!(after, b);
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/sync/hlc.rs
+++ b/src-tauri/crates/app/src/sync/hlc.rs
@@ -47,10 +47,36 @@
 //! - `sync.hlc.last_wall` — `i64`, last drawn wall (epoch-ms)
 //! - `sync.hlc.last_logical` — `i32`, last drawn logical counter
 
+use std::sync::LazyLock;
+
 use chrono::Utc;
 use sqlx::{SqliteConnection, SqlitePool};
+use tokio::sync::Mutex;
 
 use crate::error::{AppError, AppResult};
+
+/// Process-wide mutex serialising the read-modify-write cycle that
+/// makes up an HLC draw. The two-step nature of the draw —
+/// `read_pair_conn` SELECT followed by `write_pair_conn` SAVEPOINT
+/// — is not atomic at the SQLite layer when the caller does not
+/// already hold a write lock: two concurrent callers on sibling
+/// connections can read the same baseline, compute the same
+/// candidate, and both UPSERT it, returning duplicate pairs that
+/// would break the RFC-003 §2 total order.
+///
+/// The mutex closes that window for every caller that goes through
+/// [`next_conn`] or [`observe_remote_conn`]. In the production
+/// hook path the mutex is technically redundant (the caller's
+/// `Transaction<'_, Sqlite>` already serialises HLC writes via the
+/// SQLite write lock once the entity write fires), but it stays
+/// cheap (sub-microsecond contention) and gives the public API a
+/// race-free contract that doesn't depend on caller discipline.
+///
+/// Single mutex per process is enough — the desktop runs at most
+/// one active profile at a time, and cross-profile HLC contention
+/// is rare enough that per-pool granularity would buy nothing
+/// while complicating the ownership story.
+static HLC_DRAW_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 pub const KEY_WALL: &str = "sync.hlc.last_wall";
 pub const KEY_LOGICAL: &str = "sync.hlc.last_logical";
@@ -92,15 +118,17 @@ pub async fn next(profile_pool: &SqlitePool) -> AppResult<HlcPair> {
 /// 1. SELECT the persisted pair (defaults to `(0, 0)` on first
 ///    call).
 /// 2. Compute the candidate in Rust (cheap, no SQL trip).
-/// 3. UPSERT the new pair atomically.
+/// 3. UPSERT the new pair through a SAVEPOINT so both rows land or
+///    none.
 ///
-/// The connection serialises every other write under the SQLite
-/// per-connection lock — two concurrent `next_conn` calls on the
-/// same connection are impossible by construction, and two callers
-/// holding separate connections still hit the wall-clock floor
-/// (whichever commits first sets `last_wall`; the other reads it
-/// and either advances or bumps logical).
+/// [`HLC_DRAW_LOCK`] wraps the whole cycle. Without it, two
+/// concurrent callers on sibling connections could each
+/// read-compute-write the same baseline and return duplicate
+/// pairs — a §2 total-order violation. The mutex is held for the
+/// duration of the three round-trips (microseconds in practice).
 pub async fn next_conn(conn: &mut SqliteConnection) -> AppResult<HlcPair> {
+    let _guard = HLC_DRAW_LOCK.lock().await;
+
     let last = read_pair_conn(conn).await?;
     let now = now_ms();
 
@@ -138,6 +166,11 @@ pub async fn observe_remote_conn(conn: &mut SqliteConnection, remote: HlcPair) -
     if remote == HlcPair::ZERO {
         return Ok(());
     }
+    // Same serialisation rationale as `next_conn` — without the
+    // lock, a concurrent `next_conn` (or another `observe_remote`)
+    // could read between this read and the write_pair_conn UPSERT,
+    // missing the bump and shipping a stale pair on the next draw.
+    let _guard = HLC_DRAW_LOCK.lock().await;
     let local = read_pair_conn(conn).await?;
     // §2 total order — only bump if the remote strictly outranks.
     if (remote.wall, remote.logical) <= (local.wall, local.logical) {
@@ -383,6 +416,58 @@ mod tests {
         observe_remote_conn(&mut conn, HlcPair::ZERO).await.unwrap();
         let after = read_pair_conn(&mut conn).await.unwrap();
         assert_eq!(after, before);
+    }
+
+    #[tokio::test]
+    async fn next_serialises_concurrent_callers_on_sibling_connections() {
+        // Two concurrent draws through the public pool-level `next`
+        // — each acquires its own connection. Without the
+        // module-level mutex they would race the read/write cycle
+        // and could return duplicate pairs. The mutex makes the
+        // draws strictly ordered, so the returned pairs are
+        // distinct under the §2 total order.
+        let pool = pool().await;
+        // Need a pool that can serve > 1 connection so the two
+        // `acquire()` calls inside `next` don't queue at the pool
+        // level (which would mask the actual mutex behaviour).
+        let multi_pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE profile_setting (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                value_type TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+        )
+        .execute(&multi_pool)
+        .await
+        .unwrap();
+        drop(pool); // freed; the rest of the test runs on multi_pool
+
+        // Fire 8 draws concurrently. The mutex must give each one
+        // a distinct triple under §2. We collect them and assert
+        // distinctness via a HashSet on the derived ordering key.
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let pool = multi_pool.clone();
+                tokio::spawn(async move { next(&pool).await.unwrap() })
+            })
+            .collect();
+        let mut pairs = Vec::with_capacity(handles.len());
+        for h in handles {
+            pairs.push(h.await.unwrap());
+        }
+        let unique: std::collections::HashSet<(i64, i32)> =
+            pairs.iter().map(|p| (p.wall, p.logical)).collect();
+        assert_eq!(
+            unique.len(),
+            pairs.len(),
+            "all concurrent draws must return distinct (wall, logical) pairs; got {pairs:?}",
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/sync/hooks.rs
+++ b/src-tauri/crates/app/src/sync/hooks.rs
@@ -35,7 +35,7 @@ use sqlx::SqliteConnection;
 use crate::{
     error::AppResult,
     server_client,
-    sync::{lamport, mode, queue},
+    sync::{hlc, lamport, mode, queue},
 };
 
 pub use crate::sync::queue::PendingOpDraft;
@@ -62,6 +62,13 @@ pub async fn enqueue_op_in_tx(
         return Ok(false);
     }
     let lamport_ts = lamport::next_conn(conn).await?;
-    queue::enqueue_conn(conn, draft, lamport_ts).await?;
+    // Phase A.4.2 — draw the HLC pair on the same connection so the
+    // entity write + outbox row + Lamport bump + HLC bump are one
+    // atomic SQLite commit. The pair rides on the row for the drain
+    // to lift onto `SyncOpIn.hlc` (v2 wire shape — waveflow-server
+    // #52). v1 server reads still work because the dual-shape ingest
+    // there derives `(0, lamport_ts)` when `hlc` is absent.
+    let hlc_pair = hlc::next_conn(conn).await?;
+    queue::enqueue_conn(conn, draft, lamport_ts, hlc_pair.wall, hlc_pair.logical).await?;
     Ok(true)
 }

--- a/src-tauri/crates/app/src/sync/mod.rs
+++ b/src-tauri/crates/app/src/sync/mod.rs
@@ -15,6 +15,13 @@
 //!   local clock past it so the next local op stays globally
 //!   monotonic.
 //!
+//! - [`hlc`] — RFC-003 §2 Hybrid Logical Clock pair `(wall,
+//!   logical)`. [`hlc::next`] atomically draws a strictly-increasing
+//!   pair the desktop ships under the v2 wire shape
+//!   `SyncOpIn.hlc: Option<Hlc>` (waveflow-server #52). Lamport stays
+//!   in the protocol during Phase A (still required by the dual-shape
+//!   ingest) and retires in Phase D.
+//!
 //! - [`queue`] — the local write-ahead log. Rows here are ops the
 //!   user produced while signed into a `waveflow-server`; the
 //!   [`drain`] task posts them to `/api/v1/sync/ops` and removes the
@@ -52,6 +59,7 @@ pub mod canonical;
 pub mod cursor;
 pub mod device;
 pub mod drain;
+pub mod hlc;
 pub mod hooks;
 pub mod lamport;
 pub mod mode;

--- a/src-tauri/crates/app/src/sync/queue.rs
+++ b/src-tauri/crates/app/src/sync/queue.rs
@@ -67,6 +67,13 @@ pub struct PendingOpDraft {
 /// A row read back from the queue. The drain task hydrates this and
 /// hands it to the server; `id` is the local SQLite rowid the drain
 /// later passes to [`drop_acked`].
+///
+/// `hlc_wall` + `hlc_logical` (Phase A.4.2) are the per-op pair
+/// drawn by [`crate::sync::hlc::next`] at enqueue time. The drain
+/// emits the v2 wire shape (`SyncOpIn.hlc: Some(Hlc)`) when both are
+/// > 0 — pre-A.4.2 rows backfill to `(0, 0)` via the migration
+/// DEFAULT and round-trip as v1 (server-side dual-shape ingest
+/// swallows either form, waveflow-server #52).
 #[derive(Debug, Clone, Serialize)]
 pub struct PendingOp {
     pub id: i64,
@@ -81,12 +88,15 @@ pub struct PendingOp {
     pub last_attempt_at: Option<i64>,
     pub attempt_count: i64,
     pub last_error: Option<String>,
+    pub hlc_wall: i64,
+    pub hlc_logical: i32,
 }
 
 /// Append a draft to the queue under the caller-supplied
-/// `lamport_ts`. The caller is responsible for drawing the lamport
-/// value via [`crate::sync::lamport::next`] — splitting the two
-/// responsibilities means the queue stays a pure-storage layer.
+/// `lamport_ts` + HLC pair. The caller is responsible for drawing
+/// both values (via [`crate::sync::lamport::next`] +
+/// [`crate::sync::hlc::next`]) — splitting the two responsibilities
+/// means the queue stays a pure-storage layer.
 ///
 /// Returns the assigned `(id, operation_id)` so the caller can
 /// correlate logs without an extra SELECT.
@@ -94,19 +104,24 @@ pub async fn enqueue(
     profile_pool: &SqlitePool,
     draft: &PendingOpDraft,
     lamport_ts: i64,
+    hlc_wall: i64,
+    hlc_logical: i32,
 ) -> AppResult<(i64, String)> {
     let mut conn = profile_pool.acquire().await?;
-    enqueue_conn(&mut conn, draft, lamport_ts).await
+    enqueue_conn(&mut conn, draft, lamport_ts, hlc_wall, hlc_logical).await
 }
 
 /// Same as [`enqueue`] but takes a caller-owned connection so the
 /// INSERT joins an open transaction. Used by
 /// [`crate::sync::hooks::enqueue_op_in_tx`] to keep the playlist
-/// write + outbox row + Lamport bump in a single atomic commit.
+/// write + outbox row + Lamport bump + HLC bump in a single atomic
+/// commit.
 pub async fn enqueue_conn(
     conn: &mut SqliteConnection,
     draft: &PendingOpDraft,
     lamport_ts: i64,
+    hlc_wall: i64,
+    hlc_logical: i32,
 ) -> AppResult<(i64, String)> {
     let operation_id = Uuid::new_v4().to_string();
     let payload_json = match draft.payload.as_ref() {
@@ -118,8 +133,9 @@ pub async fn enqueue_conn(
     let now = now_ms();
     let row: (i64,) = sqlx::query_as(
         "INSERT INTO sync_pending_op
-            (operation_id, lamport_ts, entity, entity_id, field, op, payload, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (operation_id, lamport_ts, entity, entity_id, field, op, payload, created_at,
+             hlc_wall, hlc_logical)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          RETURNING id",
     )
     .bind(&operation_id)
@@ -130,6 +146,8 @@ pub async fn enqueue_conn(
     .bind(&draft.op)
     .bind(payload_json.as_deref())
     .bind(now)
+    .bind(hlc_wall)
+    .bind(hlc_logical)
     .fetch_one(conn)
     .await?;
     Ok((row.0, operation_id))
@@ -152,6 +170,8 @@ struct PendingOpRow {
     last_attempt_at: Option<i64>,
     attempt_count: i64,
     last_error: Option<String>,
+    hlc_wall: i64,
+    hlc_logical: i32,
 }
 
 /// Return the next `limit` pending rows in FIFO order. The drain
@@ -171,7 +191,8 @@ pub async fn list_pending(profile_pool: &SqlitePool, limit: i64) -> AppResult<Ve
     }
     let rows: Vec<PendingOpRow> = sqlx::query_as(
         "SELECT id, operation_id, lamport_ts, entity, entity_id, field, op,
-                payload, created_at, last_attempt_at, attempt_count, last_error
+                payload, created_at, last_attempt_at, attempt_count, last_error,
+                hlc_wall, hlc_logical
          FROM sync_pending_op
          ORDER BY id ASC
          LIMIT ?",
@@ -204,6 +225,8 @@ pub async fn list_pending(profile_pool: &SqlitePool, limit: i64) -> AppResult<Ve
             last_attempt_at: row.last_attempt_at,
             attempt_count: row.attempt_count,
             last_error: row.last_error,
+            hlc_wall: row.hlc_wall,
+            hlc_logical: row.hlc_logical,
         });
     }
     Ok(out)
@@ -278,7 +301,9 @@ mod tests {
     /// copy-pasted from the migration. Updating the migration without
     /// updating this fixture would silently diverge the unit tests
     /// from production behaviour — a small price for not pulling the
-    /// real migrator into the unit suite.
+    /// real migrator into the unit suite. Phase A.4.2 added
+    /// `hlc_wall` / `hlc_logical` columns; the CHECK on the latter
+    /// mirrors the migration's `0..=i32::MAX` bound.
     async fn pool() -> SqlitePool {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
@@ -298,7 +323,10 @@ mod tests {
                 created_at INTEGER NOT NULL,
                 last_attempt_at INTEGER,
                 attempt_count INTEGER NOT NULL DEFAULT 0,
-                last_error TEXT
+                last_error TEXT,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0
+                    CHECK (hlc_logical BETWEEN 0 AND 2147483647)
             )",
         )
         .execute(&pool)
@@ -317,10 +345,26 @@ mod tests {
         }
     }
 
+    /// Wrap [`enqueue`] with a zero HLC pair. Phase A.4.2 added two
+    /// columns + `enqueue` parameters; the legacy tests in this
+    /// module exercise the storage layer's shape concerns
+    /// (`UNIQUE`, FIFO, `AUTOINCREMENT`, …) which are orthogonal to
+    /// the HLC values. Passing `(0, 0)` mirrors the migration's
+    /// backfill semantics — rows landed before A.4.2 carry the
+    /// DEFAULT 0/0 pair which the drain treats as "absent" and
+    /// falls back to the v1 wire shape.
+    async fn enqueue_t(
+        pool: &SqlitePool,
+        draft: &PendingOpDraft,
+        lamport: i64,
+    ) -> AppResult<(i64, String)> {
+        enqueue(pool, draft, lamport, 0, 0).await
+    }
+
     #[tokio::test]
     async fn enqueue_writes_row_and_returns_ids() {
         let pool = pool().await;
-        let (id, operation_id) = enqueue(&pool, &draft("1", Some("name")), 1).await.unwrap();
+        let (id, operation_id) = enqueue_t(&pool, &draft("1", Some("name")), 1).await.unwrap();
         assert!(id > 0);
         Uuid::parse_str(&operation_id).expect("operation_id is a UUID");
 
@@ -345,7 +389,7 @@ mod tests {
     async fn list_pending_returns_fifo_order() {
         let pool = pool().await;
         for lamport in 1..=5 {
-            enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+            enqueue_t(&pool, &draft(&lamport.to_string(), None), lamport)
                 .await
                 .unwrap();
         }
@@ -357,8 +401,8 @@ mod tests {
     #[tokio::test]
     async fn lamport_unique_constraint_rejects_duplicates() {
         let pool = pool().await;
-        enqueue(&pool, &draft("1", None), 42).await.unwrap();
-        let err = enqueue(&pool, &draft("2", None), 42).await.unwrap_err();
+        enqueue_t(&pool, &draft("1", None), 42).await.unwrap();
+        let err = enqueue_t(&pool, &draft("2", None), 42).await.unwrap_err();
         let s = format!("{err}");
         assert!(
             s.contains("UNIQUE") || s.contains("constraint"),
@@ -371,7 +415,7 @@ mod tests {
         let pool = pool().await;
         let mut ids = Vec::new();
         for lamport in 1..=5 {
-            let (id, _) = enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+            let (id, _) = enqueue_t(&pool, &draft(&lamport.to_string(), None), lamport)
                 .await
                 .unwrap();
             ids.push(id);
@@ -390,7 +434,7 @@ mod tests {
     #[tokio::test]
     async fn drop_acked_empty_input_is_noop() {
         let pool = pool().await;
-        enqueue(&pool, &draft("1", None), 1).await.unwrap();
+        enqueue_t(&pool, &draft("1", None), 1).await.unwrap();
         assert_eq!(drop_acked(&pool, &[]).await.unwrap(), 0);
         assert_eq!(count_pending(&pool).await.unwrap(), 1);
     }
@@ -398,7 +442,7 @@ mod tests {
     #[tokio::test]
     async fn mark_failed_bumps_counter_and_records_error() {
         let pool = pool().await;
-        let (id, _) = enqueue(&pool, &draft("1", None), 1).await.unwrap();
+        let (id, _) = enqueue_t(&pool, &draft("1", None), 1).await.unwrap();
         mark_failed(&pool, id, "503 Service Unavailable")
             .await
             .unwrap();
@@ -419,7 +463,7 @@ mod tests {
             op: "rename".into(), // not in CHECK list
             payload: None,
         };
-        let err = enqueue(&pool, &draft, 1).await.unwrap_err();
+        let err = enqueue_t(&pool, &draft, 1).await.unwrap_err();
         assert!(format!("{err}").to_lowercase().contains("check"));
     }
 
@@ -427,7 +471,7 @@ mod tests {
     async fn list_pending_guards_against_non_positive_limit() {
         let pool = pool().await;
         for lamport in 1..=3 {
-            enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+            enqueue_t(&pool, &draft(&lamport.to_string(), None), lamport)
                 .await
                 .unwrap();
         }
@@ -450,9 +494,9 @@ mod tests {
         // would silently miss ops appended after the reset; pin the
         // AUTOINCREMENT behaviour with a regression test.
         let pool = pool().await;
-        let (id_a, _) = enqueue(&pool, &draft("1", None), 1).await.unwrap();
+        let (id_a, _) = enqueue_t(&pool, &draft("1", None), 1).await.unwrap();
         clear(&pool).await.unwrap();
-        let (id_b, _) = enqueue(&pool, &draft("2", None), 2).await.unwrap();
+        let (id_b, _) = enqueue_t(&pool, &draft("2", None), 2).await.unwrap();
         assert!(
             id_b > id_a,
             "AUTOINCREMENT must keep ids monotonic across clears: id_a={id_a}, id_b={id_b}",
@@ -463,7 +507,7 @@ mod tests {
     async fn count_and_clear_observable() {
         let pool = pool().await;
         for lamport in 1..=3 {
-            enqueue(&pool, &draft(&lamport.to_string(), None), lamport)
+            enqueue_t(&pool, &draft(&lamport.to_string(), None), lamport)
                 .await
                 .unwrap();
         }
@@ -471,5 +515,54 @@ mod tests {
         let cleared = clear(&pool).await.unwrap();
         assert_eq!(cleared, 3);
         assert_eq!(count_pending(&pool).await.unwrap(), 0);
+    }
+
+    // ── Phase A.4.2 — HLC pair round-trip ─────────────────────────
+
+    #[tokio::test]
+    async fn enqueue_persists_and_returns_hlc_pair() {
+        let pool = pool().await;
+        let (_, _) = enqueue(&pool, &draft("1", Some("name")), 1, 1_700_000_000_001, 7)
+            .await
+            .unwrap();
+        let row = &list_pending(&pool, 1).await.unwrap()[0];
+        assert_eq!(row.hlc_wall, 1_700_000_000_001);
+        assert_eq!(row.hlc_logical, 7);
+    }
+
+    #[tokio::test]
+    async fn enqueue_legacy_zero_pair_round_trips() {
+        // A pre-A.4.2 caller (still on the v1 wire shape) passes
+        // `(0, 0)` and the row carries the DEFAULT pair. The drain
+        // reads these as "absent HLC" and falls back to the legacy
+        // wire format.
+        let pool = pool().await;
+        enqueue_t(&pool, &draft("1", None), 1).await.unwrap();
+        let row = &list_pending(&pool, 1).await.unwrap()[0];
+        assert_eq!(row.hlc_wall, 0);
+        assert_eq!(row.hlc_logical, 0);
+    }
+
+    #[tokio::test]
+    async fn check_constraint_rejects_negative_logical_via_raw_sql() {
+        // The migration plants a CHECK on `hlc_logical` mirroring the
+        // RFC-003 §2 bound `0..=i32::MAX`. The Rust-side bind cannot
+        // express the `> i32::MAX` direction (parameter is `i32`), so
+        // we exercise the same CHECK via raw SQL — verifies the in-
+        // memory fixture stays in sync with the real migration. The
+        // sibling test in `db::rfc003_hlc_tests` exercises the
+        // overflow direction against the actual migrator.
+        let pool = pool().await;
+        let err = sqlx::query(
+            "INSERT INTO sync_pending_op
+                (operation_id, lamport_ts, entity, entity_id, op, created_at,
+                 hlc_wall, hlc_logical)
+             VALUES ('op-x', 1, 'playlist', '1', 'set', 0, 0, -1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap_err();
+        let s = format!("{err}").to_lowercase();
+        assert!(s.contains("check"), "expected CHECK constraint failure: {s}");
     }
 }

--- a/src-tauri/migrations/profile/20260616000000_sync_pending_op_hlc.sql
+++ b/src-tauri/migrations/profile/20260616000000_sync_pending_op_hlc.sql
@@ -1,0 +1,37 @@
+-- RFC-003 Phase A.4.2 — HLC pair on local pending ops.
+--
+-- Every row in `sync_pending_op` now carries the `(hlc_wall,
+-- hlc_logical)` pair the v2 wire shape ships under
+-- `SyncOpIn.hlc: Option<Hlc>` (waveflow-server #52). The drain task
+-- (1.f.desktop.4a + A.4.2) reads these columns when serialising the
+-- batch and includes them on the JSON when both are present and
+-- > (0, 0); v1 (legacy) rows landed before this migration come up
+-- with the DEFAULT 0/0 pair which the drain treats as "absent" and
+-- falls back to the legacy shape. The server's dual-shape ingest
+-- swallows either form transparently.
+--
+-- `origin_device_id` is intentionally NOT stored here — it's the
+-- whole-install identity returned by `sync::device::ensure` (lives
+-- in `app.db`, app-wide), shared across every row in this queue. The
+-- drain plants it on the batch via `PushBatchRequest::device_id`,
+-- exactly the way the legacy push already does (per A.1.1's header
+-- the server treats this string as UUID-shaped TEXT and parses it
+-- into the entity row's `origin_device_id`).
+--
+-- ## CHECK on hlc_logical (CodeRabbit follow-up from A.3)
+--
+-- The A.3 review flagged that the §2 total order keys on a 32-bit
+-- logical counter, but SQLite's INTEGER column accepts any 64-bit
+-- value. Without a guard, a future `sync::hlc::next` regression
+-- (counter overflow, narrowing bug) could plant `hlc_logical >
+-- i32::MAX` into a row, which would then refuse to round-trip
+-- through the server's bind site (waveflow-server A.1.1 enforces
+-- `0..=i32::MAX` on insert). CHECK at the storage layer surfaces
+-- the bug local-first rather than at the server's 23505 path.
+--
+-- The bound is `0..=2147483647` (i32::MAX). `hlc_wall` is BIGINT-
+-- range so no narrowing constraint applies there.
+
+ALTER TABLE sync_pending_op ADD COLUMN hlc_wall    INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sync_pending_op ADD COLUMN hlc_logical INTEGER NOT NULL DEFAULT 0
+    CHECK (hlc_logical BETWEEN 0 AND 2147483647);


### PR DESCRIPTION
## Summary

Phase A.4.2 of RFC-003. Wires the HLC clock all the way through the
local outbox so the desktop drain emits the v2 shape
`SyncOpIn.hlc: Some(Hlc)` (waveflow-server #52) for every op produced
after this migration. v1 (legacy) rows backfilled to `(0, 0)` via the
migration DEFAULT keep shipping under the v1 form — the server's
dual-shape ingest derives `(0, lamport_ts)` itself so old desktop
rows round-trip without coordination.

`origin_device_id` rides through the existing top-level `device_id`
on `PushBatchRequest` (UUID-shaped TEXT round-trip per
waveflow-server A.1.1's header). No separate wire key, no extra
column on `sync_pending_op`.

## Migration

`migrations/profile/20260616000000_sync_pending_op_hlc.sql`:
- `ALTER TABLE sync_pending_op ADD COLUMN hlc_wall INTEGER NOT NULL DEFAULT 0`
- `ALTER TABLE sync_pending_op ADD COLUMN hlc_logical INTEGER NOT NULL DEFAULT 0 CHECK (hlc_logical BETWEEN 0 AND 2147483647)`

The CHECK is the defence-in-depth follow-up to CodeRabbit's A.3
review (deferred to A.4 per the review's \"non-bloquant pour A.3\"
tag).

## Code

- [`sync::hlc`](src-tauri/crates/app/src/sync/hlc.rs) (new) — atomic monotonic `(wall, logical)` draw via `next_conn`. Refuses to roll past `i32::MAX`. `observe_remote_conn` mirrors `lamport::observe_remote` for Phase B's WS subscriber. Read path clamps poisoned values defensively.
- [`sync::queue`](src-tauri/crates/app/src/sync/queue.rs) — `enqueue` / `enqueue_conn` grow `hlc_wall: i64, hlc_logical: i32` params; `PendingOp` carries them through.
- [`sync::hooks::enqueue_op_in_tx`](src-tauri/crates/app/src/sync/hooks.rs) — draws `hlc::next_conn` on the same caller-owned connection so the entity write + Lamport + HLC + outbox land in a single atomic SQLite commit.
- [`sync::drain::SyncOpInBody`](src-tauri/crates/app/src/sync/drain.rs) — grows `hlc: Option<WireHlc>` with `skip_serializing_if = \"Option::is_none\"` so the v1 form ships bit-identical JSON when both components are 0. `wire_hlc_from_row(0, 0)` returns `None`.

## What this does NOT do

- ❌ Compute `payload_hash` on the desktop side per op type
- ❌ Store HLC quartet + payload_hash on local entity rows (A.3 added the columns; the writer that populates them is server-side only)
- ❌ Bump local `metadata_digest_version` on each enqueue

Deferred because each multiplies the surface per-entity (a
`build_canonical_fields` helper per `commands/<entity>.rs`) and
doesn't gate v2 wire emission — the server already recomputes
`payload_hash` from the payload. Likely lands as A.4.2.b or in
Phase B alongside the digest reconciliation UI.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` — 271 pass (was 253, +18)
  - +9 `sync::hlc` (monotonic, fresh-wall reset, i32 overflow, observe_remote, clamp)
  - +3 `sync::queue` (HLC round-trip, legacy 0/0 round-trip, raw-SQL CHECK rejection)
  - +3 `sync::drain` (v1 wire stability, v2 wire shape carries hlc, wire_hlc_from_row mapping)
  - +2 `db::rfc003_hlc_tests` (PRAGMA pair check, CHECK rejects out-of-range via real migrator)
- [x] `bun run typecheck` + `bun run lint` clean

## Refs

- RFC-003 §2 (total order), §3 (wire shape)
- waveflow-server #52 (dual-shape ingest)
- waveflow-server #56 (apply pipeline + digest endpoint)
- Next: A.4.3 server bumps `waveflow-core` pin + retires `src/payload_hash.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mise en place d’un ordre de synchronisation basé sur la Hybrid Logical Clock (HLC).
  * Prise en charge de la forme wire RFC-003 v2 avec inclusion optionnelle des informations HLC lors des envois.

* **Bug Fixes**
  * Compatibilité préservée lorsque les valeurs HLC sont à zéro (mode “legacy”).

* **Tests**
  * Renforcement des tests de migration RFC-003 : schéma, valeurs par défaut et contraintes.
  * Ajout de tests HLC : progression, observation distante et garde-fous contre les valeurs hors plage.

* **Chores**
  * Mise à jour du schéma et de la file de synchronisation pour stocker les valeurs HLC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->