### PR TITLE
feat(sync): rfc-003 phase b.0a — library payload_hash + digest bump

### DIFF
--- a/src-tauri/crates/app/src/commands/library.rs
+++ b/src-tauri/crates/app/src/commands/library.rs
@@ -84,7 +84,7 @@ pub async fn create_library(
     let mut tx = pool.begin().await?;
     let id = insert_conn(&mut tx, &draft).await?;
     let canonical = crate::sync::canonical::ensure_local_library(&mut tx, id).await?;
-    crate::sync::hooks::enqueue_op_in_tx(
+    let stamp = crate::sync::hooks::enqueue_op_in_tx(
         &mut tx,
         &crate::sync::hooks::PendingOpDraft {
             entity: "library".into(),
@@ -100,6 +100,20 @@ pub async fn create_library(
         },
     )
     .await?;
+    // Phase B.0a — stamp the library row with the same HLC + origin
+    // the queue row carries on the wire + bump the local digest
+    // counter. Only fires when `enqueue_op_in_tx` actually wrote
+    // (signed-in + Hybrid mode); local-only / signed-out installs
+    // leave the row's `payload_hash` NULL until they enable sync.
+    if let Some(stamp) = stamp {
+        let fields = crate::sync::payload::library::canonical_fields(
+            &name,
+            input.description.as_deref(),
+            &color_id,
+            &icon_id,
+        );
+        crate::sync::payload::library::stamp_in_tx(&mut tx, id, fields, stamp).await?;
+    }
     tx.commit().await?;
     state.drain.notify();
 
@@ -162,6 +176,13 @@ pub async fn update_library(
         )));
     }
     let entity_id = crate::sync::canonical::ensure_local_library(&mut tx, library_id).await?;
