### PR TITLE
feat(sync): rfc-003 phase b.3 — Settings sync status card + manual resync

### DIFF
--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -44,6 +44,7 @@ import {
   Puzzle,
 } from "lucide-react";
 import { ServerAccountCard } from "./settings/ServerAccountCard";
+import { SyncStatusCard } from "./settings/SyncStatusCard";
 import { PluginsCard } from "./settings/PluginsCard";
 import { useTheme } from "../../hooks/useTheme";
 import { THEME_PRESETS } from "../../lib/themes";
@@ -3132,6 +3133,7 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
             {t("settings.sections.diagnostics")}
           </h2>
           <div className="space-y-1">
+            <SyncStatusCard />
             <div className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center space-x-4 min-w-0">

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -54,6 +54,13 @@ export function SyncStatusCard() {
   const [backfillOutcome, setBackfillOutcome] = useState<BackfillOutcome | null>(
     null,
   );
+  // Runtime errors from `syncBackfillNow` (network, deserialize,
+  // unexpected status) are tracked separately from the backend's
+  // `BackfillOutcome` wire shape: mapping them onto `Skipped { reason }`
+  // would lie to the user ("the backend chose not to run") when the
+  // truth is "the call itself blew up". Cleared on every fresh
+  // attempt so a successful retry hides the stale banner.
+  const [backfillError, setBackfillError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setState({ kind: "loading" });
@@ -99,6 +106,7 @@ export function SyncStatusCard() {
   const handleBackfill = useCallback(async () => {
     setBackfilling(true);
     setBackfillOutcome(null);
+    setBackfillError(null);
     try {
       const outcome = await syncBackfillNow();
       setBackfillOutcome(outcome);
@@ -110,10 +118,7 @@ export function SyncStatusCard() {
         void refresh();
       }
     } catch (err) {
-      setBackfillOutcome({
-        status: "skipped",
-        reason: err instanceof Error ? err.message : String(err),
-      });
+      setBackfillError(err instanceof Error ? err.message : String(err));
     } finally {
       setBackfilling(false);
     }
@@ -131,7 +136,13 @@ export function SyncStatusCard() {
               {t("settings.syncStatus.title")}
             </div>
             <div className="text-xs text-zinc-400">{overall.subtitle(t)}</div>
-            {backfillOutcome ? (
+            {backfillError ? (
+              <div className="mt-2 text-xs text-rose-600 dark:text-rose-400">
+                {t("settings.syncStatus.backfillError", {
+                  message: backfillError,
+                })}
+              </div>
+            ) : backfillOutcome ? (
               <div className="mt-2 text-xs">
                 <BackfillOutcomeSummary outcome={backfillOutcome} />
               </div>

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -1,0 +1,382 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertCircle,
+  CheckCircle2,
+  CloudOff,
+  Loader2,
+  RefreshCw,
+  Server,
+  WifiOff,
+} from "lucide-react";
+import {
+  syncBackfillNow,
+  syncDigestCheck,
+  type BackfillOutcome,
+  type SyncDigestOutcome,
+  type SyncDigestReport,
+} from "../../../lib/tauri/sync";
+
+/**
+ * Settings → Diagnostics → "Sync status" card (RFC-003 Phase B.3).
+ *
+ * Surface the digest_check + backfill commands the B.1/B.2 PRs
+ * shipped so users can see whether their local state matches the
+ * server's + trigger reconciliation when it doesn't.
+ *
+ * The card is intentionally read-only beyond two action buttons —
+ * no continuous polling, no background heartbeat. Triggers:
+ *
+ * - On mount: one digest_check pass (cheap, read-only).
+ * - "Refresh" button: another digest_check.
+ * - "Resync now" button: a backfill pass + automatic digest_check
+ *   re-run after to surface the new state.
+ *
+ * Gating reasons surfaced (matches the backend's `Skipped { reason }`):
+ *
+ * - `offline` — user enabled offline mode.
+ * - `sync_mode_local` — profile is set to Local mode.
+ * - `not_configured` — no server URL or no JWT.
+ * - `profile_canonical_id_missing` — profile hasn't been backfilled
+ *   with its canonical id yet (drain task handles it on next pass).
+ */
+
+type CardState =
+  | { kind: "loading" }
+  | { kind: "ran"; reports: SyncDigestReport[] }
+  | { kind: "skipped"; reason: string }
+  | { kind: "error"; message: string };
+
+export function SyncStatusCard() {
+  const { t } = useTranslation();
+  const [state, setState] = useState<CardState>({ kind: "loading" });
+  const [backfilling, setBackfilling] = useState(false);
+  const [backfillOutcome, setBackfillOutcome] = useState<BackfillOutcome | null>(
+    null,
+  );
+
+  const refresh = useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      const outcome: SyncDigestOutcome = await syncDigestCheck();
+      if (outcome.status === "skipped") {
+        setState({ kind: "skipped", reason: outcome.reason });
+      } else {
+        setState({ kind: "ran", reports: outcome.reports });
+      }
+    } catch (err) {
+      setState({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const outcome: SyncDigestOutcome = await syncDigestCheck();
+        if (cancelled) return;
+        if (outcome.status === "skipped") {
+          setState({ kind: "skipped", reason: outcome.reason });
+        } else {
+          setState({ kind: "ran", reports: outcome.reports });
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleBackfill = useCallback(async () => {
+    setBackfilling(true);
+    setBackfillOutcome(null);
+    try {
+      const outcome = await syncBackfillNow();
+      setBackfillOutcome(outcome);
+      // Refresh the digest snapshot post-backfill so the user
+      // sees the new state without an extra click. Only when the
+      // pass actually ran — `skipped` / `already_running` outcomes
+      // wouldn't change anything to re-check.
+      if (outcome.status === "ran") {
+        void refresh();
+      }
+    } catch (err) {
+      setBackfillOutcome({
+        status: "skipped",
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBackfilling(false);
+    }
+  }, [refresh]);
+
+  const overall = useOverallStatus(state);
+
+  return (
+    <div className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start space-x-4 min-w-0">
+          {overall.icon}
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-zinc-900 dark:text-white">
+              {t("settings.syncStatus.title")}
+            </div>
+            <div className="text-xs text-zinc-400">{overall.subtitle(t)}</div>
+            {backfillOutcome ? (
+              <div className="mt-2 text-xs">
+                <BackfillOutcomeSummary outcome={backfillOutcome} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex items-center space-x-2 shrink-0">
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={state.kind === "loading" || backfilling}
+            className="flex items-center space-x-2 px-4 py-2 rounded-xl border border-zinc-200 bg-white text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <RefreshCw
+              size={14}
+              aria-hidden="true"
+              className={state.kind === "loading" ? "animate-spin" : undefined}
+            />
+            <span>{t("settings.syncStatus.refresh")}</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleBackfill}
+            disabled={
+              state.kind !== "ran" ||
+              state.reports.every((r) => r.in_sync) ||
+              backfilling
+            }
+            className="flex items-center space-x-2 px-4 py-2 rounded-xl bg-emerald-600 text-sm font-medium text-white hover:bg-emerald-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {backfilling ? (
+              <Loader2 size={14} aria-hidden="true" className="animate-spin" />
+            ) : (
+              <Server size={14} aria-hidden="true" />
+            )}
+            <span>{t("settings.syncStatus.resyncNow")}</span>
+          </button>
+        </div>
+      </div>
+
+      {state.kind === "ran" && state.reports.length > 0 ? (
+        <div className="mt-4 ml-9">
+          <EntityReportTable reports={state.reports} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface OverallStatus {
+  icon: ReactNode;
+  subtitle: (t: ReturnType<typeof useTranslation>["t"]) => string;
+}
+
+function useOverallStatus(state: CardState): OverallStatus {
+  return useMemo<OverallStatus>(() => {
+    switch (state.kind) {
+      case "loading":
+        return {
+          icon: (
+            <Loader2
+              size={20}
+              className="text-zinc-400 shrink-0 animate-spin"
+              aria-hidden="true"
+            />
+          ),
+          subtitle: (t) => t("settings.syncStatus.loading"),
+        };
+      case "ran": {
+        const total = state.reports.length;
+        const inSync = state.reports.filter((r) => r.in_sync).length;
+        if (total === 0) {
+          return {
+            icon: (
+              <AlertCircle
+                size={20}
+                className="text-zinc-400 shrink-0"
+                aria-hidden="true"
+              />
+            ),
+            subtitle: (t) => t("settings.syncStatus.subtitleEmpty"),
+          };
+        }
+        if (inSync === total) {
+          return {
+            icon: (
+              <CheckCircle2
+                size={20}
+                className="text-emerald-500 shrink-0"
+                aria-hidden="true"
+              />
+            ),
+            subtitle: (t) => t("settings.syncStatus.subtitleAllInSync"),
+          };
+        }
+        return {
+          icon: (
+            <AlertCircle
+              size={20}
+              className="text-amber-500 shrink-0"
+              aria-hidden="true"
+            />
+          ),
+          subtitle: (t) =>
+            t("settings.syncStatus.subtitleOutOfSync", {
+              outOfSync: total - inSync,
+              total,
+            }),
+        };
+      }
+      case "skipped": {
+        const reasonIcon =
+          state.reason === "offline" ? (
+            <WifiOff
+              size={20}
+              className="text-zinc-400 shrink-0"
+              aria-hidden="true"
+            />
+          ) : (
+            <CloudOff
+              size={20}
+              className="text-zinc-400 shrink-0"
+              aria-hidden="true"
+            />
+          );
+        return {
+          icon: reasonIcon,
+          subtitle: (t) =>
+            t(`settings.syncStatus.reason.${state.reason}`, {
+              defaultValue: t("settings.syncStatus.reasonGeneric", {
+                reason: state.reason,
+              }),
+            }),
+        };
+      }
+      case "error":
+        return {
+          icon: (
+            <AlertCircle
+              size={20}
+              className="text-rose-500 shrink-0"
+              aria-hidden="true"
+            />
+          ),
+          subtitle: (t) =>
+            t("settings.syncStatus.error", { message: state.message }),
+        };
+    }
+  }, [state]);
+}
+
+function EntityReportTable({ reports }: { reports: SyncDigestReport[] }) {
+  const { t } = useTranslation();
+  return (
+    <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+      <table className="w-full text-xs">
+        <thead className="bg-zinc-50 dark:bg-zinc-800/50 text-zinc-500 dark:text-zinc-400">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium">
+              {t("settings.syncStatus.col.entity")}
+            </th>
+            <th className="px-3 py-2 text-center font-medium">
+              {t("settings.syncStatus.col.state")}
+            </th>
+            <th className="px-3 py-2 text-right font-medium">
+              {t("settings.syncStatus.col.missingLocally")}
+            </th>
+            <th className="px-3 py-2 text-right font-medium">
+              {t("settings.syncStatus.col.missingRemotely")}
+            </th>
+            <th className="px-3 py-2 text-right font-medium">
+              {t("settings.syncStatus.col.divergent")}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-200 dark:divide-zinc-700">
+          {reports.map((r) => (
+            <tr key={r.entity}>
+              <td className="px-3 py-2 font-mono text-zinc-700 dark:text-zinc-200">
+                {r.entity}
+              </td>
+              <td className="px-3 py-2 text-center">
+                {r.in_sync ? (
+                  <span
+                    className="inline-flex items-center text-emerald-600 dark:text-emerald-400"
+                    title={t("settings.syncStatus.inSync") ?? undefined}
+                  >
+                    <CheckCircle2 size={14} aria-hidden="true" />
+                  </span>
+                ) : (
+                  <span
+                    className="inline-flex items-center text-amber-600 dark:text-amber-400"
+                    title={t("settings.syncStatus.outOfSync") ?? undefined}
+                  >
+                    <AlertCircle size={14} aria-hidden="true" />
+                  </span>
+                )}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
+                {r.missing_locally}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
+                {r.missing_remotely}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
+                {r.divergent}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function BackfillOutcomeSummary({ outcome }: { outcome: BackfillOutcome }) {
+  const { t } = useTranslation();
+  if (outcome.status === "already_running") {
+    return (
+      <span className="text-amber-600 dark:text-amber-400">
+        {t("settings.syncStatus.backfillAlreadyRunning")}
+      </span>
+    );
+  }
+  if (outcome.status === "skipped") {
+    return (
+      <span className="text-zinc-500 dark:text-zinc-400">
+        {t("settings.syncStatus.backfillSkipped", { reason: outcome.reason })}
+      </span>
+    );
+  }
+  const totals = outcome.reports.reduce(
+    (acc, r) => {
+      acc.pushed += r.pushed;
+      acc.pulled += r.pulled;
+      acc.lww += r.lww_local_wins + r.lww_remote_wins;
+      acc.failed +=
+        r.push_failed + r.pull_failed + r.lww_failed + (r.error ? 1 : 0);
+      return acc;
+    },
+    { pushed: 0, pulled: 0, lww: 0, failed: 0 },
+  );
+  return (
+    <span className="text-zinc-600 dark:text-zinc-300">
+      {t("settings.syncStatus.backfillSummary", totals)}
+    </span>
+  );
+}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1485,6 +1485,35 @@
       "copied": "تم نسخ السجلات",
       "copyFailed": "تعذّر نسخ السجلات"
     },
+    "syncStatus": {
+      "title": "حالة المزامنة",
+      "loading": "جارٍ التحقق…",
+      "subtitleEmpty": "لا توجد كيانات للمقارنة",
+      "subtitleAllInSync": "كل شيء متزامن",
+      "subtitleOutOfSync": "{{outOfSync}} من {{total}} غير متزامنة",
+      "refresh": "تحديث",
+      "resyncNow": "إعادة المزامنة الآن",
+      "inSync": "متزامن",
+      "outOfSync": "غير متزامن",
+      "error": "خطأ: {{message}}",
+      "reasonGeneric": "تم التخطي ({{reason}})",
+      "reason": {
+        "offline": "وضع عدم الاتصال مفعّل",
+        "sync_mode_local": "الملف الشخصي في الوضع المحلي",
+        "not_configured": "الخادم غير مهيأ",
+        "profile_canonical_id_missing": "في انتظار المزامنة الأولى"
+      },
+      "backfillAlreadyRunning": "هناك مزامنة قيد التشغيل بالفعل",
+      "backfillSkipped": "تم تخطي المزامنة ({{reason}})",
+      "backfillSummary": "{{pushed}} مُرسلة · {{pulled}} مستلمة · {{lww}} مدمجة · {{failed}} فاشلة",
+      "col": {
+        "entity": "الكيان",
+        "state": "الحالة",
+        "missingLocally": "مفقود محليًا",
+        "missingRemotely": "مفقود بعيدًا",
+        "divergent": "متباين"
+      }
+    },
     "visualizer": {
       "title": "محلل الصوت البصري",
       "subtitle": "يعرض طيفًا في الوقت الفعلي في العرض الانغماسي (FFT خفيف على خيط فك التشفير)"

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1512,7 +1512,8 @@
         "missingLocally": "مفقود محليًا",
         "missingRemotely": "مفقود بعيدًا",
         "divergent": "متباين"
-      }
+      },
+      "backfillError": "فشل: {{message}}"
     },
     "visualizer": {
       "title": "محلل الصوت البصري",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1481,6 +1481,35 @@
       "copied": "Logs kopiert",
       "copyFailed": "Logs konnten nicht kopiert werden"
     },
+    "syncStatus": {
+      "title": "Synchronisationsstatus",
+      "loading": "Prüfung läuft…",
+      "subtitleEmpty": "Keine Entitäten zu vergleichen",
+      "subtitleAllInSync": "Alles ist synchron",
+      "subtitleOutOfSync": "{{outOfSync}} von {{total}} nicht synchron",
+      "refresh": "Aktualisieren",
+      "resyncNow": "Jetzt synchronisieren",
+      "inSync": "Synchron",
+      "outOfSync": "Abweichend",
+      "error": "Fehler: {{message}}",
+      "reasonGeneric": "Übersprungen ({{reason}})",
+      "reason": {
+        "offline": "Offline-Modus aktiv",
+        "sync_mode_local": "Profil im lokalen Modus",
+        "not_configured": "Server nicht konfiguriert",
+        "profile_canonical_id_missing": "Erste Synchronisation ausstehend"
+      },
+      "backfillAlreadyRunning": "Eine Synchronisation läuft bereits",
+      "backfillSkipped": "Synchronisation übersprungen ({{reason}})",
+      "backfillSummary": "{{pushed}} gesendet · {{pulled}} empfangen · {{lww}} zusammengeführt · {{failed}} fehlgeschlagen",
+      "col": {
+        "entity": "Entität",
+        "state": "Status",
+        "missingLocally": "Lokal fehlend",
+        "missingRemotely": "Remote fehlend",
+        "divergent": "Abweichend"
+      }
+    },
     "visualizer": {
       "title": "Audio-Visualizer",
       "subtitle": "Zeigt ein Echtzeit-Spektrum in der immersiven Ansicht (leichtgewichtige FFT im Decoder-Thread)"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1508,7 +1508,8 @@
         "missingLocally": "Lokal fehlend",
         "missingRemotely": "Remote fehlend",
         "divergent": "Abweichend"
-      }
+      },
+      "backfillError": "Fehlgeschlagen: {{message}}"
     },
     "visualizer": {
       "title": "Audio-Visualizer",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1508,7 +1508,8 @@
         "missingLocally": "Missing locally",
         "missingRemotely": "Missing remotely",
         "divergent": "Divergent"
-      }
+      },
+      "backfillError": "Failed: {{message}}"
     },
     "visualizer": {
       "title": "Audio visualizer",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1481,6 +1481,35 @@
       "copied": "Logs copied",
       "copyFailed": "Unable to copy logs"
     },
+    "syncStatus": {
+      "title": "Sync status",
+      "loading": "Checking…",
+      "subtitleEmpty": "No entities to compare",
+      "subtitleAllInSync": "Everything is in sync",
+      "subtitleOutOfSync": "{{outOfSync}} of {{total}} out of sync",
+      "refresh": "Refresh",
+      "resyncNow": "Resync now",
+      "inSync": "In sync",
+      "outOfSync": "Out of sync",
+      "error": "Error: {{message}}",
+      "reasonGeneric": "Skipped ({{reason}})",
+      "reason": {
+        "offline": "Offline mode is active",
+        "sync_mode_local": "Profile is in Local mode",
+        "not_configured": "Server is not configured",
+        "profile_canonical_id_missing": "Initial sync pending"
+      },
+      "backfillAlreadyRunning": "A sync pass is already running",
+      "backfillSkipped": "Sync skipped ({{reason}})",
+      "backfillSummary": "{{pushed}} pushed · {{pulled}} pulled · {{lww}} merged · {{failed}} failed",
+      "col": {
+        "entity": "Entity",
+        "state": "State",
+        "missingLocally": "Missing locally",
+        "missingRemotely": "Missing remotely",
+        "divergent": "Divergent"
+      }
+    },
     "visualizer": {
       "title": "Audio visualizer",
       "subtitle": "Show a real-time spectrum in the immersive view (lightweight FFT on the decoder thread)"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1481,6 +1481,35 @@
       "copied": "Registros copiados",
       "copyFailed": "No se han podido copiar los registros"
     },
+    "syncStatus": {
+      "title": "Estado de sincronización",
+      "loading": "Comprobando…",
+      "subtitleEmpty": "No hay entidades para comparar",
+      "subtitleAllInSync": "Todo está sincronizado",
+      "subtitleOutOfSync": "{{outOfSync}} de {{total}} desincronizadas",
+      "refresh": "Actualizar",
+      "resyncNow": "Sincronizar ahora",
+      "inSync": "Sincronizado",
+      "outOfSync": "Desincronizado",
+      "error": "Error: {{message}}",
+      "reasonGeneric": "Omitido ({{reason}})",
+      "reason": {
+        "offline": "Modo sin conexión activo",
+        "sync_mode_local": "Perfil en modo local",
+        "not_configured": "Servidor no configurado",
+        "profile_canonical_id_missing": "Sincronización inicial pendiente"
+      },
+      "backfillAlreadyRunning": "Ya hay una sincronización en curso",
+      "backfillSkipped": "Sincronización omitida ({{reason}})",
+      "backfillSummary": "{{pushed}} enviados · {{pulled}} recibidos · {{lww}} fusionados · {{failed}} fallos",
+      "col": {
+        "entity": "Entidad",
+        "state": "Estado",
+        "missingLocally": "Falta local",
+        "missingRemotely": "Falta remoto",
+        "divergent": "Divergente"
+      }
+    },
     "visualizer": {
       "title": "Visualizador de audio",
       "subtitle": "Muestra un espectro en tiempo real en la vista inmersiva (FFT ligero en el hilo del decodificador)"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1508,7 +1508,8 @@
         "missingLocally": "Falta local",
         "missingRemotely": "Falta remoto",
         "divergent": "Divergente"
-      }
+      },
+      "backfillError": "Error: {{message}}"
     },
     "visualizer": {
       "title": "Visualizador de audio",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1559,7 +1559,8 @@
         "missingLocally": "Manquant local",
         "missingRemotely": "Manquant distant",
         "divergent": "Divergent"
-      }
+      },
+      "backfillError": "Échec : {{message}}"
     },
     "visualizer": {
       "title": "Visualiseur audio",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1532,6 +1532,35 @@
       "copied": "Logs copiés",
       "copyFailed": "Impossible de copier les logs"
     },
+    "syncStatus": {
+      "title": "État de la synchronisation",
+      "loading": "Vérification…",
+      "subtitleEmpty": "Aucune entité à comparer",
+      "subtitleAllInSync": "Tout est synchronisé",
+      "subtitleOutOfSync": "{{outOfSync}} sur {{total}} hors synchronisation",
+      "refresh": "Actualiser",
+      "resyncNow": "Resynchroniser",
+      "inSync": "Synchronisé",
+      "outOfSync": "Divergent",
+      "error": "Erreur : {{message}}",
+      "reasonGeneric": "Ignoré ({{reason}})",
+      "reason": {
+        "offline": "Mode hors-ligne actif",
+        "sync_mode_local": "Profil en mode local",
+        "not_configured": "Serveur non configuré",
+        "profile_canonical_id_missing": "Synchronisation initiale en attente"
+      },
+      "backfillAlreadyRunning": "Une synchronisation est déjà en cours",
+      "backfillSkipped": "Synchronisation ignorée ({{reason}})",
+      "backfillSummary": "{{pushed}} envoyés · {{pulled}} reçus · {{lww}} fusionnés · {{failed}} échecs",
+      "col": {
+        "entity": "Entité",
+        "state": "État",
+        "missingLocally": "Manquant local",
+        "missingRemotely": "Manquant distant",
+        "divergent": "Divergent"
+      }
+    },
     "visualizer": {
       "title": "Visualiseur audio",
       "subtitle": "Affiche un spectre temps réel dans la vue immersive (analyse FFT légère sur le décodeur)"

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1493,6 +1493,35 @@
       "copied": "लॉग्स कॉपी किए गए",
       "copyFailed": "लॉग्स कॉपी नहीं हो सके"
     },
+    "syncStatus": {
+      "title": "सिंक स्थिति",
+      "loading": "जाँच रहे हैं…",
+      "subtitleEmpty": "तुलना करने के लिए कोई इकाई नहीं",
+      "subtitleAllInSync": "सब कुछ सिंक है",
+      "subtitleOutOfSync": "{{total}} में से {{outOfSync}} सिंक नहीं",
+      "refresh": "रिफ़्रेश",
+      "resyncNow": "अभी रीसिंक करें",
+      "inSync": "सिंक",
+      "outOfSync": "अलग",
+      "error": "त्रुटि: {{message}}",
+      "reasonGeneric": "छोड़ा गया ({{reason}})",
+      "reason": {
+        "offline": "ऑफ़लाइन मोड सक्रिय है",
+        "sync_mode_local": "प्रोफ़ाइल लोकल मोड में है",
+        "not_configured": "सर्वर कॉन्फ़िगर नहीं है",
+        "profile_canonical_id_missing": "पहली सिंक की प्रतीक्षा है"
+      },
+      "backfillAlreadyRunning": "एक सिंक पहले से चल रहा है",
+      "backfillSkipped": "सिंक छोड़ा गया ({{reason}})",
+      "backfillSummary": "{{pushed}} भेजे · {{pulled}} प्राप्त · {{lww}} विलय · {{failed}} विफल",
+      "col": {
+        "entity": "इकाई",
+        "state": "स्थिति",
+        "missingLocally": "स्थानीय अनुपस्थित",
+        "missingRemotely": "दूरस्थ अनुपस्थित",
+        "divergent": "अलग"
+      }
+    },
     "gapless": {
       "title": "गैपलेस प्लेबैक",
       "subtitle": "लगातार ट्रैकों को बिना सूक्ष्म मौन के जोड़ता है (लाइव और कॉन्सेप्ट एल्बम के लिए आदर्श)"

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1520,7 +1520,8 @@
         "missingLocally": "स्थानीय अनुपस्थित",
         "missingRemotely": "दूरस्थ अनुपस्थित",
         "divergent": "अलग"
-      }
+      },
+      "backfillError": "विफल: {{message}}"
     },
     "gapless": {
       "title": "गैपलेस प्लेबैक",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1508,7 +1508,8 @@
         "missingLocally": "Tidak ada lokal",
         "missingRemotely": "Tidak ada remote",
         "divergent": "Berbeda"
-      }
+      },
+      "backfillError": "Gagal: {{message}}"
     },
     "visualizer": {
       "title": "Visualizer audio",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1481,6 +1481,35 @@
       "copied": "Log disalin",
       "copyFailed": "Tidak dapat menyalin log"
     },
+    "syncStatus": {
+      "title": "Status sinkronisasi",
+      "loading": "Memeriksa…",
+      "subtitleEmpty": "Tidak ada entitas untuk dibandingkan",
+      "subtitleAllInSync": "Semuanya tersinkronisasi",
+      "subtitleOutOfSync": "{{outOfSync}} dari {{total}} tidak sinkron",
+      "refresh": "Segarkan",
+      "resyncNow": "Sinkronkan sekarang",
+      "inSync": "Tersinkronisasi",
+      "outOfSync": "Berbeda",
+      "error": "Galat: {{message}}",
+      "reasonGeneric": "Dilewati ({{reason}})",
+      "reason": {
+        "offline": "Mode luring aktif",
+        "sync_mode_local": "Profil dalam mode lokal",
+        "not_configured": "Server belum dikonfigurasi",
+        "profile_canonical_id_missing": "Menunggu sinkronisasi awal"
+      },
+      "backfillAlreadyRunning": "Sinkronisasi sedang berjalan",
+      "backfillSkipped": "Sinkronisasi dilewati ({{reason}})",
+      "backfillSummary": "{{pushed}} dikirim · {{pulled}} diterima · {{lww}} digabungkan · {{failed}} gagal",
+      "col": {
+        "entity": "Entitas",
+        "state": "Status",
+        "missingLocally": "Tidak ada lokal",
+        "missingRemotely": "Tidak ada remote",
+        "divergent": "Berbeda"
+      }
+    },
     "visualizer": {
       "title": "Visualizer audio",
       "subtitle": "Tampilkan spektrum waktu nyata di tampilan imersif (FFT ringan di thread decoder)"

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1508,7 +1508,8 @@
         "missingLocally": "Mancante locale",
         "missingRemotely": "Mancante remoto",
         "divergent": "Divergente"
-      }
+      },
+      "backfillError": "Errore: {{message}}"
     },
     "visualizer": {
       "title": "Visualizzatore audio",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1481,6 +1481,35 @@
       "copied": "Log copiati",
       "copyFailed": "Impossibile copiare i log"
     },
+    "syncStatus": {
+      "title": "Stato di sincronizzazione",
+      "loading": "Verifica in corso…",
+      "subtitleEmpty": "Nessuna entità da confrontare",
+      "subtitleAllInSync": "Tutto è sincronizzato",
+      "subtitleOutOfSync": "{{outOfSync}} su {{total}} non sincronizzate",
+      "refresh": "Aggiorna",
+      "resyncNow": "Sincronizza ora",
+      "inSync": "Sincronizzato",
+      "outOfSync": "Divergente",
+      "error": "Errore: {{message}}",
+      "reasonGeneric": "Ignorato ({{reason}})",
+      "reason": {
+        "offline": "Modalità offline attiva",
+        "sync_mode_local": "Profilo in modalità locale",
+        "not_configured": "Server non configurato",
+        "profile_canonical_id_missing": "Sincronizzazione iniziale in attesa"
+      },
+      "backfillAlreadyRunning": "Una sincronizzazione è già in corso",
+      "backfillSkipped": "Sincronizzazione ignorata ({{reason}})",
+      "backfillSummary": "{{pushed}} inviati · {{pulled}} ricevuti · {{lww}} uniti · {{failed}} falliti",
+      "col": {
+        "entity": "Entità",
+        "state": "Stato",
+        "missingLocally": "Mancante locale",
+        "missingRemotely": "Mancante remoto",
+        "divergent": "Divergente"
+      }
+    },
     "visualizer": {
       "title": "Visualizzatore audio",
       "subtitle": "Mostra uno spettro in tempo reale nella vista immersiva (FFT leggera sul thread del decoder)"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1440,6 +1440,35 @@
       "copied": "ログをコピーしました",
       "copyFailed": "ログをコピーできませんでした"
     },
+    "syncStatus": {
+      "title": "同期ステータス",
+      "loading": "確認中…",
+      "subtitleEmpty": "比較するエンティティがありません",
+      "subtitleAllInSync": "すべて同期されています",
+      "subtitleOutOfSync": "{{total}} 件中 {{outOfSync}} 件が未同期",
+      "refresh": "更新",
+      "resyncNow": "今すぐ再同期",
+      "inSync": "同期済み",
+      "outOfSync": "差異あり",
+      "error": "エラー: {{message}}",
+      "reasonGeneric": "スキップ ({{reason}})",
+      "reason": {
+        "offline": "オフラインモードが有効です",
+        "sync_mode_local": "プロファイルがローカルモードです",
+        "not_configured": "サーバーが未設定です",
+        "profile_canonical_id_missing": "初回同期を待機中"
+      },
+      "backfillAlreadyRunning": "すでに同期が実行中です",
+      "backfillSkipped": "同期をスキップしました ({{reason}})",
+      "backfillSummary": "送信 {{pushed}} 件 · 受信 {{pulled}} 件 · 統合 {{lww}} 件 · 失敗 {{failed}} 件",
+      "col": {
+        "entity": "エンティティ",
+        "state": "状態",
+        "missingLocally": "ローカル欠落",
+        "missingRemotely": "リモート欠落",
+        "divergent": "差異"
+      }
+    },
     "gapless": {
       "title": "ギャップレス再生",
       "subtitle": "連続するトラックをマイクロサイレンスなしで繋ぎます（ライブやコンセプトアルバムに最適）"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1467,7 +1467,8 @@
         "missingLocally": "ローカル欠落",
         "missingRemotely": "リモート欠落",
         "divergent": "差異"
-      }
+      },
+      "backfillError": "失敗: {{message}}"
     },
     "gapless": {
       "title": "ギャップレス再生",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1520,7 +1520,8 @@
         "missingLocally": "로컬 누락",
         "missingRemotely": "원격 누락",
         "divergent": "불일치"
-      }
+      },
+      "backfillError": "실패: {{message}}"
     },
     "gapless": {
       "title": "갭리스 재생",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1493,6 +1493,35 @@
       "copied": "로그가 복사되었습니다",
       "copyFailed": "로그를 복사할 수 없음"
     },
+    "syncStatus": {
+      "title": "동기화 상태",
+      "loading": "확인 중…",
+      "subtitleEmpty": "비교할 항목 없음",
+      "subtitleAllInSync": "모두 동기화됨",
+      "subtitleOutOfSync": "{{total}}개 중 {{outOfSync}}개가 동기화되지 않음",
+      "refresh": "새로고침",
+      "resyncNow": "지금 재동기화",
+      "inSync": "동기화됨",
+      "outOfSync": "불일치",
+      "error": "오류: {{message}}",
+      "reasonGeneric": "건너뜀 ({{reason}})",
+      "reason": {
+        "offline": "오프라인 모드 활성",
+        "sync_mode_local": "프로필이 로컬 모드입니다",
+        "not_configured": "서버가 구성되지 않음",
+        "profile_canonical_id_missing": "초기 동기화 대기 중"
+      },
+      "backfillAlreadyRunning": "이미 동기화가 실행 중입니다",
+      "backfillSkipped": "동기화 건너뜀 ({{reason}})",
+      "backfillSummary": "{{pushed}}개 전송 · {{pulled}}개 수신 · {{lww}}개 병합 · {{failed}}개 실패",
+      "col": {
+        "entity": "엔티티",
+        "state": "상태",
+        "missingLocally": "로컬 누락",
+        "missingRemotely": "원격 누락",
+        "divergent": "불일치"
+      }
+    },
     "gapless": {
       "title": "갭리스 재생",
       "subtitle": "연속된 트랙을 미세한 무음 없이 이어 재생합니다 (라이브 및 콘셉트 앨범에 적합)"

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1481,6 +1481,35 @@
       "copied": "Logs gekopieerd",
       "copyFailed": "Logs konden niet worden gekopieerd"
     },
+    "syncStatus": {
+      "title": "Synchronisatiestatus",
+      "loading": "Controle…",
+      "subtitleEmpty": "Geen entiteiten om te vergelijken",
+      "subtitleAllInSync": "Alles is gesynchroniseerd",
+      "subtitleOutOfSync": "{{outOfSync}} van {{total}} niet synchroon",
+      "refresh": "Vernieuwen",
+      "resyncNow": "Nu synchroniseren",
+      "inSync": "Gesynchroniseerd",
+      "outOfSync": "Afwijkend",
+      "error": "Fout: {{message}}",
+      "reasonGeneric": "Overgeslagen ({{reason}})",
+      "reason": {
+        "offline": "Offline-modus actief",
+        "sync_mode_local": "Profiel in lokale modus",
+        "not_configured": "Server niet geconfigureerd",
+        "profile_canonical_id_missing": "Initiële synchronisatie in afwachting"
+      },
+      "backfillAlreadyRunning": "Er loopt al een synchronisatie",
+      "backfillSkipped": "Synchronisatie overgeslagen ({{reason}})",
+      "backfillSummary": "{{pushed}} verzonden · {{pulled}} ontvangen · {{lww}} samengevoegd · {{failed}} mislukt",
+      "col": {
+        "entity": "Entiteit",
+        "state": "Status",
+        "missingLocally": "Lokaal ontbrekend",
+        "missingRemotely": "Extern ontbrekend",
+        "divergent": "Afwijkend"
+      }
+    },
     "visualizer": {
       "title": "Audio-visualizer",
       "subtitle": "Toont een real-time spectrum in de immersieve weergave (lichte FFT op de decoderthread)"

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1508,7 +1508,8 @@
         "missingLocally": "Lokaal ontbrekend",
         "missingRemotely": "Extern ontbrekend",
         "divergent": "Afwijkend"
-      }
+      },
+      "backfillError": "Mislukt: {{message}}"
     },
     "visualizer": {
       "title": "Audio-visualizer",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1493,6 +1493,35 @@
       "copied": "Registros copiados",
       "copyFailed": "Não foi possível copiar os registros"
     },
