### PR TITLE
feat(sync): rfc-003 phase b.1 — desktop digest client + local vs server diff

### DIFF
--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -197,6 +197,14 @@ pub async fn sync_digest_check(
     state: tauri::State<'_, AppState>,
     entity: Option<String>,
 ) -> AppResult<SyncDigestOutcome> {
+    // Gate 0 — process-wide offline mode. Same short-circuit every
+    // other outbound HTTP path applies (CLAUDE.md cross-cutting
+    // rule); no point building the HTTP client or hitting SQLite
+    // when the user explicitly set `network.offline_mode`.
+    if crate::offline::is_offline() {
+        return Ok(SyncDigestOutcome::Skipped { reason: "offline" });
+    }
+
     // Gate 1 — local-only profile means the digest comparison has
     // no remote to compare against. Surface the same `Skipped`
     // shape the drain task uses so the UI can treat them
@@ -234,6 +242,7 @@ pub async fn sync_digest_check(
     };
 
     let mut reports = Vec::with_capacity(entities.len());
+    let mut skipped_canonical = 0usize;
     for e in entities {
         let canonical_arg = match e {
             "library" | "playlist" | "track" => {
@@ -246,6 +255,7 @@ pub async fn sync_digest_check(
                         entity = e,
                         "digest: profile.canonical_id is NULL — skipping entity",
                     );
+                    skipped_canonical += 1;
                     continue;
                 };
                 Some(canon)
@@ -265,6 +275,17 @@ pub async fn sync_digest_check(
             missing_locally: d.missing_locally.len() as u32,
             missing_remotely: d.missing_remotely.len() as u32,
             divergent: d.divergent.len() as u32,
+        });
+    }
+
+    // If every targeted entity was skipped (caller asked for
+    // profile-scoped entities only, and `profile.canonical_id` is
+    // NULL pending the drain's backfill), `Ran { reports: [] }`
+    // would falsely render as "everything in sync" in the UI.
+    // Promote to `Skipped` so the surface matches reality.
+    if reports.is_empty() && skipped_canonical > 0 {
+        return Ok(SyncDigestOutcome::Skipped {
+            reason: "profile_canonical_id_missing",
         });
     }
 

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -12,8 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{AppError, AppResult},
+    server_client::WaveflowServerClient,
     state::AppState,
-    sync::{device, drain, lamport, mode, queue},
+    sync::{device, digest, drain, lamport, mode, queue},
 };
 
 #[derive(Debug, Serialize)]
