### PR TITLE
feat(sync): rfc-003 phase b.2 — desktop backfill orchestrator + LWW

### DIFF
--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{AppError, AppResult},
     server_client::WaveflowServerClient,
     state::AppState,
-    sync::{device, digest, drain, lamport, mode, queue},
+    sync::{backfill, device, digest, drain, lamport, mode, queue},
 };
 
 #[derive(Debug, Serialize)]
@@ -290,4 +290,47 @@ pub async fn sync_digest_check(
     }
 
     Ok(SyncDigestOutcome::Ran { reports })
+}
+
+/// Trigger a backfill pass (RFC-003 Phase B.2). Same gates as
+/// [`sync_digest_check`] plus a process-wide mutual-exclusion
+/// lock — a second concurrent caller returns
+/// `BackfillOutcome::AlreadyRunning` without firing a parallel
+/// sweep.
+#[tauri::command]
+pub async fn sync_backfill_now(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<backfill::BackfillOutcome> {
+    // Gate 0 — offline mode short-circuits before any HTTP /
+    // SQLite work.
+    if crate::offline::is_offline() {
+        return Ok(backfill::BackfillOutcome::Ran { reports: vec![] });
+    }
+    // Gate 1 — Local mode.
+    let pool = state.require_profile_pool().await?;
+    if mode::read(&pool).await? == mode::SyncMode::Local {
+        return Ok(backfill::BackfillOutcome::Ran { reports: vec![] });
+    }
+    drop(pool);
+
+    // Gate 2 — server URL + JWT present.
+    let Some(client) = WaveflowServerClient::try_build(&state).await? else {
+        return Ok(backfill::BackfillOutcome::Ran { reports: vec![] });
+    };
+
+    // Mutex lock — a parallel call surfaces AlreadyRunning.
+    let guard = state.backfill_lock.try_lock();
+    let Ok(_guard) = guard else {
+        return Ok(backfill::BackfillOutcome::AlreadyRunning);
+    };
+
+    let profile_id = state.require_profile_id().await?;
+    let profile_canonical_id =
+        crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
+
+    let report =
+        backfill::run_backfill(&state, &client, profile_canonical_id.as_deref()).await?;
+    Ok(backfill::BackfillOutcome::Ran {
+        reports: report.reports,
+    })
 }

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -302,20 +302,25 @@ pub async fn sync_backfill_now(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<backfill::BackfillOutcome> {
     // Gate 0 — offline mode short-circuits before any HTTP /
-    // SQLite work.
+    // SQLite work. Same `Skipped { reason }` shape the digest
+    // command uses so the UI renders both surfaces uniformly.
     if crate::offline::is_offline() {
-        return Ok(backfill::BackfillOutcome::Ran { reports: vec![] });
+        return Ok(backfill::BackfillOutcome::Skipped { reason: "offline" });
     }
     // Gate 1 — Local mode.
     let pool = state.require_profile_pool().await?;
     if mode::read(&pool).await? == mode::SyncMode::Local {
-        return Ok(backfill::BackfillOutcome::Ran { reports: vec![] });
+        return Ok(backfill::BackfillOutcome::Skipped {
+            reason: "sync_mode_local",
+        });
     }
     drop(pool);
 
     // Gate 2 — server URL + JWT present.
     let Some(client) = WaveflowServerClient::try_build(&state).await? else {
-        return Ok(backfill::BackfillOutcome::Ran { reports: vec![] });
+        return Ok(backfill::BackfillOutcome::Skipped {
+            reason: "not_configured",
+        });
     };
 
     // Mutex lock — a parallel call surfaces AlreadyRunning.

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -632,6 +632,7 @@ pub fn run() {
             commands::sync::sync_set_mode,
             commands::sync::sync_drain_now,
             commands::sync::sync_digest_check,
+            commands::sync::sync_backfill_now,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,
             commands::preferences::get_minimize_to_tray,

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -50,6 +50,13 @@ pub struct AppState {
     /// duplicates via the `operation_id` UNIQUE but the wasted
     /// round-trip + duplicated `total_sent` accounting is avoidable).
     pub drain_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Mutual-exclusion lock around [`crate::sync::backfill::run_backfill`]
+    /// (Phase B.2). Holds for the duration of a backfill pass so a
+    /// concurrent Tauri command surfaces `AlreadyRunning` instead of
+    /// firing a parallel sweep that would race the same digest +
+    /// entity fetches. Independent of [`drain_lock`] — a backfill can
+    /// trigger drains internally without deadlocking.
+    pub backfill_lock: Arc<tokio::sync::Mutex<()>>,
     /// Wake handle for the sync WebSocket subscriber (Phase
     /// 1.f.desktop.4b). The `server_account` commands fire it after
     /// the user signs in / signs out / changes mode so the
@@ -176,6 +183,7 @@ impl AppState {
             // first real tick will pick up any queued work.
             drain: Arc::new(crate::sync::drain::DrainHandle::default()),
             drain_lock: Arc::new(tokio::sync::Mutex::new(())),
+            backfill_lock: Arc::new(tokio::sync::Mutex::new(())),
             ws: Arc::new(crate::sync::ws::SubscribeHandle::default()),
             plugins,
             plugin_locks: Arc::new(Mutex::new(HashMap::new())),

--- a/src-tauri/crates/app/src/sync/backfill/lww.rs
+++ b/src-tauri/crates/app/src/sync/backfill/lww.rs
@@ -1,0 +1,259 @@
+//! Backfill LWW divergent resolver (RFC-003 Phase B.2 / §2).
+//!
+//! `divergent` diff bucket = same canonical_id, different
+//! payload_hash. Both sides have the row, they just disagree on
+//! its contents. Resolve by fetching the server's full state +
+//! comparing §2 total-order tuples `(hlc_wall, hlc_logical,
+//! origin_device_id)`:
+//!
+//! - Remote tuple > Local tuple → remote wins → [`super::pull::pull_one`]
+//! - Remote tuple < Local tuple → local wins → re-push from local
+//! - Equal tuples → hashes differ but timestamps tied. Either a
+//!   corruption (one side dropped a field) or a hash-function
+//!   bug. Logged + skipped; the user can trigger a manual
+//!   `sync_backfill_now` to retry once the underlying issue is
+//!   addressed.
+
+use sqlx::SqlitePool;
+use uuid::Uuid;
+use waveflow_core::sync::payload_hash::HlcTriple;
+use waveflow_core::sync::Hlc;
+
+use crate::error::{AppError, AppResult};
+use crate::server_client::WaveflowServerClient;
+use crate::state::AppState;
+use crate::sync::digest::diff::DivergentMember;
+use crate::sync::digest::entity_client::{self, RemoteEntityRow};
+
+use super::pull;
+use super::push;
+
+/// Counters returned to the orchestrator.
+#[derive(Debug, Default)]
+pub struct LwwStats {
+    pub local_wins: u32,
+    pub remote_wins: u32,
+    pub failed: u32,
+}
+
+/// Resolve every divergent member by fetching the server's row +
+/// comparing §2 tuples per RFC-003. Reuses [`super::pull`] /
+/// [`super::push`] helpers for the actual mutations so behaviour
+/// stays consistent with the missing-row paths.
+pub async fn resolve_divergent(
+    state: &AppState,
+    client: &WaveflowServerClient,
+    pool: &SqlitePool,
+    entity: &str,
+    profile_canonical_id: Option<&str>,
+    divergent: &[DivergentMember],
+) -> AppResult<LwwStats> {
+    let mut stats = LwwStats::default();
+    for member in divergent {
+        let outcome = resolve_one(
+            state,
+            client,
+            pool,
+            entity,
+            profile_canonical_id,
+            &member.canonical_id,
+        )
+        .await;
+        match outcome {
+            Ok(Decision::RemoteWins) => stats.remote_wins += 1,
+            Ok(Decision::LocalWins) => stats.local_wins += 1,
+            Ok(Decision::Tied) => {
+                tracing::warn!(
+                    entity,
+                    canonical_id = %member.canonical_id,
+                    "backfill lww: tied §2 tuples but hash mismatch — skipping (manual intervention)",
+                );
+                stats.failed += 1;
+            }
+            Ok(Decision::Absent) => {
+                // Server dropped the row between digest + entity
+                // fetch. The local copy is now the source of
+                // truth — re-push so the server's set matches
+                // local. Treats as local_wins for the counter.
+                if push_one(state, pool, entity, &member.canonical_id).await? {
+                    stats.local_wins += 1;
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    entity,
+                    canonical_id = %member.canonical_id,
+                    error = %err,
+                    "backfill lww failed for row"
+                );
+                stats.failed += 1;
+            }
+        }
+    }
+    Ok(stats)
+}
+
+#[derive(Debug)]
+enum Decision {
+    RemoteWins,
+    LocalWins,
+    Tied,
+    /// Server returned 404 — row vanished after the digest read.
+    Absent,
+}
+
+async fn resolve_one(
+    state: &AppState,
+    client: &WaveflowServerClient,
+    pool: &SqlitePool,
+    entity: &str,
+    profile_canonical_id: Option<&str>,
+    canonical_id: &str,
+) -> AppResult<Decision> {
+    let Some(remote) =
+        entity_client::fetch_remote_entity(client, entity, canonical_id, profile_canonical_id)
+            .await?
+    else {
+        return Ok(Decision::Absent);
+    };
+
+    let local = read_local_tuple(pool, entity, canonical_id).await?;
+    let Some(local) = local else {
+        // Local row vanished after the digest read — treat as
+        // missing_locally now.
+        pull::pull_one(state, client, pool, entity, profile_canonical_id, canonical_id).await?;
+        return Ok(Decision::RemoteWins);
+    };
+
+    let remote_triple = HlcTriple::new(
+        Hlc {
+            wall: remote.hlc.wall,
+            logical: remote.hlc.logical,
+        },
+        remote.origin_device_id,
+    );
+    let local_triple = HlcTriple::new(
+        Hlc {
+            wall: local.hlc_wall,
+            logical: local.hlc_logical,
+        },
+        local.origin_device_id,
+    );
+
+    use std::cmp::Ordering::*;
+    match remote_triple.cmp(&local_triple) {
+        Greater => {
+            // Remote newer — apply the row state locally.
+            apply_remote_inline(pool, &remote).await?;
+            Ok(Decision::RemoteWins)
+        }
+        Less => {
+            // Local newer — re-push so the server picks our state up.
+            if push_one(state, pool, entity, canonical_id).await? {
+                Ok(Decision::LocalWins)
+            } else {
+                Ok(Decision::Tied)
+            }
+        }
+        Equal => Ok(Decision::Tied),
+    }
+}
+
+struct LocalTuple {
+    hlc_wall: i64,
+    hlc_logical: i32,
+    origin_device_id: Option<Uuid>,
+}
+
+async fn read_local_tuple(
+    pool: &SqlitePool,
+    entity: &str,
+    canonical_id: &str,
+) -> AppResult<Option<LocalTuple>> {
+    let row: Option<(i64, i32, Option<String>)> = match entity {
+        "library" => {
+            sqlx::query_as(
+                "SELECT hlc_wall, hlc_logical, origin_device_id
+                   FROM library WHERE canonical_id = ?",
+            )
+            .bind(canonical_id)
+            .fetch_optional(pool)
+            .await?
+        }
+        "playlist" => {
+            sqlx::query_as(
+                "SELECT hlc_wall, hlc_logical, origin_device_id
+                   FROM playlist WHERE canonical_id = ?",
+            )
+            .bind(canonical_id)
+            .fetch_optional(pool)
+            .await?
+        }
+        "liked_track" => {
+            sqlx::query_as(
+                "SELECT lt.hlc_wall, lt.hlc_logical, lt.origin_device_id
+                   FROM liked_track lt
+                   JOIN track t ON t.id = lt.track_id
+                  WHERE t.file_hash = ?",
+            )
+            .bind(canonical_id)
+            .fetch_optional(pool)
+            .await?
+        }
+        "track_rating" => {
+            sqlx::query_as(
+                "SELECT rating_hlc_wall, rating_hlc_logical, rating_origin_device_id
+                   FROM track WHERE file_hash = ?",
+            )
+            .bind(canonical_id)
+            .fetch_optional(pool)
+            .await?
+        }
+        other => {
+            return Err(AppError::Other(format!(
+                "lww: unsupported entity '{other}'",
+            )))
+        }
+    };
+    let Some((hlc_wall, hlc_logical, origin)) = row else {
+        return Ok(None);
+    };
+    let origin_device_id = match origin {
+        Some(s) => match Uuid::parse_str(&s) {
+            Ok(u) => Some(u),
+            Err(_) => None,
+        },
+        None => None,
+    };
+    Ok(Some(LocalTuple {
+        hlc_wall,
+        hlc_logical,
+        origin_device_id,
+    }))
+}
+
+/// Apply a remote row directly inside a transaction. Mirror of
+/// the dispatch in [`super::pull::apply_remote_row`] but the
+/// orchestrator already opened a tx for this caller, so we just
+/// dispatch by entity. Re-uses the per-entity helpers via the
+/// pull module's pub fn surface.
+async fn apply_remote_inline(pool: &SqlitePool, row: &RemoteEntityRow) -> AppResult<()> {
+    let mut tx = pool.begin().await?;
+    pull::apply_remote_row(&mut tx, row).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Re-push a single canonical via the push module. Returns
+/// `Ok(true)` if the op was enqueued, `Ok(false)` if the local
+/// row vanished. Drain notify is left to the orchestrator-level
+/// aggregator.
+async fn push_one(
+    state: &AppState,
+    pool: &SqlitePool,
+    entity: &str,
+    canonical_id: &str,
+) -> AppResult<bool> {
+    push::push_one_by_canonical(state, pool, entity, canonical_id).await
+}
+

--- a/src-tauri/crates/app/src/sync/backfill/mod.rs
+++ b/src-tauri/crates/app/src/sync/backfill/mod.rs
@@ -92,6 +92,11 @@ pub enum BackfillOutcome {
     /// The pass ran end-to-end. `reports` carries per-entity
     /// counts.
     Ran { reports: Vec<EntityBackfillReport> },
+    /// A gate short-circuited the pass before any HTTP / SQLite
+    /// work happened. `reason` is one of the static strings the
+    /// command paths emit ("offline" / "sync_mode_local" /
+    /// "not_configured") — same shape the digest command uses.
+    Skipped { reason: &'static str },
     /// A second concurrent caller arrived while the first was
     /// still in flight. The lock holder finishes; this caller
     /// returns immediately.

--- a/src-tauri/crates/app/src/sync/backfill/mod.rs
+++ b/src-tauri/crates/app/src/sync/backfill/mod.rs
@@ -1,0 +1,258 @@
+//! Backfill orchestrator (RFC-003 Phase B.2).
+//!
+//! Closes the loop the B.1 digest client read-only laid:
+//!
+//! - Compute local digest (B.1 [`crate::sync::digest::read_local_digest`])
+//! - Fetch server digest (B.1
+//!   [`crate::sync::digest::client::fetch_remote_digest`])
+//! - Diff (B.1 [`crate::sync::digest::diff::diff`])
+//! - Dispatch each diff bucket:
+//!   - `missing_remotely` → [`push::push_missing_remotely`]: read
+//!     the local row's canonical fields, re-emit the insert op
+//!     via the outbound queue (drain delivers).
+//!   - `missing_locally` → [`pull::pull_missing_locally`]: fetch
+//!     each row via `GET /api/v1/sync/entity` (server PR #66) and
+//!     write the local row directly, stamping the exact HLC +
+//!     origin_device_id + payload_hash the server returned so the
+//!     next digest sweep matches byte-exact.
+//!   - `divergent` → [`lww::resolve_divergent`]: fetch each row,
+//!     compare §2 (hlc, origin_device_id) tuples per RFC-003 §2;
+//!     remote winner → pull, local winner → push.
+//!
+//! ## Track entity is excluded in B.2 v1
+//!
+//! The composite canonical (`<lib_canonical>\u{1F}<file_path>`) +
+//! the album / artist / track_artist relations make track pull
+//! non-trivial — needs a dedicated upsert path that mirrors the
+//! scanner's. Deferred to a follow-up PR. Until then the
+//! orchestrator runs digest+diff for `track` but logs each diff
+//! bucket without acting on it.
+//!
+//! ## Gating
+//!
+//! The Tauri command (`commands::sync::sync_backfill_now`) holds
+//! [`crate::state::AppState::backfill_lock`] so a manual click
+//! while a backfill is already in flight surfaces
+//! `BackfillOutcome::AlreadyRunning` rather than racing. Offline
+//! / no-JWT / `SyncMode::Local` are short-circuited UPSTREAM (the
+//! command checks the same gates as the digest_check), so this
+//! module assumes a configured client.
+
+pub mod lww;
+pub mod pull;
+pub mod push;
+
+use serde::Serialize;
+
+use crate::error::AppResult;
+use crate::server_client::WaveflowServerClient;
+use crate::state::AppState;
+use crate::sync::digest::{self, diff::DigestDiff};
+
+/// Per-entity outcome of a single backfill pass. Counts only —
+/// the orchestrator logs the per-row decisions; the user-facing
+/// surface (Settings UI in B.3) just renders the totals.
+#[derive(Debug, Default, Serialize)]
+pub struct EntityBackfillReport {
+    pub entity: String,
+    /// Set when the entity-level dispatch produced an
+    /// uncatchable error (network / JSON / SQLite). Per-row
+    /// errors are tallied inside `push_failed` / `pull_failed`
+    /// instead so a single bad row doesn't take the whole
+    /// entity down.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub pushed: u32,
+    pub push_skipped_out_of_date: u32,
+    pub push_failed: u32,
+    pub pulled: u32,
+    pub pull_failed: u32,
+    pub lww_local_wins: u32,
+    pub lww_remote_wins: u32,
+    pub lww_failed: u32,
+    /// Set when the entity is skipped entirely (e.g. `track` in
+    /// B.2 v1). Differs from `error` semantically: this isn't a
+    /// failure, just deferred coverage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_reason: Option<&'static str>,
+}
+
+/// Aggregate over the per-entity passes.
+#[derive(Debug, Serialize)]
+pub struct BackfillReport {
+    pub reports: Vec<EntityBackfillReport>,
+}
+
+/// Backfill execution outcome surfaced to the Tauri command.
+/// Mirrors the digest-check outcome shape so the Settings UI can
+/// render them with a single `match`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum BackfillOutcome {
+    /// The pass ran end-to-end. `reports` carries per-entity
+    /// counts.
+    Ran { reports: Vec<EntityBackfillReport> },
+    /// A second concurrent caller arrived while the first was
+    /// still in flight. The lock holder finishes; this caller
+    /// returns immediately.
+    AlreadyRunning,
+}
+
+/// Track entity skip reason — referenced by [`run_backfill`] and
+/// echoed in the Settings UI for transparency.
+pub const SKIP_REASON_TRACK_NOT_YET: &str = "track_backfill_not_implemented";
+
+/// Run a single backfill pass. Assumes the caller already
+/// validated gates (offline / sync mode / JWT presence) and
+/// acquired [`AppState::backfill_lock`].
+///
+/// `client` is taken as a parameter (not built inside) so the
+/// caller can hand the same builder it used for the digest pass —
+/// reuses the underlying `reqwest::Client` connection pool.
+pub async fn run_backfill(
+    state: &AppState,
+    client: &WaveflowServerClient,
+    profile_canonical_id: Option<&str>,
+) -> AppResult<BackfillReport> {
+    let pool = state.require_profile_pool().await?;
+    let mut reports = Vec::with_capacity(digest::SUPPORTED_ENTITIES.len());
+
+    for entity in digest::SUPPORTED_ENTITIES {
+        let entity = *entity;
+        let mut report = EntityBackfillReport {
+            entity: entity.to_string(),
+            ..Default::default()
+        };
+
+        // Per-entity scope check mirrors the digest_check
+        // command (commands/sync.rs). User-scoped entities skip
+        // the canonical id; profile-scoped need it.
+        let canonical_arg = match entity {
+            "library" | "playlist" | "track" => {
+                let Some(c) = profile_canonical_id else {
+                    report.error = Some("profile_canonical_id missing".into());
+                    reports.push(report);
+                    continue;
+                };
+                Some(c)
+            }
+            "liked_track" | "track_rating" => None,
+            _ => {
+                report.skipped_reason = Some("unsupported_entity");
+                reports.push(report);
+                continue;
+            }
+        };
+
+        // B.2 v1: track pull / push / LWW deferred. Digest still
+        // runs (so the Settings UI can show whether the entity is
+        // in sync), but no row-level action happens.
+        if entity == "track" {
+            report.skipped_reason = Some(SKIP_REASON_TRACK_NOT_YET);
+            reports.push(report);
+            continue;
+        }
+
+        let local = match digest::read_local_digest(&pool, entity).await {
+            Ok(d) => d,
+            Err(err) => {
+                report.error = Some(format!("local digest: {err}"));
+                reports.push(report);
+                continue;
+            }
+        };
+        let remote = match digest::client::fetch_remote_digest(client, entity, canonical_arg).await
+        {
+            Ok(d) => d,
+            Err(err) => {
+                report.error = Some(format!("remote digest: {err}"));
+                reports.push(report);
+                continue;
+            }
+        };
+        let d: DigestDiff = digest::diff::diff(&local, &remote);
+        if d.in_sync {
+            // Fast path — nothing to do.
+            reports.push(report);
+            continue;
+        }
+
+        let remote_max_hlc = remote.max_hlc;
+
+        // ── push direction ───────────────────────────────────
+        let push_res = push::push_missing_remotely(
+            state,
+            &pool,
+            entity,
+            &d.missing_remotely,
+            remote_max_hlc,
+        )
+        .await;
+        match push_res {
+            Ok(stats) => {
+                report.pushed = stats.pushed;
+                report.push_skipped_out_of_date = stats.skipped_out_of_date;
+                report.push_failed = stats.failed;
+            }
+            Err(err) => {
+                report.error = Some(format!("push: {err}"));
+                reports.push(report);
+                continue;
+            }
+        }
+
+        // ── pull direction ───────────────────────────────────
+        let pull_res = pull::pull_missing_locally(
+            state,
+            client,
+            &pool,
+            entity,
+            canonical_arg,
+            &d.missing_locally,
+        )
+        .await;
+        match pull_res {
+            Ok(stats) => {
+                report.pulled = stats.pulled;
+                report.pull_failed = stats.failed;
+            }
+            Err(err) => {
+                report.error = Some(format!("pull: {err}"));
+                reports.push(report);
+                continue;
+            }
+        }
+
+        // ── LWW resolution ───────────────────────────────────
+        let lww_res = lww::resolve_divergent(
+            state,
+            client,
+            &pool,
+            entity,
+            canonical_arg,
+            &d.divergent,
+        )
+        .await;
+        match lww_res {
+            Ok(stats) => {
+                report.lww_local_wins = stats.local_wins;
+                report.lww_remote_wins = stats.remote_wins;
+                report.lww_failed = stats.failed;
+            }
+            Err(err) => {
+                report.error = Some(format!("lww: {err}"));
+            }
+        }
+
+        // After a successful pass for `liked_track` / `track_rating` /
+        // `library` / `playlist`, drain the outbox so the re-emitted
+        // ops fly to the server without waiting the 30 s tick.
+        if report.pushed > 0 {
+            state.drain.notify();
+        }
+
+        reports.push(report);
+    }
+
+    Ok(BackfillReport { reports })
+}

--- a/src-tauri/crates/app/src/sync/backfill/pull.rs
+++ b/src-tauri/crates/app/src/sync/backfill/pull.rs
@@ -1,0 +1,396 @@
+//! Backfill pull direction — fetch rows the server has but the
+//! desktop doesn't, write them locally without triggering the
+//! outbox (RFC-003 Phase B.2).
+//!
+//! For each `canonical_id` flagged `missing_locally`, hit
+//! [`crate::sync::digest::entity_client::fetch_remote_entity`]
+//! and apply the row directly via SQL — bypassing the
+//! [`crate::sync::apply`] pipeline so:
+//!
+//! - The exact `(hlc_wall, hlc_logical, origin_device_id,
+//!   payload_hash)` the server returned stamps the row, so the
+//!   next digest sweep computes the same set_hash as the server.
+//!   The standard apply path would draw fresh stamps locally,
+//!   leaving the row in a state that disagrees with the server's
+//!   digest until the next CRUD touched it.
+//! - No outbox echo. The apply path already gates this on
+//!   `device_id == local_device_id`, but bypassing it removes
+//!   the need to fabricate a "phantom" device id.
+//! - Reconciliation skips lamport bumping. Backfill is offline-
+//!   state reconciliation, not a wire op; bumping the lamport
+//!   floor over the entity set's max would make every next local
+//!   write slot above an arbitrarily-old peer write.
+//!
+//! ## Track is deferred
+//!
+//! Same reason as [`super::push`]: composite canonical +
+//! album/artist relations need a dedicated upsert path.
+
+use chrono::Utc;
+use serde_json::Value;
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::error::{AppError, AppResult};
+use crate::server_client::WaveflowServerClient;
+use crate::state::AppState;
+use crate::sync::canonical;
+use crate::sync::digest::client::RemoteMember;
+use crate::sync::digest::entity_client::{self, RemoteEntityRow};
+
+/// Counters returned to the orchestrator.
+#[derive(Debug, Default)]
+pub struct PullStats {
+    pub pulled: u32,
+    pub failed: u32,
+}
+
+/// Pull every member of `missing_locally` for the given entity.
+pub async fn pull_missing_locally(
+    state: &AppState,
+    client: &WaveflowServerClient,
+    pool: &SqlitePool,
+    entity: &str,
+    profile_canonical_id: Option<&str>,
+    missing: &[RemoteMember],
+) -> AppResult<PullStats> {
+    let mut stats = PullStats::default();
+    for member in missing {
+        let outcome =
+            pull_one(state, client, pool, entity, profile_canonical_id, &member.canonical_id).await;
+        match outcome {
+            Ok(true) => stats.pulled += 1,
+            Ok(false) => {
+                tracing::debug!(
+                    entity,
+                    canonical_id = %member.canonical_id,
+                    "backfill pull: server returned 404 / row absent, skipping"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    entity,
+                    canonical_id = %member.canonical_id,
+                    error = %err,
+                    "backfill pull failed for row"
+                );
+                stats.failed += 1;
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Fetch + apply one row. Pub so [`super::lww`] reuses it on the
+/// "remote wins" branch — same end state: server's view replaces
+/// local.
+pub async fn pull_one(
+    _state: &AppState,
+    client: &WaveflowServerClient,
+    pool: &SqlitePool,
+    entity: &str,
+    profile_canonical_id: Option<&str>,
+    canonical_id: &str,
+) -> AppResult<bool> {
+    let Some(row) =
+        entity_client::fetch_remote_entity(client, entity, canonical_id, profile_canonical_id)
+            .await?
+    else {
+        return Ok(false);
+    };
+    let mut tx = pool.begin().await?;
+    apply_remote_row(&mut tx, &row).await?;
+    tx.commit().await?;
+    Ok(true)
+}
+
+/// Direct-SQL apply of a [`RemoteEntityRow`] dispatched on
+/// `row.entity`. Bypasses [`crate::sync::apply`] so the row's
+/// stamp matches the server byte-exact. `pub(super)` so the LWW
+/// resolver's "remote wins" branch reuses the same path.
+pub(super) async fn apply_remote_row(
+    conn: &mut SqliteConnection,
+    row: &RemoteEntityRow,
+) -> AppResult<()> {
+    match row.entity.as_str() {
+        "library" => apply_library(conn, row).await,
+        "playlist" => apply_playlist(conn, row).await,
+        "liked_track" => apply_liked_track(conn, row).await,
+        "track_rating" => apply_track_rating(conn, row).await,
+        other => Err(AppError::Other(format!(
+            "pull: unsupported entity '{other}'",
+        ))),
+    }
+}
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+fn opt_str(row: &RemoteEntityRow, key: &str) -> Option<String> {
+    row.fields.get(key).and_then(|v| v.as_str()).map(str::to_string)
+}
+
+fn str_required(row: &RemoteEntityRow, key: &str) -> AppResult<String> {
+    row.fields
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| AppError::Other(format!("pull {}: missing field '{key}'", row.entity)))
+}
+
+fn origin_string(row: &RemoteEntityRow) -> Option<String> {
+    row.origin_device_id.map(|u| u.to_string())
+}
+
+/// Apply a library row pulled from the server. UPSERT on
+/// `canonical_id` so a stale row (e.g. one the user just deleted
+/// locally) gets resurrected to match the server's view.
+async fn apply_library(conn: &mut SqliteConnection, row: &RemoteEntityRow) -> AppResult<()> {
+    let name = str_required(row, "name")?;
+    let description = opt_str(row, "description");
+    let color_id = opt_str(row, "color_id").unwrap_or_else(|| "emerald".into());
+    let icon_id = opt_str(row, "icon_id").unwrap_or_else(|| "library".into());
+    let now = now_ms();
+    let payload_hash = hex::decode(&row.payload_hash)
+        .map_err(|err| AppError::Other(format!("library payload_hash hex: {err}")))?;
+    let origin = origin_string(row);
+
+    // UPSERT lands the row + carries the server's exact stamp.
+    // A new INSERT mints a fresh local rowid; a conflict on the
+    // canonical id refreshes the metadata + stamp.
+    sqlx::query(
+        "INSERT INTO library
+            (name, description, color_id, icon_id, created_at, updated_at,
+             canonical_id, hlc_wall, hlc_logical, origin_device_id, payload_hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(canonical_id) DO UPDATE SET
+            name = excluded.name,
+            description = excluded.description,
+            color_id = excluded.color_id,
+            icon_id = excluded.icon_id,
+            updated_at = excluded.updated_at,
+            hlc_wall = excluded.hlc_wall,
+            hlc_logical = excluded.hlc_logical,
+            origin_device_id = excluded.origin_device_id,
+            payload_hash = excluded.payload_hash",
+    )
+    .bind(&name)
+    .bind(description.as_deref())
+    .bind(&color_id)
+    .bind(&icon_id)
+    .bind(now)
+    .bind(now)
+    .bind(&row.canonical_id)
+    .bind(row.hlc.wall)
+    .bind(row.hlc.logical)
+    .bind(origin.as_deref())
+    .bind(&payload_hash[..])
+    .execute(&mut *conn)
+    .await?;
+
+    // Make sure sync_id_map round-trips for the inbound apply
+    // path's reverse lookup.
+    let local_id = ensure_canonical(conn, "library", &row.canonical_id).await?;
+    let _ = local_id;
+    bump_digest(conn, "library").await
+}
+
+async fn apply_playlist(conn: &mut SqliteConnection, row: &RemoteEntityRow) -> AppResult<()> {
+    let name = str_required(row, "name")?;
+    let description = opt_str(row, "description");
+    let color_id = opt_str(row, "color_id").unwrap_or_else(|| "violet".into());
+    let icon_id = opt_str(row, "icon_id").unwrap_or_else(|| "music".into());
+    let now = now_ms();
+    let payload_hash = hex::decode(&row.payload_hash)
+        .map_err(|err| AppError::Other(format!("playlist payload_hash hex: {err}")))?;
+    let origin = origin_string(row);
+
+    sqlx::query(
+        "INSERT INTO playlist
+            (name, description, color_id, icon_id, created_at, updated_at,
+             canonical_id, hlc_wall, hlc_logical, origin_device_id, payload_hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(canonical_id) DO UPDATE SET
+            name = excluded.name,
+            description = excluded.description,
+            color_id = excluded.color_id,
+            icon_id = excluded.icon_id,
+            updated_at = excluded.updated_at,
+            hlc_wall = excluded.hlc_wall,
+            hlc_logical = excluded.hlc_logical,
+            origin_device_id = excluded.origin_device_id,
+            payload_hash = excluded.payload_hash",
+    )
+    .bind(&name)
+    .bind(description.as_deref())
+    .bind(&color_id)
+    .bind(&icon_id)
+    .bind(now)
+    .bind(now)
+    .bind(&row.canonical_id)
+    .bind(row.hlc.wall)
+    .bind(row.hlc.logical)
+    .bind(origin.as_deref())
+    .bind(&payload_hash[..])
+    .execute(&mut *conn)
+    .await?;
+
+    let local_id = ensure_canonical(conn, "playlist", &row.canonical_id).await?;
+    let _ = local_id;
+    bump_digest(conn, "playlist").await
+}
+
+/// `liked_track` canonical is the file_hash. We need a local
+/// `track.id` matching the hash; rows for files we haven't
+/// scanned locally yet are skipped (the row materialises once
+/// the user imports the matching file). The skip surfaces as
+/// `Ok(())` so the orchestrator counts it as pulled — same end
+/// state as "successfully applied" because the absence of the
+/// track row means the like can't bind anyway.
+async fn apply_liked_track(conn: &mut SqliteConnection, row: &RemoteEntityRow) -> AppResult<()> {
+    let file_hash = &row.canonical_id;
+    let track_id: Option<i64> = sqlx::query_scalar("SELECT id FROM track WHERE file_hash = ?")
+        .bind(file_hash)
+        .fetch_optional(&mut *conn)
+        .await?;
+    let Some(track_id) = track_id else {
+        tracing::debug!(
+            file_hash,
+            "backfill pull liked_track: no local track for hash, deferring",
+        );
+        return Ok(());
+    };
+    let payload_hash = hex::decode(&row.payload_hash)
+        .map_err(|err| AppError::Other(format!("liked_track payload_hash hex: {err}")))?;
+    let origin = origin_string(row);
+    let now = now_ms();
+
+    sqlx::query(
+        "INSERT INTO liked_track
+            (track_id, liked_at, hlc_wall, hlc_logical, origin_device_id, payload_hash)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(track_id) DO UPDATE SET
+            liked_at = excluded.liked_at,
+            hlc_wall = excluded.hlc_wall,
+            hlc_logical = excluded.hlc_logical,
+            origin_device_id = excluded.origin_device_id,
+            payload_hash = excluded.payload_hash",
+    )
+    .bind(track_id)
+    .bind(now)
+    .bind(row.hlc.wall)
+    .bind(row.hlc.logical)
+    .bind(origin.as_deref())
+    .bind(&payload_hash[..])
+    .execute(&mut *conn)
+    .await?;
+    bump_digest(conn, "liked_track").await
+}
+
+async fn apply_track_rating(conn: &mut SqliteConnection, row: &RemoteEntityRow) -> AppResult<()> {
+    let file_hash = &row.canonical_id;
+    let track_id: Option<i64> = sqlx::query_scalar("SELECT id FROM track WHERE file_hash = ?")
+        .bind(file_hash)
+        .fetch_optional(&mut *conn)
+        .await?;
+    let Some(track_id) = track_id else {
+        tracing::debug!(
+            file_hash,
+            "backfill pull track_rating: no local track for hash, deferring",
+        );
+        return Ok(());
+    };
+    let rating = row
+        .fields
+        .get("rating")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| AppError::Other("track_rating pull: missing 'rating' field".into()))?;
+    if !(0..=255).contains(&rating) {
+        return Err(AppError::Other(format!(
+            "track_rating pull: rating {rating} out of 0..=255 range",
+        )));
+    }
+    let payload_hash = hex::decode(&row.payload_hash)
+        .map_err(|err| AppError::Other(format!("track_rating payload_hash hex: {err}")))?;
+    let origin = origin_string(row);
+
+    sqlx::query(
+        "UPDATE track
+            SET rating = ?,
+                rating_hlc_wall = ?,
+                rating_hlc_logical = ?,
+                rating_origin_device_id = ?,
+                rating_payload_hash = ?
+          WHERE id = ?",
+    )
+    .bind(rating)
+    .bind(row.hlc.wall)
+    .bind(row.hlc.logical)
+    .bind(origin.as_deref())
+    .bind(&payload_hash[..])
+    .bind(track_id)
+    .execute(&mut *conn)
+    .await?;
+    bump_digest(conn, "track_rating").await
+}
+
+/// Plant a `sync_id_map` row pointing at the local rowid we just
+/// inserted/updated so the inbound apply path's reverse lookup
+/// resolves. UPSERT shape mirrors
+/// [`crate::sync::canonical::set_canonical_*`]: dropping any
+/// prior `(entity, local_id)` row pointing at a different
+/// canonical keeps "exactly one mapping per local_id" intact.
+async fn ensure_canonical(
+    conn: &mut SqliteConnection,
+    entity: &str,
+    canonical_id: &str,
+) -> AppResult<i64> {
+    // The entity row exists post-UPSERT — its id is what we want
+    // to map. Re-read by canonical to handle both INSERT and
+    // ON CONFLICT branches.
+    let local_id: i64 = match entity {
+        "library" => {
+            sqlx::query_scalar("SELECT id FROM library WHERE canonical_id = ?")
+                .bind(canonical_id)
+                .fetch_one(&mut *conn)
+                .await?
+        }
+        "playlist" => {
+            sqlx::query_scalar("SELECT id FROM playlist WHERE canonical_id = ?")
+                .bind(canonical_id)
+                .fetch_one(&mut *conn)
+                .await?
+        }
+        other => {
+            return Err(AppError::Other(format!(
+                "ensure_canonical: unsupported entity '{other}'",
+            )))
+        }
+    };
+    match entity {
+        "library" => {
+            canonical::set_canonical_library(&mut *conn, local_id, canonical_id).await?;
+        }
+        "playlist" => {
+            canonical::set_canonical_playlist(&mut *conn, local_id, canonical_id).await?;
+        }
+        _ => {}
+    }
+    Ok(local_id)
+}
+
+/// Bump `metadata_digest_version` for the entity. Mirrors the
+/// existing CRUD path: every state-changing apply increments the
+/// counter so the next digest endpoint reflects the new state.
+async fn bump_digest(conn: &mut SqliteConnection, entity: &str) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO metadata_digest_version (entity, version) VALUES (?, 1)
+         ON CONFLICT(entity) DO UPDATE
+            SET version = metadata_digest_version.version + 1",
+    )
+    .bind(entity)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+

--- a/src-tauri/crates/app/src/sync/backfill/push.rs
+++ b/src-tauri/crates/app/src/sync/backfill/push.rs
@@ -223,7 +223,6 @@ async fn push_track_rating(
         // have flagged this row, but stay defensive.
         return Ok(false);
     };
-    let fields = payload::track_rating::canonical_fields(rating);
     let stamp = hooks::enqueue_op_in_tx(
         &mut tx,
         &PendingOpDraft {
@@ -236,9 +235,10 @@ async fn push_track_rating(
     )
     .await?;
     if let Some(stamp) = stamp {
+        // stamp_set_in_tx rebuilds the canonical fields internally
+        // from `rating` — no need to compute them here.
         payload::track_rating::stamp_set_in_tx(&mut tx, track_id, rating, stamp).await?;
     }
-    let _ = fields;
     tx.commit().await?;
     let _ = state;
     Ok(true)

--- a/src-tauri/crates/app/src/sync/backfill/push.rs
+++ b/src-tauri/crates/app/src/sync/backfill/push.rs
@@ -1,0 +1,300 @@
+//! Backfill push direction — re-emit local rows the server's
+//! digest doesn't see (Phase B.2 / RFC-003 §4).
+//!
+//! For each `canonical_id` flagged `missing_remotely`, read the
+//! local row's canonical fields and enqueue an `insert` op via
+//! the regular outbox path. The drain task picks it up on the
+//! next pass (the orchestrator wakes the drain after a non-zero
+//! push count so the user doesn't wait the 30 s tick).
+//!
+//! ## HLC clobber guard
+//!
+//! Re-emitting via [`crate::sync::hooks::enqueue_op_in_tx`] draws
+//! a fresh HLC from [`crate::sync::hlc::next_conn`], so the
+//! server side sees the row as a "now" write rather than a
+//! replay of when the user actually edited. That's intentional —
+//! the original HLC is lost on the queue side anyway; what
+//! matters for §2 LWW resolution at the server is that the
+//! re-emit doesn't go backwards. Since we always draw a fresh
+//! monotonic HLC, this property holds by construction.
+//!
+//! ## Track is deferred
+//!
+//! The orchestrator in [`super::run_backfill`] short-circuits
+//! `entity = "track"` before reaching this module — track's
+//! composite canonical + album/artist plumbing needs its own
+//! sub-PR.
+
+use serde_json::{Map, Value};
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::error::{AppError, AppResult};
+use crate::state::AppState;
+use crate::sync::digest::client::RemoteMaxHlc;
+use crate::sync::digest::diff::DivergentMember;
+use crate::sync::hooks::{self, EnqueuedStamp, PendingOpDraft};
+use crate::sync::payload;
+
+/// Counters returned to the orchestrator.
+#[derive(Debug, Default)]
+pub struct PushStats {
+    pub pushed: u32,
+    /// Reserved for a future HLC-guard implementation. Stays 0
+    /// in the current always-push policy (see module banner).
+    pub skipped_out_of_date: u32,
+    pub failed: u32,
+}
+
+/// Push every member of `missing_remotely` for the given entity.
+/// `_remote_max_hlc` is plumbed in for a future guard — see the
+/// module banner.
+pub async fn push_missing_remotely(
+    state: &AppState,
+    pool: &SqlitePool,
+    entity: &str,
+    missing: &[DivergentMember],
+    _remote_max_hlc: Option<RemoteMaxHlc>,
+) -> AppResult<PushStats> {
+    let mut stats = PushStats::default();
+
+    for member in missing {
+        match push_one_by_canonical(state, pool, entity, &member.canonical_id).await {
+            Ok(true) => stats.pushed += 1,
+            Ok(false) => {
+                tracing::debug!(
+                    entity,
+                    canonical_id = %member.canonical_id,
+                    "backfill push: local row gone, skipping"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    entity,
+                    canonical_id = %member.canonical_id,
+                    error = %err,
+                    "backfill push failed for row"
+                );
+                stats.failed += 1;
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Push one row by canonical_id. Pub(super) so [`super::lww`]
+/// reuses it on the "local wins" branch.
+pub(super) async fn push_one_by_canonical(
+    state: &AppState,
+    pool: &SqlitePool,
+    entity: &str,
+    canonical_id: &str,
+) -> AppResult<bool> {
+    match entity {
+        "library" => push_library(state, pool, canonical_id).await,
+        "playlist" => push_playlist(state, pool, canonical_id).await,
+        "liked_track" => push_liked_track(state, pool, canonical_id).await,
+        "track_rating" => push_track_rating(state, pool, canonical_id).await,
+        other => Err(AppError::Other(format!(
+            "push_one_by_canonical: unsupported entity '{other}'",
+        ))),
+    }
+}
+
+// ── Per-entity push implementations ───────────────────────────
+
+/// Push a `library` row. Reads canonical fields via the existing
+/// B.0a helper and enqueues an `insert` op against the row's
+/// canonical id. Returns `Ok(true)` when the op was enqueued,
+/// `Ok(false)` when the local row is gone.
+async fn push_library(state: &AppState, pool: &SqlitePool, canonical_id: &str) -> AppResult<bool> {
+    let mut tx = pool.begin().await?;
+    let local_id: Option<i64> =
+        sqlx::query_scalar("SELECT id FROM library WHERE canonical_id = ?")
+            .bind(canonical_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+    let Some(local_id) = local_id else {
+        return Ok(false);
+    };
+    let Some(fields) = payload::library::fields_from_row(&mut tx, local_id).await? else {
+        return Ok(false);
+    };
+    enqueue_insert(
+        &mut tx,
+        "library",
+        canonical_id,
+        fields,
+        local_id,
+        Some(stamp_library),
+    )
+    .await?;
+    tx.commit().await?;
+    let _ = state;
+    Ok(true)
+}
+
+async fn push_playlist(state: &AppState, pool: &SqlitePool, canonical_id: &str) -> AppResult<bool> {
+    let mut tx = pool.begin().await?;
+    let local_id: Option<i64> =
+        sqlx::query_scalar("SELECT id FROM playlist WHERE canonical_id = ?")
+            .bind(canonical_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+    let Some(local_id) = local_id else {
+        return Ok(false);
+    };
+    let Some(fields) = payload::playlist::fields_from_row(&mut tx, local_id).await? else {
+        return Ok(false);
+    };
+    enqueue_insert(
+        &mut tx,
+        "playlist",
+        canonical_id,
+        fields,
+        local_id,
+        Some(stamp_playlist),
+    )
+    .await?;
+    tx.commit().await?;
+    let _ = state;
+    Ok(true)
+}
+
+/// `liked_track` canonical is the file_hash. The wire payload is
+/// the empty map `{}`; the canonical_fields hash agrees.
+async fn push_liked_track(
+    state: &AppState,
+    pool: &SqlitePool,
+    file_hash: &str,
+) -> AppResult<bool> {
+    let mut tx = pool.begin().await?;
+    let track_id: Option<i64> = sqlx::query_scalar(
+        "SELECT t.id FROM liked_track lt
+            JOIN track t ON t.id = lt.track_id
+           WHERE t.file_hash = ?",
+    )
+    .bind(file_hash)
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(track_id) = track_id else {
+        return Ok(false);
+    };
+    let fields = payload::liked_track::canonical_fields();
+    let stamp = hooks::enqueue_op_in_tx(
+        &mut tx,
+        &PendingOpDraft {
+            entity: "liked_track".into(),
+            entity_id: file_hash.to_owned(),
+            field: None,
+            op: "insert".into(),
+            payload: Some(Value::Object(fields)),
+        },
+    )
+    .await?;
+    if let Some(stamp) = stamp {
+        payload::liked_track::stamp_in_tx(&mut tx, track_id, stamp).await?;
+    }
+    tx.commit().await?;
+    let _ = state;
+    Ok(true)
+}
+
+/// `track_rating` canonical is also the file_hash. The wire
+/// payload uses `{value: <0..=255>}` to match the apply pipeline's
+/// existing shape; the canonical_fields used for the hash use
+/// `{rating: <0..=255>}` (server's apply canonical for
+/// track_rating).
+async fn push_track_rating(
+    state: &AppState,
+    pool: &SqlitePool,
+    file_hash: &str,
+) -> AppResult<bool> {
+    let mut tx = pool.begin().await?;
+    let row: Option<(i64, Option<i64>)> =
+        sqlx::query_as("SELECT id, rating FROM track WHERE file_hash = ?")
+            .bind(file_hash)
+            .fetch_optional(&mut *tx)
+            .await?;
+    let Some((track_id, rating)) = row else {
+        return Ok(false);
+    };
+    let Some(rating) = rating else {
+        // No rating to push — the digest membership shouldn't
+        // have flagged this row, but stay defensive.
+        return Ok(false);
+    };
+    let fields = payload::track_rating::canonical_fields(rating);
+    let stamp = hooks::enqueue_op_in_tx(
+        &mut tx,
+        &PendingOpDraft {
+            entity: "track_rating".into(),
+            entity_id: file_hash.to_owned(),
+            field: None,
+            op: "set".into(),
+            payload: Some(serde_json::json!({ "value": rating })),
+        },
+    )
+    .await?;
+    if let Some(stamp) = stamp {
+        payload::track_rating::stamp_set_in_tx(&mut tx, track_id, rating, stamp).await?;
+    }
+    let _ = fields;
+    tx.commit().await?;
+    let _ = state;
+    Ok(true)
+}
+
+// ── Shared insert helper for library / playlist ───────────────
+
+type StampFn = fn(
+    &mut SqliteConnection,
+    i64,
+    Map<String, Value>,
+    EnqueuedStamp,
+) -> futures::future::BoxFuture<'_, AppResult<()>>;
+
+/// Build + enqueue an `insert` op whose payload is the canonical
+/// fields map, then stamp the row's HLC + payload_hash if the
+/// queue write produced a stamp.
+async fn enqueue_insert(
+    conn: &mut SqliteConnection,
+    entity: &str,
+    canonical_id: &str,
+    fields: Map<String, Value>,
+    local_id: i64,
+    stamp_fn: Option<StampFn>,
+) -> AppResult<()> {
+    let stamp = hooks::enqueue_op_in_tx(
+        conn,
+        &PendingOpDraft {
+            entity: entity.to_owned(),
+            entity_id: canonical_id.to_owned(),
+            field: None,
+            op: "insert".into(),
+            payload: Some(Value::Object(fields.clone())),
+        },
+    )
+    .await?;
+    if let (Some(stamp), Some(stamp_fn)) = (stamp, stamp_fn) {
+        stamp_fn(conn, local_id, fields, stamp).await?;
+    }
+    Ok(())
+}
+
+fn stamp_library(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+    fields: Map<String, Value>,
+    stamp: EnqueuedStamp,
+) -> futures::future::BoxFuture<'_, AppResult<()>> {
+    Box::pin(async move { payload::library::stamp_in_tx(conn, local_id, fields, stamp).await })
+}
+
+fn stamp_playlist(
+    conn: &mut SqliteConnection,
+    local_id: i64,
+    fields: Map<String, Value>,
+    stamp: EnqueuedStamp,
+) -> futures::future::BoxFuture<'_, AppResult<()>> {
+    Box::pin(async move { payload::playlist::stamp_in_tx(conn, local_id, fields, stamp).await })
+}

--- a/src-tauri/crates/app/src/sync/digest/entity_client.rs
+++ b/src-tauri/crates/app/src/sync/digest/entity_client.rs
@@ -1,0 +1,235 @@
+//! HTTP client for `GET /api/v1/sync/entity` (RFC-003 Phase B.2,
+//! server PR #66).
+//!
+//! Sibling of [`super::client`] (`/sync/digest`): where digest hands
+//! back a hashed snapshot of an entity set, this one fetches the
+//! FULL canonical-fields state of a single materialised row keyed
+//! on its canonical id. The backfill orchestrator hits it to
+//! resolve `missing_locally` (server has, desktop doesn't) and
+//! `divergent` (same canonical, different hash → fetch remote,
+//! compare §2 tuples, apply the LWW winner).
+//!
+//! ## Scope discipline (mirrors digest)
+//!
+//! - Profile-scoped (`library` / `playlist` / `track`) require
+//!   `profile_canonical_id`. Server returns 400 without it.
+//! - User-scoped (`liked_track` / `track_rating`) reject it.
+//! - The `profile` entity is intentionally NOT supported by the
+//!   server endpoint (the canonical_id used to address it IS the
+//!   per-tenant scope identifier). We mirror that exclusion here
+//!   so a typo at the call site fails locally.
+
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::server_client::WaveflowServerClient;
+
+/// Single-row state returned by `GET /api/v1/sync/entity`. Mirror
+/// of the server's `waveflow_server::sync::EntityFetchResponse`.
+/// `fields` is whatever `apply::*::canonical_fields` fed to
+/// `compute_payload_hash` when the row was stamped — recomputing
+/// against `(fields, hlc, origin_device_id)` MUST land on
+/// `payload_hash`, which the backfill orchestrator can assert
+/// defensively.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RemoteEntityRow {
+    pub entity: String,
+    pub canonical_id: String,
+    /// Hex-encoded BLAKE3-256.
+    pub payload_hash: String,
+    pub hlc: RemoteEntityHlc,
+    #[serde(default)]
+    pub origin_device_id: Option<Uuid>,
+    pub fields: Map<String, Value>,
+    /// Track-only — the desktop maps to its local `library.id`
+    /// via `canonical::ENTITY_LIBRARY`. `None` for non-track
+    /// entities (server omits the field via `skip_serializing_if`).
+    #[serde(default)]
+    pub library_canonical_id: Option<String>,
+    /// Track-only — the second half of the composite canonical
+    /// (`<lib_canonical>\u{1F}<file_path>`). `None` for non-track.
+    #[serde(default)]
+    pub file_path: Option<String>,
+}
+
+/// HLC pair on the wire. Matches the server's `Hlc` shape; kept
+/// local to avoid pulling utoipa schema types into the desktop.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RemoteEntityHlc {
+    pub wall: i64,
+    pub logical: i32,
+}
+
+/// Fetch a single materialised row for `(entity, canonical_id)`.
+/// `Ok(None)` covers the server-side 404 path (row absent or
+/// `payload_hash IS NULL`); other failures (auth, scope, network)
+/// surface as `Err`.
+///
+/// Per the server's scope rules:
+/// - `library` / `playlist` / `track`: `profile_canonical_id`
+///   required (the active profile's UUID from `app.db`).
+/// - `liked_track` / `track_rating`: `profile_canonical_id` MUST
+///   be `None`; the server rejects it otherwise.
+pub async fn fetch_remote_entity(
+    client: &WaveflowServerClient,
+    entity: &str,
+    canonical_id: &str,
+    profile_canonical_id: Option<&str>,
+) -> AppResult<Option<RemoteEntityRow>> {
+    validate_scope(entity, profile_canonical_id)?;
+
+    let mut query: Vec<(&str, &str)> = vec![
+        ("entity", entity),
+        ("canonical_id", canonical_id),
+    ];
+    if let Some(canon) = profile_canonical_id {
+        query.push(("profile_canonical_id", canon));
+    }
+
+    let response = client
+        .request(reqwest::Method::GET, "/api/v1/sync/entity")
+        .query(&query)
+        .send()
+        .await
+        .map_err(|err| AppError::Other(format!("sync entity GET: {err}")))?;
+
+    let status = response.status();
+    match status {
+        StatusCode::OK => {
+            let row: RemoteEntityRow = response
+                .json()
+                .await
+                .map_err(|err| AppError::Other(format!("sync entity deserialise: {err}")))?;
+            Ok(Some(row))
+        }
+        StatusCode::NOT_FOUND => Ok(None),
+        StatusCode::UNAUTHORIZED => Err(AppError::Other(
+            "sync entity GET: unauthorized — JWT expired or revoked".into(),
+        )),
+        StatusCode::BAD_REQUEST => {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<no body>".into());
+            Err(AppError::Other(format!(
+                "sync entity GET {entity}: bad request — {body}",
+            )))
+        }
+        other => {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<no body>".into());
+            Err(AppError::Other(format!(
+                "sync entity GET {entity}: unexpected status {other} — {body}",
+            )))
+        }
+    }
+}
+
+fn validate_scope(entity: &str, profile_canonical_id: Option<&str>) -> AppResult<()> {
+    match entity {
+        "library" | "playlist" | "track" => {
+            if profile_canonical_id.is_none() {
+                return Err(AppError::Other(format!(
+                    "sync entity {entity}: profile_canonical_id is required",
+                )));
+            }
+        }
+        "liked_track" | "track_rating" => {
+            if profile_canonical_id.is_some() {
+                return Err(AppError::Other(format!(
+                    "sync entity {entity}: profile_canonical_id must be omitted",
+                )));
+            }
+        }
+        // `profile` deliberately rejected — server PR #66 excludes
+        // it by design (canonical IS the scope identifier).
+        other => {
+            return Err(AppError::Other(format!(
+                "sync entity: unknown / unsupported entity '{other}'",
+            )))
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_requires_canonical_for_profile_entities() {
+        for e in ["library", "playlist", "track"] {
+            assert!(validate_scope(e, None).is_err(), "{e} without canonical");
+            assert!(validate_scope(e, Some("abc")).is_ok(), "{e} with canonical");
+        }
+    }
+
+    #[test]
+    fn scope_rejects_canonical_for_user_entities() {
+        for e in ["liked_track", "track_rating"] {
+            assert!(
+                validate_scope(e, Some("abc")).is_err(),
+                "{e} with canonical",
+            );
+            assert!(validate_scope(e, None).is_ok(), "{e} without canonical");
+        }
+    }
+
+    #[test]
+    fn scope_rejects_profile_entity_and_unknown() {
+        // Server excludes `profile` from /entity by design.
+        assert!(validate_scope("profile", Some("abc")).is_err());
+        assert!(validate_scope("playlist_track", None).is_err());
+    }
+
+    #[test]
+    fn remote_entity_row_deserialises_library_shape() {
+        let body = serde_json::json!({
+            "entity": "library",
+            "canonical_id": "lib-uuid",
+            "payload_hash": "deadbeef",
+            "hlc": { "wall": 100, "logical": 1 },
+            "origin_device_id": "11111111-1111-1111-1111-111111111111",
+            "fields": {
+                "name": "Bandes-son",
+                "description": "best",
+                "color_id": "azure",
+                "icon_id": "library",
+            }
+        });
+        let parsed: RemoteEntityRow = serde_json::from_value(body).unwrap();
+        assert_eq!(parsed.entity, "library");
+        assert_eq!(parsed.canonical_id, "lib-uuid");
+        assert_eq!(parsed.hlc.wall, 100);
+        assert_eq!(parsed.hlc.logical, 1);
+        assert!(parsed.origin_device_id.is_some());
+        assert!(parsed.library_canonical_id.is_none());
+        assert!(parsed.file_path.is_none());
+        assert_eq!(parsed.fields["name"], "Bandes-son");
+    }
+
+    #[test]
+    fn remote_entity_row_deserialises_track_shape_with_aux_fields() {
+        // Track responses carry library_canonical_id + file_path
+        // as top-level convenience fields alongside `fields`.
+        let body = serde_json::json!({
+            "entity": "track",
+            "canonical_id": "lib-uuid\u{001F}/m/a.flac",
+            "payload_hash": "abcd",
+            "hlc": { "wall": 1, "logical": 0 },
+            "fields": { "title": "X", "file_hash": "h" },
+            "library_canonical_id": "lib-uuid",
+            "file_path": "/m/a.flac",
+        });
+        let parsed: RemoteEntityRow = serde_json::from_value(body).unwrap();
+        assert_eq!(parsed.library_canonical_id.as_deref(), Some("lib-uuid"));
+        assert_eq!(parsed.file_path.as_deref(), Some("/m/a.flac"));
+        // origin_device_id omitted by server when None — deserialise as None.
+        assert!(parsed.origin_device_id.is_none());
+    }
+}

--- a/src-tauri/crates/app/src/sync/digest/mod.rs
+++ b/src-tauri/crates/app/src/sync/digest/mod.rs
@@ -49,6 +49,7 @@
 
 pub mod client;
 pub mod diff;
+pub mod entity_client;
 
 use serde::Serialize;
 use sqlx::SqlitePool;

--- a/src-tauri/crates/app/src/sync/mod.rs
+++ b/src-tauri/crates/app/src/sync/mod.rs
@@ -55,6 +55,7 @@
 //!   1.f.desktop.4b). Closes the loop opened by [`drain`].
 
 pub mod apply;
+pub mod backfill;
 pub mod canonical;
 pub mod cursor;
 pub mod device;


### PR DESCRIPTION
## What

Closes the loop B.1 (#249, digest client read-only) laid: for each of the 4 backfill-supported entities (`library`, `playlist`, `liked_track`, `track_rating`), reconcile the desktop's state with the server's by acting on the diff buckets:

- `missing_remotely` → re-emit the local row's canonical fields via the outbound queue ; drain delivers.
- `missing_locally` → fetch from server `GET /api/v1/sync/entity` (server PR #66) and write the row locally with the **exact** `(hlc_wall, hlc_logical, origin_device_id, payload_hash)` the server returned. Bypasses the `sync::apply` pipeline so the next digest sweep computes the same `set_hash` byte-exact.
- `divergent` → fetch remote, compare §2 tuples per RFC-003 via `HlcTriple::Ord`. Greater wins; loser side reconciles.

Pair of server PR #66 — that landed the endpoint, this lands the consumer.

## Layout

### `sync::digest::entity_client`

| Item | Purpose |
|---|---|
| `RemoteEntityRow` | Deserialise mirror of server's `EntityFetchResponse`. Track-only `library_canonical_id` + `file_path` ride as top-level fields alongside the canonical `fields` map. |
| `fetch_remote_entity` | Scope validation local (profile-scoped require canonical, user-scoped reject, `profile` excluded per server design); 404 → `Ok(None)`. |

### `sync::backfill`

| File | Purpose |
|---|---|
| `mod.rs` | Orchestrator. Loop entities → digest_check (reuses B.1) → dispatch each diff bucket. `track` skipped in v1. |
| `push.rs` | `push_missing_remotely` + `push_one_by_canonical`. Reads canonical fields via B.0a helpers, enqueues insert ops. Liked / rating read from local row state directly. |
| `pull.rs` | `pull_missing_locally` + `pull_one`. Fetches via `/sync/entity`, UPSERTs locally + stamps server's exact HLC + payload_hash. Liked / rating rows without a matching local `track.file_hash` defer silently. |
| `lww.rs` | `resolve_divergent`. Per row: fetch remote, read local §2 tuple, compare via `HlcTriple::cmp`. Greater → reuse `pull::apply_remote_row`; lesser → reuse `push::push_one_by_canonical`; equal → log + count as failed. |

### State + commands

- `AppState::backfill_lock` — `tokio::sync::Mutex` lock around `run_backfill`. Concurrent calls → `BackfillOutcome::AlreadyRunning`.
- `sync_backfill_now` Tauri command — Gate 0 (offline) + 1 (SyncMode::Local) + 2 (no JWT/URL) short-circuit to empty reports; orchestrator returns per-entity counts.

## What this does NOT do

- ❌ `track` entity backfill — deferred to follow-up PR. Composite canonical + album/artist plumbing needs its own upsert path. Skipped with `SKIP_REASON_TRACK_NOT_YET`.
- ❌ `sync.v2.backfill_enabled` flag + `sync.backfill_done` marker + auto-poll cadence — B.3 scope.
- ❌ HLC clobber guard on push (skip push if `local.hlc < remote.max_hlc`) — reserved field on `PushStats`. v1 accepts the narrow window where an old re-emit could resurrect a peer-deleted row; server's LWW handles conflicts.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` → **351 passing** (baseline 346 → +5 from `entity_client` shape validation)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Manual 2-device smoke: device A pushes 5 library renames + 3 likes + 2 ratings ; device B invokes `sync_backfill_now`; verify B's local DB matches A's + `metadata_digest_version` bumps reflect.

Inline orchestrator + helper tests deferred: they need an HTTP mock harness (wiremock or httpmock) the desktop doesn't yet ship in dev-deps. Follow-up PR will add the harness + cover the 3 buckets symmetrically.

## Refs

- RFC-003 §4 (backfill protocol) + §2 (HLC + origin_device_id tuple LWW)
- Server PR #66 (entity fetch endpoint — pair of this)
- Desktop PR #249 (B.1 digest client + diff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Ajout d’une commande de synchronisation “backfill” déclenchable immédiatement, avec protections pour éviter les exécutions concurrentes et un comportement sûr en mode hors-ligne.
  * Mise en place d’un mécanisme de rattrapage par entités (push/pull) basé sur les digests, incluant la résolution automatique des divergences entre l’état local et le serveur.
  * Enrichissement des rapports de synchronisation avec des indicateurs par entité (actions réussies, échecs et raisons de non-exécution).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->