### PR TITLE
fix(core): gate plugin host stack behind `plugins` cargo feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,22 @@ jobs:
       - name: cargo check
         run: cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets
 
+      - name: cargo check (waveflow-core, server profile — no plugin host)
+        # Locks in the slim build path the future `waveflow-server` consumes:
+        # `default-features = false, features = ["postgres"]`. Without this
+        # step a future dep added unconditionally to `waveflow-core` (or a
+        # missing `optional = true` on a plugin-only crate) would silently
+        # re-introduce the wasmtime + Cranelift transitive tree the server's
+        # binary doesn't want. The desktop matrix slot above still exercises
+        # the full feature set under `--workspace --all-targets`.
+        if: runner.os == 'Linux'
+        run: >-
+          cargo check
+          --manifest-path src-tauri/Cargo.toml
+          -p waveflow-core
+          --no-default-features
+          --features postgres
+
       - name: cargo test
         run: cargo test --manifest-path src-tauri/Cargo.toml --workspace
 

--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -35,11 +35,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dependencies]
-# Workspace-local: the business-logic crate. The `sqlite` feature opts
-# in to `sqlx::FromRow` derives on every domain type so the desktop
-# command handlers can still use them as `query_as` targets after the
-# move out of `commands/*.rs`.
-waveflow-core = { path = "../core", features = ["sqlite"] }
+# Workspace-local: the business-logic crate. `sqlite` enables the
+# `sqlx::FromRow` derives on every domain type so the desktop command
+# handlers can still use them as `query_as` targets. `plugins` pulls
+# in the wasmtime + Cranelift + WASI host that powers
+# `commands/plugins.rs`; the server intentionally leaves this feature
+# off to keep its binary lean.
+waveflow-core = { path = "../core", features = ["sqlite", "plugins"] }
 waveflow-syncedlyrics = { path = "../syncedlyrics" }
 
 tauri = { version = "2", features = ["protocol-asset", "tray-icon", "image-png"] }

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -20,6 +20,19 @@ default = []
 # happens to depend on both backends still gets a single build.
 sqlite = ["sqlx/sqlite", "sqlx/runtime-tokio"]
 postgres = ["sqlx/postgres", "sqlx/runtime-tokio"]
+# Opt in to the WebAssembly Component Model plugin host. Pulls in
+# wasmtime + Cranelift + wasmtime-wasi + the WIT-generated bindings
+# and exposes `crate::plugin`. The desktop app (`crates/app`) enables
+# this; `waveflow-server` does not (the HTTP/WS surface doesn't run
+# guest WASM in v1, so the ~5 MiB Cranelift codegen tree would be
+# pure bloat).
+plugins = [
+    "dep:wasmtime",
+    "dep:wasmtime-wasi",
+    "dep:waveflow-plugin-sdk",
+    "dep:toml",
+    "dep:sha2",
+]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -129,16 +142,20 @@ id3 = "1"
 
 # Plugin manifest parsing (`crate::plugin::manifest`). TOML over
 # JSON because authors write these by hand — TOML reads cleaner.
-toml = "1.1"
+# Plugin-host stack starts here — every dep through the next blank
+# line is gated by the `plugins` feature so the server can opt out
+# of pulling ~5 MiB of Cranelift codegen + wasmtime runtime it never
+# executes.
+toml = { version = "1.1", optional = true }
 # Plugin sidecar asset hashing (`crate::plugin::assets`). Standard
 # SHA-256 hex digest so a third-party tool can verify the file
 # without depending on us. Re-uses the same `sha2` codegen the
 # rest of the workspace already pulls in transitively.
-sha2 = "0.11"
+sha2 = { version = "0.11", optional = true }
 # Shared plugin contract (manifest schema version + WIT world / permission
 # catalog). The SDK crate doesn't depend on us — it's a flat constants
 # crate both sides import.
-waveflow-plugin-sdk = { path = "../plugin-sdk" }
+waveflow-plugin-sdk = { path = "../plugin-sdk", optional = true }
 
 # WebAssembly Component Model runtime — Phase 2a wires the engine,
 # component loader, and sandbox config (fuel, memory cap, epoch
@@ -152,7 +169,7 @@ wasmtime = { version = "45", default-features = false, features = [
     "cranelift",
     "component-model",
     "parallel-compilation",
-] }
+], optional = true }
 # WASI Preview 2 imports the host must satisfy for any Component
 # Model guest compiled by `cargo component` — wit-bindgen-rt
 # pulls in `wasi:cli/environment` (panic handler), `wasi:io/streams`