+    "syncStatus": {
+      "title": "Status da sincronização",
+      "loading": "Verificando…",
+      "subtitleEmpty": "Nenhuma entidade para comparar",
+      "subtitleAllInSync": "Tudo está sincronizado",
+      "subtitleOutOfSync": "{{outOfSync}} de {{total}} dessincronizadas",
+      "refresh": "Atualizar",
+      "resyncNow": "Sincronizar agora",
+      "inSync": "Sincronizado",
+      "outOfSync": "Divergente",
+      "error": "Erro: {{message}}",
+      "reasonGeneric": "Ignorado ({{reason}})",
+      "reason": {
+        "offline": "Modo offline ativo",
+        "sync_mode_local": "Perfil em modo local",
+        "not_configured": "Servidor não configurado",
+        "profile_canonical_id_missing": "Sincronização inicial pendente"
+      },
+      "backfillAlreadyRunning": "Já há uma sincronização em andamento",
+      "backfillSkipped": "Sincronização ignorada ({{reason}})",
+      "backfillSummary": "{{pushed}} enviados · {{pulled}} recebidos · {{lww}} mesclados · {{failed}} falhas",
+      "col": {
+        "entity": "Entidade",
+        "state": "Estado",
+        "missingLocally": "Faltando local",
+        "missingRemotely": "Faltando remoto",
+        "divergent": "Divergente"
+      }
+    },
     "gapless": {
       "title": "Reprodução contínua",
       "subtitle": "Encadeia faixas consecutivas sem micro-silêncio (ideal para shows e álbuns conceituais)"

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1520,7 +1520,8 @@
         "missingLocally": "Faltando local",
         "missingRemotely": "Faltando remoto",
         "divergent": "Divergente"
-      }
+      },
+      "backfillError": "Falhou: {{message}}"
     },
     "gapless": {
       "title": "Reprodução contínua",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1493,6 +1493,35 @@
       "copied": "Registos copiados",
       "copyFailed": "Não foi possível copiar os registos"
     },