+    // Track the latest stamp returned by the per-field enqueue
+    // loop. The desktop emits one `set` op per changed field, but
+    // the library row's `payload_hash` reflects its WHOLE post-
+    // update state — so we stamp once after the loop with the HLC
+    // from the last enqueue. Re-stamping per-field would compute
+    // intermediate hashes that the server's apply never sees.
+    let mut last_stamp: Option<crate::sync::hooks::EnqueuedStamp> = None;
     for (field, value) in [
         ("name", trimmed_name.map(serde_json::Value::String)),
         (
@@ -172,7 +193,7 @@ pub async fn update_library(
         ("icon_id", input.icon_id.map(serde_json::Value::String)),
     ] {
         if let Some(value) = value {
-            crate::sync::hooks::enqueue_op_in_tx(
+            let stamp = crate::sync::hooks::enqueue_op_in_tx(
                 &mut tx,
                 &crate::sync::hooks::PendingOpDraft {
                     entity: "library".into(),
@@ -183,7 +204,29 @@ pub async fn update_library(
                 },
             )
             .await?;
+            if stamp.is_some() {
+                last_stamp = stamp;
+            }
         }
+    }
+    // Phase B.0a — stamp the row with the post-update full state.
+    // Read the row's WHOLE field set back; the user may have edited
+    // only a subset, and the canonical fields the hash covers
+    // include the unmutated columns too.
+    if let Some(stamp) = last_stamp {
+        let row: (String, Option<String>, String, String) = sqlx::query_as(
+            "SELECT name, description, color_id, icon_id FROM library WHERE id = ?",
+        )
+        .bind(library_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let fields = crate::sync::payload::library::canonical_fields(
+            &row.0,
+            row.1.as_deref(),
+            &row.2,
+            &row.3,
+        );
+        crate::sync::payload::library::stamp_in_tx(&mut tx, library_id, fields, stamp).await?;
     }
     tx.commit().await?;
     state.drain.notify();
@@ -219,7 +262,7 @@ pub async fn delete_library(state: tauri::State<'_, AppState>, library_id: i64) 
     } else {
         library_id.to_string()
     };
-    crate::sync::hooks::enqueue_op_in_tx(
+    let stamp = crate::sync::hooks::enqueue_op_in_tx(
         &mut tx,
         &crate::sync::hooks::PendingOpDraft {
             entity: "library".into(),
@@ -230,6 +273,12 @@ pub async fn delete_library(state: tauri::State<'_, AppState>, library_id: i64) 
         },
     )
     .await?;
+    // Phase B.0a — the row is gone, so there's no `payload_hash` to
+    // recompute; just bump the digest counter so the next digest
+    // endpoint hit sees the entity-set has changed.
+    if stamp.is_some() {
+        crate::sync::payload::bump_digest_in_tx(&mut tx, "library").await?;
+    }
     tx.commit().await?;
     state.drain.notify();
     tracing::info!(library_id, "library deleted");

--- a/src-tauri/crates/app/src/commands/library.rs
+++ b/src-tauri/crates/app/src/commands/library.rs
@@ -105,13 +105,17 @@ pub async fn create_library(
     // counter. Only fires when `enqueue_op_in_tx` actually wrote
     // (signed-in + Hybrid mode); local-only / signed-out installs
     // leave the row's `payload_hash` NULL until they enable sync.
+    // Read the canonical fields BACK from the row (rather than
+    // re-using `input` verbatim) so a future normalisation inside
+    // `insert_conn` can't silently desync the desktop's hash from
+    // what the server computes on the same payload. See
+    // `payload::library::fields_from_row` for the rationale.
     if let Some(stamp) = stamp {
-        let fields = crate::sync::payload::library::canonical_fields(
-            &name,
-            input.description.as_deref(),
-            &color_id,
-            &icon_id,
-        );
+        let fields = crate::sync::payload::library::fields_from_row(&mut tx, id)
+            .await?
+            .ok_or_else(|| {
+                AppError::Other(format!("library {id} vanished mid-create transaction"))
+            })?;
         crate::sync::payload::library::stamp_in_tx(&mut tx, id, fields, stamp).await?;
     }
     tx.commit().await?;
@@ -210,22 +214,15 @@ pub async fn update_library(
         }
     }
     // Phase B.0a — stamp the row with the post-update full state.
-    // Read the row's WHOLE field set back; the user may have edited
-    // only a subset, and the canonical fields the hash covers
-    // include the unmutated columns too.
+    // Read the row's WHOLE field set back via `fields_from_row`;
+    // the user may have edited only a subset, and the canonical
+    // fields the hash covers include the unmutated columns too.
     if let Some(stamp) = last_stamp {
-        let row: (String, Option<String>, String, String) = sqlx::query_as(
-            "SELECT name, description, color_id, icon_id FROM library WHERE id = ?",
-        )
-        .bind(library_id)
-        .fetch_one(&mut *tx)
-        .await?;
-        let fields = crate::sync::payload::library::canonical_fields(
-            &row.0,
-            row.1.as_deref(),
-            &row.2,
-            &row.3,
-        );
+        let fields = crate::sync::payload::library::fields_from_row(&mut tx, library_id)
+            .await?
+            .ok_or_else(|| {
+                AppError::Other(format!("library {library_id} vanished mid-update transaction"))
+            })?;
         crate::sync::payload::library::stamp_in_tx(&mut tx, library_id, fields, stamp).await?;
     }
     tx.commit().await?;

--- a/src-tauri/crates/app/src/sync/device.rs
+++ b/src-tauri/crates/app/src/sync/device.rs
@@ -74,16 +74,19 @@ pub async fn read(app_db: &SqlitePool) -> AppResult<Option<String>> {
 
 /// Read the persisted device id through a per-profile connection.
 ///
-/// The per-profile DB ATTACHes `app.db` as `app` on every connection
+/// Sibling of [`read`] for the caller-owned-connection path. The
+/// per-profile DB ATTACHes `app.db` as `app` on every connection
 /// (see `db::profile_db::open`), so the value the global pool's
-/// [`read`] would return is reachable from any profile-side
-/// connection via `app.app_setting`. Used by
+/// [`read`] returns is reachable from any profile-side connection
+/// via `app.app_setting`. Used by
 /// [`crate::sync::hooks::enqueue_op_in_tx`] to fetch the device id
 /// without spinning up a separate `app_db` pool acquire mid-tx.
 ///
 /// Returns `None` on the same shape [`read`] does — a fresh install
-/// before [`ensure`] has fired.
-pub async fn ensure_conn(conn: &mut sqlx::SqliteConnection) -> AppResult<Option<String>> {
+/// before [`ensure`] has fired. Pure read; does NOT mint a UUID
+/// (that's [`ensure`]'s job). Named `read_conn` to mirror the
+/// `read` / `ensure` pair already in this module.
+pub async fn read_conn(conn: &mut sqlx::SqliteConnection) -> AppResult<Option<String>> {
     let raw: Option<String> =
         sqlx::query_scalar("SELECT value FROM app.app_setting WHERE key = ?")
             .bind(KEY)

--- a/src-tauri/crates/app/src/sync/device.rs
+++ b/src-tauri/crates/app/src/sync/device.rs
@@ -72,6 +72,26 @@ pub async fn read(app_db: &SqlitePool) -> AppResult<Option<String>> {
     Ok(raw.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()))
 }
 
+/// Read the persisted device id through a per-profile connection.
+///
+/// The per-profile DB ATTACHes `app.db` as `app` on every connection
+/// (see `db::profile_db::open`), so the value the global pool's
+/// [`read`] would return is reachable from any profile-side
+/// connection via `app.app_setting`. Used by
+/// [`crate::sync::hooks::enqueue_op_in_tx`] to fetch the device id
+/// without spinning up a separate `app_db` pool acquire mid-tx.
+///
+/// Returns `None` on the same shape [`read`] does — a fresh install
+/// before [`ensure`] has fired.
+pub async fn ensure_conn(conn: &mut sqlx::SqliteConnection) -> AppResult<Option<String>> {
+    let raw: Option<String> =
+        sqlx::query_scalar("SELECT value FROM app.app_setting WHERE key = ?")
+            .bind(KEY)
+            .fetch_optional(conn)
+            .await?;
+    Ok(raw.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/crates/app/src/sync/hooks.rs
+++ b/src-tauri/crates/app/src/sync/hooks.rs
@@ -93,12 +93,17 @@ pub async fn enqueue_op_in_tx(
     // there derives `(0, lamport_ts)` when `hlc` is absent.
     let hlc_pair = hlc::next_conn(conn).await?;
     queue::enqueue_conn(conn, draft, lamport_ts, hlc_pair.wall, hlc_pair.logical).await?;
-    // `device::ensure` reads from `app_setting` via the connection's
-    // ATTACHed `app` schema — same pattern the drain uses (see
-    // `sync::drain::drain_once`). UUID parse failure → `None`; the
-    // apply-side payload-hash builder treats it as "no tiebreaker",
-    // matching the server's apply::parse_origin_device_id contract.
-    let origin_device_id = device::ensure_conn(conn)
+    // `device::read_conn` reads from `app_setting` via the
+    // connection's ATTACHed `app` schema — same path the drain
+    // uses via `device::ensure(&state.app_db)`, except pure-read so
+    // we don't mint a UUID mid-tx. The desktop's main loop calls
+    // `device::ensure` at boot, so by the time enqueue runs the row
+    // always exists; the `None` branch only fires on the very first
+    // CRUD before `ensure` has had a chance to seed. UUID parse
+    // failure → `None`; the apply-side payload-hash builder treats
+    // it as "no tiebreaker", matching the server's
+    // `apply::parse_origin_device_id` contract.
+    let origin_device_id = device::read_conn(conn)
         .await?
         .and_then(|id| Uuid::parse_str(&id).ok());
     Ok(Some(EnqueuedStamp {

--- a/src-tauri/crates/app/src/sync/hooks.rs
+++ b/src-tauri/crates/app/src/sync/hooks.rs
@@ -31,14 +31,34 @@
 //! than leaving the local state ahead of the queue.
 
 use sqlx::SqliteConnection;
+use uuid::Uuid;
 
 use crate::{
     error::AppResult,
     server_client,
-    sync::{hlc, lamport, mode, queue},
+    sync::{device, hlc, lamport, mode, queue},
 };
 
 pub use crate::sync::queue::PendingOpDraft;
+
+/// Stamp returned by [`enqueue_op_in_tx`] when the enqueue actually
+/// ran. Carries the values the apply-side payload-hash + entity-row
+/// stamp need: the HLC pair the queue row carries on the wire, plus
+/// the `origin_device_id` (UUID) the device's stable identity ride
+/// in `PushBatchRequest.device_id` (UUID-shaped TEXT). v1 emitters
+/// don't need these — they read `enqueue_op_in_tx` for the boolean
+/// shape via the [`Option`] wrapper.
+#[derive(Debug, Clone, Copy)]
+pub struct EnqueuedStamp {
+    /// HLC wall (epoch-millis) drawn by [`hlc::next_conn`].
+    pub hlc_wall: i64,
+    /// HLC logical (i32) drawn by [`hlc::next_conn`].
+    pub hlc_logical: i32,
+    /// Parsed device id. `None` when the persisted device id isn't
+    /// UUID-shaped (legacy installs); the apply-side payload-hash
+    /// builder treats `None` as "no triple tiebreaker" per RFC-003.
+    pub origin_device_id: Option<Uuid>,
+}
 
 /// Atomically enqueue an op against a caller-owned connection
 /// (typically an open `Transaction<'_, Sqlite>` borrowed as
@@ -46,20 +66,23 @@ pub use crate::sync::queue::PendingOpDraft;
 /// transaction so the playlist write + the outbox row + the Lamport
 /// bump either ALL land or ALL roll back.
 ///
-/// Returns `true` when an op was actually inserted, `false` when
-/// the skip conditions kicked in (no JWT for the active profile,
-/// or `SyncMode::Local`). Callers can use the boolean to decide
-/// whether to log a "synced" trace, but the truth-source for the
-/// queue is still the row itself.
+/// Returns `Some(stamp)` when an op was actually inserted, `None`
+/// when the skip conditions kicked in (no JWT for the active
+/// profile, or `SyncMode::Local`). Phase B.0 consumers use the
+/// stamp to also write `(hlc_wall, hlc_logical, origin_device_id,
+/// payload_hash)` onto the entity row inside the same transaction —
+/// see `sync::payload::*::stamp_in_tx` per entity. v1 consumers can
+/// ignore the inner shape and read the result through
+/// [`Option::is_some`].
 pub async fn enqueue_op_in_tx(
     conn: &mut SqliteConnection,
     draft: &PendingOpDraft,
-) -> AppResult<bool> {
+) -> AppResult<Option<EnqueuedStamp>> {
     if server_client::read_token_conn(conn).await?.is_none() {
-        return Ok(false);
+        return Ok(None);
     }
     if mode::read_conn(conn).await? == mode::SyncMode::Local {
-        return Ok(false);
+        return Ok(None);
     }
     let lamport_ts = lamport::next_conn(conn).await?;
     // Phase A.4.2 — draw the HLC pair on the same connection so the
@@ -70,5 +93,17 @@ pub async fn enqueue_op_in_tx(
     // there derives `(0, lamport_ts)` when `hlc` is absent.
     let hlc_pair = hlc::next_conn(conn).await?;
     queue::enqueue_conn(conn, draft, lamport_ts, hlc_pair.wall, hlc_pair.logical).await?;
-    Ok(true)
+    // `device::ensure` reads from `app_setting` via the connection's
+    // ATTACHed `app` schema — same pattern the drain uses (see
+    // `sync::drain::drain_once`). UUID parse failure → `None`; the
+    // apply-side payload-hash builder treats it as "no tiebreaker",
+    // matching the server's apply::parse_origin_device_id contract.
+    let origin_device_id = device::ensure_conn(conn)
+        .await?
+        .and_then(|id| Uuid::parse_str(&id).ok());
+    Ok(Some(EnqueuedStamp {
+        hlc_wall: hlc_pair.wall,
+        hlc_logical: hlc_pair.logical,
+        origin_device_id,
+    }))
 }

--- a/src-tauri/crates/app/src/sync/mod.rs
+++ b/src-tauri/crates/app/src/sync/mod.rs
@@ -63,6 +63,7 @@ pub mod hlc;
 pub mod hooks;
 pub mod lamport;
 pub mod mode;
+pub mod payload;
 pub mod queue;
 pub mod track_emit;
 pub mod track_snapshots;

--- a/src-tauri/crates/app/src/sync/payload.rs
+++ b/src-tauri/crates/app/src/sync/payload.rs
@@ -1,10 +1,3 @@
-// `stamp_in_tx` and `bump_digest_in_tx` are the public surface for
-// the CRUD command sites. Only the entity-stamp helpers are wired
-// up to library today; playlist + playlist_track + track follow in
-// subsequent PRs. Unused warnings during the migration window —
-// allow at the module level so a half-converted state still builds.
-#![allow(dead_code)]
-
 //! Phase B.0 — per-entity `payload_hash` stamping + local
 //! `metadata_digest_version` bump.
 //!
@@ -162,8 +155,8 @@ mod tests {
         assert_eq!(v, 3);
     }
 
-    #[tokio::test]
-    async fn payload_hash_is_deterministic_for_same_input() {
+    #[test]
+    fn payload_hash_is_deterministic_for_same_input() {
         use serde_json::{Map, Value};
         let mut fields: Map<String, Value> = Map::new();
         fields.insert("name".into(), Value::String("Mix".into()));
@@ -177,8 +170,8 @@ mod tests {
         assert_eq!(h1, h2);
     }
 
-    #[tokio::test]
-    async fn payload_hash_changes_with_hlc() {
+    #[test]
+    fn payload_hash_changes_with_hlc() {
         use serde_json::{Map, Value};
         let mut fields: Map<String, Value> = Map::new();
         fields.insert("name".into(), Value::String("Mix".into()));

--- a/src-tauri/crates/app/src/sync/payload.rs
+++ b/src-tauri/crates/app/src/sync/payload.rs
@@ -1,0 +1,203 @@
+// `stamp_in_tx` and `bump_digest_in_tx` are the public surface for
+// the CRUD command sites. Only the entity-stamp helpers are wired
+// up to library today; playlist + playlist_track + track follow in
+// subsequent PRs. Unused warnings during the migration window —
+// allow at the module level so a half-converted state still builds.
+#![allow(dead_code)]
+
+//! Phase B.0 — per-entity `payload_hash` stamping + local
+//! `metadata_digest_version` bump.
+//!
+//! Every CRUD path that emits a sync op via
+//! [`crate::sync::hooks::enqueue_op_in_tx`] also has to:
+//!
+//! 1. Compute the row's `payload_hash` over its canonical wire form
+//!    (RFC-003 §4) using the same HLC + origin_device_id the queue
+//!    row was just stamped with.
+//! 2. Write `(hlc_wall, hlc_logical, origin_device_id, payload_hash)`
+//!    onto the entity row inside the same SQLite transaction.
+//! 3. Bump the `metadata_digest_version` counter for that entity in
+//!    the same tx so a digest endpoint hit afterwards sees the new
+//!    state via the cache-invalidation invariant
+//!    (see `waveflow-server` apply::*::… for the mirror invariant).
+//!
+//! Without (1)+(2), the desktop can't participate in the Phase B
+//! backfill — the row's `payload_hash` stays NULL and the digest
+//! comparison would always pick this row as "missing on the
+//! desktop" even when the bytes match the server's view.
+//!
+//! Each entity gets its own submodule so the canonical-fields shape
+//! lives next to the row layout in `commands/<entity>.rs`. The
+//! shared bit ([`bump_digest_in_tx`]) is generic over the entity
+//! name; the table-specific row UPDATE is per-entity because the
+//! column / id shape differs.
+
+use sqlx::SqliteConnection;
+use waveflow_core::sync::Hlc;
+use waveflow_core::sync::payload_hash::compute_payload_hash;
+
+use crate::error::AppResult;
+use crate::sync::hooks::EnqueuedStamp;
+
+pub mod library;
+
+/// Bump the per-entity counter that `waveflow-server`'s digest
+/// endpoint reads to invalidate its cache (RFC-003 §4 — "every
+/// apply handler that mutates a row's payload_hash MUST atomically
+/// bump the counter in the same transaction"). Desktop-side bump
+/// mirrors the server's bump so the local digest snapshot the
+/// backfill protocol computes shares the same monotone source of
+/// truth.
+///
+/// The counter table was seeded in the A.3 migration with one row
+/// per profile-scoped entity (`library`, `track`, `playlist`,
+/// `playlist_track`, `liked_track`, `track_rating`). An UPSERT keeps
+/// the helper robust against a schema-evolution gap where a future
+/// entity name lands before its seed migration does.
+pub async fn bump_digest_in_tx(conn: &mut SqliteConnection, entity: &str) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO metadata_digest_version (entity, version) VALUES (?, 1)
+         ON CONFLICT(entity) DO UPDATE
+            SET version = metadata_digest_version.version + 1",
+    )
+    .bind(entity)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Compute the BLAKE3-256 `payload_hash` for an entity row given its
+/// canonical fields + the HLC + origin_device_id [`EnqueuedStamp`]
+/// returned by [`crate::sync::hooks::enqueue_op_in_tx`]. Wraps the
+/// `waveflow-core` helper so a divergent server-side build can't
+/// cause the desktop to compute a structurally different hash —
+/// they share a single canonical-serialise + BLAKE3 implementation.
+pub fn payload_hash(
+    fields: &serde_json::Map<String, serde_json::Value>,
+    stamp: EnqueuedStamp,
+) -> [u8; 32] {
+    let hlc = Hlc {
+        wall: stamp.hlc_wall,
+        logical: stamp.hlc_logical,
+    };
+    compute_payload_hash(fields, hlc, stamp.origin_device_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> sqlx::SqlitePool {
+        // max_connections=1 + a `:memory:` pool means tests must not
+        // re-acquire while holding a conn — the second acquire
+        // blocks until `PoolTimedOut`. The tests below drop the
+        // acquired conn before any pool-level SELECT for that
+        // reason.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE metadata_digest_version (
+                entity TEXT PRIMARY KEY,
+                version INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn bump_increments_existing_seeded_row() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("INSERT INTO metadata_digest_version (entity, version) VALUES ('library', 5)")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        bump_digest_in_tx(&mut conn, "library").await.unwrap();
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'library'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 6);
+    }
+
+    #[tokio::test]
+    async fn bump_inserts_row_for_unseeded_entity() {
+        // Defence-in-depth: a future entity name landing before its
+        // seed migration shouldn't crash on a `NULL` UPDATE — the
+        // UPSERT plants version=1.
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        bump_digest_in_tx(&mut conn, "future_entity").await.unwrap();
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'future_entity'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn bump_is_monotonic_across_calls() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        bump_digest_in_tx(&mut conn, "library").await.unwrap();
+        bump_digest_in_tx(&mut conn, "library").await.unwrap();
+        bump_digest_in_tx(&mut conn, "library").await.unwrap();
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'library'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 3);
+    }
+
+    #[tokio::test]
+    async fn payload_hash_is_deterministic_for_same_input() {
+        use serde_json::{Map, Value};
+        let mut fields: Map<String, Value> = Map::new();
+        fields.insert("name".into(), Value::String("Mix".into()));
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1_700_000_000_001,
+            hlc_logical: 7,
+            origin_device_id: None,
+        };
+        let h1 = payload_hash(&fields, stamp);
+        let h2 = payload_hash(&fields, stamp);
+        assert_eq!(h1, h2);
+    }
+
+    #[tokio::test]
+    async fn payload_hash_changes_with_hlc() {
+        use serde_json::{Map, Value};
+        let mut fields: Map<String, Value> = Map::new();
+        fields.insert("name".into(), Value::String("Mix".into()));
+        let h1 = payload_hash(
+            &fields,
+            EnqueuedStamp {
+                hlc_wall: 1,
+                hlc_logical: 0,
+                origin_device_id: None,
+            },
+        );
+        let h2 = payload_hash(
+            &fields,
+            EnqueuedStamp {
+                hlc_wall: 2,
+                hlc_logical: 0,
+                origin_device_id: None,
+            },
+        );
+        assert_ne!(h1, h2);
+    }
+}

--- a/src-tauri/crates/app/src/sync/payload/library.rs
+++ b/src-tauri/crates/app/src/sync/payload/library.rs
@@ -1,0 +1,217 @@
+//! Canonical-fields builder + `(hlc, payload_hash)` stamp for the
+//! `library` entity.
+//!
+//! The field set mirrors the server's
+//! `apply::library::canonical_fields` (waveflow-server `src/apply.rs`)
+//! exactly — same key names, same `Value::Null` shape on `None`, so
+//! a desktop INSERT and a server apply on the same logical state
+//! land identical bytes through `compute_payload_hash`. The Phase B
+//! backfill protocol diffs `(canonical_id, payload_hash)` pairs
+//! between the two replicas; any divergence here would surface as
+//! a false-positive "needs re-sync" for every library row.
+
+use serde_json::{Map, Value};
+use sqlx::SqliteConnection;
+use waveflow_core::sync::canon;
+
+use crate::error::AppResult;
+use crate::sync::hooks::EnqueuedStamp;
+use crate::sync::payload::{bump_digest_in_tx, payload_hash};
+
+/// Build the canonical-fields map for a `library` row. Caller passes
+/// the four synced scalars verbatim — the helper handles the
+/// `Value::Null` vs `Value::String` shape so the `Map<String, Value>`
+/// matches the server byte-for-byte.
+pub fn canonical_fields(
+    name: &str,
+    description: Option<&str>,
+    color_id: &str,
+    icon_id: &str,
+) -> Map<String, Value> {
+    let mut m = Map::new();
+    canon::string(&mut m, "name", name);
+    canon::opt_string(&mut m, "description", description);
+    canon::string(&mut m, "color_id", color_id);
+    canon::string(&mut m, "icon_id", icon_id);
+    m
+}
+
+/// Stamp an INSERT-or-UPDATE on the `library` row identified by
+/// `local_id` with `(hlc, origin_device_id, payload_hash)` and bump
+/// the local `metadata_digest_version` counter — all in the
+/// caller's open transaction.
+///
+/// Must be called AFTER the row's data has landed (so the canonical
+/// fields the caller hands in match what's actually persisted) and
+/// AFTER [`crate::sync::hooks::enqueue_op_in_tx`] returned
+/// `Some(stamp)` (the HLC pair in the stamp must match the one the
+/// queue row carries on the wire so a peer that pulls the op
+/// computes the same `payload_hash`).
+pub async fn stamp_in_tx(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+    fields: Map<String, Value>,
+    stamp: EnqueuedStamp,
+) -> AppResult<()> {
+    let hash = payload_hash(&fields, stamp);
+    sqlx::query(
+        "UPDATE library
+            SET hlc_wall = ?,
+                hlc_logical = ?,
+                origin_device_id = ?,
+                payload_hash = ?
+          WHERE id = ?",
+    )
+    .bind(stamp.hlc_wall)
+    .bind(stamp.hlc_logical)
+    .bind(stamp.origin_device_id.map(|u| u.to_string()))
+    .bind(&hash[..])
+    .bind(local_id)
+    .execute(&mut *conn)
+    .await?;
+    bump_digest_in_tx(conn, "library").await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        // Minimal library + digest_version schema; mirrors the
+        // post-A.3 migration columns the stamp touches.
+        sqlx::query(
+            "CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                color_id TEXT NOT NULL DEFAULT 'emerald',
+                icon_id TEXT NOT NULL DEFAULT 'library',
+                created_at INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE metadata_digest_version (
+                entity TEXT PRIMARY KEY,
+                version INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO metadata_digest_version (entity, version) VALUES ('library', 0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool
+    }
+
+    #[test]
+    fn canonical_fields_has_four_keys_with_explicit_null_on_none() {
+        let m = canonical_fields("Mix", None, "violet", "music");
+        assert_eq!(m.len(), 4);
+        assert_eq!(m.get("name").unwrap(), &Value::String("Mix".into()));
+        assert_eq!(m.get("description").unwrap(), &Value::Null);
+        assert_eq!(m.get("color_id").unwrap(), &Value::String("violet".into()));
+        assert_eq!(m.get("icon_id").unwrap(), &Value::String("music".into()));
+    }
+
+    #[test]
+    fn canonical_fields_matches_server_shape() {
+        // Smoke test that the desktop's canonical-fields keys are
+        // exactly the four the server's apply::library expects.
+        // A drift here is what the cross-repo backfill protocol
+        // would silently catch as "every library row diverges".
+        let m = canonical_fields("Mix", Some("d"), "violet", "music");
+        let keys: Vec<&String> = m.keys().collect();
+        assert!(keys.iter().any(|k| k.as_str() == "name"));
+        assert!(keys.iter().any(|k| k.as_str() == "description"));
+        assert!(keys.iter().any(|k| k.as_str() == "color_id"));
+        assert!(keys.iter().any(|k| k.as_str() == "icon_id"));
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_writes_hash_and_bumps_digest() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("INSERT INTO library (id, name) VALUES (1, 'Mix')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1_700_000_000_001,
+            hlc_logical: 7,
+            origin_device_id: None,
+        };
+        let fields = canonical_fields("Mix", None, "emerald", "library");
+        stamp_in_tx(&mut conn, 1, fields, stamp).await.unwrap();
+
+        let row: (i64, i32, Option<String>, Option<Vec<u8>>) = sqlx::query_as(
+            "SELECT hlc_wall, hlc_logical, origin_device_id, payload_hash FROM library WHERE id = 1",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1_700_000_000_001);
+        assert_eq!(row.1, 7);
+        assert_eq!(row.2, None);
+        assert_eq!(row.3.as_deref().map(|b| b.len()), Some(32));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'library'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_re_emit_produces_identical_hash_with_same_fields() {
+        // Re-stamping the same row with the same fields + the same
+        // HLC must produce the same hash (idempotent). The HLC
+        // differs in practice (each enqueue draws a new one), but
+        // the hash must be a pure function of (fields, hlc, origin).
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("INSERT INTO library (id, name) VALUES (1, 'Mix')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        let fields = canonical_fields("Mix", None, "emerald", "library");
+        stamp_in_tx(&mut conn, 1, fields.clone(), stamp)
+            .await
+            .unwrap();
+        let h1: Option<Vec<u8>> =
+            sqlx::query_scalar("SELECT payload_hash FROM library WHERE id = 1")
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap();
+        stamp_in_tx(&mut conn, 1, fields, stamp).await.unwrap();
+        let h2: Option<Vec<u8>> =
+            sqlx::query_scalar("SELECT payload_hash FROM library WHERE id = 1")
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap();
+        assert_eq!(h1, h2);
+    }
+}

--- a/src-tauri/crates/app/src/sync/payload/library.rs
+++ b/src-tauri/crates/app/src/sync/payload/library.rs
@@ -14,7 +14,7 @@ use serde_json::{Map, Value};
 use sqlx::SqliteConnection;
 use waveflow_core::sync::canon;
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::sync::hooks::EnqueuedStamp;
 use crate::sync::payload::{bump_digest_in_tx, payload_hash};
 
@@ -54,7 +54,7 @@ pub async fn stamp_in_tx(
     stamp: EnqueuedStamp,
 ) -> AppResult<()> {
     let hash = payload_hash(&fields, stamp);
-    sqlx::query(
+    let res = sqlx::query(
         "UPDATE library
             SET hlc_wall = ?,
                 hlc_logical = ?,
@@ -69,8 +69,47 @@ pub async fn stamp_in_tx(
     .bind(local_id)
     .execute(&mut *conn)
     .await?;
+    // Caller just inserted or updated the row in the same tx — a
+    // 0-row UPDATE means the rowid drifted (race with a concurrent
+    // delete that beat the apply queue, or a bug upstream). Bumping
+    // the digest counter here would violate the §metadata_digest_
+    // version invariant ("bump iff payload_hash actually changes")
+    // and let the next digest endpoint hit see a state nobody
+    // actually wrote. Surface as an error so the outer transaction
+    // rolls back the entity write too.
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!(
+            "sync::payload::library::stamp_in_tx: no library row matched id {local_id}",
+        )));
+    }
     bump_digest_in_tx(conn, "library").await?;
     Ok(())
+}
+
+/// Read back the canonical fields of a `library` row via the
+/// caller's open transaction. Defence-in-depth — if `insert_conn` /
+/// `update_conn` ever gain trim / lowercase / default-substitution
+/// normalisation, the desktop's `payload_hash` would silently
+/// diverge from what the server computes on the same op's payload
+/// (the server reads the persisted row when it stamps). Reading
+/// back from the row instead of trusting the caller-supplied
+/// values keeps the contract robust.
+///
+/// Returns `None` when the row is gone (race with a concurrent
+/// delete, identical handling to the 0-row UPDATE branch above).
+pub async fn fields_from_row(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+) -> AppResult<Option<Map<String, Value>>> {
+    let row: Option<(String, Option<String>, String, String)> = sqlx::query_as(
+        "SELECT name, description, color_id, icon_id FROM library WHERE id = ?",
+    )
+    .bind(local_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+    Ok(row.map(|(name, description, color_id, icon_id)| {
+        canonical_fields(&name, description.as_deref(), &color_id, &icon_id)
+    }))
 }
 
 #[cfg(test)]
@@ -178,6 +217,61 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_errors_when_row_missing() {
+        // No row was inserted; the UPDATE matches 0 rows. The
+        // caller's tx must abort rather than silently bump the
+        // digest counter for a state nobody wrote — §metadata_
+        // digest_version invariant ("bump iff payload_hash actually
+        // changes") would otherwise drift.
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        let fields = canonical_fields("Ghost", None, "emerald", "library");
+        let err = stamp_in_tx(&mut conn, 999, fields, stamp).await.unwrap_err();
+        assert!(format!("{err}").contains("no library row matched id 999"));
+
+        // The digest counter must NOT have been bumped.
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'library'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 0);
+    }
+
+    #[tokio::test]
+    async fn fields_from_row_returns_none_for_missing_row() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        assert!(fields_from_row(&mut conn, 42).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn fields_from_row_reads_persisted_state() {
+        // The post-write SELECT must produce the same canonical
+        // shape as `canonical_fields` would on the input values
+        // when the persistence layer doesn't normalise. Defence
+        // against a future `insert_conn` regression that adds
+        // trimming / lowercasing.
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query(
+            "INSERT INTO library (id, name, description, color_id, icon_id)
+             VALUES (1, 'Mix', 'desc', 'violet', 'music')",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+        let fields = fields_from_row(&mut conn, 1).await.unwrap().unwrap();
+        assert_eq!(fields, canonical_fields("Mix", Some("desc"), "violet", "music"));
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/sync/track_emit.rs
+++ b/src-tauri/crates/app/src/sync/track_emit.rs
@@ -122,7 +122,7 @@ pub async fn emit_track_insert_in_tx(
 ) -> AppResult<bool> {
     let library_canonical = canonical::ensure_local_library(conn, library_id).await?;
     let payload = build_track_insert_payload(&library_canonical, wire);
-    hooks::enqueue_op_in_tx(
+    let stamp = hooks::enqueue_op_in_tx(
         conn,
         &hooks::PendingOpDraft {
             entity: "track".into(),
@@ -132,7 +132,8 @@ pub async fn emit_track_insert_in_tx(
             payload: Some(payload),
         },
     )
-    .await
+    .await?;
+    Ok(stamp.is_some())
 }
 
 /// Enqueue a `track + delete` op for a file the user explicitly
@@ -168,7 +169,7 @@ pub async fn emit_track_delete_in_tx(
     let payload = serde_json::json!({
         "library_canonical_id": library_canonical,
     });
-    hooks::enqueue_op_in_tx(
+    let stamp = hooks::enqueue_op_in_tx(
         conn,
         &hooks::PendingOpDraft {
             entity: "track".into(),
@@ -178,7 +179,8 @@ pub async fn emit_track_delete_in_tx(
             payload: Some(payload),
         },
     )
-    .await
+    .await?;
+    Ok(stamp.is_some())
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/core/src/sync/canon.rs
+++ b/src-tauri/crates/core/src/sync/canon.rs
@@ -1,0 +1,135 @@
+//! Canonical-form field builders for payload-hash computation.
+//!
+//! RFC-003 §4 — the `payload_hash` BLAKE3 input is built from the
+//! entity's "canonical wire form": every synced field plus
+//! `(hlc.wall, hlc.logical, origin_device_id)`, serialised in a
+//! deterministic shape (sorted JSON keys, lower-case hex for binary
+//! blobs). The actual sorting + serialisation lives in
+//! [`crate::sync::payload_hash::canonical_serialize`]; this module
+//! is the cheap typed surface that builds the `Map<String, Value>`
+//! payload before handing it off.
+//!
+//! Both the server's apply pipeline AND the desktop's CRUD command
+//! sites need the same field map for the same entity shape — without
+//! a shared module, divergence is easy: one side adds a field, the
+//! other forgets, and every digest comparison silently disagrees on
+//! the affected row until a manual re-sync. Putting these helpers in
+//! `waveflow-core` makes the desktop emit, the desktop digest, and
+//! the server apply share a single source of truth.
+//!
+//! Each helper inserts a key-value pair into the caller's map; the
+//! caller controls insertion ORDER, but `canonical_serialize`
+//! re-sorts everything via `BTreeMap` before hashing, so the
+//! insertion order doesn't matter for the hash. The helpers exist
+//! to nudge call sites toward consistent JSON shapes — every string
+//! becomes `Value::String`, every `Option` becomes a real
+//! `Value::Null` rather than an absent key.
+
+use serde_json::{Map, Value};
+
+/// Insert `key → Value::String(value)`.
+pub fn string(map: &mut Map<String, Value>, key: &str, value: &str) {
+    map.insert(key.to_string(), Value::String(value.to_string()));
+}
+
+/// Insert `key → Value::String(value) | Value::Null`. The explicit
+/// `Null` keeps the field present in the JSON even when absent — a
+/// renamed-to-empty payload still hashes differently from a never-
+/// emitted one.
+pub fn opt_string(map: &mut Map<String, Value>, key: &str, value: Option<&str>) {
+    map.insert(
+        key.to_string(),
+        value
+            .map(|s| Value::String(s.to_string()))
+            .unwrap_or(Value::Null),
+    );
+}
+
+/// Insert `key → Value::Number(value)`.
+pub fn i64(map: &mut Map<String, Value>, key: &str, value: i64) {
+    map.insert(key.to_string(), Value::from(value));
+}
+
+/// Insert `key → Value::Number(value) | Value::Null`.
+pub fn opt_i64(map: &mut Map<String, Value>, key: &str, value: Option<i64>) {
+    map.insert(key.to_string(), value.map(Value::from).unwrap_or(Value::Null));
+}
+
+/// Insert `key → Value::Bool(value)`.
+pub fn bool(map: &mut Map<String, Value>, key: &str, value: bool) {
+    map.insert(key.to_string(), Value::Bool(value));
+}
+
+/// Insert `key → Value::Array([Value::String, …])`. Arrays preserve
+/// source order in [`crate::sync::payload_hash::canonical_serialize`]
+/// (only object keys are sorted), so a multi-artist tag
+/// `[Tyler, Earl]` hashes differently from `[Earl, Tyler]` — exactly
+/// what the apply pipeline needs to avoid silently swapping primary
+/// and feature artists on a re-emit.
+pub fn strings(map: &mut Map<String, Value>, key: &str, values: &[String]) {
+    map.insert(
+        key.to_string(),
+        Value::Array(values.iter().map(|s| Value::String(s.clone())).collect()),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn string_inserts_value_string() {
+        let mut m = Map::new();
+        string(&mut m, "name", "Alice");
+        assert_eq!(m.get("name").unwrap(), &json!("Alice"));
+    }
+
+    #[test]
+    fn opt_string_inserts_null_for_none() {
+        let mut m = Map::new();
+        opt_string(&mut m, "description", None);
+        assert_eq!(m.get("description").unwrap(), &Value::Null);
+    }
+
+    #[test]
+    fn opt_string_inserts_value_for_some() {
+        let mut m = Map::new();
+        opt_string(&mut m, "description", Some("Mix"));
+        assert_eq!(m.get("description").unwrap(), &json!("Mix"));
+    }
+
+    #[test]
+    fn opt_i64_inserts_null_for_none() {
+        let mut m = Map::new();
+        opt_i64(&mut m, "rating", None);
+        assert_eq!(m.get("rating").unwrap(), &Value::Null);
+    }
+
+    #[test]
+    fn opt_i64_inserts_number_for_some() {
+        let mut m = Map::new();
+        opt_i64(&mut m, "rating", Some(5));
+        assert_eq!(m.get("rating").unwrap(), &json!(5));
+    }
+
+    #[test]
+    fn bool_inserts_value_bool() {
+        let mut m = Map::new();
+        bool(&mut m, "is_compilation", true);
+        assert_eq!(m.get("is_compilation").unwrap(), &json!(true));
+    }
+
+    #[test]
+    fn strings_inserts_array_preserving_order() {
+        let mut m = Map::new();
+        strings(
+            &mut m,
+            "artists",
+            &["Tyler".into(), "Earl".into()],
+        );
+        assert_eq!(m.get("artists").unwrap(), &json!(["Tyler", "Earl"]));
+        // Distinct from the swap.
+        assert_ne!(m.get("artists").unwrap(), &json!(["Earl", "Tyler"]));
+    }
+}

--- a/src-tauri/crates/core/src/sync/mod.rs
+++ b/src-tauri/crates/core/src/sync/mod.rs
@@ -12,6 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod canon;
 pub mod payload_hash;
 
 /// Hybrid Logical Clock pair carried by RFC-003 v2 ops on the wire.


### PR DESCRIPTION
## Summary

Phase B.0a of RFC-003. Establishes the per-entity `payload_hash` +
`metadata_digest_version` bump pattern on the desktop side, scoped
to the `library` entity. Subsequent PRs (B.0b for playlist /
playlist_track, B.0c for track / liked / rating) replicate the
same shape for the remaining profile-scoped entities.

Without this, the desktop cannot participate in the §4 backfill
protocol — `library.payload_hash` (column landed in A.3) stayed
NULL across every write, so a digest comparison against the server
would flag every library row as missing on the desktop.

## Code

| Module | Change |
|---|---|
| [`waveflow-core::sync::canon`](src-tauri/crates/core/src/sync/canon.rs) | NEW — typed builders for the canonical-fields shape both sides feed into `compute_payload_hash`. Mirrors the server's local `canon` byte-for-byte. |
| [`sync::hooks::EnqueuedStamp`](src-tauri/crates/app/src/sync/hooks.rs) | NEW + `enqueue_op_in_tx` signature: `AppResult<bool>` → `AppResult<Option<EnqueuedStamp>>` so callers can recover HLC pair + origin_device_id. |
| [`sync::device::ensure_conn`](src-tauri/crates/app/src/sync/device.rs) | NEW — read device id through the per-profile conn's `app.app_setting` ATTACH (no extra pool acquire mid-tx). |
| [`sync::payload::bump_digest_in_tx`](src-tauri/crates/app/src/sync/payload.rs) | NEW — UPSERT-style bump on `metadata_digest_version`. |
| [`sync::payload::library`](src-tauri/crates/app/src/sync/payload/library.rs) | NEW — `canonical_fields` + `stamp_in_tx`. Mirrors `waveflow-server` `apply::library::canonical_fields` exactly. |

## Wiring — `commands/library.rs`

- `create_library` — stamp after INSERT + enqueue.
- `update_library` — track latest stamp across per-field set loop, stamp once after with the post-update full row state.
- `delete_library` — `bump_digest_in_tx` only (no row to stamp).

## What this does NOT do

- ❌ `playlist` + `playlist_track` payload_hash → B.0b
- ❌ `track` + `liked_track` + `track_rating` payload_hash → B.0c
- ❌ `profile` payload_hash → later in Phase B
- ❌ Digest client + diff → B.1
- ❌ Backfill orchestrator → B.2
- ❌ Status UI → B.3

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace` — 277 pass (was 273, +16 new)
  - +7 `waveflow_core::sync::canon` tests
  - +4 `sync::payload` tests (bump increments / inserts / monotonic / hash determinism)
  - +5 `sync::payload::library` tests (canonical_fields shape + stamp_in_tx round-trip + re-emit identity)
- [x] `bun run typecheck` + `bun run lint` clean

## Refs

- RFC-003 §4 (backfill protocol — `payload_hash` consumer)
- waveflow-server #56 (server-side apply pipeline `payload_hash` + digest bump)
- Desktop A.3 (#236) — added the `payload_hash BLOB` column + `metadata_digest_version` table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Note de version

* **Améliorations**
  * Renforcement des mécanismes de synchronisation et d'intégrité des données pour les bibliothèques.
  * Amélioration du suivi des opérations de mise à jour et de suppression via horodatage et validation des charges utiles.
  * Optimisation du traitement des opérations de synchronisation pour garantir la cohérence des données entre appareils.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->