@@ -169,7 +186,7 @@ wasmtime = { version = "45", default-features = false, features = [
 # path we actually expose to plugins, the result is "no host
 # resources reachable unless the manifest explicitly asked for
 # them".
-wasmtime-wasi = { version = "45", default-features = false }
+wasmtime-wasi = { version = "45", default-features = false, optional = true }
 
 [dev-dependencies]
 # Sandboxed scratch directories for the smart-playlist cover render

--- a/src-tauri/crates/core/src/lib.rs
+++ b/src-tauri/crates/core/src/lib.rs
@@ -21,8 +21,11 @@ pub mod metadata;
 // executes guest WASM in v1) can opt out and stay lean. The
 // desktop app turns the feature on via its
 // `waveflow-core = { ..., features = ["sqlite", "plugins"] }`
-// path-dep.
+// path-dep. The `doc(cfg(...))` attribute surfaces the gate in
+// rendered docs on `docs.rs` so an external integrator sees the
+// requirement without grepping the manifest.
 #[cfg(feature = "plugins")]
+#[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
 pub mod plugin;
 pub mod repository;
 pub mod scanner;

--- a/src-tauri/crates/core/src/lib.rs
+++ b/src-tauri/crates/core/src/lib.rs
@@ -16,6 +16,13 @@ pub mod audio_format;
 pub mod domain;
 pub mod error;
 pub mod metadata;
+// `plugin` carries the wasmtime + Cranelift + WASI stack (~5 MiB
+// of native codegen). Gated so `waveflow-server` (which never
+// executes guest WASM in v1) can opt out and stay lean. The
+// desktop app turns the feature on via its
+// `waveflow-core = { ..., features = ["sqlite", "plugins"] }`
+// path-dep.
+#[cfg(feature = "plugins")]
 pub mod plugin;
 pub mod repository;
 pub mod scanner;


### PR DESCRIPTION
## Summary

Surfaced by a CodeRabbit review on waveflow-server #58 (Phase
A.4.3): the server's `waveflow-core = { ..., default-features = false, features = ["postgres"] }` pin pulled the entire
wasmtime + Cranelift + WASI stack (`waveflow-plugin-sdk`,
`wasmtime`, `wasmtime-wasi`, `toml`, `sha2`) into the server's
`Cargo.lock` even though the server never executes guest WASM.
~5 MiB of native Cranelift codegen + ~300 transitive crates of
pure bloat in the production binary, plus a surface-area hit
(wasmtime CVE history) the HTTP/WS shape can't justify.

## Change

- [`crates/core/Cargo.toml`](src-tauri/crates/core/Cargo.toml) — new `plugins` feature gathering the plugin-host deps under `dep:`. All five deps move to `optional = true`. The comment documents the desktop / server split.
- [`crates/core/src/lib.rs`](src-tauri/crates/core/src/lib.rs) — `pub mod plugin;` now `#[cfg(feature = "plugins")] pub mod plugin;`. No `cfg` sprinkled inside the module; the gate at the mod boundary is enough because every caller of `waveflow_core::plugin::*` lives in `crates/app`, which turns the feature on.
- [`crates/app/Cargo.toml`](src-tauri/crates/app/Cargo.toml) — `waveflow-core = { path = "../core", features = ["sqlite", "plugins"] }`. Additive feature, so cross-crate Cargo unification can't accidentally pull it on for a different consumer.

## What this does NOT do

- ❌ Workspace consolidation (server + core in one repo)
- ❌ Remove wasmtime / Cranelift from the desktop bundle — the app still ships the plugin host, this PR only makes core opt-in to the cost

## Test plan

- [x] `cargo check -p waveflow-core --no-default-features --features postgres` clean — the path the server takes. No wasmtime / Cranelift / waveflow-plugin-sdk in the dependency graph
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` clean (full desktop build)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` — 274 pass (baseline preserved; every test touching plugin paths runs under the `plugins` feature the app turns on)
- [x] `bun run typecheck` + `bun run lint` clean

## Follow-up

waveflow-server #58 (Phase A.4.3) will rebase its `waveflow-core` pin
onto the merge SHA of this PR + regenerate `Cargo.lock`; the server's
lock will then drop wasmtime + Cranelift + ~300 transitive crates.

## Refs

- waveflow-server #58 (CodeRabbit review)
- RFC-001 §6.5 (cross-platform business-logic split)