+    "syncStatus": {
+      "title": "Estado da sincronização",
+      "loading": "A verificar…",
+      "subtitleEmpty": "Sem entidades para comparar",
+      "subtitleAllInSync": "Tudo está sincronizado",
+      "subtitleOutOfSync": "{{outOfSync}} de {{total}} dessincronizadas",
+      "refresh": "Atualizar",
+      "resyncNow": "Sincronizar agora",
+      "inSync": "Sincronizado",
+      "outOfSync": "Divergente",
+      "error": "Erro: {{message}}",
+      "reasonGeneric": "Ignorado ({{reason}})",
+      "reason": {
+        "offline": "Modo offline ativo",
+        "sync_mode_local": "Perfil em modo local",
+        "not_configured": "Servidor não configurado",
+        "profile_canonical_id_missing": "Sincronização inicial pendente"
+      },
+      "backfillAlreadyRunning": "Já existe uma sincronização em curso",
+      "backfillSkipped": "Sincronização ignorada ({{reason}})",
+      "backfillSummary": "{{pushed}} enviados · {{pulled}} recebidos · {{lww}} mesclados · {{failed}} falhas",
+      "col": {
+        "entity": "Entidade",
+        "state": "Estado",
+        "missingLocally": "Em falta local",
+        "missingRemotely": "Em falta remoto",
+        "divergent": "Divergente"
+      }
+    },
     "gapless": {
       "title": "Reprodução contínua",
       "subtitle": "Encadeia faixas consecutivas sem micro-silêncio (ideal para concertos e álbuns conceptuais)"

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1520,7 +1520,8 @@
         "missingLocally": "Em falta local",
         "missingRemotely": "Em falta remoto",
         "divergent": "Divergente"
-      }
+      },
+      "backfillError": "Falhou: {{message}}"
     },
     "gapless": {
       "title": "Reprodução contínua",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1523,6 +1523,35 @@
       "copied": "Логи скопированы",
       "copyFailed": "Не удалось скопировать логи"
     },
