### PR TITLE
feat(sync): rfc-003 phase b.0-rest — playlist/track/liked/rating payload_hash + digest bump

### DIFF
--- a/src-tauri/crates/app/src/commands/playlist.rs
+++ b/src-tauri/crates/app/src/commands/playlist.rs
@@ -120,7 +120,7 @@ pub async fn create_playlist(
     // devices reading the broadcast will route entity_id through
     // their own sync_id_map to find the local rowid.
     let canonical = crate::sync::canonical::ensure_local_playlist(&mut tx, id).await?;
-    crate::sync::hooks::enqueue_op_in_tx(
+    let stamp = crate::sync::hooks::enqueue_op_in_tx(
         &mut tx,
         &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
@@ -136,6 +136,18 @@ pub async fn create_playlist(
         },
     )
     .await?;
+    // Phase B.0 — stamp the playlist row with the queued op's HLC +
+    // payload_hash so the desktop's metadata_digest reflects the
+    // INSERT. Only fires when `enqueue_op_in_tx` actually wrote (sync
+    // gate / SyncMode::Local short-circuits return `None`); the row
+    // INSERT itself proceeds either way.
+    if let Some(stamp) = stamp {
+        if let Some(fields) =
+            crate::sync::payload::playlist::fields_from_row(&mut tx, id).await?
+        {
+            crate::sync::payload::playlist::stamp_in_tx(&mut tx, id, fields, stamp).await?;
+        }
+    }
     tx.commit().await?;
     // Wake the drain task so a chatty user's edits don't wait the
     // full 30 s tick before reaching the server.
@@ -209,6 +221,7 @@ pub async fn update_playlist(
     // dodged the migration backfill — shouldn't happen, but the
     // fallback keeps the tx atomic) gets one minted here.
     let entity_id = crate::sync::canonical::ensure_local_playlist(&mut tx, playlist_id).await?;
+    let mut last_stamp: Option<crate::sync::hooks::EnqueuedStamp> = None;
     for (field, value) in [
         ("name", trimmed_name.map(serde_json::Value::String)),
         (
@@ -219,7 +232,7 @@ pub async fn update_playlist(
         ("icon_id", input.icon_id.map(serde_json::Value::String)),
     ] {
         if let Some(value) = value {
-            crate::sync::hooks::enqueue_op_in_tx(
+            let stamp = crate::sync::hooks::enqueue_op_in_tx(
                 &mut tx,
                 &crate::sync::hooks::PendingOpDraft {
                     entity: "playlist".into(),
@@ -230,6 +243,21 @@ pub async fn update_playlist(
                 },
             )
             .await?;
+            if let Some(s) = stamp {
+                last_stamp = Some(s);
+            }
+        }
+    }
+    // Phase B.0 — stamp once at the end with the latest queued op's
+    // HLC, reading the canonical fields from the persisted row so the
+    // hash reflects what's actually on disk (defence-in-depth against
+    // future normalisation in `update_conn`).
+    if let Some(stamp) = last_stamp {
+        if let Some(fields) =
+            crate::sync::payload::playlist::fields_from_row(&mut tx, playlist_id).await?
+        {
+            crate::sync::payload::playlist::stamp_in_tx(&mut tx, playlist_id, fields, stamp)
+                .await?;
         }
     }
     tx.commit().await?;
@@ -273,7 +301,7 @@ pub async fn delete_playlist(state: tauri::State<'_, AppState>, playlist_id: i64
     } else {
         playlist_id.to_string()
     };
-    crate::sync::hooks::enqueue_op_in_tx(
+    let stamp = crate::sync::hooks::enqueue_op_in_tx(
         &mut tx,
         &crate::sync::hooks::PendingOpDraft {
             entity: "playlist".into(),
@@ -284,6 +312,12 @@ pub async fn delete_playlist(state: tauri::State<'_, AppState>, playlist_id: i64
         },
     )
     .await?;
+    // Phase B.0 — bump the playlist digest counter on delete. No row
+    // to stamp (the DELETE already ran), but the set member's removal
+    // still has to be visible to the backfill protocol.
+    if stamp.is_some() {
+        crate::sync::payload::bump_digest_in_tx(&mut tx, "playlist").await?;
+    }
     tx.commit().await?;
     // Wake the drain task so a chatty user's edits don't wait the
     // full 30 s tick before reaching the server.

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -656,6 +656,7 @@ pub(crate) async fn scan_folder_inner(
                     emit_track_insert_from_extracted(
                         &mut tx,
                         library_id,
+                        existing_track_id,
                         &extracted,
                         existing_added_at,
                     )
@@ -785,6 +786,7 @@ pub(crate) async fn scan_folder_inner(
                 emit_track_insert_from_extracted(
                     &mut tx,
                     library_id,
+                    existing_track_id,
                     &extracted,
                     existing_added_at,
                 )
@@ -894,7 +896,8 @@ pub(crate) async fn scan_folder_inner(
             // write — outbox rolls back with the track row if the
             // commit fails. Skipped gracefully when sync isn't
             // configured.
-            emit_track_insert_from_extracted(&mut tx, library_id, &extracted, now).await?;
+            emit_track_insert_from_extracted(&mut tx, library_id, track_id, &extracted, now)
+                .await?;
 
             summary.added += 1;
             tx_count += 1;
@@ -1088,6 +1091,7 @@ pub async fn rescan_local_artist_images(
 async fn emit_track_insert_from_extracted(
     tx: &mut sqlx::SqliteConnection,
     library_id: i64,
+    track_id: i64,
     extracted: &ExtractedFile,
     added_at: i64,
 ) -> AppResult<()> {
@@ -1120,7 +1124,13 @@ async fn emit_track_insert_from_extracted(
         is_compilation: extracted.is_compilation,
         artists: &artists,
     };
-    crate::sync::track_emit::emit_track_insert_in_tx(tx, library_id, &extracted.abs_path, &wire)
-        .await?;
+    crate::sync::track_emit::emit_track_insert_in_tx(
+        tx,
+        library_id,
+        track_id,
+        &extracted.abs_path,
+        &wire,
+    )
+    .await?;
     Ok(())
 }

--- a/src-tauri/crates/app/src/commands/track.rs
+++ b/src-tauri/crates/app/src/commands/track.rs
@@ -514,7 +514,7 @@ pub async fn set_track_rating(
         .await?;
     let file_hash = crate::sync::canonical::file_hash_for_local_track(&mut tx, track_id).await?;
     if let Some(hash) = file_hash {
-        crate::sync::hooks::enqueue_op_in_tx(
+        let stamp = crate::sync::hooks::enqueue_op_in_tx(
             &mut tx,
             &crate::sync::hooks::PendingOpDraft {
                 entity: "track_rating".into(),
@@ -525,6 +525,26 @@ pub async fn set_track_rating(
             },
         )
         .await?;
+        // Phase B.0 — stamp the rating_* mirror columns on the
+        // same track row. The metadata sub-entity ([`super::track`])
+        // owns the regular hlc_*/payload_hash columns; rating runs
+        // in parallel under its own §2 tuple so a metadata edit
+        // and a rating change don't clobber each other on
+        // read-modify-write.
+        if let Some(stamp) = stamp {
+            if let Some(value) = rating {
+                crate::sync::payload::track_rating::stamp_set_in_tx(
+                    &mut tx,
+                    track_id,
+                    i64::from(value),
+                    stamp,
+                )
+                .await?;
+            } else {
+                crate::sync::payload::track_rating::stamp_delete_in_tx(&mut tx, track_id, stamp)
+                    .await?;
+            }
+        }
     }
     tx.commit().await?;
     state.drain.notify();
@@ -653,7 +673,7 @@ pub async fn toggle_like_track(
     // bloats the queue with a like the peer can't resolve anyway.
     if did_change {
         if let Some(hash) = file_hash {
-            crate::sync::hooks::enqueue_op_in_tx(
+            let stamp = crate::sync::hooks::enqueue_op_in_tx(
                 &mut tx,
                 &crate::sync::hooks::PendingOpDraft {
                     entity: "liked_track".into(),
@@ -664,6 +684,17 @@ pub async fn toggle_like_track(
                 },
             )
             .await?;
+            // Phase B.0 — stamp the liked_track row's payload_hash
+            // on insert; on delete the row is already gone, so bump
+            // the digest counter directly.
+            if let Some(stamp) = stamp {
+                if now_liked {
+                    crate::sync::payload::liked_track::stamp_in_tx(&mut tx, track_id, stamp)
+                        .await?;
+                } else {
+                    crate::sync::payload::liked_track::bump_for_delete_in_tx(&mut tx).await?;
+                }
+            }
         }
     }
     tx.commit().await?;

--- a/src-tauri/crates/app/src/sync/payload.rs
+++ b/src-tauri/crates/app/src/sync/payload.rs
@@ -33,6 +33,10 @@ use crate::error::AppResult;
 use crate::sync::hooks::EnqueuedStamp;
 
 pub mod library;
+pub mod liked_track;
+pub mod playlist;
+pub mod track;
+pub mod track_rating;
 
 /// Bump the per-entity counter that `waveflow-server`'s digest
 /// endpoint reads to invalidate its cache (RFC-003 §4 — "every

--- a/src-tauri/crates/app/src/sync/payload/liked_track.rs
+++ b/src-tauri/crates/app/src/sync/payload/liked_track.rs
@@ -1,0 +1,194 @@
+//! Canonical-fields builder + `(hlc, payload_hash)` stamp for the
+//! `liked_track` entity.
+//!
+//! `liked` is a binary state on the server (`apply::liked` in
+//! waveflow-server `src/apply.rs`) — no synced fields beyond the
+//! row identity itself, so the canonical form is just `{}` and the
+//! `payload_hash` distinguishes rows purely by HLC + origin under
+//! the §2 tuple.
+//!
+//! ## Key shape — wire vs row
+//!
+//! On the wire, `entity: "liked_track"` carries `entity_id =
+//! track.file_hash` (the cross-device identity for tracks). On
+//! desktop, `liked_track` is a sibling table keyed on `track_id`
+//! (REFERENCES `track(id)`), so [`stamp_in_tx`] resolves through
+//! the rowid; the caller already knows the track_id at the
+//! enqueue site (`commands/track.rs::toggle_like_track`).
+
+use serde_json::{Map, Value};
+use sqlx::SqliteConnection;
+
+use crate::error::{AppError, AppResult};
+use crate::sync::hooks::EnqueuedStamp;
+use crate::sync::payload::{bump_digest_in_tx, payload_hash};
+
+/// Build the canonical-fields map for a `liked_track` row. Always
+/// empty — see module docs.
+pub fn canonical_fields() -> Map<String, Value> {
+    Map::new()
+}
+
+/// Stamp the `liked_track` row for `track_id` with
+/// `(hlc, origin_device_id, payload_hash)` and bump the local
+/// `metadata_digest_version` counter for `liked_track`.
+///
+/// Must be called AFTER the `INSERT INTO liked_track (track_id, ...)`
+/// (or `INSERT OR IGNORE`'s successful materialisation — caller
+/// gates on `rows_affected() > 0` to skip phantom enqueues; see
+/// `commands/track.rs::toggle_like_track`) and AFTER
+/// [`crate::sync::hooks::enqueue_op_in_tx`] returned `Some(stamp)`.
+pub async fn stamp_in_tx(
+    conn: &mut SqliteConnection,
+    track_id: i64,
+    stamp: EnqueuedStamp,
+) -> AppResult<()> {
+    let hash = payload_hash(&canonical_fields(), stamp);
+    let res = sqlx::query(
+        "UPDATE liked_track
+            SET hlc_wall = ?,
+                hlc_logical = ?,
+                origin_device_id = ?,
+                payload_hash = ?
+          WHERE track_id = ?",
+    )
+    .bind(stamp.hlc_wall)
+    .bind(stamp.hlc_logical)
+    .bind(stamp.origin_device_id.map(|u| u.to_string()))
+    .bind(&hash[..])
+    .bind(track_id)
+    .execute(&mut *conn)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!(
+            "sync::payload::liked_track::stamp_in_tx: no liked_track row matched track_id {track_id}",
+        )));
+    }
+    bump_digest_in_tx(conn, "liked_track").await?;
+    Ok(())
+}
+
+/// Bump-only path for `liked_track` DELETE ops (the user unliked
+/// the track). The row is already gone post-DELETE — there's
+/// nothing to UPDATE — but the digest still has to move so the
+/// set member's removal is visible to the backfill protocol.
+pub async fn bump_for_delete_in_tx(conn: &mut SqliteConnection) -> AppResult<()> {
+    bump_digest_in_tx(conn, "liked_track").await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE liked_track (
+                track_id INTEGER PRIMARY KEY,
+                liked_at INTEGER NOT NULL,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE metadata_digest_version (
+                entity TEXT PRIMARY KEY,
+                version INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO metadata_digest_version (entity, version) VALUES ('liked_track', 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[test]
+    fn canonical_fields_is_empty() {
+        assert_eq!(canonical_fields().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_writes_hash_and_bumps_digest() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("INSERT INTO liked_track (track_id, liked_at) VALUES (42, 1000)")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1_700_000_000_001,
+            hlc_logical: 3,
+            origin_device_id: None,
+        };
+        stamp_in_tx(&mut conn, 42, stamp).await.unwrap();
+
+        let row: (i64, i32, Option<Vec<u8>>) = sqlx::query_as(
+            "SELECT hlc_wall, hlc_logical, payload_hash FROM liked_track WHERE track_id = 42",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1_700_000_000_001);
+        assert_eq!(row.1, 3);
+        assert_eq!(row.2.as_deref().map(|b| b.len()), Some(32));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'liked_track'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_errors_when_row_missing() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        let err = stamp_in_tx(&mut conn, 999, stamp).await.unwrap_err();
+        assert!(format!("{err}").contains("no liked_track row matched track_id 999"));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'liked_track'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 0);
+    }
+
+    #[tokio::test]
+    async fn bump_for_delete_in_tx_increments_digest_only() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        bump_for_delete_in_tx(&mut conn).await.unwrap();
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'liked_track'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+}

--- a/src-tauri/crates/app/src/sync/payload/playlist.rs
+++ b/src-tauri/crates/app/src/sync/payload/playlist.rs
@@ -1,0 +1,250 @@
+//! Canonical-fields builder + `(hlc, payload_hash)` stamp for the
+//! `playlist` entity.
+//!
+//! The field set mirrors the server's
+//! `apply::playlist::canonical_fields` (waveflow-server `src/apply.rs`)
+//! exactly — same key names, same `Value::Null` shape on `None`. The
+//! desktop CRUD path and the server apply pipeline land identical
+//! bytes through `compute_payload_hash` for the same logical state,
+//! so the Phase B backfill diff sees zero spurious "needs re-sync"
+//! rows. Sibling of [`super::library`] — same 4-key shape (name +
+//! opt description + color_id + icon_id), keyed on the playlist's
+//! local rowid.
+
+use serde_json::{Map, Value};
+use sqlx::SqliteConnection;
+use waveflow_core::sync::canon;
+
+use crate::error::{AppError, AppResult};
+use crate::sync::hooks::EnqueuedStamp;
+use crate::sync::payload::{bump_digest_in_tx, payload_hash};
+
+/// Build the canonical-fields map for a `playlist` row. Caller passes
+/// the four synced scalars verbatim — the helper handles the
+/// `Value::Null` vs `Value::String` shape so the `Map<String, Value>`
+/// matches the server byte-for-byte.
+pub fn canonical_fields(
+    name: &str,
+    description: Option<&str>,
+    color_id: &str,
+    icon_id: &str,
+) -> Map<String, Value> {
+    let mut m = Map::new();
+    canon::string(&mut m, "name", name);
+    canon::opt_string(&mut m, "description", description);
+    canon::string(&mut m, "color_id", color_id);
+    canon::string(&mut m, "icon_id", icon_id);
+    m
+}
+
+/// Stamp an INSERT-or-UPDATE on the `playlist` row identified by
+/// `local_id` with `(hlc, origin_device_id, payload_hash)` and bump
+/// the local `metadata_digest_version` counter — all in the
+/// caller's open transaction.
+///
+/// Must be called AFTER the row's data has landed and AFTER
+/// [`crate::sync::hooks::enqueue_op_in_tx`] returned `Some(stamp)`
+/// (the HLC pair in the stamp must match the one the queue row
+/// carries on the wire so a peer computes the same `payload_hash`).
+pub async fn stamp_in_tx(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+    fields: Map<String, Value>,
+    stamp: EnqueuedStamp,
+) -> AppResult<()> {
+    let hash = payload_hash(&fields, stamp);
+    let res = sqlx::query(
+        "UPDATE playlist
+            SET hlc_wall = ?,
+                hlc_logical = ?,
+                origin_device_id = ?,
+                payload_hash = ?
+          WHERE id = ?",
+    )
+    .bind(stamp.hlc_wall)
+    .bind(stamp.hlc_logical)
+    .bind(stamp.origin_device_id.map(|u| u.to_string()))
+    .bind(&hash[..])
+    .bind(local_id)
+    .execute(&mut *conn)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!(
+            "sync::payload::playlist::stamp_in_tx: no playlist row matched id {local_id}",
+        )));
+    }
+    bump_digest_in_tx(conn, "playlist").await?;
+    Ok(())
+}
+
+/// Read back the canonical fields of a `playlist` row via the
+/// caller's open transaction. Defence-in-depth — if the CRUD path
+/// ever gains trim / lowercase / default-substitution normalisation,
+/// the desktop's `payload_hash` would silently diverge from what the
+/// server computes on the same op's payload. Reading back from the
+/// persisted row keeps the contract robust against that drift.
+///
+/// Returns `None` when the row is gone (race with a concurrent
+/// delete, identical handling to the 0-row UPDATE branch above).
+pub async fn fields_from_row(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+) -> AppResult<Option<Map<String, Value>>> {
+    let row: Option<(String, Option<String>, String, String)> = sqlx::query_as(
+        "SELECT name, description, color_id, icon_id FROM playlist WHERE id = ?",
+    )
+    .bind(local_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+    Ok(row.map(|(name, description, color_id, icon_id)| {
+        canonical_fields(&name, description.as_deref(), &color_id, &icon_id)
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE playlist (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                color_id TEXT NOT NULL DEFAULT 'emerald',
+                icon_id TEXT NOT NULL DEFAULT 'music',
+                created_at INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE metadata_digest_version (
+                entity TEXT PRIMARY KEY,
+                version INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO metadata_digest_version (entity, version) VALUES ('playlist', 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[test]
+    fn canonical_fields_has_four_keys_with_explicit_null_on_none() {
+        let m = canonical_fields("Mix", None, "violet", "music");
+        assert_eq!(m.len(), 4);
+        assert_eq!(m.get("name").unwrap(), &Value::String("Mix".into()));
+        assert_eq!(m.get("description").unwrap(), &Value::Null);
+        assert_eq!(m.get("color_id").unwrap(), &Value::String("violet".into()));
+        assert_eq!(m.get("icon_id").unwrap(), &Value::String("music".into()));
+    }
+
+    #[test]
+    fn canonical_fields_matches_server_shape() {
+        let m = canonical_fields("Mix", Some("d"), "violet", "music");
+        let keys: Vec<&String> = m.keys().collect();
+        assert!(keys.iter().any(|k| k.as_str() == "name"));
+        assert!(keys.iter().any(|k| k.as_str() == "description"));
+        assert!(keys.iter().any(|k| k.as_str() == "color_id"));
+        assert!(keys.iter().any(|k| k.as_str() == "icon_id"));
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_writes_hash_and_bumps_digest() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("INSERT INTO playlist (id, name) VALUES (1, 'Mix')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1_700_000_000_001,
+            hlc_logical: 7,
+            origin_device_id: None,
+        };
+        let fields = canonical_fields("Mix", None, "emerald", "music");
+        stamp_in_tx(&mut conn, 1, fields, stamp).await.unwrap();
+
+        let row: (i64, i32, Option<String>, Option<Vec<u8>>) = sqlx::query_as(
+            "SELECT hlc_wall, hlc_logical, origin_device_id, payload_hash FROM playlist WHERE id = 1",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1_700_000_000_001);
+        assert_eq!(row.1, 7);
+        assert_eq!(row.2, None);
+        assert_eq!(row.3.as_deref().map(|b| b.len()), Some(32));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'playlist'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_errors_when_row_missing() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        let fields = canonical_fields("Ghost", None, "emerald", "music");
+        let err = stamp_in_tx(&mut conn, 999, fields, stamp).await.unwrap_err();
+        assert!(format!("{err}").contains("no playlist row matched id 999"));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'playlist'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 0);
+    }
+
+    #[tokio::test]
+    async fn fields_from_row_returns_none_for_missing_row() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        assert!(fields_from_row(&mut conn, 42).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn fields_from_row_reads_persisted_state() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query(
+            "INSERT INTO playlist (id, name, description, color_id, icon_id)
+             VALUES (1, 'Mix', 'desc', 'violet', 'music')",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+        let fields = fields_from_row(&mut conn, 1).await.unwrap().unwrap();
+        assert_eq!(fields, canonical_fields("Mix", Some("desc"), "violet", "music"));
+    }
+}

--- a/src-tauri/crates/app/src/sync/payload/track.rs
+++ b/src-tauri/crates/app/src/sync/payload/track.rs
@@ -1,0 +1,327 @@
+//! Canonical-fields builder + `(hlc, payload_hash)` stamp for the
+//! `track` entity.
+//!
+//! The 18-key field set mirrors the server's
+//! `apply::track::canonical_fields` (waveflow-server `src/apply.rs`,
+//! the block inside `track::insert`) exactly — same key names, same
+//! `Value::Null` shape on `None`, arrays preserve source order. The
+//! Phase B backfill protocol diffs `(canonical_id, payload_hash)`
+//! pairs between server and desktop; any drift here would surface
+//! every track row as a false-positive "needs re-sync".
+//!
+//! ## Why fields come from the wire, not the row
+//!
+//! Unlike [`super::library`] / [`super::playlist`] which read back
+//! from the row in [`fields_from_row`] for defence-in-depth against
+//! future normalisation, track's canonical fields span three tables
+//! (`track`, `album`, `track_artist` → `artist`) and the `artists`
+//! key is a multi-row GROUP_CONCAT. Reading them back would double
+//! the scanner's slow-path latency (one extra SELECT per imported
+//! file). The wire is already constructed by the caller
+//! (`commands/scan.rs::emit_track_insert_from_extracted`,
+//! `commands/edit.rs::update_track_tags`, etc.) and carries the
+//! same values the server will receive over HTTP — trusting the
+//! wire keeps desktop's `payload_hash` byte-identical to whatever
+//! the server computes on its end of the round-trip.
+//!
+//! Net effect: the canonical wire form IS the source of truth for
+//! the hash; the row UPDATE writes back the resulting bytes.
+
+use serde_json::{Map, Value};
+use sqlx::SqliteConnection;
+use waveflow_core::sync::canon;
+
+use crate::error::{AppError, AppResult};
+use crate::sync::hooks::EnqueuedStamp;
+use crate::sync::payload::{bump_digest_in_tx, payload_hash};
+use crate::sync::track_emit::TrackInsertWire;
+
+/// Build the canonical-fields map for a `track` row, sourced from
+/// the same [`TrackInsertWire`] the desktop is about to push to the
+/// server. The 18 keys match the server's `apply::track` block (no
+/// `file_modified` here — that field rides on the wire so a peer
+/// device's scanner fast-path can match by mtime, but it is NOT in
+/// the payload-hash canonical form because the same logical track
+/// re-imported from a copy with a different mtime would otherwise
+/// diverge across devices).
+pub fn canonical_fields_from_wire(wire: &TrackInsertWire<'_>) -> Map<String, Value> {
+    let mut m = Map::new();
+    canon::string(&mut m, "title", wire.title);
+    canon::string(&mut m, "file_hash", wire.file_hash);
+    canon::i64(&mut m, "file_size", wire.file_size);
+    canon::i64(&mut m, "duration_ms", wire.duration_ms);
+    canon::opt_i64(&mut m, "track_number", wire.track_number);
+    canon::opt_i64(&mut m, "disc_number", wire.disc_number);
+    canon::opt_i64(&mut m, "year", wire.year);
+    canon::opt_i64(&mut m, "bitrate", wire.bitrate);
+    canon::opt_i64(&mut m, "sample_rate", wire.sample_rate);
+    canon::opt_i64(&mut m, "channels", wire.channels);
+    canon::opt_i64(&mut m, "bit_depth", wire.bit_depth);
+    canon::opt_string(&mut m, "codec", wire.codec);
+    canon::opt_string(&mut m, "musical_key", wire.musical_key);
+    canon::i64(&mut m, "added_at", wire.added_at);
+    canon::opt_string(&mut m, "album_title", wire.album_title);
+    canon::opt_string(&mut m, "album_artist_name", wire.album_artist_name);
+    canon::bool(&mut m, "is_compilation", wire.is_compilation);
+    canon::strings(&mut m, "artists", wire.artists);
+    m
+}
+
+/// Stamp an INSERT-or-UPDATE on the `track` row identified by
+/// `local_id` (the desktop's `track.id` rowid). Writes
+/// `(hlc, origin_device_id, payload_hash)` onto the regular HLC
+/// columns (the `rating_*` mirror columns are owned by
+/// [`super::track_rating`]) and bumps the local
+/// `metadata_digest_version` counter for `track`.
+///
+/// Must be called AFTER the row's data has landed in
+/// `commands/scan.rs::upsert_track_row` (or `edit.rs::update_track_tags`)
+/// and AFTER [`crate::sync::hooks::enqueue_op_in_tx`] returned
+/// `Some(stamp)`.
+pub async fn stamp_in_tx(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+    fields: Map<String, Value>,
+    stamp: EnqueuedStamp,
+) -> AppResult<()> {
+    let hash = payload_hash(&fields, stamp);
+    let res = sqlx::query(
+        "UPDATE track
+            SET hlc_wall = ?,
+                hlc_logical = ?,
+                origin_device_id = ?,
+                payload_hash = ?
+          WHERE id = ?",
+    )
+    .bind(stamp.hlc_wall)
+    .bind(stamp.hlc_logical)
+    .bind(stamp.origin_device_id.map(|u| u.to_string()))
+    .bind(&hash[..])
+    .bind(local_id)
+    .execute(&mut *conn)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!(
+            "sync::payload::track::stamp_in_tx: no track row matched id {local_id}",
+        )));
+    }
+    bump_digest_in_tx(conn, "track").await?;
+    Ok(())
+}
+
+/// Bump-only path for `track` DELETE ops. The row is already gone
+/// (caller DELETEd it before emitting), so there's nothing to UPDATE
+/// — but the digest still has to reflect that the set member left.
+/// Used by `commands/duplicates.rs::delete_tracks` and
+/// `commands/library.rs::remove_folder_from_library` after their
+/// per-row DELETE FROM track.
+pub async fn bump_for_delete_in_tx(conn: &mut SqliteConnection) -> AppResult<()> {
+    bump_digest_in_tx(conn, "track").await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    fn sample_wire<'a>(artists: &'a [String]) -> TrackInsertWire<'a> {
+        TrackInsertWire {
+            file_hash: "blake3-abc",
+            title: "Get Lucky",
+            file_size: 12_345_678,
+            file_modified: 1_700_000_001_000,
+            duration_ms: 369_000,
+            track_number: Some(8),
+            disc_number: Some(1),
+            year: Some(2013),
+            bitrate: Some(1_411_000),
+            sample_rate: Some(44_100),
+            channels: Some(2),
+            bit_depth: Some(16),
+            codec: Some("flac"),
+            musical_key: Some("F#m"),
+            added_at: 1_700_000_000_000,
+            album_title: Some("Random Access Memories"),
+            album_artist_name: Some("Daft Punk"),
+            is_compilation: false,
+            artists,
+        }
+    }
+
+    async fn pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE track (
+                id INTEGER PRIMARY KEY,
+                file_path TEXT NOT NULL,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE metadata_digest_version (
+                entity TEXT PRIMARY KEY,
+                version INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO metadata_digest_version (entity, version) VALUES ('track', 0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool
+    }
+
+    #[test]
+    fn canonical_fields_from_wire_has_eighteen_keys() {
+        let artists = vec!["Daft Punk".into(), "Pharrell Williams".into()];
+        let m = canonical_fields_from_wire(&sample_wire(&artists));
+        assert_eq!(m.len(), 18);
+        assert!(m.contains_key("title"));
+        assert!(m.contains_key("file_hash"));
+        assert!(m.contains_key("artists"));
+        assert!(m.contains_key("is_compilation"));
+    }
+
+    #[test]
+    fn canonical_fields_excludes_file_modified() {
+        // file_modified rides on the wire (fast-path matching for
+        // peer-device scanners on shared drives) but is NOT in the
+        // canonical payload-hash form — the server's
+        // apply::track block doesn't hash it. Keeping it out here
+        // avoids cross-device hash divergence on identical content
+        // copied with a different mtime.
+        let artists: Vec<String> = vec![];
+        let m = canonical_fields_from_wire(&sample_wire(&artists));
+        assert!(!m.contains_key("file_modified"));
+    }
+
+    #[test]
+    fn canonical_fields_emits_explicit_null_on_missing_optionals() {
+        let artists: Vec<String> = vec![];
+        let wire = TrackInsertWire {
+            file_hash: "h",
+            title: "T",
+            file_size: 1,
+            file_modified: 0,
+            duration_ms: 1,
+            track_number: None,
+            disc_number: None,
+            year: None,
+            bitrate: None,
+            sample_rate: None,
+            channels: None,
+            bit_depth: None,
+            codec: None,
+            musical_key: None,
+            added_at: 0,
+            album_title: None,
+            album_artist_name: None,
+            is_compilation: false,
+            artists: &artists,
+        };
+        let m = canonical_fields_from_wire(&wire);
+        assert_eq!(m.get("album_title").unwrap(), &Value::Null);
+        assert_eq!(m.get("track_number").unwrap(), &Value::Null);
+        assert_eq!(m.get("codec").unwrap(), &Value::Null);
+        assert_eq!(m.get("artists").unwrap().as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn canonical_fields_preserves_artist_order() {
+        // RFC-003 §4 — array source order is preserved through
+        // `canon::strings`. A swap (e.g. featured-artist drift on
+        // re-tag) MUST hash differently so the desktop's apply
+        // pipeline can't silently flip primary/feature artists on
+        // a re-emit.
+        let a = vec!["Tyler".into(), "Earl".into()];
+        let b = vec!["Earl".into(), "Tyler".into()];
+        let ma = canonical_fields_from_wire(&sample_wire(&a));
+        let mb = canonical_fields_from_wire(&sample_wire(&b));
+        assert_ne!(ma.get("artists"), mb.get("artists"));
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_writes_hash_and_bumps_digest() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("INSERT INTO track (id, file_path) VALUES (1, '/m/a.flac')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1_700_000_000_001,
+            hlc_logical: 9,
+            origin_device_id: None,
+        };
+        let artists: Vec<String> = vec!["Daft Punk".into()];
+        let fields = canonical_fields_from_wire(&sample_wire(&artists));
+        stamp_in_tx(&mut conn, 1, fields, stamp).await.unwrap();
+
+        let row: (i64, i32, Option<Vec<u8>>) = sqlx::query_as(
+            "SELECT hlc_wall, hlc_logical, payload_hash FROM track WHERE id = 1",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1_700_000_000_001);
+        assert_eq!(row.1, 9);
+        assert_eq!(row.2.as_deref().map(|b| b.len()), Some(32));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'track'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn stamp_in_tx_errors_when_row_missing() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        let artists: Vec<String> = vec![];
+        let fields = canonical_fields_from_wire(&sample_wire(&artists));
+        let err = stamp_in_tx(&mut conn, 999, fields, stamp).await.unwrap_err();
+        assert!(format!("{err}").contains("no track row matched id 999"));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'track'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 0);
+    }
+
+    #[tokio::test]
+    async fn bump_for_delete_in_tx_increments_digest_only() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        bump_for_delete_in_tx(&mut conn).await.unwrap();
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'track'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+}

--- a/src-tauri/crates/app/src/sync/payload/track_rating.rs
+++ b/src-tauri/crates/app/src/sync/payload/track_rating.rs
@@ -1,0 +1,262 @@
+//! Canonical-fields builder + `(hlc, payload_hash)` stamp for the
+//! `track_rating` entity.
+//!
+//! Server (`apply::rating` in waveflow-server `src/apply.rs`) keeps
+//! `user_track_rating` as a sibling table keyed on
+//! `(user_id, file_hash)` with a single synced field `rating: i64`
+//! (0..=255 POPM range). On desktop the per-profile DB IS the user
+//! scope, so the rating column rides on the same `track` row as the
+//! metadata — under a `rating_` prefix on the HLC + payload_hash
+//! columns so the rating's §2 tuple stays independent of the
+//! metadata-edit tuple. Same physical row, two logical sync
+//! entities; the `metadata_digest_version` table seeds both
+//! `track` and `track_rating` as separate counters in A.3.
+//!
+//! Canonical form: `{"rating": <i64>}` for set ops, empty for delete
+//! (rating cleared). The empty-canonical-on-delete shape matches
+//! the server's "DELETE drops the row, no payload_hash needed"
+//! behaviour — the bump still fires to invalidate the digest.
+
+use serde_json::{Map, Value};
+use sqlx::SqliteConnection;
+use waveflow_core::sync::canon;
+
+use crate::error::{AppError, AppResult};
+use crate::sync::hooks::EnqueuedStamp;
+use crate::sync::payload::{bump_digest_in_tx, payload_hash};
+
+/// Build the canonical-fields map for a `track_rating` set op.
+/// Single key `rating` carrying the POPM-range value the caller is
+/// about to persist.
+pub fn canonical_fields(rating: i64) -> Map<String, Value> {
+    let mut m = Map::new();
+    canon::i64(&mut m, "rating", rating);
+    m
+}
+
+/// Stamp a `track_rating` SET op on the rating-prefixed HLC + hash
+/// columns of `track.id = track_id`, and bump
+/// `metadata_digest_version['track_rating']`. The regular
+/// `hlc_*` + `payload_hash` columns owned by [`super::track`] are
+/// untouched — they track the metadata sub-entity.
+///
+/// Must be called AFTER the `UPDATE track SET rating = ? WHERE id = ?`
+/// has landed and AFTER [`crate::sync::hooks::enqueue_op_in_tx`]
+/// returned `Some(stamp)`.
+pub async fn stamp_set_in_tx(
+    conn: &mut SqliteConnection,
+    track_id: i64,
+    rating: i64,
+    stamp: EnqueuedStamp,
+) -> AppResult<()> {
+    let hash = payload_hash(&canonical_fields(rating), stamp);
+    let res = sqlx::query(
+        "UPDATE track
+            SET rating_hlc_wall = ?,
+                rating_hlc_logical = ?,
+                rating_origin_device_id = ?,
+                rating_payload_hash = ?
+          WHERE id = ?",
+    )
+    .bind(stamp.hlc_wall)
+    .bind(stamp.hlc_logical)
+    .bind(stamp.origin_device_id.map(|u| u.to_string()))
+    .bind(&hash[..])
+    .bind(track_id)
+    .execute(&mut *conn)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!(
+            "sync::payload::track_rating::stamp_set_in_tx: no track row matched id {track_id}",
+        )));
+    }
+    bump_digest_in_tx(conn, "track_rating").await?;
+    Ok(())
+}
+
+/// Stamp a `track_rating` DELETE op on the rating-prefixed columns.
+/// The track row still exists (the rating column itself just went
+/// NULL); we clear the rating_payload_hash to mirror the server's
+/// "DELETE drops the user_track_rating row" shape, but keep the
+/// HLC + origin pair so a future LWW order check against an older
+/// peer write can still resolve.
+pub async fn stamp_delete_in_tx(
+    conn: &mut SqliteConnection,
+    track_id: i64,
+    stamp: EnqueuedStamp,
+) -> AppResult<()> {
+    let res = sqlx::query(
+        "UPDATE track
+            SET rating_hlc_wall = ?,
+                rating_hlc_logical = ?,
+                rating_origin_device_id = ?,
+                rating_payload_hash = NULL
+          WHERE id = ?",
+    )
+    .bind(stamp.hlc_wall)
+    .bind(stamp.hlc_logical)
+    .bind(stamp.origin_device_id.map(|u| u.to_string()))
+    .bind(track_id)
+    .execute(&mut *conn)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!(
+            "sync::payload::track_rating::stamp_delete_in_tx: no track row matched id {track_id}",
+        )));
+    }
+    bump_digest_in_tx(conn, "track_rating").await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE track (
+                id INTEGER PRIMARY KEY,
+                rating INTEGER,
+                rating_hlc_wall INTEGER NOT NULL DEFAULT 0,
+                rating_hlc_logical INTEGER NOT NULL DEFAULT 0,
+                rating_origin_device_id TEXT,
+                rating_payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE metadata_digest_version (
+                entity TEXT PRIMARY KEY,
+                version INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO metadata_digest_version (entity, version) VALUES ('track_rating', 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[test]
+    fn canonical_fields_has_single_rating_key() {
+        let m = canonical_fields(180);
+        assert_eq!(m.len(), 1);
+        assert_eq!(m.get("rating").unwrap(), &Value::from(180));
+    }
+
+    #[tokio::test]
+    async fn stamp_set_in_tx_writes_hash_and_bumps_digest() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("INSERT INTO track (id, rating) VALUES (7, 200)")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1_700_000_000_001,
+            hlc_logical: 4,
+            origin_device_id: None,
+        };
+        stamp_set_in_tx(&mut conn, 7, 200, stamp).await.unwrap();
+
+        let row: (i64, i32, Option<Vec<u8>>) = sqlx::query_as(
+            "SELECT rating_hlc_wall, rating_hlc_logical, rating_payload_hash FROM track WHERE id = 7",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1_700_000_000_001);
+        assert_eq!(row.1, 4);
+        assert_eq!(row.2.as_deref().map(|b| b.len()), Some(32));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'track_rating'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn stamp_delete_in_tx_clears_hash_and_bumps_digest() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query(
+            "INSERT INTO track (id, rating, rating_payload_hash) VALUES (7, 200, X'00112233')",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1_700_000_000_002,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        stamp_delete_in_tx(&mut conn, 7, stamp).await.unwrap();
+
+        let row: (i64, Option<Vec<u8>>) = sqlx::query_as(
+            "SELECT rating_hlc_wall, rating_payload_hash FROM track WHERE id = 7",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1_700_000_000_002);
+        assert!(row.1.is_none(), "rating_payload_hash cleared on delete");
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'track_rating'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn stamp_set_in_tx_errors_when_row_missing() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        let err = stamp_set_in_tx(&mut conn, 999, 50, stamp).await.unwrap_err();
+        assert!(format!("{err}").contains("no track row matched id 999"));
+
+        let v: i64 = sqlx::query_scalar(
+            "SELECT version FROM metadata_digest_version WHERE entity = 'track_rating'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(v, 0);
+    }
+
+    #[tokio::test]
+    async fn stamp_delete_in_tx_errors_when_row_missing() {
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        let stamp = EnqueuedStamp {
+            hlc_wall: 1,
+            hlc_logical: 0,
+            origin_device_id: None,
+        };
+        let err = stamp_delete_in_tx(&mut conn, 999, stamp).await.unwrap_err();
+        assert!(format!("{err}").contains("no track row matched id 999"));
+    }
+}

--- a/src-tauri/crates/app/src/sync/track_emit.rs
+++ b/src-tauri/crates/app/src/sync/track_emit.rs
@@ -105,21 +105,29 @@ pub fn build_track_insert_payload(library_canonical_id: &str, wire: &TrackInsert
     })
 }
 
-/// Resolve the library's canonical id, build the payload, and
-/// enqueue the `track + insert` op. All inside the caller's
-/// transaction so the entity write + outbox row + Lamport bump
-/// either ALL land or ALL roll back.
+/// Resolve the library's canonical id, build the payload, enqueue
+/// the `track + insert` op, AND stamp the local `track` row with
+/// the queued op's HLC + payload_hash. All inside the caller's
+/// transaction so the entity write + outbox row + HLC bump +
+/// `metadata_digest_version` bump either ALL land or ALL roll back.
 ///
-/// Returns `Ok(true)` when the op was enqueued, `Ok(false)` when
-/// the sync gate short-circuited (no JWT for the active profile,
-/// or `SyncMode::Local`). Either way the entity write proceeds —
-/// the boolean is just for telemetry.
+/// `track_id` is the rowid of the `track` row the caller just
+/// inserted or updated — required for the Phase B.0 stamp step.
+/// Used by scanner branches (`commands/scan.rs::emit_track_insert_from_extracted`)
+/// where the track row has already been INSERTed/UPDATEd before
+/// emission.
+///
+/// Returns `Ok(())`; the sync gate short-circuit (no JWT for the
+/// active profile, or `SyncMode::Local`) is handled silently — the
+/// entity write proceeds and the stamp step skips since
+/// `enqueue_op_in_tx` returned `None`.
 pub async fn emit_track_insert_in_tx(
     conn: &mut SqliteConnection,
     library_id: i64,
+    track_id: i64,
     file_path: &str,
     wire: &TrackInsertWire<'_>,
-) -> AppResult<bool> {
+) -> AppResult<()> {
     let library_canonical = canonical::ensure_local_library(conn, library_id).await?;
     let payload = build_track_insert_payload(&library_canonical, wire);
     let stamp = hooks::enqueue_op_in_tx(
@@ -133,7 +141,11 @@ pub async fn emit_track_insert_in_tx(
         },
     )
     .await?;
-    Ok(stamp.is_some())
+    if let Some(stamp) = stamp {
+        let fields = crate::sync::payload::track::canonical_fields_from_wire(wire);
+        crate::sync::payload::track::stamp_in_tx(conn, track_id, fields, stamp).await?;
+    }
+    Ok(())
 }
 
 /// Enqueue a `track + delete` op for a file the user explicitly
@@ -164,7 +176,7 @@ pub async fn emit_track_delete_in_tx(
     conn: &mut SqliteConnection,
     library_id: i64,
     file_path: &str,
-) -> AppResult<bool> {
+) -> AppResult<()> {
     let library_canonical = canonical::ensure_local_library(conn, library_id).await?;
     let payload = serde_json::json!({
         "library_canonical_id": library_canonical,
@@ -180,7 +192,14 @@ pub async fn emit_track_delete_in_tx(
         },
     )
     .await?;
-    Ok(stamp.is_some())
+    // Phase B.0 — the row is already gone (caller DELETEd it
+    // before emitting), so there's nothing to UPDATE — but the
+    // digest still has to move so the backfill protocol observes
+    // the set member's removal.
+    if stamp.is_some() {
+        crate::sync::payload::track::bump_for_delete_in_tx(conn).await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Extends the Phase B.0a pattern (library) to the four remaining profile- + user-scoped entities with row-level `payload_hash`. The desktop's `metadata_digest_version` now reflects every CRUD path on **playlist + track + liked_track + track_rating**, so the upcoming Phase B.1 digest-diff protocol sees a consistent snapshot vs the server's view.

Follows the [`pr-batching-coderabbit-limits` policy](../../../../../#) — instead of three sequential PRs (B.0b/B.0c…), grouped because the pattern is mechanical-repetitive (same `canonical_fields` + `stamp_in_tx` + `fields_from_row` shape across 4 entities, applied to a known set of call sites).

## New modules under `sync/payload/`

| Module | Canonical shape | Key | Notes |
|---|---|---|---|
| `playlist.rs` | 4 keys: name + opt description + color_id + icon_id | rowid | Identical shape to `library`. Includes `fields_from_row` defence-in-depth. |
| `track.rs` | 18 keys (title, file_hash, file_size, duration_ms, track/disc_number, year, audio specs, codec, musical_key, added_at, album_title, album_artist_name, is_compilation, artists[]) | rowid | Sourced from `TrackInsertWire` — wire IS the canonical (re-SELECT would join album + GROUP_CONCAT artists on every scanner row). `file_modified` rides on wire but NOT in canonical (cross-device mtime divergence). |
| `liked_track.rs` | empty `{}` (binary state) | track_id | `bump_for_delete_in_tx` handles post-DELETE bump-only. |
| `track_rating.rs` | 1 key: rating | track.id (mirror cols `rating_*`) | Separate §2 tuple from track metadata so edit + rating don't clobber each other. `stamp_delete_in_tx` clears `rating_payload_hash` to mirror server's `DELETE FROM user_track_rating`. |

## Why `playlist_track` stays unwired

The server's `apply.rs` has **no `canonical_fields` nor `payload_hash` stamping** for `playlist_track` — the A.1.2 migration added the columns but the apply pipeline never populates them (`append_tracks` / `remove_tracks` / `set_position` touch the row without hashing). Bumping the desktop's `playlist_track` digest counter would have no consumer until the server catches up; emitting it now would only create false-positive backfill diffs. Leaving it for the matching server-side PR.

## Call sites wired

| File | Sites | Pattern |
|---|---|---|
| `commands/playlist.rs` | `create_playlist`, `update_playlist`, `delete_playlist` | insert → stamp via `fields_from_row` ; per-field loop → track `last_stamp` then stamp once ; delete → `bump_digest_in_tx` only. The 5 `field: "tracks"` paths skip the stamp (canonical fields don't change with add/remove track — mirrors server). |
| `commands/track.rs` | `set_rating`, `toggle_like_track` | rating set/delete via `stamp_set_in_tx` / `stamp_delete_in_tx` ; like via `liked_track::stamp_in_tx`, unlike via `bump_for_delete_in_tx`. |
| `sync/track_emit.rs` | `emit_track_insert_in_tx`, `emit_track_delete_in_tx` | Insert gains `track_id` param + stamps via `track::stamp_in_tx` post-enqueue. Delete bumps the `track` digest post-enqueue. Return type narrowed from `AppResult<bool>` → `AppResult<()>` (no caller used the bool). |
| `commands/scan.rs` | `emit_track_insert_from_extracted` | Gains `track_id` param; 3 caller branches (skip-fast-path / update / brand-new) pass the local rowid they already had. |

## What this does NOT do

- Does NOT wire `playlist_track` (server has no canonical_fields / payload_hash for it; would be a no-op).
- Does NOT compute the local digest endpoint (Phase B.1).
- Does NOT implement the backfill orchestrator (Phase B.2).
- Does NOT touch the `profile` entity (lives in `app.db`, separate schema, handled later if needed).

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` → **317 passing** (baseline 280 → +37)
- [x] `sync::payload::*` → 34 tests (16 B.0a + 18 new B.0-rest)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Manual smoke: create/rename/delete playlist with a sync-enabled profile; like/unlike a track; set/clear a rating — confirm the corresponding `metadata_digest_version` row bumps in the per-profile DB and the entity row gets a non-NULL `payload_hash`.

## Refs

- RFC-003 §4 (payload_hash canonical form)
- §metadata_digest_version invariant ("bump iff payload_hash actually changes")
- Phase B.0a precedent: #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization consistency for playlist operations, track metadata, ratings, and likes
  * Enhanced reliability of data integrity when syncing changes across devices
  * Fixed synchronization digest updates for deleted playlists and tracks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->