@@ -145,4 +146,127 @@ pub async fn sync_set_mode(
 pub async fn sync_drain_now(state: tauri::State<'_, AppState>) -> AppResult<drain::DrainOutcome> {
     let _guard = state.drain_lock.lock().await;
     drain::drain_once(&state).await
+}
+
+/// Per-entity outcome of a digest check pass. Mirrors
+/// [`digest::diff::DigestDiff`] minus the bulk member lists so the
+/// IPC payload stays bounded — the full diff is kept server-side
+/// internally for the future B.2 backfill orchestrator. Counts are
+/// `u32` because the wire never carries more than the row counts
+/// the user actually owns.
+#[derive(Debug, Serialize)]
+pub struct SyncDigestReport {
+    pub entity: String,
+    /// `true` when the server's `set_hash` matches the locally
+    /// recomputed one. Equivalent to `missing_*` + `divergent` all
+    /// being zero, but cheaper for the UI to render.
+    pub in_sync: bool,
+    pub local_version: i64,
+    pub remote_version: i64,
+    pub missing_locally: u32,
+    pub missing_remotely: u32,
+    pub divergent: u32,
+}
+
+/// Status returned to the frontend describing why
+/// [`sync_digest_check`] couldn't talk to the server. Mirrors the
+/// drain task's gating shape so the Settings card can render a
+/// single "All synced / Syncing / Offline" affordance.
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SyncDigestOutcome {
+    /// The active profile is sync-enabled and the digest pass ran.
+    /// `reports` holds one entry per checked entity.
+    Ran { reports: Vec<SyncDigestReport> },
+    /// The active profile isn't sync-enabled (no URL, no JWT, or
+    /// `SyncMode::Local`). Same shape the drain task surfaces as
+    /// `DrainOutcome::Skipped`.
+    Skipped { reason: &'static str },
+}
+
+/// Compute the local digest, fetch the server's digest, and diff
+/// per entity. Used by the Settings UI's "Sync status" card +
+/// future B.2 backfill orchestrator.
+///
+/// `entity` is optional — when omitted the check runs across every
+/// supported entity (`library`, `playlist`, `track`, `liked_track`,
+/// `track_rating`). When supplied, only that one is checked; an
+/// unknown name surfaces as `Err`.
+#[tauri::command]
+pub async fn sync_digest_check(
+    state: tauri::State<'_, AppState>,
+    entity: Option<String>,
+) -> AppResult<SyncDigestOutcome> {
+    // Gate 1 — local-only profile means the digest comparison has
+    // no remote to compare against. Surface the same `Skipped`
+    // shape the drain task uses so the UI can treat them
+    // uniformly.
+    let pool = state.require_profile_pool().await?;
+    if mode::read(&pool).await? == mode::SyncMode::Local {
+        return Ok(SyncDigestOutcome::Skipped {
+            reason: "sync_mode_local",
+        });
+    }
+
+    // Gate 2 — server URL + JWT present.
+    let Some(client) = WaveflowServerClient::try_build(&state).await? else {
+        return Ok(SyncDigestOutcome::Skipped {
+            reason: "not_configured",
+        });
+    };
+
+    // Gate 3 — the profile carries a canonical id; profile-scoped
+    // digest queries require it.
+    let profile_id = state.require_profile_id().await?;
+    let profile_canonical_id =
+        crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
+
+    let entities: Vec<&str> = match entity.as_deref() {
+        Some(e) => {
+            if !digest::SUPPORTED_ENTITIES.contains(&e) {
+                return Err(AppError::Other(format!(
+                    "sync_digest_check: unknown entity '{e}'"
+                )));
+            }
+            vec![e]
+        }
+        None => digest::SUPPORTED_ENTITIES.to_vec(),
+    };
+
+    let mut reports = Vec::with_capacity(entities.len());
+    for e in entities {
+        let canonical_arg = match e {
+            "library" | "playlist" | "track" => {
+                let Some(canon) = profile_canonical_id.as_deref() else {
+                    // Same defer-don't-fail semantic as the drain
+                    // task — without a canonical id the
+                    // profile-scoped query would 400 on the server.
+                    tracing::warn!(
+                        profile_id,
+                        entity = e,
+                        "digest: profile.canonical_id is NULL — skipping entity",
+                    );
+                    continue;
+                };
+                Some(canon)
+            }
+            "liked_track" | "track_rating" => None,
+            _ => continue,
+        };
+
+        let local = digest::read_local_digest(&pool, e).await?;
+        let remote = digest::client::fetch_remote_digest(&client, e, canonical_arg).await?;
+        let d = digest::diff::diff(&local, &remote);
+        reports.push(SyncDigestReport {
+            entity: d.entity,
+            in_sync: d.in_sync,
+            local_version: d.local_version,
+            remote_version: d.remote_version,
+            missing_locally: d.missing_locally.len() as u32,
+            missing_remotely: d.missing_remotely.len() as u32,
+            divergent: d.divergent.len() as u32,
+        });
+    }
+
+    Ok(SyncDigestOutcome::Ran { reports })
 }

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -631,6 +631,7 @@ pub fn run() {
             commands::sync::sync_get_mode,
             commands::sync::sync_set_mode,
             commands::sync::sync_drain_now,
+            commands::sync::sync_digest_check,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,
             commands::preferences::get_minimize_to_tray,

--- a/src-tauri/crates/app/src/sync/digest/client.rs
+++ b/src-tauri/crates/app/src/sync/digest/client.rs
@@ -1,0 +1,231 @@
+//! HTTP client for `GET /api/v1/sync/digest`.
+//!
+//! Returns the server's `DigestResponse` deserialised into local
+//! wire types. The types mirror the server's
+//! `waveflow_server::sync::{DigestResponse, DigestMember, MaxHlc}`
+//! shape (same JSON keys, same `skip_serializing_if = Option::is_none`
+//! on `max_hlc.origin_device_id`). Putting them in
+//! `waveflow-core` would let us share the deserialise types
+//! cross-repo, but the server's copies derive `utoipa::ToSchema`
+//! and the desktop never needs the OpenAPI surface, so private
+//! deserialise structs here keeps `waveflow-core` schema-free.
+//!
+//! ## Scope discipline
+//!
+//! - Profile-scoped entities (`library`, `playlist`, `track`)
+//!   REQUIRE `profile_canonical_id`. The server returns 400
+//!   without it.
+//! - User-scoped entities (`liked_track`, `track_rating`) REJECT
+//!   `profile_canonical_id`. The server returns 400 if it's
+//!   present.
+//!
+//! We mirror that gate here so a typo at the call site fails
+//! locally before the HTTP round-trip.
+
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::server_client::WaveflowServerClient;
+
+/// One `(canonical_id, payload_hash)` pair from the server response.
+/// `payload_hash` is hex-encoded BLAKE3-256 — the diff layer
+/// decodes once before feeding the local set-hash comparison.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RemoteMember {
+    pub canonical_id: String,
+    pub payload_hash: String,
+}
+
+/// The `max_hlc` field of the server response. `Option<Uuid>` is
+/// `None` when no row carries an origin_device_id (every materialised
+/// row predates v2 — Lamport-only era).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RemoteMaxHlc {
+    pub wall: i64,
+    pub logical: i32,
+    #[serde(default)]
+    pub origin_device_id: Option<Uuid>,
+}
+
+/// Top-level response. Mirrors `waveflow_server::sync::DigestResponse`.
+/// `entity` isn't part of the wire shape (the server doesn't echo
+/// the query param back); the diff layer carries it alongside.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RemoteDigest {
+    pub set_hash: String,
+    pub version: i64,
+    #[serde(default)]
+    pub max_hlc: Option<RemoteMaxHlc>,
+    pub members: Vec<RemoteMember>,
+}
+
+/// Fetch the server digest for `entity`.
+///
+/// Profile-scoped entities (`library` / `playlist` / `track`)
+/// require `profile_canonical_id`; user-scoped ones (`liked_track`
+/// / `track_rating`) require it absent. Mismatched pairs short-
+/// circuit with a local error rather than wasting a 400 round-trip.
+pub async fn fetch_remote_digest(
+    client: &WaveflowServerClient,
+    entity: &str,
+    profile_canonical_id: Option<&str>,
+) -> AppResult<RemoteDigest> {
+    validate_scope(entity, profile_canonical_id)?;
+
+    let mut query: Vec<(&str, &str)> = vec![("entity", entity)];
+    if let Some(canon) = profile_canonical_id {
+        query.push(("profile_canonical_id", canon));
+    }
+
+    let response = client
+        .request(reqwest::Method::GET, "/api/v1/sync/digest")
+        .query(&query)
+        .send()
+        .await
+        .map_err(|err| AppError::Other(format!("sync digest GET: {err}")))?;
+
+    let status = response.status();
+    match status {
+        StatusCode::OK => {
+            let digest: RemoteDigest = response.json().await.map_err(|err| {
+                AppError::Other(format!("sync digest deserialise: {err}"))
+            })?;
+            Ok(digest)
+        }
+        StatusCode::NOT_FOUND => Err(AppError::Other(format!(
+            "sync digest GET {entity}: profile_canonical_id not visible to this user",
+        ))),
+        StatusCode::UNAUTHORIZED => Err(AppError::Other(
+            "sync digest GET: unauthorized — JWT expired or revoked".into(),
+        )),
+        StatusCode::BAD_REQUEST => {
+            // Server's body is plain text for the 400 path; surface
+            // it verbatim so a wrong-scope call (caught locally now,
+            // but defence-in-depth) yields a readable error.
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<no body>".into());
+            Err(AppError::Other(format!(
+                "sync digest GET {entity}: bad request — {body}",
+            )))
+        }
+        other => {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<no body>".into());
+            Err(AppError::Other(format!(
+                "sync digest GET {entity}: unexpected status {other} — {body}",
+            )))
+        }
+    }
+}
+
+fn validate_scope(entity: &str, profile_canonical_id: Option<&str>) -> AppResult<()> {
+    match entity {
+        "library" | "playlist" | "track" => {
+            if profile_canonical_id.is_none() {
+                return Err(AppError::Other(format!(
+                    "sync digest {entity}: profile_canonical_id is required",
+                )));
+            }
+        }
+        "liked_track" | "track_rating" => {
+            if profile_canonical_id.is_some() {
+                return Err(AppError::Other(format!(
+                    "sync digest {entity}: profile_canonical_id must be omitted",
+                )));
+            }
+        }
+        other => {
+            return Err(AppError::Other(format!(
+                "sync digest: unknown entity '{other}'",
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_scope_requires_canonical_for_profile_entities() {
+        for e in ["library", "playlist", "track"] {
+            assert!(validate_scope(e, None).is_err(), "{e} without canonical");
+            assert!(validate_scope(e, Some("abc")).is_ok(), "{e} with canonical");
+        }
+    }
+
+    #[test]
+    fn validate_scope_rejects_canonical_for_user_entities() {
+        for e in ["liked_track", "track_rating"] {
+            assert!(
+                validate_scope(e, Some("abc")).is_err(),
+                "{e} with canonical",
+            );
+            assert!(validate_scope(e, None).is_ok(), "{e} without canonical");
+        }
+    }
+
+    #[test]
+    fn validate_scope_rejects_unknown_entity() {
+        assert!(validate_scope("playlist_track", None).is_err());
+        assert!(validate_scope("profile", Some("abc")).is_err());
+    }
+
+    #[test]
+    fn remote_digest_deserialises_full_shape() {
+        let body = serde_json::json!({
+            "set_hash": "deadbeef",
+            "version": 42,
+            "max_hlc": {
+                "wall": 1_700_000_000_000_i64,
+                "logical": 3,
+                "origin_device_id": "11111111-1111-1111-1111-111111111111"
+            },
+            "members": [
+                { "canonical_id": "aaa", "payload_hash": "00aa" },
+                { "canonical_id": "bbb", "payload_hash": "11bb" }
+            ]
+        });
+        let parsed: RemoteDigest = serde_json::from_value(body).unwrap();
+        assert_eq!(parsed.set_hash, "deadbeef");
+        assert_eq!(parsed.version, 42);
+        let max = parsed.max_hlc.unwrap();
+        assert_eq!(max.wall, 1_700_000_000_000);
+        assert_eq!(max.logical, 3);
+        assert!(max.origin_device_id.is_some());
+        assert_eq!(parsed.members.len(), 2);
+    }
+
+    #[test]
+    fn remote_digest_deserialises_with_omitted_max_hlc_and_no_origin() {
+        // Server's `max_hlc.origin_device_id` is
+        // `skip_serializing_if = Option::is_none`, and the whole
+        // `max_hlc` is `Option<MaxHlc>` (None when set is empty).
+        // Both shapes must round-trip through `serde(default)`.
+        let body = serde_json::json!({
+            "set_hash": "abcd",
+            "version": 0,
+            "members": []
+        });
+        let parsed: RemoteDigest = serde_json::from_value(body).unwrap();
+        assert!(parsed.max_hlc.is_none());
+
+        let body2 = serde_json::json!({
+            "set_hash": "abcd",
+            "version": 1,
+            "max_hlc": { "wall": 10, "logical": 0 },
+            "members": [{ "canonical_id": "x", "payload_hash": "00" }]
+        });
+        let parsed2: RemoteDigest = serde_json::from_value(body2).unwrap();
+        let max = parsed2.max_hlc.unwrap();
+        assert_eq!(max.wall, 10);
+        assert!(max.origin_device_id.is_none());
+    }
+}

--- a/src-tauri/crates/app/src/sync/digest/diff.rs
+++ b/src-tauri/crates/app/src/sync/digest/diff.rs
@@ -1,0 +1,299 @@
+//! Local-vs-remote digest comparison.
+//!
+//! Inputs are a [`super::LocalDigest`] (computed by
+//! [`super::read_local_digest`]) and a [`super::client::RemoteDigest`]
+//! (fetched by [`super::client::fetch_remote_digest`]). Output is a
+//! [`DigestDiff`] flagging the rows the two replicas disagree on.
+//!
+//! ## Algorithm
+//!
+//! 1. **Fast path** — compare `set_hash` (hex). Equal hashes mean
+//!    the two sets are identical at the member level. The diff
+//!    short-circuits to "in sync" without walking the lists.
+//! 2. **Member sweep** — both lists are sorted by `canonical_id`
+//!    ASC (the server's `ORDER BY canonical_id` and our matching
+//!    `read_local_digest` queries guarantee it). Two-pointer merge
+//!    classifies each canonical_id as:
+//!    - `MissingLocally` — present on the server, absent locally.
+//!      The backfill (Phase B.2) will pull these.
+//!    - `MissingRemotely` — present locally, absent on the server.
+//!      The backfill will push these.
+//!    - `Divergent` — same canonical_id, different `payload_hash`.
+//!      The backfill picks the LWW winner via §2 total order
+//!      (HLC + origin_device_id, not in this struct yet).
+//!
+//! The version + max_hlc deltas ride alongside for the Settings
+//! UI status surface (Phase B.3).
+
+use serde::Serialize;
+
+use super::client::{RemoteDigest, RemoteMember};
+use super::LocalDigest;
+
+/// Classification of one canonical_id-keyed disagreement.
+#[derive(Debug, Clone, Serialize)]
+pub struct DivergentMember {
+    pub canonical_id: String,
+    /// Hex-encoded local `payload_hash`. Empty when the member is
+    /// absent locally (the variant communicates direction; the
+    /// hash field stays present for a uniform JSON shape consumed
+    /// by the Settings UI).
+    pub local_payload_hash: String,
+    /// Hex-encoded remote `payload_hash`. Empty when absent remotely.
+    pub remote_payload_hash: String,
+}
+
+/// Summary returned by [`diff`]. Empty `Vec`s + `in_sync = true`
+/// when the two replicas agree.
+#[derive(Debug, Clone, Serialize)]
+pub struct DigestDiff {
+    pub entity: String,
+    pub in_sync: bool,
+    pub local_version: i64,
+    pub remote_version: i64,
+    /// `(canonical_id, remote_payload_hash)` pairs the server has
+    /// but the desktop doesn't.
+    pub missing_locally: Vec<RemoteMember>,
+    /// `(canonical_id, local_payload_hash hex)` pairs the desktop
+    /// has but the server doesn't.
+    pub missing_remotely: Vec<DivergentMember>,
+    /// Same canonical_id, different payload_hash.
+    pub divergent: Vec<DivergentMember>,
+}
+
+/// Diff a local digest against the matching server response.
+///
+/// `local.entity` is echoed onto the output; the function does not
+/// re-validate that `remote` corresponds to the same entity
+/// (the caller fetches one after computing the other against the
+/// same `entity` arg).
+pub fn diff(local: &LocalDigest, remote: &RemoteDigest) -> DigestDiff {
+    let local_set_hex = hex::encode(local.set_hash);
+    if local_set_hex == remote.set_hash {
+        return DigestDiff {
+            entity: local.entity.clone(),
+            in_sync: true,
+            local_version: local.version,
+            remote_version: remote.version,
+            missing_locally: Vec::new(),
+            missing_remotely: Vec::new(),
+            divergent: Vec::new(),
+        };
+    }
+
+    let mut missing_locally = Vec::new();
+    let mut missing_remotely = Vec::new();
+    let mut divergent = Vec::new();
+
+    let mut li = 0usize;
+    let mut ri = 0usize;
+    let locals = &local.members;
+    let remotes = &remote.members;
+
+    while li < locals.len() && ri < remotes.len() {
+        let l = &locals[li];
+        let r = &remotes[ri];
+        match l.canonical_id.as_str().cmp(r.canonical_id.as_str()) {
+            std::cmp::Ordering::Equal => {
+                let local_hex = hex::encode(&l.payload_hash);
+                if local_hex != r.payload_hash {
+                    divergent.push(DivergentMember {
+                        canonical_id: l.canonical_id.clone(),
+                        local_payload_hash: local_hex,
+                        remote_payload_hash: r.payload_hash.clone(),
+                    });
+                }
+                li += 1;
+                ri += 1;
+            }
+            std::cmp::Ordering::Less => {
+                // Local has a canonical the server doesn't — push
+                // candidate.
+                missing_remotely.push(DivergentMember {
+                    canonical_id: l.canonical_id.clone(),
+                    local_payload_hash: hex::encode(&l.payload_hash),
+                    remote_payload_hash: String::new(),
+                });
+                li += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                missing_locally.push(r.clone());
+                ri += 1;
+            }
+        }
+    }
+    while li < locals.len() {
+        let l = &locals[li];
+        missing_remotely.push(DivergentMember {
+            canonical_id: l.canonical_id.clone(),
+            local_payload_hash: hex::encode(&l.payload_hash),
+            remote_payload_hash: String::new(),
+        });
+        li += 1;
+    }
+    while ri < remotes.len() {
+        missing_locally.push(remotes[ri].clone());
+        ri += 1;
+    }
+
+    DigestDiff {
+        entity: local.entity.clone(),
+        in_sync: false,
+        local_version: local.version,
+        remote_version: remote.version,
+        missing_locally,
+        missing_remotely,
+        divergent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::digest::LocalMember;
+
+    fn local(entity: &str, members: Vec<(&str, &str)>, version: i64) -> LocalDigest {
+        let members: Vec<LocalMember> = members
+            .into_iter()
+            .map(|(id, hash_hex)| LocalMember {
+                canonical_id: id.to_string(),
+                payload_hash: hex::decode(hash_hex).unwrap(),
+            })
+            .collect();
+        // Compute set_hash from members so the equality fast-path
+        // mirrors what `read_local_digest` would produce.
+        let pairs: Vec<(&str, &[u8])> = members
+            .iter()
+            .map(|m| (m.canonical_id.as_str(), m.payload_hash.as_slice()))
+            .collect();
+        let set_hash = waveflow_core::sync::digest::compute_set_hash(&pairs);
+        LocalDigest {
+            entity: entity.to_string(),
+            set_hash,
+            version,
+            max_hlc: None,
+            members,
+        }
+    }
+
+    fn remote(set_hash: &str, members: Vec<(&str, &str)>, version: i64) -> RemoteDigest {
+        RemoteDigest {
+            set_hash: set_hash.to_string(),
+            version,
+            max_hlc: None,
+            members: members
+                .into_iter()
+                .map(|(id, hash)| RemoteMember {
+                    canonical_id: id.to_string(),
+                    payload_hash: hash.to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn matching_set_hash_short_circuits_to_in_sync() {
+        let l = local("library", vec![("aaa", "0011223344")], 1);
+        let r = remote(&hex::encode(l.set_hash), vec![("aaa", "0011223344")], 1);
+        let d = diff(&l, &r);
+        assert!(d.in_sync);
+        assert!(d.missing_locally.is_empty());
+        assert!(d.missing_remotely.is_empty());
+        assert!(d.divergent.is_empty());
+        assert_eq!(d.local_version, 1);
+        assert_eq!(d.remote_version, 1);
+    }
+
+    #[test]
+    fn missing_locally_flagged_when_server_has_extra() {
+        // Local empty, server has one row.
+        let l = local("library", vec![], 0);
+        let r = remote("ffff", vec![("aaa", "00aa")], 1);
+        let d = diff(&l, &r);
+        assert!(!d.in_sync);
+        assert_eq!(d.missing_locally.len(), 1);
+        assert_eq!(d.missing_locally[0].canonical_id, "aaa");
+        assert!(d.missing_remotely.is_empty());
+        assert!(d.divergent.is_empty());
+    }
+
+    #[test]
+    fn missing_remotely_flagged_when_desktop_has_extra() {
+        let l = local("library", vec![("zzz", "00bb")], 1);
+        let r = remote("ffff", vec![], 0);
+        let d = diff(&l, &r);
+        assert!(!d.in_sync);
+        assert_eq!(d.missing_remotely.len(), 1);
+        assert_eq!(d.missing_remotely[0].canonical_id, "zzz");
+        assert!(d.missing_locally.is_empty());
+        assert!(d.divergent.is_empty());
+    }
+
+    #[test]
+    fn divergent_flagged_when_same_id_different_hash() {
+        let l = local("library", vec![("aaa", "0011")], 1);
+        let r = remote("ffff", vec![("aaa", "0099")], 1);
+        let d = diff(&l, &r);
+        assert!(!d.in_sync);
+        assert_eq!(d.divergent.len(), 1);
+        assert_eq!(d.divergent[0].canonical_id, "aaa");
+        assert_eq!(d.divergent[0].local_payload_hash, "0011");
+        assert_eq!(d.divergent[0].remote_payload_hash, "0099");
+    }
+
+    #[test]
+    fn mixed_diff_correctly_classifies_each_canonical() {
+        // local: {alpha:01, gamma:02, mike:03}
+        // remote: {beta:0b, gamma:0c, mike:03, zulu:0d}
+        // → divergent: gamma (02 vs 0c)
+        //   in sync: mike (03 == 03)
+        //   missing_remotely: alpha
+        //   missing_locally: beta, zulu
+        let l = local(
+            "library",
+            vec![("alpha", "01"), ("gamma", "02"), ("mike", "03")],
+            5,
+        );
+        let r = remote(
+            "ffff",
+            vec![("beta", "0b"), ("gamma", "0c"), ("mike", "03"), ("zulu", "0d")],
+            7,
+        );
+        let d = diff(&l, &r);
+        assert!(!d.in_sync);
+        assert_eq!(d.local_version, 5);
+        assert_eq!(d.remote_version, 7);
+
+        let mr_ids: Vec<&str> = d
+            .missing_remotely
+            .iter()
+            .map(|m| m.canonical_id.as_str())
+            .collect();
+        assert_eq!(mr_ids, vec!["alpha"]);
+
+        let ml_ids: Vec<&str> = d
+            .missing_locally
+            .iter()
+            .map(|m| m.canonical_id.as_str())
+            .collect();
+        assert_eq!(ml_ids, vec!["beta", "zulu"]);
+
+        assert_eq!(d.divergent.len(), 1);
+        assert_eq!(d.divergent[0].canonical_id, "gamma");
+    }
+
+    #[test]
+    fn matching_members_with_mismatched_set_hash_still_diff_clean() {
+        // Edge: somehow set_hash mismatch (corruption / wire bug)
+        // but the per-row data agrees. The slow path still walks
+        // and finds zero disagreements; in_sync stays false to
+        // surface the metadata-level drift to the operator.
+        let l = local("library", vec![("aaa", "01")], 1);
+        let r = remote("ffff", vec![("aaa", "01")], 1);
+        let d = diff(&l, &r);
+        assert!(!d.in_sync);
+        assert!(d.missing_locally.is_empty());
+        assert!(d.missing_remotely.is_empty());
+        assert!(d.divergent.is_empty());
+    }
+}

--- a/src-tauri/crates/app/src/sync/digest/mod.rs
+++ b/src-tauri/crates/app/src/sync/digest/mod.rs
@@ -1,0 +1,668 @@
+//! Local-side digest computation, mirror of the server's
+//! `GET /api/v1/sync/digest` (RFC-003 §4 / `waveflow-server`
+//! `src/db.rs::digest_read`).
+//!
+//! For each synced entity the digest is `(set_hash, version,
+//! max_hlc, members)` where:
+//!
+//! - `set_hash` is BLAKE3 over the sorted `(canonical_id,
+//!   payload_hash)` pairs (see [`waveflow_core::sync::digest`] for
+//!   the shared algorithm).
+//! - `version` is the monotone counter from
+//!   `metadata_digest_version` that B.0a/B.0-rest bumps on every
+//!   row-level change.
+//! - `max_hlc` is the highest §2 total-order triple across the
+//!   non-NULL `payload_hash` rows (the same filter the server
+//!   applies — rows whose hash hasn't been stamped yet stay out
+//!   of the set).
+//! - `members` is the sorted list itself, kept around so the
+//!   diff layer ([`diff`]) can identify which rows differ once a
+//!   `set_hash` mismatch has flagged divergence.
+//!
+//! ## Per-entity SQL shape
+//!
+//! Mirrors the server's `db::digest_read::members_*` exactly:
+//!
+//! | Entity         | Source table       | Canonical id                                | Sort by                  |
+//! |----------------|--------------------|---------------------------------------------|--------------------------|
+//! | `library`      | `library`          | `library.canonical_id`                      | `canonical_id`           |
+//! | `playlist`     | `playlist`         | `playlist.canonical_id`                     | `canonical_id`           |
+//! | `track`        | `track + library`  | `format!("{lib_canonical}\\u{{1F}}{file_path}")` | `(lib_canonical, file_path)` |
+//! | `liked_track`  | `liked_track + track` | `track.file_hash`                        | `file_hash`              |
+//! | `track_rating` | `track`            | `track.file_hash`                           | `file_hash`              |
+//!
+//! For `track_rating` we read the `rating_*` mirror column quartet
+//! co-located on the `track` row (the desktop holds the rating as a
+//! column rather than a sibling table — see the A.3 migration
+//! header). `liked_track` joins back to `track` for the file_hash
+//! because the local table is keyed on `track_id`.
+//!
+//! ## Filters mirror the server
+//!
+//! - `payload_hash IS NOT NULL` — rows that pre-date B.0 stamping
+//!   are excluded so a partial-backfill desktop doesn't disagree
+//!   with the server on the set membership.
+//! - For profile-scoped entities, `canonical_id IS NOT NULL` —
+//!   defensive against a row that lost its mapping (shouldn't
+//!   happen post-1.f.desktop.4b, but the filter keeps the
+//!   invariant explicit).
+
+pub mod client;
+pub mod diff;
+
+use serde::Serialize;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+use waveflow_core::sync::digest as core_digest;
+
+use crate::error::{AppError, AppResult};
+
+/// One member of the local digest, raw-bytes form so the
+/// `set_hash` feed runs without a round-trip through hex.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LocalMember {
+    pub canonical_id: String,
+    /// Raw BLAKE3-256 bytes from the row's `payload_hash` column.
+    /// Encoded to hex only when crossing the diff boundary against
+    /// the server's response.
+    #[serde(serialize_with = "serialize_bytes_hex")]
+    pub payload_hash: Vec<u8>,
+}
+
+/// The local mirror of the server's `MaxHlc` triple. `None` when
+/// the entity set is empty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct MaxHlcLocal {
+    pub wall: i64,
+    pub logical: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin_device_id: Option<Uuid>,
+}
+
+/// Output of [`read_local_digest`] — same shape as the server's
+/// `DigestResponse` modulo internal representation (raw bytes vs
+/// hex strings). The diff layer compares against the deserialised
+/// server response in [`client::RemoteDigest`].
+#[derive(Debug, Clone, Serialize)]
+pub struct LocalDigest {
+    pub entity: String,
+    #[serde(serialize_with = "serialize_array_hex")]
+    pub set_hash: [u8; 32],
+    pub version: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_hlc: Option<MaxHlcLocal>,
+    pub members: Vec<LocalMember>,
+}
+
+fn serialize_bytes_hex<S: serde::Serializer>(
+    bytes: &Vec<u8>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&hex::encode(bytes))
+}
+
+fn serialize_array_hex<S: serde::Serializer>(
+    bytes: &[u8; 32],
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&hex::encode(bytes))
+}
+
+/// Whitelist of entities the digest endpoint accepts on either
+/// side. Same set the server's API layer matches in
+/// `api::sync::get_digest`. `playlist_track` is deliberately out —
+/// the server has no `canonical_fields`/`payload_hash` stamping
+/// for it (see Phase B.0-rest memory entry).
+pub const SUPPORTED_ENTITIES: &[&str] = &[
+    "library",
+    "playlist",
+    "track",
+    "liked_track",
+    "track_rating",
+];
+
+/// Read the local digest for `entity` from the active profile's
+/// SQLite pool. Returns `Err` for unknown entities so a caller
+/// typo surfaces instead of silently producing an empty set.
+pub async fn read_local_digest(pool: &SqlitePool, entity: &str) -> AppResult<LocalDigest> {
+    let (members, max_hlc) = match entity {
+        "library" => read_library_members(pool).await?,
+        "playlist" => read_playlist_members(pool).await?,
+        "track" => read_track_members(pool).await?,
+        "liked_track" => read_liked_members(pool).await?,
+        "track_rating" => read_rating_members(pool).await?,
+        other => {
+            return Err(AppError::Other(format!(
+                "sync::digest::read_local_digest: unknown entity '{other}'",
+            )))
+        }
+    };
+    let version = read_version(pool, entity).await?;
+    let set_hash = compute_set_hash_from(&members);
+    Ok(LocalDigest {
+        entity: entity.to_string(),
+        set_hash,
+        version,
+        max_hlc,
+        members,
+    })
+}
+
+/// Read the monotone counter for `entity` from
+/// `metadata_digest_version`. Missing rows surface as `0` to match
+/// the server's `unwrap_or(0)` behaviour — both replicas treat
+/// "no row yet" as version 0.
+async fn read_version(pool: &SqlitePool, entity: &str) -> AppResult<i64> {
+    let row: Option<i64> =
+        sqlx::query_scalar("SELECT version FROM metadata_digest_version WHERE entity = ?")
+            .bind(entity)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.unwrap_or(0))
+}
+
+/// Build the BLAKE3 feed from the local members. Cheap zero-copy
+/// pairs — the helper just borrows.
+fn compute_set_hash_from(members: &[LocalMember]) -> [u8; 32] {
+    let pairs: Vec<(&str, &[u8])> = members
+        .iter()
+        .map(|m| (m.canonical_id.as_str(), m.payload_hash.as_slice()))
+        .collect();
+    core_digest::compute_set_hash(&pairs)
+}
+
+// ── Per-entity readers ────────────────────────────────────────────
+
+async fn read_library_members(
+    pool: &SqlitePool,
+) -> AppResult<(Vec<LocalMember>, Option<MaxHlcLocal>)> {
+    let rows: Vec<(String, Vec<u8>, i64, i32, Option<String>)> = sqlx::query_as(
+        "SELECT canonical_id, payload_hash, hlc_wall, hlc_logical, origin_device_id
+           FROM library
+          WHERE canonical_id IS NOT NULL
+            AND payload_hash IS NOT NULL
+          ORDER BY canonical_id ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(collect_simple_members(rows))
+}
+
+async fn read_playlist_members(
+    pool: &SqlitePool,
+) -> AppResult<(Vec<LocalMember>, Option<MaxHlcLocal>)> {
+    let rows: Vec<(String, Vec<u8>, i64, i32, Option<String>)> = sqlx::query_as(
+        "SELECT canonical_id, payload_hash, hlc_wall, hlc_logical, origin_device_id
+           FROM playlist
+          WHERE canonical_id IS NOT NULL
+            AND payload_hash IS NOT NULL
+          ORDER BY canonical_id ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(collect_simple_members(rows))
+}
+
+async fn read_track_members(
+    pool: &SqlitePool,
+) -> AppResult<(Vec<LocalMember>, Option<MaxHlcLocal>)> {
+    // Mirror `db::digest_read::track_members` — composite
+    // canonical key is `<library.canonical_id>\u{1F}<track.file_path>`.
+    // The U+001F separator is illegal in real filesystem paths, so
+    // the split round-trips uniquely on the diff side.
+    let rows: Vec<(String, String, Vec<u8>, i64, i32, Option<String>)> = sqlx::query_as(
+        "SELECT l.canonical_id, t.file_path, t.payload_hash, t.hlc_wall, t.hlc_logical, t.origin_device_id
+           FROM track t
+           JOIN library l ON l.id = t.library_id
+          WHERE l.canonical_id IS NOT NULL
+            AND t.payload_hash IS NOT NULL
+          ORDER BY l.canonical_id ASC, t.file_path ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    let mut members = Vec::with_capacity(rows.len());
+    let mut max: Option<(i64, i32, Option<Uuid>)> = None;
+    for (lib_canonical, file_path, payload_hash, hlc_wall, hlc_logical, origin) in rows {
+        let composite = format!("{lib_canonical}\u{001F}{file_path}");
+        members.push(LocalMember {
+            canonical_id: composite,
+            payload_hash,
+        });
+        update_max(&mut max, hlc_wall, hlc_logical, origin.as_deref());
+    }
+    Ok((members, max.map(into_local_max)))
+}
+
+async fn read_liked_members(
+    pool: &SqlitePool,
+) -> AppResult<(Vec<LocalMember>, Option<MaxHlcLocal>)> {
+    // The desktop's `liked_track` is keyed on `track_id`. The
+    // server's digest emits `track.file_hash` as the canonical id,
+    // so we join back.
+    let rows: Vec<(String, Vec<u8>, i64, i32, Option<String>)> = sqlx::query_as(
+        "SELECT t.file_hash, lt.payload_hash, lt.hlc_wall, lt.hlc_logical, lt.origin_device_id
+           FROM liked_track lt
+           JOIN track t ON t.id = lt.track_id
+          WHERE lt.payload_hash IS NOT NULL
+          ORDER BY t.file_hash ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(collect_simple_members(rows))
+}
+
+async fn read_rating_members(
+    pool: &SqlitePool,
+) -> AppResult<(Vec<LocalMember>, Option<MaxHlcLocal>)> {
+    // The rating quartet (`rating_hlc_wall` / `rating_hlc_logical` /
+    // `rating_origin_device_id` / `rating_payload_hash`) is co-
+    // located on the same `track` row as the metadata HLC — see
+    // the A.3 migration header.
+    let rows: Vec<(String, Vec<u8>, i64, i32, Option<String>)> = sqlx::query_as(
+        "SELECT file_hash, rating_payload_hash, rating_hlc_wall, rating_hlc_logical, rating_origin_device_id
+           FROM track
+          WHERE rating_payload_hash IS NOT NULL
+          ORDER BY file_hash ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(collect_simple_members(rows))
+}
+
+fn collect_simple_members(
+    rows: Vec<(String, Vec<u8>, i64, i32, Option<String>)>,
+) -> (Vec<LocalMember>, Option<MaxHlcLocal>) {
+    let mut members = Vec::with_capacity(rows.len());
+    let mut max: Option<(i64, i32, Option<Uuid>)> = None;
+    for (canonical_id, payload_hash, hlc_wall, hlc_logical, origin) in rows {
+        members.push(LocalMember {
+            canonical_id,
+            payload_hash,
+        });
+        update_max(&mut max, hlc_wall, hlc_logical, origin.as_deref());
+    }
+    (members, max.map(into_local_max))
+}
+
+fn update_max(
+    current: &mut Option<(i64, i32, Option<Uuid>)>,
+    wall: i64,
+    logical: i32,
+    origin: Option<&str>,
+) {
+    // A bad UUID string in the row is treated as `None` — same as
+    // server's `Option<Uuid>` fetch which would surface a sqlx
+    // decode error. We swallow + log so a single corrupt row
+    // doesn't take the whole digest down; the row stays out of
+    // the max_hlc tuple but still contributes to set_hash.
+    let parsed = match origin {
+        Some(s) => match Uuid::parse_str(s) {
+            Ok(u) => Some(u),
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    value = s,
+                    "digest: ignoring malformed origin_device_id",
+                );
+                None
+            }
+        },
+        None => None,
+    };
+    let candidate = (wall, logical, parsed);
+    match current {
+        Some(curr) if *curr >= candidate => {}
+        _ => *current = Some(candidate),
+    }
+}
+
+fn into_local_max((wall, logical, origin_device_id): (i64, i32, Option<Uuid>)) -> MaxHlcLocal {
+    MaxHlcLocal {
+        wall,
+        logical,
+        origin_device_id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        // Minimal schema covering every entity the digest reads.
+        sqlx::query(
+            "CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                canonical_id TEXT,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE playlist (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                canonical_id TEXT,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE track (
+                id INTEGER PRIMARY KEY,
+                library_id INTEGER NOT NULL,
+                file_path TEXT NOT NULL,
+                file_hash TEXT NOT NULL,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB,
+                rating_hlc_wall INTEGER NOT NULL DEFAULT 0,
+                rating_hlc_logical INTEGER NOT NULL DEFAULT 0,
+                rating_origin_device_id TEXT,
+                rating_payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE liked_track (
+                track_id INTEGER PRIMARY KEY,
+                liked_at INTEGER NOT NULL,
+                hlc_wall INTEGER NOT NULL DEFAULT 0,
+                hlc_logical INTEGER NOT NULL DEFAULT 0,
+                origin_device_id TEXT,
+                payload_hash BLOB
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE metadata_digest_version (
+                entity TEXT PRIMARY KEY,
+                version INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        for e in SUPPORTED_ENTITIES {
+            sqlx::query("INSERT INTO metadata_digest_version (entity, version) VALUES (?, 0)")
+                .bind(e)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+        pool
+    }
+
+    fn h(byte: u8) -> Vec<u8> {
+        vec![byte; 32]
+    }
+
+    #[tokio::test]
+    async fn read_library_empty_returns_zero_version_and_no_max_hlc() {
+        let pool = pool().await;
+        let d = read_local_digest(&pool, "library").await.unwrap();
+        assert_eq!(d.entity, "library");
+        assert_eq!(d.version, 0);
+        assert!(d.members.is_empty());
+        assert!(d.max_hlc.is_none());
+        // Empty set hash matches the empty BLAKE3 digest (same
+        // sanity assertion as the core test).
+        assert_eq!(
+            hex::encode(d.set_hash),
+            "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        );
+    }
+
+    #[tokio::test]
+    async fn read_library_returns_sorted_members_and_max_hlc() {
+        let pool = pool().await;
+        // Two rows with deliberately reversed canonical_id ASC
+        // ordering vs insert order — the SQL ORDER BY has to
+        // dominate, otherwise the set_hash would mismatch the
+        // server's.
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, hlc_wall, hlc_logical, origin_device_id, payload_hash)
+             VALUES (1, 'B', 'zzz', 10, 1, NULL, ?)",
+        )
+        .bind(h(0xBB))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, hlc_wall, hlc_logical, origin_device_id, payload_hash)
+             VALUES (2, 'A', 'aaa', 20, 5, NULL, ?)",
+        )
+        .bind(h(0xAA))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE metadata_digest_version SET version = 7 WHERE entity = 'library'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let d = read_local_digest(&pool, "library").await.unwrap();
+        assert_eq!(d.version, 7);
+        assert_eq!(d.members.len(), 2);
+        assert_eq!(d.members[0].canonical_id, "aaa");
+        assert_eq!(d.members[1].canonical_id, "zzz");
+        // max_hlc is (20, 5, None) — strictly greater than (10, 1, None).
+        let max = d.max_hlc.expect("max_hlc present with members");
+        assert_eq!(max.wall, 20);
+        assert_eq!(max.logical, 5);
+        assert_eq!(max.origin_device_id, None);
+    }
+
+    #[tokio::test]
+    async fn read_library_skips_rows_missing_canonical_or_payload_hash() {
+        let pool = pool().await;
+        // canonical_id NULL — excluded.
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, payload_hash)
+             VALUES (1, 'X', NULL, ?)",
+        )
+        .bind(h(0x11))
+        .execute(&pool)
+        .await
+        .unwrap();
+        // payload_hash NULL — excluded.
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, payload_hash)
+             VALUES (2, 'Y', 'yyy', NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        // Both present — included.
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, payload_hash)
+             VALUES (3, 'Z', 'zzz', ?)",
+        )
+        .bind(h(0x33))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let d = read_local_digest(&pool, "library").await.unwrap();
+        assert_eq!(d.members.len(), 1);
+        assert_eq!(d.members[0].canonical_id, "zzz");
+    }
+
+    #[tokio::test]
+    async fn read_track_uses_composite_canonical_key() {
+        let pool = pool().await;
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, payload_hash)
+             VALUES (1, 'L', 'lib-canon-uuid', ?)",
+        )
+        .bind(h(0xAA))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO track (id, library_id, file_path, file_hash, payload_hash)
+             VALUES (1, 1, '/music/a.flac', 'hash-a', ?)",
+        )
+        .bind(h(0x01))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let d = read_local_digest(&pool, "track").await.unwrap();
+        assert_eq!(d.members.len(), 1);
+        assert_eq!(
+            d.members[0].canonical_id,
+            "lib-canon-uuid\u{001F}/music/a.flac"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_track_skips_rows_whose_library_lacks_canonical() {
+        let pool = pool().await;
+        // Library without canonical_id — track is excluded even if
+        // payload_hash is set.
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, payload_hash)
+             VALUES (1, 'L', NULL, ?)",
+        )
+        .bind(h(0xAA))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO track (id, library_id, file_path, file_hash, payload_hash)
+             VALUES (1, 1, '/music/a.flac', 'hash-a', ?)",
+        )
+        .bind(h(0x01))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let d = read_local_digest(&pool, "track").await.unwrap();
+        assert!(d.members.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_liked_track_joins_back_to_file_hash() {
+        let pool = pool().await;
+        sqlx::query("INSERT INTO library (id, name, canonical_id) VALUES (1, 'L', 'lib')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO track (id, library_id, file_path, file_hash)
+             VALUES (1, 1, '/a.flac', 'hash-a')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO liked_track (track_id, liked_at, payload_hash)
+             VALUES (1, 1000, ?)",
+        )
+        .bind(h(0xCC))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let d = read_local_digest(&pool, "liked_track").await.unwrap();
+        assert_eq!(d.members.len(), 1);
+        assert_eq!(d.members[0].canonical_id, "hash-a");
+    }
+
+    #[tokio::test]
+    async fn read_track_rating_uses_rating_payload_hash_column() {
+        let pool = pool().await;
+        sqlx::query("INSERT INTO library (id, name, canonical_id) VALUES (1, 'L', 'lib')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO track (id, library_id, file_path, file_hash, rating_payload_hash, rating_hlc_wall, rating_hlc_logical)
+             VALUES (1, 1, '/a.flac', 'hash-a', ?, 42, 0)",
+        )
+        .bind(h(0xDD))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let d = read_local_digest(&pool, "track_rating").await.unwrap();
+        assert_eq!(d.members.len(), 1);
+        assert_eq!(d.members[0].canonical_id, "hash-a");
+        let max = d.max_hlc.expect("rating max_hlc present");
+        assert_eq!(max.wall, 42);
+    }
+
+    #[tokio::test]
+    async fn read_track_rating_ignores_rows_without_rating_hash() {
+        // Track with metadata payload_hash but no rating_payload_hash —
+        // doesn't contribute to the rating set.
+        let pool = pool().await;
+        sqlx::query("INSERT INTO library (id, name, canonical_id) VALUES (1, 'L', 'lib')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO track (id, library_id, file_path, file_hash, payload_hash, rating_payload_hash)
+             VALUES (1, 1, '/a.flac', 'hash-a', ?, NULL)",
+        )
+        .bind(h(0x01))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let d = read_local_digest(&pool, "track_rating").await.unwrap();
+        assert!(d.members.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_entity_errors_with_typo_friendly_message() {
+        let pool = pool().await;
+        let err = read_local_digest(&pool, "playlist_track").await.unwrap_err();
+        assert!(format!("{err}").contains("unknown entity 'playlist_track'"));
+    }
+
+    #[tokio::test]
+    async fn max_hlc_uses_largest_tuple_not_first_inserted() {
+        // Insert in non-monotonic order, confirm max_hlc reflects
+        // the actual MAX across the set.
+        let pool = pool().await;
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, hlc_wall, hlc_logical, payload_hash)
+             VALUES (1, 'A', 'aaa', 100, 5, ?)",
+        )
+        .bind(h(0x01))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO library (id, name, canonical_id, hlc_wall, hlc_logical, payload_hash)
+             VALUES (2, 'B', 'bbb', 50, 9, ?)",
+        )
+        .bind(h(0x02))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let d = read_local_digest(&pool, "library").await.unwrap();
+        let max = d.max_hlc.expect("max_hlc present");
+        // (100, 5) > (50, 9) under §2 lexicographic tuple order.
+        assert_eq!(max.wall, 100);
+        assert_eq!(max.logical, 5);
+    }
+}

--- a/src-tauri/crates/app/src/sync/mod.rs
+++ b/src-tauri/crates/app/src/sync/mod.rs
@@ -58,6 +58,7 @@ pub mod apply;
 pub mod canonical;
 pub mod cursor;
 pub mod device;
+pub mod digest;
 pub mod drain;
 pub mod hlc;
 pub mod hooks;

--- a/src-tauri/crates/core/src/sync/digest.rs
+++ b/src-tauri/crates/core/src/sync/digest.rs
@@ -1,0 +1,185 @@
+//! Set-hash computation for the `GET /api/v1/sync/digest` endpoint
+//! (RFC-003 §4).
+//!
+//! Two replicas — the desktop and `waveflow-server` — must arrive at
+//! the same `[u8; 32]` when they compute the digest over the same
+//! materialised set, so the BLAKE3 feed has to be bit-identical on
+//! both sides. The server already lives in
+//! `waveflow-server/src/db.rs::digest_read::compute_set_hash`; this
+//! module is the desktop's mirror, held in `waveflow-core` so a
+//! future server-side cleanup can switch to importing it instead of
+//! keeping a parallel impl.
+//!
+//! ## Feed shape
+//!
+//! For every member, ordered by ascending `canonical_id`:
+//!
+//! 1. `canonical_id.len() as u32` (little-endian, 4 bytes)
+//! 2. `canonical_id` UTF-8 bytes
+//! 3. `payload_bytes.len() as u32` (little-endian, 4 bytes)
+//! 4. `payload_bytes` (raw BLAKE3-256, 32 bytes when present)
+//!
+//! Length prefixes are required: without them, two distinct
+//! (canonical_id, payload_hash) pairs whose concatenations alias
+//! would collide on the set hash. The corner case is rare in
+//! practice (UUID canonical ids are fixed-width) but the file-path
+//! composite key the `track` entity uses (`<lib_canonical>\u{1F}<file_path>`)
+//! has variable length, which makes the prefix non-negotiable.
+//!
+//! ## Caller responsibilities
+//!
+//! - Members MUST be sorted by `canonical_id` ASC before hashing.
+//!   The helper does not sort — sorting at the SQL layer is cheap
+//!   (`ORDER BY canonical_id`) and lets the caller produce the
+//!   sorted set with the same query that filters
+//!   `payload_hash IS NOT NULL`.
+//! - The `payload_bytes` slice is whatever the server stores in
+//!   the row's `payload_hash` column — typically `[u8; 32]` from
+//!   [`crate::sync::payload_hash::compute_payload_hash`]. The
+//!   helper does not assume a fixed length; an empty slice falls
+//!   through cleanly (still gets a `0u32` length prefix).
+//!
+//! ## Why the server hex-decodes and we do not
+//!
+//! The server feeds `hex::decode(&m.payload_hash)` because its
+//! `DigestMember.payload_hash` is the JSON-serialised hex string.
+//! The desktop's local read fetches the BLOB directly from SQLite,
+//! so the bytes are already raw. The wire shape (hex) is only used
+//! at the HTTP boundary; the hash feed shape (raw bytes) is the
+//! protocol.
+
+use blake3::Hasher;
+
+/// Compute the BLAKE3-256 `set_hash` over a sorted list of members.
+///
+/// `members` MUST be sorted by `canonical_id` ASC. The helper does
+/// not validate the order — feeding an unsorted slice produces a
+/// hash that, by RFC-003 §4, no other compliant replica will match.
+pub fn compute_set_hash(members: &[(&str, &[u8])]) -> [u8; 32] {
+    let mut hasher = Hasher::new();
+    for (canonical_id, payload_bytes) in members {
+        let id_bytes = canonical_id.as_bytes();
+        // RFC-003 §4 frames each field with a `u32` little-endian
+        // length prefix. Realistic inputs are bounded by OS
+        // PATH_MAX (`canonical_id` peaks ~33 KB on Windows extended,
+        // ~4 KB on Linux) and BLAKE3-256 (`payload_bytes` always 32
+        // bytes), both several orders of magnitude below `u32::MAX`
+        // (~4.3 GB). The `as u32` cast would silently truncate if
+        // those invariants ever broke — and since the server uses
+        // the identical cast (`waveflow-server/src/db.rs::compute_set_hash`),
+        // truncation on either side stays cross-replica-consistent
+        // by accident rather than design. `debug_assert!` documents
+        // the contract + traps the regression in tests/dev without
+        // forcing every caller to thread a `Result`.
+        debug_assert!(
+            id_bytes.len() <= u32::MAX as usize,
+            "canonical_id length {} exceeds u32::MAX — RFC-003 §4 length prefix would truncate",
+            id_bytes.len(),
+        );
+        debug_assert!(
+            payload_bytes.len() <= u32::MAX as usize,
+            "payload_bytes length {} exceeds u32::MAX — RFC-003 §4 length prefix would truncate",
+            payload_bytes.len(),
+        );
+        hasher.update(&(id_bytes.len() as u32).to_le_bytes());
+        hasher.update(id_bytes);
+        hasher.update(&(payload_bytes.len() as u32).to_le_bytes());
+        hasher.update(payload_bytes);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two empty inputs hash identically (the empty BLAKE3 digest).
+    #[test]
+    fn empty_set_hashes_to_blake3_of_nothing() {
+        let h1 = compute_set_hash(&[]);
+        let h2 = compute_set_hash(&[]);
+        assert_eq!(h1, h2);
+        // Sanity: known empty BLAKE3 digest hex.
+        assert_eq!(
+            hex::encode(h1),
+            "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        );
+    }
+
+    /// Same members in same order produce the same hash.
+    #[test]
+    fn same_members_same_order_match() {
+        let payload = [0x42u8; 32];
+        let m = vec![("alpha", payload.as_slice()), ("beta", payload.as_slice())];
+        let h1 = compute_set_hash(&m);
+        let h2 = compute_set_hash(&m);
+        assert_eq!(h1, h2);
+    }
+
+    /// Different orderings produce different hashes — the caller's
+    /// sort-by-canonical-id is what guarantees cross-replica
+    /// agreement.
+    #[test]
+    fn different_orderings_differ() {
+        let p1 = [0x01u8; 32];
+        let p2 = [0x02u8; 32];
+        let ordered = compute_set_hash(&[("alpha", &p1[..]), ("beta", &p2[..])]);
+        let reversed = compute_set_hash(&[("beta", &p2[..]), ("alpha", &p1[..])]);
+        assert_ne!(ordered, reversed);
+    }
+
+    /// Length prefixes prevent the concatenation collision: the
+    /// pairs `("a", "bc")` and `("ab", "c")` would produce the same
+    /// raw byte stream without the `u32` length frames between
+    /// them.
+    #[test]
+    fn length_prefixes_prevent_concatenation_collision() {
+        let a = compute_set_hash(&[("a", b"bc")]);
+        let b = compute_set_hash(&[("ab", b"c")]);
+        assert_ne!(a, b);
+    }
+
+    /// Empty payload (e.g. `liked_track` canonical form is `{}`,
+    /// but the row's `payload_hash` column is still a 32-byte
+    /// BLAKE3 — this test covers the corner case where a row's
+    /// hash was stored as an empty slice for whatever reason; the
+    /// algorithm still terminates).
+    #[test]
+    fn empty_payload_bytes_terminate_cleanly() {
+        let h = compute_set_hash(&[("x", b"")]);
+        // Smoke: deterministic across calls.
+        assert_eq!(h, compute_set_hash(&[("x", b"")]));
+    }
+
+    /// Changing one canonical_id byte changes the hash — i.e. the
+    /// canonical_id contributes to the feed (not just the payload).
+    #[test]
+    fn canonical_id_change_changes_hash() {
+        let p = [0xAAu8; 32];
+        let a = compute_set_hash(&[("alpha", &p[..])]);
+        let b = compute_set_hash(&[("alphz", &p[..])]);
+        assert_ne!(a, b);
+    }
+
+    /// Changing one payload byte changes the hash.
+    #[test]
+    fn payload_change_changes_hash() {
+        let mut p = [0xAAu8; 32];
+        let a = compute_set_hash(&[("alpha", &p[..])]);
+        p[0] = 0xBB;
+        let b = compute_set_hash(&[("alpha", &p[..])]);
+        assert_ne!(a, b);
+    }
+
+    /// Composite canonical_id with the `\u{1F}` track separator
+    /// hashes deterministically — sanity that the multibyte unit
+    /// separator passes through `as_bytes()` unchanged.
+    #[test]
+    fn composite_track_key_round_trips() {
+        let p = [0u8; 32];
+        let composite = "11111111-1111-1111-1111-111111111111\u{1F}/music/x.flac";
+        let a = compute_set_hash(&[(composite, &p[..])]);
+        let b = compute_set_hash(&[(composite, &p[..])]);
+        assert_eq!(a, b);
+    }
+}

--- a/src-tauri/crates/core/src/sync/mod.rs
+++ b/src-tauri/crates/core/src/sync/mod.rs
@@ -13,6 +13,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod canon;
+pub mod digest;
 pub mod payload_hash;
 
 /// Hybrid Logical Clock pair carried by RFC-003 v2 ops on the wire.


### PR DESCRIPTION
## What

Adds the read-only digest comparison layer the Phase B.2 backfill orchestrator will drive. For each of the 5 synced entities (`library`, `playlist`, `track`, `liked_track`, `track_rating`), the desktop computes its local `set_hash` + `version` + `max_hlc`, fetches the matching server snapshot via `GET /api/v1/sync/digest`, and diffs `(canonical_id, payload_hash)` pairs.

Closes the read side of RFC-003 §4 backfill protocol on desktop.

## Layout

### Shared algorithm in `waveflow-core`

- `waveflow_core::sync::digest::compute_set_hash(&[(&str, &[u8])])` — BLAKE3 over the sorted member list, **mirror byte-exact of the server's `db.rs::digest_read::compute_set_hash`**. Length-prefixed feed (`u32` LE) so two `(canonical_id, payload)` pairs whose concatenations would alias can't collide.

### Desktop module `sync::digest`

| File | Purpose |
|---|---|
| `mod.rs` | `read_local_digest(pool, entity) -> LocalDigest`. Five SQL queries mirror server's `members_*` exactly. |
| `client.rs` | `fetch_remote_digest(client, entity, profile_canonical_id?)`. Private deserialise types mirror server wire shape; scope gate local (profile-scoped require canonical, user-scoped reject it) short-circuits before HTTP. |
| `diff.rs` | `diff(local, remote) -> DigestDiff`. Fast path: equal `set_hash` → `in_sync`. Otherwise two-pointer merge classifies each canonical_id as MissingLocally / MissingRemotely / Divergent. |

### Per-entity SQL shape

| Entity | Canonical id | Sort by |
|---|---|---|
| `library` | `library.canonical_id` | `canonical_id` |
| `playlist` | `playlist.canonical_id` | `canonical_id` |
| `track` | `<library.canonical_id>\u{1F}<file_path>` (composite, U+001F separator) | `(lib_canonical, file_path)` |
| `liked_track` | `track.file_hash` (JOIN back from `liked_track.track_id`) | `file_hash` |
| `track_rating` | `track.file_hash` (reads `rating_*` mirror cols on same row) | `file_hash` |

`payload_hash IS NOT NULL` + `canonical_id IS NOT NULL` filters mirror server, so a partial-backfill desktop doesn't disagree with the server on set membership.

### Tauri command

`sync_digest_check(entity?: String) -> SyncDigestOutcome`:
- `Ran { reports }` — per-entity `SyncDigestReport { entity, in_sync, local_version, remote_version, missing_locally, missing_remotely, divergent }`.
- `Skipped { reason }` — `SyncMode::Local` / no JWT / no URL / `profile.canonical_id` NULL (per-entity skip with warn log).

Counts only on the IPC; full diff member lists stay backend-side for the B.2 orchestrator.

## What this does NOT do

- ❌ Does NOT backfill yet (B.2 — push `missing_remotely` ops, pull `missing_locally` rows, LWW-resolve `divergent`).
- ❌ Does NOT auto-poll background (B.3 — Settings UI + cadence).
- ❌ Does NOT include `profile` entity (lives in `app.db`, scoped separately; revisit if needed).
- ❌ Does NOT include `playlist_track` (server has no canonical_fields/payload_hash for it; see B.0-rest rationale).

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` → **346 passing** (baseline 317 → +29)
- [x] `sync::digest::*` desktop → 21 tests (read 11 + client 5 + diff 5)
- [x] `waveflow_core::sync::digest` → 8 tests (empty BLAKE3, length-prefix collision, ordering matters, byte sensitivity)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Manual smoke: with a sync-enabled profile, invoke `sync_digest_check` from the frontend — confirm 5 reports come back with `in_sync: true` after a clean drain.

## Refs

- RFC-003 §4 — digest endpoint contract
- Server PR #56 (A.2.3 — endpoint + `compute_set_hash` server-side)
- Desktop PRs #247 (B.0a library `payload_hash`) + #248 (B.0-rest playlist/track/liked/rating)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Ajout d'une commande de vérification de synchronisation permettant de comparer l'état des données locales et distantes.
  * Génération de rapports de synchronisation détaillés indiquant les divergences, les éléments manquants localement ou à distance.
  * Support de la vérification pour plusieurs types d'entités avec gestion automatique des configurations serveur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->