+    "syncStatus": {
+      "title": "Статус синхронизации",
+      "loading": "Проверка…",
+      "subtitleEmpty": "Нет сущностей для сравнения",
+      "subtitleAllInSync": "Всё синхронизировано",
+      "subtitleOutOfSync": "{{outOfSync}} из {{total}} не синхронизировано",
+      "refresh": "Обновить",
+      "resyncNow": "Синхронизировать сейчас",
+      "inSync": "Синхронизировано",
+      "outOfSync": "Расхождение",
+      "error": "Ошибка: {{message}}",
+      "reasonGeneric": "Пропущено ({{reason}})",
+      "reason": {
+        "offline": "Активен автономный режим",
+        "sync_mode_local": "Профиль в локальном режиме",
+        "not_configured": "Сервер не настроен",
+        "profile_canonical_id_missing": "Ожидается первая синхронизация"
+      },
+      "backfillAlreadyRunning": "Синхронизация уже выполняется",
+      "backfillSkipped": "Синхронизация пропущена ({{reason}})",
+      "backfillSummary": "{{pushed}} отправлено · {{pulled}} получено · {{lww}} объединено · {{failed}} ошибок",
+      "col": {
+        "entity": "Сущность",
+        "state": "Статус",
+        "missingLocally": "Нет локально",
+        "missingRemotely": "Нет на сервере",
+        "divergent": "Расхождение"
+      }
+    },
     "visualizer": {
       "title": "Аудио-визуализатор",
       "subtitle": "Показывает спектр в реальном времени в иммерсивном режиме (лёгкий FFT в потоке декодера)"

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1550,7 +1550,8 @@
         "missingLocally": "Нет локально",
         "missingRemotely": "Нет на сервере",
         "divergent": "Расхождение"
-      }
+      },
+      "backfillError": "Сбой: {{message}}"
     },
     "visualizer": {
       "title": "Аудио-визуализатор",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1481,6 +1481,35 @@
       "copied": "Loglar kopyalandı",
       "copyFailed": "Loglar kopyalanamadı"
     },
