### PR TITLE
feat(sync): rfc-003 phase b — close Phase B (track backfill + auto-poll)

### DIFF
--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -108,6 +108,7 @@ pub async fn sync_get_mode(state: tauri::State<'_, AppState>) -> AppResult<&'sta
 /// Persist the active profile's sync mode.
 #[tauri::command]
 pub async fn sync_set_mode(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     req: SetSyncModeRequest,
 ) -> AppResult<&'static str> {
@@ -130,6 +131,18 @@ pub async fn sync_set_mode(
     if parsed == mode::SyncMode::Hybrid {
         state.drain.notify();
         state.ws.wake();
+        // Fire an auto-backfill pass too if the user opted in.
+        // Best-effort, fire-and-forget — the pass logs internally
+        // and the mode-flip response shouldn't wait on a multi-
+        // second network round-trip.
+        let app_handle = app.clone();
+        tokio::spawn(async move {
+            use tauri::Manager;
+            let inner_state = app_handle.state::<AppState>();
+            if let Err(err) = backfill::maybe_auto_backfill(inner_state.inner()).await {
+                tracing::warn!(error = %err, "auto-backfill after mode flip failed");
+            }
+        });
     }
     Ok(parsed.as_str())
 }
@@ -290,6 +303,30 @@ pub async fn sync_digest_check(
     }
 
     Ok(SyncDigestOutcome::Ran { reports })
+}
+
+/// Read the per-profile auto-backfill enabled flag. Settings UI
+/// reads this to render the toggle state on mount.
+#[tauri::command]
+pub async fn sync_backfill_get_enabled(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<bool> {
+    let pool = state.require_profile_pool().await?;
+    backfill::read_auto_enabled(&pool).await
+}
+
+/// Persist the per-profile auto-backfill enabled flag. The user
+/// can click the manual "Resync now" button immediately after to
+/// trigger a pass; the next boot / sync-mode flip to Hybrid
+/// fires it automatically.
+#[tauri::command]
+pub async fn sync_backfill_set_enabled(
+    state: tauri::State<'_, AppState>,
+    enabled: bool,
+) -> AppResult<bool> {
+    let pool = state.require_profile_pool().await?;
+    backfill::write_auto_enabled(&pool, enabled).await?;
+    Ok(enabled)
 }
 
 /// Trigger a backfill pass (RFC-003 Phase B.2). Same gates as

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -122,13 +122,20 @@ pub async fn sync_set_mode(
         }
     };
     let pool = state.require_profile_pool().await?;
+    // Read the previous mode so the post-write side-effects only
+    // fire on a genuine Local → Hybrid transition. Without this,
+    // a user who clicks the same "Hybrid" radio repeatedly would
+    // spawn a fresh drain notify + WS wake + auto-backfill on
+    // every click.
+    let previous = mode::read(&pool).await?;
     mode::write(&pool, parsed).await?;
+    let became_hybrid = parsed == mode::SyncMode::Hybrid && previous != mode::SyncMode::Hybrid;
     // Flipping to Hybrid likely means the user wants their pending
     // ops to fly upstream right away — wake the drain task so the
     // first push doesn't wait for the 30 s tick, and wake the WS
     // subscriber so the catch-up pull + live socket connect without
     // the 30 s idle gate.
-    if parsed == mode::SyncMode::Hybrid {
+    if became_hybrid {
         state.drain.notify();
         state.ws.wake();
         // Fire an auto-backfill pass too if the user opted in.

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -160,6 +160,22 @@ pub fn run() {
             // import path.
             sync::drain::spawn(app.handle().clone());
 
+            // RFC-003 Phase B.2 — fire a one-shot auto-backfill
+            // pass on boot when the user opted in via
+            // `sync.v2.backfill_enabled`. All gates (offline /
+            // SyncMode::Local / no JWT / no profile canonical)
+            // short-circuit silently inside `maybe_auto_backfill`,
+            // so this is safe to fire unconditionally — the helper
+            // owns the gate logic.
+            let boot_handle = app.handle().clone();
+            tokio::spawn(async move {
+                use tauri::Manager;
+                let state = boot_handle.state::<state::AppState>();
+                if let Err(err) = sync::backfill::maybe_auto_backfill(state.inner()).await {
+                    tracing::warn!(error = %err, "auto-backfill on boot failed");
+                }
+            });
+
             // Install the rustls process-wide CryptoProvider before
             // the WS subscriber spawns. rustls 0.23 panics on the
             // first TLS handshake when no provider is installed, and
@@ -633,6 +649,8 @@ pub fn run() {
             commands::sync::sync_drain_now,
             commands::sync::sync_digest_check,
             commands::sync::sync_backfill_now,
+            commands::sync::sync_backfill_get_enabled,
+            commands::sync::sync_backfill_set_enabled,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,
             commands::preferences::get_minimize_to_tray,

--- a/src-tauri/crates/app/src/sync/backfill/lww.rs
+++ b/src-tauri/crates/app/src/sync/backfill/lww.rs
@@ -180,6 +180,25 @@ async fn read_local_tuple(
             .fetch_optional(pool)
             .await?
         }
+        "track" => {
+            // Composite canonical: `<library.canonical_id>\u{1F}<file_path>`.
+            // Mirror the server's `entity_read::fetch_track` split.
+            let Some((lib_canonical, file_path)) = canonical_id.split_once('\u{001F}') else {
+                return Err(AppError::Other(format!(
+                    "lww track: composite canonical missing `\\u{{1F}}`, got `{canonical_id}`",
+                )));
+            };
+            sqlx::query_as(
+                "SELECT t.hlc_wall, t.hlc_logical, t.origin_device_id
+                   FROM track t
+                   JOIN library l ON l.id = t.library_id
+                  WHERE l.canonical_id = ? AND t.file_path = ?",
+            )
+            .bind(lib_canonical)
+            .bind(file_path)
+            .fetch_optional(pool)
+            .await?
+        }
         "playlist" => {
             sqlx::query_as(
                 "SELECT hlc_wall, hlc_logical, origin_device_id

--- a/src-tauri/crates/app/src/sync/backfill/mod.rs
+++ b/src-tauri/crates/app/src/sync/backfill/mod.rs
@@ -19,15 +19,6 @@
 //!     compare §2 (hlc, origin_device_id) tuples per RFC-003 §2;
 //!     remote winner → pull, local winner → push.
 //!
-//! ## Track entity is excluded in B.2 v1
-//!
-//! The composite canonical (`<lib_canonical>\u{1F}<file_path>`) +
-//! the album / artist / track_artist relations make track pull
-//! non-trivial — needs a dedicated upsert path that mirrors the
-//! scanner's. Deferred to a follow-up PR. Until then the
-//! orchestrator runs digest+diff for `track` but logs each diff
-//! bucket without acting on it.
-//!
 //! ## Gating
 //!
 //! The Tauri command (`commands::sync::sync_backfill_now`) holds

--- a/src-tauri/crates/app/src/sync/backfill/mod.rs
+++ b/src-tauri/crates/app/src/sync/backfill/mod.rs
@@ -43,11 +43,98 @@ pub mod pull;
 pub mod push;
 
 use serde::Serialize;
+use sqlx::SqlitePool;
 
 use crate::error::AppResult;
 use crate::server_client::WaveflowServerClient;
 use crate::state::AppState;
 use crate::sync::digest::{self, diff::DigestDiff};
+
+/// `profile_setting` key for the auto-poll toggle. When `true`,
+/// [`maybe_auto_backfill`] fires a pass on boot + every sync-mode
+/// flip to Hybrid. Default `false` — opt-in only.
+pub const AUTO_BACKFILL_KEY: &str = "sync.v2.backfill_enabled";
+
+/// Read the per-profile auto-backfill enabled flag. Returns
+/// `false` when the row is absent (matches the opt-in default).
+pub async fn read_auto_enabled(pool: &SqlitePool) -> AppResult<bool> {
+    let value: Option<String> =
+        sqlx::query_scalar("SELECT value FROM profile_setting WHERE key = ?")
+            .bind(AUTO_BACKFILL_KEY)
+            .fetch_optional(pool)
+            .await?;
+    Ok(value.as_deref() == Some("1"))
+}
+
+/// Persist the per-profile auto-backfill enabled flag.
+pub async fn write_auto_enabled(pool: &SqlitePool, enabled: bool) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO profile_setting (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(AUTO_BACKFILL_KEY)
+    .bind(if enabled { "1" } else { "0" })
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Best-effort auto-backfill trigger. Reads every gate (auto
+/// enabled flag, offline mode, Local sync mode, JWT presence,
+/// profile canonical id) and short-circuits silently when any
+/// gate refuses. Fires nothing when the lock is already held by
+/// a concurrent pass.
+///
+/// Designed for fire-and-forget call sites: boot-time check in
+/// `lib.rs::run`, sync-mode flip Local→Hybrid in
+/// `commands::sync::sync_set_mode`. Failures log + swallow so a
+/// transient network blip doesn't blow up the wrapping command.
+pub async fn maybe_auto_backfill(state: &AppState) -> AppResult<()> {
+    // Gate 0 — auto flag must be on.
+    let pool = state.require_profile_pool().await?;
+    if !read_auto_enabled(&pool).await? {
+        return Ok(());
+    }
+    // Gate 1 — process-wide offline.
+    if crate::offline::is_offline() {
+        return Ok(());
+    }
+    // Gate 2 — Local sync mode.
+    if crate::sync::mode::read(&pool).await? == crate::sync::mode::SyncMode::Local {
+        return Ok(());
+    }
+    // Gate 3 — server URL + JWT.
+    let Some(client) = WaveflowServerClient::try_build(state).await? else {
+        return Ok(());
+    };
+    // Lock — silent skip if a concurrent caller is already
+    // mid-pass.
+    let Ok(_guard) = state.backfill_lock.try_lock() else {
+        return Ok(());
+    };
+
+    let profile_id = state.require_profile_id().await?;
+    let profile_canonical_id =
+        crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
+
+    match run_backfill(state, &client, profile_canonical_id.as_deref()).await {
+        Ok(report) => {
+            let entities_with_action = report
+                .reports
+                .iter()
+                .filter(|r| r.pushed + r.pulled + r.lww_local_wins + r.lww_remote_wins > 0)
+                .count();
+            tracing::info!(
+                entities_with_action,
+                "auto-backfill pass completed",
+            );
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "auto-backfill pass failed");
+        }
+    }
+    Ok(())
+}
 
 /// Per-entity outcome of a single backfill pass. Counts only —
 /// the orchestrator logs the per-row decisions; the user-facing
@@ -103,10 +190,6 @@ pub enum BackfillOutcome {
     AlreadyRunning,
 }
 
-/// Track entity skip reason — referenced by [`run_backfill`] and
-/// echoed in the Settings UI for transparency.
-pub const SKIP_REASON_TRACK_NOT_YET: &str = "track_backfill_not_implemented";
-
 /// Run a single backfill pass. Assumes the caller already
 /// validated gates (offline / sync mode / JWT presence) and
 /// acquired [`AppState::backfill_lock`].
@@ -148,15 +231,6 @@ pub async fn run_backfill(
                 continue;
             }
         };
-
-        // B.2 v1: track pull / push / LWW deferred. Digest still
-        // runs (so the Settings UI can show whether the entity is
-        // in sync), but no row-level action happens.
-        if entity == "track" {
-            report.skipped_reason = Some(SKIP_REASON_TRACK_NOT_YET);
-            reports.push(report);
-            continue;
-        }
 
         let local = match digest::read_local_digest(&pool, entity).await {
             Ok(d) => d,

--- a/src-tauri/crates/app/src/sync/backfill/pull.rs
+++ b/src-tauri/crates/app/src/sync/backfill/pull.rs
@@ -114,6 +114,7 @@ pub(super) async fn apply_remote_row(
     match row.entity.as_str() {
         "library" => apply_library(conn, row).await,
         "playlist" => apply_playlist(conn, row).await,
+        "track" => apply_track(conn, row).await,
         "liked_track" => apply_liked_track(conn, row).await,
         "track_rating" => apply_track_rating(conn, row).await,
         other => Err(AppError::Other(format!(
@@ -285,6 +286,218 @@ async fn apply_liked_track(conn: &mut SqliteConnection, row: &RemoteEntityRow) -
     .execute(&mut *conn)
     .await?;
     bump_digest(conn, "liked_track").await
+}
+
+/// Apply a `track` row pulled from the server. The composite
+/// canonical `<library_canonical_id>\u{1F}<file_path>` is already
+/// split into `library_canonical_id` + `file_path` top-level
+/// fields on the response. We:
+///
+/// 1. Resolve the local `library_id` from the canonical id. If
+///    absent → defer (library backfill hasn't happened yet; the
+///    orchestrator re-runs in order).
+/// 2. Upsert `album` + every contributor `artist` via the core
+///    scanner helpers (same path the scanner uses) so the
+///    foreign keys resolve identically regardless of whether the
+///    row originated from a local scan or a remote pull.
+/// 3. UPSERT the `track` row on `(library_id, file_path)`. When
+///    the file isn't locally available yet (no scanner pass has
+///    seen it), `folder_id` stays NULL and `is_available = 0` —
+///    the next scanner pass flips the flag + populates folder_id.
+/// 4. Re-link `track_artist` to match the server's order.
+/// 5. Stamp the server's exact `(hlc, origin, payload_hash)`.
+async fn apply_track(conn: &mut SqliteConnection, row: &RemoteEntityRow) -> AppResult<()> {
+    use waveflow_core::scanner::upserts;
+
+    let library_canonical = row.library_canonical_id.as_deref().ok_or_else(|| {
+        AppError::Other("track pull: missing library_canonical_id on response".into())
+    })?;
+    let file_path = row
+        .file_path
+        .as_deref()
+        .ok_or_else(|| AppError::Other("track pull: missing file_path on response".into()))?;
+
+    let library_id: Option<i64> =
+        sqlx::query_scalar("SELECT id FROM library WHERE canonical_id = ?")
+            .bind(library_canonical)
+            .fetch_optional(&mut *conn)
+            .await?;
+    let Some(library_id) = library_id else {
+        tracing::debug!(
+            library_canonical,
+            file_path,
+            "backfill pull track: no local library for canonical, deferring",
+        );
+        return Ok(());
+    };
+
+    let title = str_required(row, "title")?;
+    let file_hash = str_required(row, "file_hash")?;
+    let file_size = row
+        .fields
+        .get("file_size")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| AppError::Other("track pull: missing 'file_size'".into()))?;
+    let duration_ms = row
+        .fields
+        .get("duration_ms")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| AppError::Other("track pull: missing 'duration_ms'".into()))?;
+    let track_number = row.fields.get("track_number").and_then(Value::as_i64);
+    let disc_number = row.fields.get("disc_number").and_then(Value::as_i64);
+    let year = row.fields.get("year").and_then(Value::as_i64);
+    let bitrate = row.fields.get("bitrate").and_then(Value::as_i64);
+    let sample_rate = row.fields.get("sample_rate").and_then(Value::as_i64);
+    let channels = row.fields.get("channels").and_then(Value::as_i64);
+    let bit_depth = row.fields.get("bit_depth").and_then(Value::as_i64);
+    let codec = opt_str(row, "codec");
+    let musical_key = opt_str(row, "musical_key");
+    let added_at = row
+        .fields
+        .get("added_at")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| AppError::Other("track pull: missing 'added_at'".into()))?;
+    let album_title = opt_str(row, "album_title");
+    let album_artist_name = opt_str(row, "album_artist_name");
+    let is_compilation = row
+        .fields
+        .get("is_compilation")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let artists: Vec<String> = row
+        .fields
+        .get("artists")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Upsert every contributor artist via the per-artist helper
+    // (the multi-artist `upsert_artist_list` takes a raw `"A; B"`
+    // string + splits internally; we already have the split form
+    // from the server, so call per-name to skip the parse).
+    let mut artist_ids: Vec<i64> = Vec::with_capacity(artists.len());
+    for name in &artists {
+        if let Some(id) = upserts::upsert_artist(&mut *conn, name)
+            .await
+            .map_err(|err| AppError::Other(format!("upsert_artist: {err}")))?
+        {
+            artist_ids.push(id);
+        }
+    }
+    let primary_artist_id = artist_ids.first().copied();
+    let album_id = match album_title.as_deref() {
+        Some(title) => upserts::upsert_album(
+            &mut *conn,
+            title,
+            album_artist_name.as_deref(),
+            is_compilation,
+            primary_artist_id,
+            year,
+        )
+        .await
+        .map_err(|err| AppError::Other(format!("upsert_album: {err}")))?,
+        None => None,
+    };
+    let _ = added_at; // bound below in the INSERT
+
+    let payload_hash = hex::decode(&row.payload_hash)
+        .map_err(|err| AppError::Other(format!("track payload_hash hex: {err}")))?;
+    let origin = origin_string(row);
+
+    // UPSERT on `(library_id, file_path)`. Folder_id stays NULL
+    // when this is a fresh pull — the scanner fills it in when
+    // the file materialises on this device. Is_available = 0 for
+    // the same reason: the UI shouldn't try to play a row backed
+    // by no local audio file. The scanner's `(mtime, size)`
+    // fast-path will flip is_available + folder_id on its next
+    // pass over the library folder.
+    sqlx::query(
+        "INSERT INTO track (
+            library_id, folder_id, file_path, file_hash, file_size, file_modified,
+            title, album_id, primary_artist,
+            track_number, disc_number, year,
+            duration_ms, bitrate, sample_rate, channels,
+            bit_depth, codec, musical_key,
+            added_at, is_available,
+            hlc_wall, hlc_logical, origin_device_id, payload_hash
+         ) VALUES (?, NULL, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
+         ON CONFLICT(library_id, file_path) DO UPDATE SET
+            file_hash       = excluded.file_hash,
+            file_size       = excluded.file_size,
+            title           = excluded.title,
+            album_id        = excluded.album_id,
+            primary_artist  = excluded.primary_artist,
+            track_number    = excluded.track_number,
+            disc_number     = excluded.disc_number,
+            year            = excluded.year,
+            duration_ms     = excluded.duration_ms,
+            bitrate         = excluded.bitrate,
+            sample_rate     = excluded.sample_rate,
+            channels        = excluded.channels,
+            bit_depth       = excluded.bit_depth,
+            codec           = excluded.codec,
+            musical_key     = excluded.musical_key,
+            added_at        = excluded.added_at,
+            hlc_wall        = excluded.hlc_wall,
+            hlc_logical     = excluded.hlc_logical,
+            origin_device_id = excluded.origin_device_id,
+            payload_hash    = excluded.payload_hash",
+    )
+    .bind(library_id)
+    .bind(file_path)
+    .bind(&file_hash)
+    .bind(file_size)
+    .bind(&title)
+    .bind(album_id)
+    .bind(primary_artist_id)
+    .bind(track_number)
+    .bind(disc_number)
+    .bind(year)
+    .bind(duration_ms)
+    .bind(bitrate)
+    .bind(sample_rate)
+    .bind(channels)
+    .bind(bit_depth)
+    .bind(codec.as_deref())
+    .bind(musical_key.as_deref())
+    .bind(added_at)
+    .bind(row.hlc.wall)
+    .bind(row.hlc.logical)
+    .bind(origin.as_deref())
+    .bind(&payload_hash[..])
+    .execute(&mut *conn)
+    .await?;
+
+    // Re-link `track_artist` to match the server's order. DELETE
+    // first because positions can shift on a re-tag — INSERT OR
+    // IGNORE would leave stale positions behind.
+    let track_id: i64 =
+        sqlx::query_scalar("SELECT id FROM track WHERE library_id = ? AND file_path = ?")
+            .bind(library_id)
+            .bind(file_path)
+            .fetch_one(&mut *conn)
+            .await?;
+    sqlx::query("DELETE FROM track_artist WHERE track_id = ?")
+        .bind(track_id)
+        .execute(&mut *conn)
+        .await?;
+    for (position, aid) in artist_ids.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO track_artist (track_id, artist_id, role, position)
+             VALUES (?, ?, 'main', ?)",
+        )
+        .bind(track_id)
+        .bind(aid)
+        .bind(position as i64)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    bump_digest(conn, "track").await
 }
 
 async fn apply_track_rating(conn: &mut SqliteConnection, row: &RemoteEntityRow) -> AppResult<()> {

--- a/src-tauri/crates/app/src/sync/backfill/pull.rs
+++ b/src-tauri/crates/app/src/sync/backfill/pull.rs
@@ -21,11 +21,6 @@
 //!   floor over the entity set's max would make every next local
 //!   write slot above an arbitrarily-old peer write.
 //!
-//! ## Track is deferred
-//!
-//! Same reason as [`super::push`]: composite canonical +
-//! album/artist relations need a dedicated upsert path.
-
 use chrono::Utc;
 use serde_json::Value;
 use sqlx::{SqliteConnection, SqlitePool};

--- a/src-tauri/crates/app/src/sync/backfill/push.rs
+++ b/src-tauri/crates/app/src/sync/backfill/push.rs
@@ -18,13 +18,6 @@
 //! re-emit doesn't go backwards. Since we always draw a fresh
 //! monotonic HLC, this property holds by construction.
 //!
-//! ## Track is deferred
-//!
-//! The orchestrator in [`super::run_backfill`] short-circuits
-//! `entity = "track"` before reaching this module — track's
-//! composite canonical + album/artist plumbing needs its own
-//! sub-PR.
-
 use serde_json::{Map, Value};
 use sqlx::{SqliteConnection, SqlitePool};
 

--- a/src-tauri/crates/app/src/sync/backfill/push.rs
+++ b/src-tauri/crates/app/src/sync/backfill/push.rs
@@ -92,6 +92,7 @@ pub(super) async fn push_one_by_canonical(
     match entity {
         "library" => push_library(state, pool, canonical_id).await,
         "playlist" => push_playlist(state, pool, canonical_id).await,
+        "track" => push_track(state, pool, canonical_id).await,
         "liked_track" => push_liked_track(state, pool, canonical_id).await,
         "track_rating" => push_track_rating(state, pool, canonical_id).await,
         other => Err(AppError::Other(format!(
@@ -197,6 +198,131 @@ async fn push_liked_track(
     tx.commit().await?;
     let _ = state;
     Ok(true)
+}
+
+/// Push a `track` row. The canonical id is the composite
+/// `<library.canonical_id>\u{1F}<track.file_path>` shipped by the
+/// digest endpoint. We split it on `U+001F`, look up the local
+/// row, rebuild the [`TrackInsertWire`] from its joined state +
+/// `track_artist` list, and re-enqueue via
+/// [`crate::sync::track_emit::emit_track_insert_in_tx`] — the
+/// same helper the scanner uses for fresh imports + tag-edit
+/// re-emits, so the wire shape stays byte-identical regardless
+/// of which path triggered the push.
+///
+/// Returns `Ok(false)` when the local row vanished between the
+/// digest read and the push (concurrent delete) or when the
+/// composite canonical is malformed.
+async fn push_track(state: &AppState, pool: &SqlitePool, canonical_id: &str) -> AppResult<bool> {
+    let Some((lib_canonical, file_path)) = canonical_id.split_once('\u{001F}') else {
+        return Err(AppError::Other(format!(
+            "push_track: composite canonical must contain `\\u{{001F}}`, got `{canonical_id}`",
+        )));
+    };
+    if lib_canonical.is_empty() || file_path.is_empty() {
+        return Err(AppError::Other(
+            "push_track: composite canonical halves must be non-empty".into(),
+        ));
+    }
+
+    let mut tx = pool.begin().await?;
+    let row: Option<TrackPushRow> = sqlx::query_as::<_, TrackPushRow>(
+        "SELECT \
+            t.id, t.library_id, t.file_path, t.file_hash, \
+            t.file_size, t.file_modified, t.duration_ms, t.title, \
+            t.track_number, t.disc_number, t.year, t.bitrate, \
+            t.sample_rate, t.channels, t.bit_depth, t.codec, \
+            t.musical_key, t.added_at, \
+            al.title AS album_title, \
+            al.album_artist AS album_artist_name, \
+            COALESCE(al.is_compilation, 0) AS is_compilation \
+           FROM track t \
+           JOIN library l ON l.id = t.library_id \
+      LEFT JOIN album al ON al.id = t.album_id \
+          WHERE l.canonical_id = ? AND t.file_path = ?",
+    )
+    .bind(lib_canonical)
+    .bind(file_path)
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(row) = row else {
+        return Ok(false);
+    };
+
+    // Multi-artist list, ordered by `track_artist.position` so the
+    // wire's array index matches the server's `position` column —
+    // critical because the canonical `artists: [String]` hash
+    // preserves source order.
+    let artists: Vec<String> = sqlx::query_scalar(
+        "SELECT a.name FROM track_artist ta \
+            JOIN artist a ON a.id = ta.artist_id \
+           WHERE ta.track_id = ? \
+           ORDER BY ta.position ASC",
+    )
+    .bind(row.id)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    let wire = crate::sync::track_emit::TrackInsertWire {
+        file_hash: &row.file_hash,
+        title: &row.title,
+        file_size: row.file_size,
+        file_modified: row.file_modified,
+        duration_ms: row.duration_ms,
+        track_number: row.track_number,
+        disc_number: row.disc_number,
+        year: row.year,
+        bitrate: row.bitrate,
+        sample_rate: row.sample_rate,
+        channels: row.channels,
+        bit_depth: row.bit_depth,
+        codec: row.codec.as_deref(),
+        musical_key: row.musical_key.as_deref(),
+        added_at: row.added_at,
+        album_title: row.album_title.as_deref(),
+        album_artist_name: row.album_artist_name.as_deref(),
+        is_compilation: row.is_compilation != 0,
+        artists: &artists,
+    };
+    crate::sync::track_emit::emit_track_insert_in_tx(
+        &mut tx,
+        row.library_id,
+        row.id,
+        file_path,
+        &wire,
+    )
+    .await?;
+    tx.commit().await?;
+    let _ = state;
+    Ok(true)
+}
+
+/// Projection mirroring `commands/scan.rs`'s track row shape +
+/// the album fields the canonical_fields map needs.
+#[derive(sqlx::FromRow)]
+struct TrackPushRow {
+    id: i64,
+    library_id: i64,
+    #[allow(dead_code)]
+    file_path: String,
+    file_hash: String,
+    file_size: i64,
+    file_modified: i64,
+    duration_ms: i64,
+    title: String,
+    track_number: Option<i64>,
+    disc_number: Option<i64>,
+    year: Option<i64>,
+    bitrate: Option<i64>,
+    sample_rate: Option<i64>,
+    channels: Option<i64>,
+    bit_depth: Option<i64>,
+    codec: Option<String>,
+    musical_key: Option<String>,
+    added_at: i64,
+    album_title: Option<String>,
+    album_artist_name: Option<String>,
+    is_compilation: i64,
 }
 
 /// `track_rating` canonical is also the file_hash. The wire

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -10,7 +10,9 @@ import {
   WifiOff,
 } from "lucide-react";
 import {
+  syncBackfillGetEnabled,
   syncBackfillNow,
+  syncBackfillSetEnabled,
   syncDigestCheck,
   type BackfillOutcome,
   type SyncDigestOutcome,
@@ -51,6 +53,8 @@ export function SyncStatusCard() {
   const { t } = useTranslation();
   const [state, setState] = useState<CardState>({ kind: "loading" });
   const [backfilling, setBackfilling] = useState(false);
+  const [autoEnabled, setAutoEnabled] = useState<boolean | null>(null);
+  const [autoToggleBusy, setAutoToggleBusy] = useState(false);
   const [backfillOutcome, setBackfillOutcome] = useState<BackfillOutcome | null>(
     null,
   );
@@ -83,8 +87,12 @@ export function SyncStatusCard() {
     let cancelled = false;
     (async () => {
       try {
-        const outcome: SyncDigestOutcome = await syncDigestCheck();
+        const [outcome, enabled] = await Promise.all([
+          syncDigestCheck(),
+          syncBackfillGetEnabled().catch(() => false),
+        ]);
         if (cancelled) return;
+        setAutoEnabled(enabled);
         if (outcome.status === "skipped") {
           setState({ kind: "skipped", reason: outcome.reason });
         } else {
@@ -101,6 +109,21 @@ export function SyncStatusCard() {
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  const handleToggleAuto = useCallback(async (next: boolean) => {
+    setAutoToggleBusy(true);
+    try {
+      const stored = await syncBackfillSetEnabled(next);
+      setAutoEnabled(stored);
+    } catch (err) {
+      // Surface as the backfill-error banner — same channel a
+      // failed manual click uses, so the user sees one consistent
+      // error path rather than a separate toast.
+      setBackfillError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAutoToggleBusy(false);
+    }
   }, []);
 
   const handleBackfill = useCallback(async () => {
@@ -188,6 +211,29 @@ export function SyncStatusCard() {
           <EntityReportTable reports={state.reports} />
         </div>
       ) : null}
+
+      <div className="mt-4 ml-9 flex items-center justify-between gap-3 text-xs">
+        <div className="min-w-0">
+          <div className="font-medium text-zinc-700 dark:text-zinc-200">
+            {t("settings.syncStatus.autoToggleTitle")}
+          </div>
+          <div className="text-zinc-400">
+            {t("settings.syncStatus.autoToggleSubtitle")}
+          </div>
+        </div>
+        <label className="inline-flex items-center cursor-pointer shrink-0">
+          <input
+            type="checkbox"
+            className="sr-only peer"
+            checked={autoEnabled === true}
+            disabled={autoEnabled === null || autoToggleBusy}
+            onChange={(e) => void handleToggleAuto(e.target.checked)}
+          />
+          <span className="relative w-10 h-6 bg-zinc-200 dark:bg-zinc-700 rounded-full peer-checked:bg-emerald-500 transition-colors peer-disabled:opacity-50">
+            <span className="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-4" />
+          </span>
+        </label>
+      </div>
     </div>
   );
 }

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -116,6 +116,9 @@ export function SyncStatusCard() {
     try {
       const stored = await syncBackfillSetEnabled(next);
       setAutoEnabled(stored);
+      // Clear any stale banner from a previous failed toggle so a
+      // successful retry doesn't keep the rose-600 error visible.
+      setBackfillError(null);
     } catch (err) {
       // Surface as the backfill-error banner — same channel a
       // failed manual click uses, so the user sees one consistent
@@ -228,8 +231,9 @@ export function SyncStatusCard() {
             checked={autoEnabled === true}
             disabled={autoEnabled === null || autoToggleBusy}
             onChange={(e) => void handleToggleAuto(e.target.checked)}
+            aria-label={t("settings.syncStatus.autoToggleTitle") ?? undefined}
           />
-          <span className="relative w-10 h-6 bg-zinc-200 dark:bg-zinc-700 rounded-full peer-checked:bg-emerald-500 transition-colors peer-disabled:opacity-50">
+          <span className="relative w-10 h-6 bg-zinc-200 dark:bg-zinc-700 rounded-full peer-checked:bg-emerald-500 transition-colors peer-disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-500 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-white dark:peer-focus-visible:ring-offset-zinc-900">
             <span className="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-4" />
           </span>
         </label>

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -86,20 +86,31 @@ export function SyncStatusCard() {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      try {
-        const [outcome, enabled] = await Promise.all([
-          syncDigestCheck(),
-          syncBackfillGetEnabled().catch(() => false),
-        ]);
-        if (cancelled) return;
-        setAutoEnabled(enabled);
+      // `Promise.allSettled` so a digest_check failure doesn't
+      // strand `autoEnabled` at `null` for the rest of the
+      // session — the toggle would then be disabled because the
+      // checkbox gates on `autoEnabled === null` (loading). The
+      // two reads are independent backend calls; surface each
+      // outcome on its own state.
+      const [digestRes, enabledRes] = await Promise.allSettled([
+        syncDigestCheck(),
+        syncBackfillGetEnabled(),
+      ]);
+      if (cancelled) return;
+
+      setAutoEnabled(
+        enabledRes.status === "fulfilled" ? enabledRes.value : false,
+      );
+
+      if (digestRes.status === "fulfilled") {
+        const outcome = digestRes.value;
         if (outcome.status === "skipped") {
           setState({ kind: "skipped", reason: outcome.reason });
         } else {
           setState({ kind: "ran", reports: outcome.reports });
         }
-      } catch (err) {
-        if (cancelled) return;
+      } else {
+        const err = digestRes.reason;
         setState({
           kind: "error",
           message: err instanceof Error ? err.message : String(err),

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1513,7 +1513,9 @@
         "missingRemotely": "مفقود بعيدًا",
         "divergent": "متباين"
       },
-      "backfillError": "فشل: {{message}}"
+      "backfillError": "فشل: {{message}}",
+      "autoToggleTitle": "المزامنة التلقائية",
+      "autoToggleSubtitle": "تشغيل مزامنة عند الإقلاع وعند التبديل إلى الوضع الهجين"
     },
     "visualizer": {
       "title": "محلل الصوت البصري",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1509,7 +1509,9 @@
         "missingRemotely": "Remote fehlend",
         "divergent": "Abweichend"
       },
-      "backfillError": "Fehlgeschlagen: {{message}}"
+      "backfillError": "Fehlgeschlagen: {{message}}",
+      "autoToggleTitle": "Auto-Sync",
+      "autoToggleSubtitle": "Führt beim Start und beim Wechsel in den Hybrid-Modus eine Synchronisation durch"
     },
     "visualizer": {
       "title": "Audio-Visualizer",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1509,7 +1509,9 @@
         "missingRemotely": "Missing remotely",
         "divergent": "Divergent"
       },
-      "backfillError": "Failed: {{message}}"
+      "backfillError": "Failed: {{message}}",
+      "autoToggleTitle": "Auto sync",
+      "autoToggleSubtitle": "Runs a pass on boot and when switching to Hybrid mode"
     },
     "visualizer": {
       "title": "Audio visualizer",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1509,7 +1509,9 @@
         "missingRemotely": "Falta remoto",
         "divergent": "Divergente"
       },
-      "backfillError": "Error: {{message}}"
+      "backfillError": "Error: {{message}}",
+      "autoToggleTitle": "Sincronización automática",
+      "autoToggleSubtitle": "Ejecuta una pasada al arrancar y al cambiar al modo Híbrido"
     },
     "visualizer": {
       "title": "Visualizador de audio",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1560,7 +1560,9 @@
         "missingRemotely": "Manquant distant",
         "divergent": "Divergent"
       },
-      "backfillError": "Échec : {{message}}"
+      "backfillError": "Échec : {{message}}",
+      "autoToggleTitle": "Synchronisation automatique",
+      "autoToggleSubtitle": "Lance un passage au démarrage et lors du passage en mode Hybride"
     },
     "visualizer": {
       "title": "Visualiseur audio",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1521,7 +1521,9 @@
         "missingRemotely": "दूरस्थ अनुपस्थित",
         "divergent": "अलग"
       },
-      "backfillError": "विफल: {{message}}"
+      "backfillError": "विफल: {{message}}",
+      "autoToggleTitle": "स्वचालित सिंक",
+      "autoToggleSubtitle": "बूट पर और हाइब्रिड मोड में स्विच करने पर एक पास चलाता है"
     },
     "gapless": {
       "title": "गैपलेस प्लेबैक",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1509,7 +1509,9 @@
         "missingRemotely": "Tidak ada remote",
         "divergent": "Berbeda"
       },
-      "backfillError": "Gagal: {{message}}"
+      "backfillError": "Gagal: {{message}}",
+      "autoToggleTitle": "Sinkronisasi otomatis",
+      "autoToggleSubtitle": "Menjalankan pass saat boot dan saat beralih ke mode Hybrid"
     },
     "visualizer": {
       "title": "Visualizer audio",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1509,7 +1509,9 @@
         "missingRemotely": "Mancante remoto",
         "divergent": "Divergente"
       },
-      "backfillError": "Errore: {{message}}"
+      "backfillError": "Errore: {{message}}",
+      "autoToggleTitle": "Sincronizzazione automatica",
+      "autoToggleSubtitle": "Esegue una passata all'avvio e al passaggio alla modalità Ibrida"
     },
     "visualizer": {
       "title": "Visualizzatore audio",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1468,7 +1468,9 @@
         "missingRemotely": "リモート欠落",
         "divergent": "差異"
       },
-      "backfillError": "失敗: {{message}}"
+      "backfillError": "失敗: {{message}}",
+      "autoToggleTitle": "自動同期",
+      "autoToggleSubtitle": "起動時とハイブリッドモード切替時に同期を実行します"
     },
     "gapless": {
       "title": "ギャップレス再生",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1521,7 +1521,9 @@
         "missingRemotely": "원격 누락",
         "divergent": "불일치"
       },
-      "backfillError": "실패: {{message}}"
+      "backfillError": "실패: {{message}}",
+      "autoToggleTitle": "자동 동기화",
+      "autoToggleSubtitle": "부팅 시 그리고 하이브리드 모드로 전환할 때 동기화를 실행합니다"
     },
     "gapless": {
       "title": "갭리스 재생",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1509,7 +1509,9 @@
         "missingRemotely": "Extern ontbrekend",
         "divergent": "Afwijkend"
       },
-      "backfillError": "Mislukt: {{message}}"
+      "backfillError": "Mislukt: {{message}}",
+      "autoToggleTitle": "Automatische sync",
+      "autoToggleSubtitle": "Voert een pass uit bij het opstarten en bij overschakeling naar Hybride"
     },
     "visualizer": {
       "title": "Audio-visualizer",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1521,7 +1521,9 @@
         "missingRemotely": "Faltando remoto",
         "divergent": "Divergente"
       },
-      "backfillError": "Falhou: {{message}}"
+      "backfillError": "Falhou: {{message}}",
+      "autoToggleTitle": "Sincronização automática",
+      "autoToggleSubtitle": "Executa uma passada na inicialização e ao mudar para o modo Híbrido"
     },
     "gapless": {
       "title": "Reprodução contínua",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1521,7 +1521,9 @@
         "missingRemotely": "Em falta remoto",
         "divergent": "Divergente"
       },
-      "backfillError": "Falhou: {{message}}"
+      "backfillError": "Falhou: {{message}}",
+      "autoToggleTitle": "Sincronização automática",
+      "autoToggleSubtitle": "Executa uma passagem ao iniciar e ao mudar para o modo Híbrido"
     },
     "gapless": {
       "title": "Reprodução contínua",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1551,7 +1551,9 @@
         "missingRemotely": "Нет на сервере",
         "divergent": "Расхождение"
       },
-      "backfillError": "Сбой: {{message}}"
+      "backfillError": "Сбой: {{message}}",
+      "autoToggleTitle": "Автосинхронизация",
+      "autoToggleSubtitle": "Запускает проход при загрузке и при переключении в режим Hybrid"
     },
     "visualizer": {
       "title": "Аудио-визуализатор",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1553,7 +1553,7 @@
       },
       "backfillError": "Сбой: {{message}}",
       "autoToggleTitle": "Автосинхронизация",
-      "autoToggleSubtitle": "Запускает проход при загрузке и при переключении в режим Hybrid"
+      "autoToggleSubtitle": "Запускает проход при загрузке и при переключении в гибридный режим"
     },
     "visualizer": {
       "title": "Аудио-визуализатор",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1509,7 +1509,9 @@
         "missingRemotely": "Sunucuda eksik",
         "divergent": "Farklı"
       },
-      "backfillError": "Başarısız: {{message}}"
+      "backfillError": "Başarısız: {{message}}",
+      "autoToggleTitle": "Otomatik senkronizasyon",
+      "autoToggleSubtitle": "Açılışta ve Hibrit moda geçişte bir geçiş çalıştırır"
     },
     "visualizer": {
       "title": "Ses görselleştirici",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1468,7 +1468,9 @@
         "missingRemotely": "远程缺失",
         "divergent": "差异"
       },
-      "backfillError": "失败：{{message}}"
+      "backfillError": "失败：{{message}}",
+      "autoToggleTitle": "自动同步",
+      "autoToggleSubtitle": "在启动时和切换至混合模式时运行一次同步"
     },
     "gapless": {
       "title": "无缝播放",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1468,7 +1468,9 @@
         "missingRemotely": "遠端缺少",
         "divergent": "差異"
       },
-      "backfillError": "失敗：{{message}}"
+      "backfillError": "失敗：{{message}}",
+      "autoToggleTitle": "自動同步",
+      "autoToggleSubtitle": "在啟動時和切換至混合模式時執行一次同步"
     },
     "gapless": {
       "title": "無縫播放",

--- a/src/lib/tauri/sync.ts
+++ b/src/lib/tauri/sync.ts
@@ -90,3 +90,23 @@ export function syncDigestCheck(entity?: string): Promise<SyncDigestOutcome> {
 export function syncBackfillNow(): Promise<BackfillOutcome> {
   return invoke<BackfillOutcome>("sync_backfill_now");
 }
+
+/**
+ * Read the per-profile auto-backfill enabled flag. The Settings
+ * card renders this as a toggle alongside the manual "Resync now"
+ * button.
+ */
+export function syncBackfillGetEnabled(): Promise<boolean> {
+  return invoke<boolean>("sync_backfill_get_enabled");
+}
+
+/**
+ * Persist the per-profile auto-backfill enabled flag. When `true`,
+ * `maybe_auto_backfill` fires a pass on boot + every sync-mode
+ * flip to Hybrid. The toggle itself doesn't fire an immediate
+ * pass — the user can click the manual button right after if
+ * they want one now.
+ */
+export function syncBackfillSetEnabled(enabled: boolean): Promise<boolean> {
+  return invoke<boolean>("sync_backfill_set_enabled", { enabled });
+}


### PR DESCRIPTION
## What

Two follow-ups bundled to **close Phase B sync v2 end-to-end**. This is the final Phase B PR — after merge, the next work moves to the next roadmap block (community-DB per memory).

## Part 1 — Track backfill (push + pull + LWW)

Extends the B.2 backfill orchestrator (#250) from 4 entities to all 5. The composite canonical `<library.canonical_id>\u{1F}<file_path>` split happens at every call site so \`track\` plumbs cleanly through push / pull / LWW without breaking the per-entity dispatch pattern.

| Direction | What |
|---|---|
| Push | Splits composite, reads local row + joined album/album_artist + position-sorted track_artist, rebuilds `TrackInsertWire`, re-emits via `track_emit::emit_track_insert_in_tx` (same helper the scanner uses → byte-identical wire shape). |
| Pull | Splits composite, resolves local library by canonical_id (defers silently when library not yet backfilled), upserts contributor artists + album via core `scanner::upserts` helpers, UPSERTs `track` on `(library_id, file_path)` with `folder_id = NULL` + `is_available = 0` (the scanner flips them when the file materialises). Re-links `track_artist` to preserve server's order. |
| LWW | `read_local_tuple` gains a track branch with composite split + JOIN; §2 tuple comparison + dispatch back to push_track / apply_track works unchanged. |

The orchestrator drops the `SKIP_REASON_TRACK_NOT_YET` short-circuit. Track now participates in every orchestration step.

## Part 2 — Auto-poll backfill

Boots the backfill on app start + on every Local→Hybrid sync-mode flip when the user opted in via the new `sync.v2.backfill_enabled` profile_setting (**default OFF** — explicit opt-in).

- \`backfill::maybe_auto_backfill(state)\` — best-effort fire-and-forget helper. Reads every gate (auto flag, offline, SyncMode::Local, JWT, profile canonical) and short-circuits silently. Owns the `backfill_lock` so a concurrent manual click can't race it.
- \`sync_backfill_get_enabled\` / \`sync_backfill_set_enabled\` Tauri commands.
- \`sync_set_mode\` fires the auto-backfill via fire-and-forget \`tokio::spawn\` when flipping to Hybrid.
- \`lib.rs::run\` fires the boot-time pass via the same shape.

### Settings UI

- New toggle row under the existing entity report table. Reads enabled state on mount alongside the digest check (one round-trip).
- Failed toggle persists as the same `backfillError` banner the manual button uses — one consistent error surface.
- 2 new i18n keys (`autoToggleTitle` / `autoToggleSubtitle`) propagated across all 17 locales with native translations.

## What this does NOT do

- ❌ Background heartbeat poll. v1 fires on boot + Hybrid flip only. A timer-driven background loop can ship later if signal demands.
- ❌ Last-run-at timestamp persistence. Could land later for a \"Last sync: 2 minutes ago\" UI string; v1 ships without.

## Test plan

- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets\` clean
- [x] \`cargo test --manifest-path src-tauri/Cargo.toml --workspace\` → **351 still passing**
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] Manual 2-device smoke for track: device A tag-edits a track ; device B clicks Resync now ; verify track row UPSERTed locally with server's stamp ; \`payload_hash\` matches.
- [x] Manual auto-poll smoke: toggle on ; restart app ; verify boot log shows the auto-backfill pass + counts.

## Refs

- RFC-003 §4 backfill protocol
- PRs #66 (server entity endpoint), #249 (digest client), #250 (backfill orchestrator 4 entities), #251 (Settings UI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Nouvelles fonctionnalités**
  * Exécution automatique du backfill au démarrage et lors du basculement en mode **Hybrid**, déclenchée uniquement lors d’un changement effectif.
  * Nouveau réglage (par profil) pour activer/désactiver l’auto-backfill depuis la carte de statut de synchronisation.

* **Améliorations**
  * Amélioration de la prise en charge de l’entité **track** pendant les opérations de backfill (pull/push et résolution LWW plus robuste).
  * Affichage d’un message d’erreur lié au backfill si l’opération échoue.

* **Localisation**
  * Nouvelles traductions pour l’option d’auto-backfill et les messages associés (16 langues).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->