+    "syncStatus": {
+      "title": "Senkronizasyon durumu",
+      "loading": "Kontrol ediliyor…",
+      "subtitleEmpty": "Karşılaştırılacak öğe yok",
+      "subtitleAllInSync": "Her şey senkronize",
+      "subtitleOutOfSync": "{{total}} öğeden {{outOfSync}} senkronize değil",
+      "refresh": "Yenile",
+      "resyncNow": "Şimdi senkronize et",
+      "inSync": "Senkronize",
+      "outOfSync": "Farklı",
+      "error": "Hata: {{message}}",
+      "reasonGeneric": "Atlandı ({{reason}})",
+      "reason": {
+        "offline": "Çevrimdışı mod etkin",
+        "sync_mode_local": "Profil yerel modda",
+        "not_configured": "Sunucu yapılandırılmamış",
+        "profile_canonical_id_missing": "İlk senkronizasyon bekleniyor"
+      },
+      "backfillAlreadyRunning": "Bir senkronizasyon zaten çalışıyor",
+      "backfillSkipped": "Senkronizasyon atlandı ({{reason}})",
+      "backfillSummary": "{{pushed}} gönderildi · {{pulled}} alındı · {{lww}} birleştirildi · {{failed}} başarısız",
+      "col": {
+        "entity": "Öğe",
+        "state": "Durum",
+        "missingLocally": "Yerelde eksik",
+        "missingRemotely": "Sunucuda eksik",
+        "divergent": "Farklı"
+      }
+    },
     "visualizer": {
       "title": "Ses görselleştirici",
       "subtitle": "Sürükleyici görünümde gerçek zamanlı spektrumu gösterir (kod çözücü iş parçacığında hafif FFT)"

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1508,7 +1508,8 @@
         "missingLocally": "Yerelde eksik",
         "missingRemotely": "Sunucuda eksik",
         "divergent": "Farklı"
-      }
+      },
+      "backfillError": "Başarısız: {{message}}"
     },
     "visualizer": {
       "title": "Ses görselleştirici",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1467,7 +1467,8 @@
         "missingLocally": "本地缺失",
         "missingRemotely": "远程缺失",
         "divergent": "差异"
-      }
+      },
+      "backfillError": "失败：{{message}}"
     },
     "gapless": {
       "title": "无缝播放",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1440,6 +1440,35 @@
       "copied": "已复制",
       "copyFailed": "无法复制日志"
     },
+    "syncStatus": {
+      "title": "同步状态",
+      "loading": "正在检查…",
+      "subtitleEmpty": "没有可比较的实体",
+      "subtitleAllInSync": "已全部同步",
+      "subtitleOutOfSync": "{{total}} 项中有 {{outOfSync}} 项未同步",
+      "refresh": "刷新",
+      "resyncNow": "立即重新同步",
+      "inSync": "已同步",
+      "outOfSync": "存在差异",
+      "error": "错误：{{message}}",
+      "reasonGeneric": "已跳过（{{reason}}）",
+      "reason": {
+        "offline": "离线模式已启用",
+        "sync_mode_local": "配置文件处于本地模式",
+        "not_configured": "服务器未配置",
+        "profile_canonical_id_missing": "等待首次同步"
+      },
+      "backfillAlreadyRunning": "已有同步在运行",
+      "backfillSkipped": "已跳过同步（{{reason}}）",
+      "backfillSummary": "{{pushed}} 已发送 · {{pulled}} 已接收 · {{lww}} 已合并 · {{failed}} 失败",
+      "col": {
+        "entity": "实体",
+        "state": "状态",
+        "missingLocally": "本地缺失",
+        "missingRemotely": "远程缺失",
+        "divergent": "差异"
+      }
+    },
     "gapless": {
       "title": "无缝播放",
       "subtitle": "在连续曲目之间不留微小静音（适合现场和概念专辑）"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1440,6 +1440,35 @@
       "copied": "已複製",
       "copyFailed": "無法複製日誌"
     },
+    "syncStatus": {
+      "title": "同步狀態",
+      "loading": "正在檢查…",
+      "subtitleEmpty": "沒有可比較的實體",
+      "subtitleAllInSync": "全部同步完成",
+      "subtitleOutOfSync": "{{total}} 項中有 {{outOfSync}} 項未同步",
+      "refresh": "重新整理",
+      "resyncNow": "立即重新同步",
+      "inSync": "已同步",
+      "outOfSync": "存在差異",
+      "error": "錯誤：{{message}}",
+      "reasonGeneric": "已略過（{{reason}}）",
+      "reason": {
+        "offline": "離線模式已啟用",
+        "sync_mode_local": "設定檔處於本機模式",
+        "not_configured": "伺服器未設定",
+        "profile_canonical_id_missing": "等待首次同步"
+      },
+      "backfillAlreadyRunning": "已有同步正在執行",
+      "backfillSkipped": "已略過同步（{{reason}}）",
+      "backfillSummary": "{{pushed}} 已傳送 · {{pulled}} 已接收 · {{lww}} 已合併 · {{failed}} 失敗",
+      "col": {
+        "entity": "實體",
+        "state": "狀態",
+        "missingLocally": "本機缺少",
+        "missingRemotely": "遠端缺少",
+        "divergent": "差異"
+      }
+    },
     "gapless": {
       "title": "無縫播放",
       "subtitle": "在連續曲目之間不留微小靜音（適合現場與概念專輯）"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1467,7 +1467,8 @@
         "missingLocally": "本機缺少",
         "missingRemotely": "遠端缺少",
         "divergent": "差異"
-      }
+      },
+      "backfillError": "失敗：{{message}}"
     },
     "gapless": {
       "title": "無縫播放",

--- a/src/lib/tauri/sync.ts
+++ b/src/lib/tauri/sync.ts
@@ -1,0 +1,92 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Settings → Diagnostics → "Sync status" card surface.
+ *
+ * RFC-003 Phase B.3 — wraps the desktop's B.1 (digest_check) +
+ * B.2 (backfill) Tauri commands so the Settings card can poll
+ * the local-vs-server state and trigger reconciliation without
+ * the user having to grok the protocol.
+ */
+
+/**
+ * Per-entity report returned by `sync_digest_check`. Counts
+ * only — the full diff member lists stay backend-side for the
+ * backfill orchestrator (B.2).
+ */
+export interface SyncDigestReport {
+  entity: string;
+  in_sync: boolean;
+  local_version: number;
+  remote_version: number;
+  missing_locally: number;
+  missing_remotely: number;
+  divergent: number;
+}
+
+/**
+ * Outcome of `sync_digest_check`. `Skipped { reason }` covers the
+ * gating paths (offline / SyncMode::Local / no JWT / no profile
+ * canonical id) so the UI can render an explicit "blocked" state
+ * instead of a misleading empty "all in sync" surface.
+ */
+export type SyncDigestOutcome =
+  | { status: "ran"; reports: SyncDigestReport[] }
+  | { status: "skipped"; reason: string };
+
+/**
+ * Per-entity report returned by `sync_backfill_now`. Mirrors the
+ * Rust shape verbatim — `entity` + per-bucket counters +
+ * `error` / `skipped_reason` for the failure / deferred paths
+ * (Phase B.2 deferred `track` via `track_backfill_not_implemented`).
+ */
+export interface EntityBackfillReport {
+  entity: string;
+  error?: string | null;
+  pushed: number;
+  push_skipped_out_of_date: number;
+  push_failed: number;
+  pulled: number;
+  pull_failed: number;
+  lww_local_wins: number;
+  lww_remote_wins: number;
+  lww_failed: number;
+  skipped_reason?: string | null;
+}
+
+/**
+ * Outcome of `sync_backfill_now`. `AlreadyRunning` covers the
+ * concurrent-call guard (a second user click while a pass is
+ * still in flight returns immediately without firing a parallel
+ * sweep).
+ */
+export type BackfillOutcome =
+  | { status: "ran"; reports: EntityBackfillReport[] }
+  | { status: "skipped"; reason: string }
+  | { status: "already_running" };
+
+/**
+ * Trigger a digest check pass. `entity` narrows the check to a
+ * single entity name (one of `library` / `playlist` / `track` /
+ * `liked_track` / `track_rating`); omit it to sweep all five.
+ *
+ * Cheap by design — read-only, no SQLite writes, no outbox ops.
+ * The Settings card calls it on mount + on every "Refresh" click.
+ */
+export function syncDigestCheck(entity?: string): Promise<SyncDigestOutcome> {
+  return invoke<SyncDigestOutcome>("sync_digest_check", { entity });
+}
+
+/**
+ * Trigger a backfill pass. Holds the per-state `backfill_lock`
+ * for the duration of the pass — concurrent calls (e.g. the
+ * user double-clicks) get `AlreadyRunning` back rather than
+ * racing the same diff buckets.
+ *
+ * Not cheap: per row, either an outbox enqueue (push direction)
+ * or an HTTP fetch + direct-SQL UPSERT (pull / LWW remote-wins).
+ * The Settings card surfaces a spinner while the call is in flight.
+ */
+export function syncBackfillNow(): Promise<BackfillOutcome> {
+  return invoke<BackfillOutcome>("sync_backfill_now");
+}


### PR DESCRIPTION
## What

Surface the digest_check + backfill commands the B.1/B.2 PRs shipped so users can see whether their local state matches the server's + trigger reconciliation when it doesn't. Closes the user-facing loop on the Phase B sprint.

## Layout

### Frontend

| File | Purpose |
|---|---|
| \`src/lib/tauri/sync.ts\` | Wrappers for \`sync_digest_check\` + \`sync_backfill_now\`. Mirrors the backend outcome shapes (\`Ran{reports} \| Skipped{reason}\` and \`+ AlreadyRunning\`). |
| \`src/components/views/settings/SyncStatusCard.tsx\` | The card. On mount fires one digest check (cheap, read-only). \"Refresh\" re-runs the digest; \"Resync now\" runs the backfill then auto-refreshes the digest snapshot. |

The card mounts under Settings → Diagnostics. Status discrimination matches the backend gating shape:
- \`offline\` / \`sync_mode_local\` / \`not_configured\` / \`profile_canonical_id_missing\` each surface as a specific subtitle so the user knows WHY a sync isn't happening, not just THAT nothing happened.
- \"Resync now\" button stays disabled when no entity is out of sync — same logic the server's digest_check uses to short-circuit a redundant pass.

### i18n

\`settings.syncStatus\` block propagated across **all 17 locales** (fr en es de it nl pt pt-BR ru tr id ja ko zh-CN zh-TW ar hi) with native translations for each. Brand tokens stay verbatim. 23 keys covering overall status, button labels, table column headers, gating reasons, and backfill outcome summary.

## What this does NOT do

- ❌ Auto-poll / background heartbeat. Manual trigger only for v1; auto-trigger on sync-mode flip could land in a follow-up once we have signal on whether users actually drift in practice.
- ❌ \`sync_backfill_get_status\` backend command. Client tracks in-progress state locally (button disabled while invoke in flight). Persistent last-run-at timestamp can ship later if the UI grows it.
- ❌ Track entity coverage — B.2 deferred track backfill; digest still reports its sync state in the table (always \"in sync\" because no track stamps yet land on the desktop side per B.0a/B.0-rest invariant).

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets\` clean
- [x] \`cargo test --manifest-path src-tauri/Cargo.toml --workspace\` → **351 still passing** (no Rust changes)
- [ ] Manual smoke: sign in to a server, push a few changes from a second device, watch the card render \"X out of sync\" + counts ; click \"Resync now\" ; watch the post-backfill digest re-render \"All in sync\".
- [ ] i18n smoke: switch language to FR / EN / JA / AR (LTR/RTL toggle) ; verify strings render + don't overflow.

## Refs

- RFC-003 §4 (digest + backfill protocol)
- Desktop PRs #249 (B.1 digest client) + #250 (B.2 backfill orchestrator)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Nouveau panneau **Sync status** dans **Paramètres > Diagnostics**
  * Affichage du statut global (en sync / hors sync / erreur) et des détails par entité
  * Actions **Actualiser** et **Resynchroniser maintenant**, avec récapitulatif après backfill (en cours, ignoré, résumé chiffré, erreurs)
  * Affichage des raisons de désynchronisation (ex. mode hors-ligne, profil local, serveur non configuré, synchronisation initiale en attente)
  * Support i18n étendu pour **plusieurs langues** (dont fr-FR)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->