### PR TITLE
feat(sync): rfc-003 phase b polish — last-sync, heartbeat, drill-down, cadence config

### DIFF
--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -379,7 +379,195 @@ pub async fn sync_backfill_now(
 
     let report =
         backfill::run_backfill(&state, &client, profile_canonical_id.as_deref()).await?;
+
+    // Stamp the per-profile last-successful-backfill timestamp now
+    // that the top-level pass returned `Ok`. Mirrors the equivalent
+    // call in `backfill::maybe_auto_backfill` so the heartbeat /
+    // boot-time / manual paths all surface the same "Last sync"
+    // affordance to the user. Per-entity row failures don't gate
+    // the stamp; the Ran outcome reports them independently.
+    let pool = state.require_profile_pool().await?;
+    backfill::stamp_last_run_at(&pool).await;
+
     Ok(backfill::BackfillOutcome::Ran {
         reports: report.reports,
+    })
+}
+
+/// Snapshot of the backfill task surfaced to the Settings card.
+/// Used by the "Last sync: X ago" timestamp + the "in progress"
+/// disabled state on the Resync button.
+#[derive(Debug, Serialize)]
+pub struct SyncBackfillStatus {
+    /// Epoch-millisecond timestamp of the last completed backfill
+    /// pass (automatic or manual). `None` when the user has never
+    /// run one — fresh profile, opted-out, or first launch.
+    pub last_run_at: Option<i64>,
+    /// `true` when [`crate::state::AppState::backfill_lock`] is
+    /// held by another caller — manual click or heartbeat tick
+    /// currently mid-flight.
+    pub in_progress: bool,
+}
+
+/// Read the persisted last-run timestamp + the live in-flight
+/// state. Cheap — one SELECT + one `try_lock`. Used by the Settings
+/// card on mount + every time the manual button completes.
+#[tauri::command]
+pub async fn sync_backfill_get_status(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<SyncBackfillStatus> {
+    let pool = state.require_profile_pool().await?;
+    let last_run_at = backfill::read_last_run_at(&pool).await?;
+    // `try_lock` is non-blocking; we hold the guard only for the
+    // duration of the `is_ok` test (drops at end of statement).
+    // The race window where a concurrent pass starts between the
+    // check and the UI rendering is bounded by IPC latency — the
+    // user's next status poll resolves it.
+    let in_progress = state.backfill_lock.try_lock().is_err();
+    Ok(SyncBackfillStatus {
+        last_run_at,
+        in_progress,
+    })
+}
+
+/// Read the per-profile heartbeat cadence (minutes). Clamped to
+/// the documented range so a malformed stored value can't surface
+/// the heartbeat task with an out-of-range interval.
+#[tauri::command]
+pub async fn sync_backfill_get_heartbeat_interval(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<i64> {
+    let pool = state.require_profile_pool().await?;
+    backfill::read_heartbeat_interval_min(&pool).await
+}
+
+/// Persist the per-profile heartbeat cadence (minutes). Returns
+/// the clamped value so the caller can hydrate its UI even when
+/// the input was out of range.
+#[tauri::command]
+pub async fn sync_backfill_set_heartbeat_interval(
+    state: tauri::State<'_, AppState>,
+    minutes: i64,
+) -> AppResult<i64> {
+    let clamped = backfill::clamp_heartbeat_interval_min(minutes);
+    let pool = state.require_profile_pool().await?;
+    backfill::write_heartbeat_interval_min(&pool, clamped).await?;
+    Ok(clamped)
+}
+
+/// Detailed digest outcome carrying the full
+/// [`digest::diff::DigestDiff`] for a single entity. Used by the
+/// Settings card's drill-down panel: a click on a row out-of-sync
+/// fetches this and renders the divergent / missing-locally /
+/// missing-remotely member lists with their canonical_ids + hash
+/// previews.
+///
+/// Member lists are truncated server-side to
+/// [`DETAILED_BUCKET_CAP`] to keep IPC payloads bounded — a 10k-row
+/// divergence would otherwise marshal ~1 MB into the frontend for
+/// little incremental UX value. The truncated flags let the UI
+/// render a "+N more" affordance.
+#[derive(Debug, Serialize)]
+pub struct SyncDigestDetailed {
+    pub entity: String,
+    pub in_sync: bool,
+    pub local_version: i64,
+    pub remote_version: i64,
+    pub missing_locally: Vec<digest::client::RemoteMember>,
+    pub missing_locally_total: u32,
+    pub missing_remotely: Vec<digest::diff::DivergentMember>,
+    pub missing_remotely_total: u32,
+    pub divergent: Vec<digest::diff::DivergentMember>,
+    pub divergent_total: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SyncDigestDetailedOutcome {
+    Ran { diff: SyncDigestDetailed },
+    Skipped { reason: &'static str },
+}
+
+/// Per-bucket truncation cap surfaced through
+/// [`sync_digest_check_detailed`]. The Settings drill-down
+/// renders the first ~20 entries per bucket; the cap leaves
+/// headroom for a "show more" affordance without unbounded
+/// growth.
+pub const DETAILED_BUCKET_CAP: usize = 100;
+
+/// Detailed digest check for a single entity. Runs the same
+/// gates as [`sync_digest_check`] (offline / Local mode / no
+/// JWT / no canonical id) and returns the full member-level
+/// diff for the requested entity, truncated to
+/// [`DETAILED_BUCKET_CAP`] per bucket.
+#[tauri::command]
+pub async fn sync_digest_check_detailed(
+    state: tauri::State<'_, AppState>,
+    entity: String,
+) -> AppResult<SyncDigestDetailedOutcome> {
+    if crate::offline::is_offline() {
+        return Ok(SyncDigestDetailedOutcome::Skipped { reason: "offline" });
+    }
+    let pool = state.require_profile_pool().await?;
+    if mode::read(&pool).await? == mode::SyncMode::Local {
+        return Ok(SyncDigestDetailedOutcome::Skipped {
+            reason: "sync_mode_local",
+        });
+    }
+    let Some(client) = WaveflowServerClient::try_build(&state).await? else {
+        return Ok(SyncDigestDetailedOutcome::Skipped {
+            reason: "not_configured",
+        });
+    };
+
+    if !digest::SUPPORTED_ENTITIES.contains(&entity.as_str()) {
+        return Err(AppError::Other(format!(
+            "sync_digest_check_detailed: unknown entity '{entity}'"
+        )));
+    }
+
+    let profile_id = state.require_profile_id().await?;
+    let profile_canonical_id =
+        crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
+    let canonical_arg = match entity.as_str() {
+        "library" | "playlist" | "track" => {
+            let Some(canon) = profile_canonical_id.as_deref() else {
+                return Ok(SyncDigestDetailedOutcome::Skipped {
+                    reason: "profile_canonical_id_missing",
+                });
+            };
+            Some(canon)
+        }
+        _ => None,
+    };
+
+    let local = digest::read_local_digest(&pool, entity.as_str()).await?;
+    let remote =
+        digest::client::fetch_remote_digest(&client, entity.as_str(), canonical_arg).await?;
+    let d = digest::diff::diff(&local, &remote);
+
+    let missing_locally_total = d.missing_locally.len() as u32;
+    let missing_remotely_total = d.missing_remotely.len() as u32;
+    let divergent_total = d.divergent.len() as u32;
+    let mut missing_locally = d.missing_locally;
+    missing_locally.truncate(DETAILED_BUCKET_CAP);
+    let mut missing_remotely = d.missing_remotely;
+    missing_remotely.truncate(DETAILED_BUCKET_CAP);
+    let mut divergent = d.divergent;
+    divergent.truncate(DETAILED_BUCKET_CAP);
+
+    Ok(SyncDigestDetailedOutcome::Ran {
+        diff: SyncDigestDetailed {
+            entity: d.entity,
+            in_sync: d.in_sync,
+            local_version: d.local_version,
+            remote_version: d.remote_version,
+            missing_locally,
+            missing_locally_total,
+            missing_remotely,
+            missing_remotely_total,
+            divergent,
+            divergent_total,
+        },
     })
 }

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -416,18 +416,41 @@ pub async fn sync_backfill_now(
 #[derive(Debug, Serialize)]
 pub struct SyncBackfillStatus {
     /// Epoch-millisecond timestamp of the last completed backfill
-    /// pass (automatic or manual). `None` when the user has never
-    /// run one — fresh profile, opted-out, or first launch.
+    /// pass on the **active** profile (automatic or manual).
+    /// Sourced from per-profile `profile_setting`, so it does NOT
+    /// reflect activity on a different profile. `None` when the
+    /// user has never run one on this profile — fresh profile,
+    /// opted-out, or first launch.
     pub last_run_at: Option<i64>,
     /// `true` when [`crate::state::AppState::backfill_lock`] is
     /// held by another caller — manual click or heartbeat tick
     /// currently mid-flight.
+    ///
+    /// **Process-wide, not per-profile.** The lock lives on the
+    /// global `AppState`, so a backfill running on profile A is
+    /// visible to a `sync_backfill_get_status` call after the
+    /// user switches to profile B. The Settings card uses this
+    /// to disable the Resync button across the swap window so a
+    /// click on B can't queue a parallel pass while A is still
+    /// in flight — `sync_backfill_now` would surface
+    /// `AlreadyRunning` anyway, but the disabled state makes the
+    /// affordance honest. The window where this matters is small
+    /// (a single backfill rarely outlives a profile switch the
+    /// user just initiated) but the conservative read keeps the
+    /// UI's "no parallel passes" contract aligned with the
+    /// backend's.
     pub in_progress: bool,
 }
 
 /// Read the persisted last-run timestamp + the live in-flight
 /// state. Cheap — one SELECT + one `try_lock`. Used by the Settings
 /// card on mount + every time the manual button completes.
+///
+/// Cross-profile note: `last_run_at` comes from the **active**
+/// profile's `profile_setting` so it's scoped per profile, but
+/// `in_progress` reflects the global `backfill_lock` — see the
+/// [`SyncBackfillStatus::in_progress`] doc for why this conservative
+/// read is the right surface.
 #[tauri::command]
 pub async fn sync_backfill_get_status(
     state: tauri::State<'_, AppState>,

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -514,7 +514,18 @@ pub async fn sync_digest_check_detailed(
     if crate::offline::is_offline() {
         return Ok(SyncDigestDetailedOutcome::Skipped { reason: "offline" });
     }
-    let pool = state.require_profile_pool().await?;
+    // Pin pool + profile_id under a SINGLE RwLock read guard so a
+    // mid-call profile switch can't pair the old pool's local
+    // digest with the new profile's canonical_id when querying
+    // the server. Two separate `require_profile_pool` +
+    // `require_profile_id` calls would each re-acquire the lock,
+    // leaving an interleave window where `activate_profile`
+    // swaps the inner `ActiveProfile` between them.
+    let (pool, profile_id) = {
+        let guard = state.profile.read().await;
+        let active = guard.as_ref().ok_or(AppError::NoActiveProfile)?;
+        (active.pool.clone(), active.profile_id)
+    };
     if mode::read(&pool).await? == mode::SyncMode::Local {
         return Ok(SyncDigestDetailedOutcome::Skipped {
             reason: "sync_mode_local",
@@ -532,7 +543,10 @@ pub async fn sync_digest_check_detailed(
         )));
     }
 
-    let profile_id = state.require_profile_id().await?;
+    // `canonical_id_for` hits the global `app.db`, not the
+    // per-profile pool, so a profile switch can't desync the
+    // canonical against the pinned profile_id (the row stays
+    // queryable by id for both the old and new active profile).
     let profile_canonical_id =
         crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
     let canonical_arg = match entity.as_str() {

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -395,7 +395,7 @@ pub async fn sync_backfill_now(
         crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
 
     let report =
-        backfill::run_backfill(&state, &client, profile_canonical_id.as_deref()).await?;
+        backfill::run_backfill(&state, &pool, &client, profile_canonical_id.as_deref()).await?;
 
     // Stamp the per-profile last-successful-backfill timestamp now
     // that the top-level pass returned `Ok`. Reuses the same pool

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -351,15 +351,23 @@ pub async fn sync_backfill_now(
     if crate::offline::is_offline() {
         return Ok(backfill::BackfillOutcome::Skipped { reason: "offline" });
     }
-    // Pin the active profile's pool ONCE at the top so the gate
-    // read, the post-pass stamp, and any future reads all hit the
-    // same per-profile SQLite database. A user-driven profile
-    // switch mid-pass would otherwise race: the gate / stamp could
-    // see one profile while the inner backfill saw another. The
-    // pool itself is `Arc<…>` internally (sqlx) so holding the
-    // clone is cheap, and the underlying connections survive the
-    // RwLock swap that `activate_profile` performs.
-    let pool = state.require_profile_pool().await?;
+    // Pin the active profile's pool AND profile_id under a SINGLE
+    // RwLock read guard so the gate read, the canonical lookup,
+    // the inner backfill orchestration, and the post-pass stamp
+    // all see the same per-profile `(pool, profile_id)` pair.
+    // Two separate `require_profile_pool` + `require_profile_id`
+    // calls would each re-acquire the lock and leave an interleave
+    // window where `activate_profile` swaps the inner
+    // `ActiveProfile` — pairing the wrong pool with the wrong
+    // canonical id silently corrupts the per-profile timestamp
+    // stamp. The pool itself is `Arc<…>` internally (sqlx) so
+    // holding the clone is cheap, and the underlying connections
+    // survive the swap that `activate_profile` performs.
+    let (pool, profile_id) = {
+        let guard = state.profile.read().await;
+        let active = guard.as_ref().ok_or(AppError::NoActiveProfile)?;
+        (active.pool.clone(), active.profile_id)
+    };
     // Gate 1 — Local mode.
     if mode::read(&pool).await? == mode::SyncMode::Local {
         return Ok(backfill::BackfillOutcome::Skipped {
@@ -380,7 +388,9 @@ pub async fn sync_backfill_now(
         return Ok(backfill::BackfillOutcome::AlreadyRunning);
     };
 
-    let profile_id = state.require_profile_id().await?;
+    // `canonical_id_for` hits the global `app.db`, not the
+    // per-profile pool, so it's safe to call with the pinned
+    // `profile_id` even after concurrent profile activity.
     let profile_canonical_id =
         crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
 

--- a/src-tauri/crates/app/src/commands/sync.rs
+++ b/src-tauri/crates/app/src/commands/sync.rs
@@ -351,14 +351,21 @@ pub async fn sync_backfill_now(
     if crate::offline::is_offline() {
         return Ok(backfill::BackfillOutcome::Skipped { reason: "offline" });
     }
-    // Gate 1 — Local mode.
+    // Pin the active profile's pool ONCE at the top so the gate
+    // read, the post-pass stamp, and any future reads all hit the
+    // same per-profile SQLite database. A user-driven profile
+    // switch mid-pass would otherwise race: the gate / stamp could
+    // see one profile while the inner backfill saw another. The
+    // pool itself is `Arc<…>` internally (sqlx) so holding the
+    // clone is cheap, and the underlying connections survive the
+    // RwLock swap that `activate_profile` performs.
     let pool = state.require_profile_pool().await?;
+    // Gate 1 — Local mode.
     if mode::read(&pool).await? == mode::SyncMode::Local {
         return Ok(backfill::BackfillOutcome::Skipped {
             reason: "sync_mode_local",
         });
     }
-    drop(pool);
 
     // Gate 2 — server URL + JWT present.
     let Some(client) = WaveflowServerClient::try_build(&state).await? else {
@@ -381,12 +388,11 @@ pub async fn sync_backfill_now(
         backfill::run_backfill(&state, &client, profile_canonical_id.as_deref()).await?;
 
     // Stamp the per-profile last-successful-backfill timestamp now
-    // that the top-level pass returned `Ok`. Mirrors the equivalent
-    // call in `backfill::maybe_auto_backfill` so the heartbeat /
-    // boot-time / manual paths all surface the same "Last sync"
-    // affordance to the user. Per-entity row failures don't gate
-    // the stamp; the Ran outcome reports them independently.
-    let pool = state.require_profile_pool().await?;
+    // that the top-level pass returned `Ok`. Reuses the same pool
+    // pinned at the top of the function so a concurrent profile
+    // switch can't land the stamp in the wrong profile's
+    // `profile_setting`. Per-entity row failures don't gate the
+    // stamp; the Ran outcome reports them independently.
     backfill::stamp_last_run_at(&pool).await;
 
     Ok(backfill::BackfillOutcome::Ran {

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -176,6 +176,17 @@ pub fn run() {
                 }
             });
 
+            // RFC-003 Phase B polish — periodic heartbeat that fires
+            // `maybe_auto_backfill` every
+            // `sync.backfill.heartbeat_interval_min` minutes (default
+            // 60 min). Same gates as the boot pass short-circuit
+            // inside the helper, so a Local / offline / no-JWT
+            // session spins idle without cost. Cadence is re-read at
+            // every tick from the active profile's
+            // `profile_setting`, so changing it from Settings applies
+            // on the next iteration without restart.
+            sync::backfill::heartbeat::spawn(app.handle().clone());
+
             // Install the rustls process-wide CryptoProvider before
             // the WS subscriber spawns. rustls 0.23 panics on the
             // first TLS handshake when no provider is installed, and
@@ -651,6 +662,10 @@ pub fn run() {
             commands::sync::sync_backfill_now,
             commands::sync::sync_backfill_get_enabled,
             commands::sync::sync_backfill_set_enabled,
+            commands::sync::sync_backfill_get_status,
+            commands::sync::sync_backfill_get_heartbeat_interval,
+            commands::sync::sync_backfill_set_heartbeat_interval,
+            commands::sync::sync_digest_check_detailed,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,
             commands::preferences::get_minimize_to_tray,

--- a/src-tauri/crates/app/src/sync/backfill/heartbeat.rs
+++ b/src-tauri/crates/app/src/sync/backfill/heartbeat.rs
@@ -1,0 +1,75 @@
+//! Background heartbeat poll for RFC-003 Phase B backfill.
+//!
+//! Periodically fires [`super::maybe_auto_backfill`] so a desktop
+//! that's been online but idle catches up with the server without
+//! the user having to flip a Settings toggle. The cadence is
+//! per-profile (`profile_setting['sync.backfill.heartbeat_interval_min']`)
+//! and re-read at the top of every tick so a user change applies on
+//! the next cycle without restarting the app.
+//!
+//! ## Why this isn't redundant with the boot-time pass
+//!
+//! [`crate::lib::run`] already fires one [`super::maybe_auto_backfill`]
+//! at startup. The heartbeat covers the long-tail case: the user
+//! keeps the app open for hours / days. Without it the only
+//! catch-up path is manual button presses or sync-mode flips —
+//! perfectly fine for active users, less so for the "I leave it
+//! open while I work" usage pattern.
+//!
+//! ## Why no wake handle
+//!
+//! Unlike the drain task ([`crate::sync::drain::DrainHandle`]) which
+//! has CRUD callers `notify()`ing after every commit, there's no
+//! latency target for the heartbeat — the gates in
+//! [`super::maybe_auto_backfill`] (offline / `SyncMode::Local` /
+//! no JWT) short-circuit cheaply, and the wall-clock cadence is the
+//! only signal that matters. A cadence change applies at the next
+//! tick boundary, which is bounded by the previous cadence value.
+//! Acceptable for a setting users typically pick once.
+
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager};
+
+use crate::state::AppState;
+
+use super::{maybe_auto_backfill, read_heartbeat_interval_min, HEARTBEAT_INTERVAL_DEFAULT_MIN};
+
+/// Spawn the heartbeat task on the global tokio runtime. Called
+/// once from `lib.rs::run` after [`AppState`] is managed.
+///
+/// The task lives for the entire process lifetime; there's no
+/// stop signal because the runtime tears it down with the rest
+/// of the tokio runtime at shutdown.
+pub fn spawn(app: AppHandle) {
+    tokio::spawn(async move {
+        // First tick fires after the configured interval — the
+        // boot-time pass in `lib.rs::run` covers the immediate
+        // catch-up window, so the heartbeat doesn't need to race
+        // it.
+        loop {
+            // Read the cadence under the *current* active profile.
+            // A profile switch mid-session reaches this naturally
+            // because `require_profile_pool` follows the live
+            // RwLock; no separate notify needed.
+            let interval_min = {
+                let state = app.state::<AppState>();
+                match state.require_profile_pool().await {
+                    Ok(pool) => read_heartbeat_interval_min(&pool)
+                        .await
+                        .unwrap_or(HEARTBEAT_INTERVAL_DEFAULT_MIN),
+                    Err(_) => HEARTBEAT_INTERVAL_DEFAULT_MIN,
+                }
+            };
+
+            // `as u64` is sound — the SET command clamps to
+            // [15, 1440], so the cast can't underflow.
+            tokio::time::sleep(Duration::from_secs((interval_min as u64) * 60)).await;
+
+            let state = app.state::<AppState>();
+            if let Err(err) = maybe_auto_backfill(state.inner()).await {
+                tracing::warn!(error = %err, "heartbeat auto-backfill failed");
+            }
+        }
+    });
+}

--- a/src-tauri/crates/app/src/sync/backfill/mod.rs
+++ b/src-tauri/crates/app/src/sync/backfill/mod.rs
@@ -38,7 +38,7 @@ use chrono::Utc;
 use serde::Serialize;
 use sqlx::SqlitePool;
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::server_client::WaveflowServerClient;
 use crate::state::AppState;
 use crate::sync::digest::{self, diff::DigestDiff};
@@ -188,8 +188,17 @@ pub async fn stamp_last_run_at(pool: &SqlitePool) {
 /// `commands::sync::sync_set_mode`. Failures log + swallow so a
 /// transient network blip doesn't blow up the wrapping command.
 pub async fn maybe_auto_backfill(state: &AppState) -> AppResult<()> {
+    // Atomic snapshot of `(pool, profile_id)` so every per-profile
+    // read in this function — auto flag, sync mode, canonical
+    // lookup, `run_backfill`, post-pass stamp — sees the same
+    // profile, even if `activate_profile` swaps in a different
+    // one mid-call. Same pattern as `commands::sync::sync_backfill_now`.
+    let (pool, profile_id) = {
+        let guard = state.profile.read().await;
+        let active = guard.as_ref().ok_or(AppError::NoActiveProfile)?;
+        (active.pool.clone(), active.profile_id)
+    };
     // Gate 0 — auto flag must be on.
-    let pool = state.require_profile_pool().await?;
     if !read_auto_enabled(&pool).await? {
         return Ok(());
     }
@@ -211,11 +220,13 @@ pub async fn maybe_auto_backfill(state: &AppState) -> AppResult<()> {
         return Ok(());
     };
 
-    let profile_id = state.require_profile_id().await?;
+    // `canonical_id_for` hits the global `app.db`, not the
+    // per-profile pool, so it stays consistent with the pinned
+    // `profile_id` even across a concurrent activation.
     let profile_canonical_id =
         crate::db::profile_meta::canonical_id_for(&state.app_db, profile_id).await?;
 
-    match run_backfill(state, &client, profile_canonical_id.as_deref()).await {
+    match run_backfill(state, &pool, &client, profile_canonical_id.as_deref()).await {
         Ok(report) => {
             let entities_with_action = report
                 .reports
@@ -299,12 +310,20 @@ pub enum BackfillOutcome {
 /// `client` is taken as a parameter (not built inside) so the
 /// caller can hand the same builder it used for the digest pass —
 /// reuses the underlying `reqwest::Client` connection pool.
+///
+/// `pool` is the **pinned** per-profile SQLite pool. The caller
+/// MUST acquire it under the same `state.profile.read()` guard
+/// that captures `profile_id` / `profile_canonical_id`, so a
+/// concurrent `activate_profile` swap can't pair this pass's
+/// local digest reads with another profile's canonical id on
+/// the wire. The submodules (`push`, `pull`, `lww`) consume the
+/// same `&pool` and never re-resolve from `state` themselves.
 pub async fn run_backfill(
     state: &AppState,
+    pool: &SqlitePool,
     client: &WaveflowServerClient,
     profile_canonical_id: Option<&str>,
 ) -> AppResult<BackfillReport> {
-    let pool = state.require_profile_pool().await?;
     let mut reports = Vec::with_capacity(digest::SUPPORTED_ENTITIES.len());
 
     for entity in digest::SUPPORTED_ENTITIES {
@@ -334,7 +353,7 @@ pub async fn run_backfill(
             }
         };
 
-        let local = match digest::read_local_digest(&pool, entity).await {
+        let local = match digest::read_local_digest(pool, entity).await {
             Ok(d) => d,
             Err(err) => {
                 report.error = Some(format!("local digest: {err}"));
@@ -363,7 +382,7 @@ pub async fn run_backfill(
         // ── push direction ───────────────────────────────────
         let push_res = push::push_missing_remotely(
             state,
-            &pool,
+            pool,
             entity,
             &d.missing_remotely,
             remote_max_hlc,
@@ -386,7 +405,7 @@ pub async fn run_backfill(
         let pull_res = pull::pull_missing_locally(
             state,
             client,
-            &pool,
+            pool,
             entity,
             canonical_arg,
             &d.missing_locally,
@@ -408,7 +427,7 @@ pub async fn run_backfill(
         let lww_res = lww::resolve_divergent(
             state,
             client,
-            &pool,
+            pool,
             entity,
             canonical_arg,
             &d.divergent,

--- a/src-tauri/crates/app/src/sync/backfill/mod.rs
+++ b/src-tauri/crates/app/src/sync/backfill/mod.rs
@@ -29,10 +29,12 @@
 //! command checks the same gates as the digest_check), so this
 //! module assumes a configured client.
 
+pub mod heartbeat;
 pub mod lww;
 pub mod pull;
 pub mod push;
 
+use chrono::Utc;
 use serde::Serialize;
 use sqlx::SqlitePool;
 
@@ -45,6 +47,40 @@ use crate::sync::digest::{self, diff::DigestDiff};
 /// [`maybe_auto_backfill`] fires a pass on boot + every sync-mode
 /// flip to Hybrid. Default `false` — opt-in only.
 pub const AUTO_BACKFILL_KEY: &str = "sync.v2.backfill_enabled";
+
+/// `profile_setting` key for the last successful backfill timestamp
+/// (epoch milliseconds). Stamped at the end of any pass — automatic
+/// (`maybe_auto_backfill`) or manual (`sync_backfill_now`) — that
+/// completed `run_backfill` without surfacing a top-level error.
+/// Per-entity row-level failures don't gate the stamp; the Settings
+/// card surfaces them via `BackfillOutcome::Ran.reports` independently.
+pub const LAST_RUN_AT_KEY: &str = "sync.backfill.last_run_at";
+
+/// `profile_setting` key for the background heartbeat cadence
+/// (minutes between successive passes). Read at the top of every
+/// [`heartbeat`] tick so a user-driven change applies on the next
+/// iteration without restarting the app.
+pub const HEARTBEAT_INTERVAL_KEY: &str = "sync.backfill.heartbeat_interval_min";
+
+/// Default heartbeat cadence — once per hour. Matches the typical
+/// "background sync" cadence other desktop clients (Spotify, Apple
+/// Music) advertise.
+pub const HEARTBEAT_INTERVAL_DEFAULT_MIN: i64 = 60;
+
+/// Lower bound on the heartbeat cadence. 15 minutes keeps a runaway
+/// `INSERT INTO profile_setting (key, value) VALUES ('…', '1')` from
+/// turning the desktop into a chatty polling client.
+pub const HEARTBEAT_INTERVAL_MIN_MIN: i64 = 15;
+
+/// Upper bound on the heartbeat cadence. 24 hours = the longest a
+/// user could reasonably want between automatic checks before they
+/// just disable the toggle outright.
+pub const HEARTBEAT_INTERVAL_MAX_MIN: i64 = 1440;
+
+/// Clamp a caller-supplied minutes value into the documented range.
+pub fn clamp_heartbeat_interval_min(minutes: i64) -> i64 {
+    minutes.clamp(HEARTBEAT_INTERVAL_MIN_MIN, HEARTBEAT_INTERVAL_MAX_MIN)
+}
 
 /// Read the per-profile auto-backfill enabled flag. Returns
 /// `false` when the row is absent (matches the opt-in default).
@@ -68,6 +104,77 @@ pub async fn write_auto_enabled(pool: &SqlitePool, enabled: bool) -> AppResult<(
     .execute(pool)
     .await?;
     Ok(())
+}
+
+/// Read the epoch-millisecond timestamp of the last successful
+/// backfill pass. `None` when the user has never run one (fresh
+/// profile, opted-out, or first launch).
+pub async fn read_last_run_at(pool: &SqlitePool) -> AppResult<Option<i64>> {
+    let value: Option<String> =
+        sqlx::query_scalar("SELECT value FROM profile_setting WHERE key = ?")
+            .bind(LAST_RUN_AT_KEY)
+            .fetch_optional(pool)
+            .await?;
+    // `parse::<i64>()` would normally fail on the corner case of a
+    // malformed value (the column is TEXT). Swallow the error so a
+    // corrupt row doesn't take the Settings card surface down — the
+    // next pass overwrites with a valid stamp.
+    Ok(value.and_then(|v| v.parse::<i64>().ok()))
+}
+
+/// Stamp the per-profile last-successful-backfill timestamp.
+async fn write_last_run_at(pool: &SqlitePool, epoch_ms: i64) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO profile_setting (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(LAST_RUN_AT_KEY)
+    .bind(epoch_ms.to_string())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Read the per-profile heartbeat cadence (minutes). Falls back to
+/// [`HEARTBEAT_INTERVAL_DEFAULT_MIN`] when the row is absent or
+/// unparseable; the [`heartbeat`] task uses the same fallback so a
+/// fresh profile starts on the default cadence.
+pub async fn read_heartbeat_interval_min(pool: &SqlitePool) -> AppResult<i64> {
+    let value: Option<String> =
+        sqlx::query_scalar("SELECT value FROM profile_setting WHERE key = ?")
+            .bind(HEARTBEAT_INTERVAL_KEY)
+            .fetch_optional(pool)
+            .await?;
+    Ok(value
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(clamp_heartbeat_interval_min)
+        .unwrap_or(HEARTBEAT_INTERVAL_DEFAULT_MIN))
+}
+
+/// Persist the per-profile heartbeat cadence (minutes). The caller
+/// is responsible for [`clamp_heartbeat_interval_min`] — the Tauri
+/// command clamps so a malformed JSON payload can't land an
+/// out-of-range row.
+pub async fn write_heartbeat_interval_min(pool: &SqlitePool, minutes: i64) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO profile_setting (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(HEARTBEAT_INTERVAL_KEY)
+    .bind(minutes.to_string())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Stamp `LAST_RUN_AT_KEY` with the current wall-clock. Best-effort:
+/// a write failure logs + swallows because losing the timestamp
+/// stamp shouldn't take down the surfaced backfill outcome.
+pub async fn stamp_last_run_at(pool: &SqlitePool) {
+    let now = Utc::now().timestamp_millis();
+    if let Err(err) = write_last_run_at(pool, now).await {
+        tracing::warn!(error = %err, "stamp_last_run_at failed");
+    }
 }
 
 /// Best-effort auto-backfill trigger. Reads every gate (auto
@@ -119,6 +226,10 @@ pub async fn maybe_auto_backfill(state: &AppState) -> AppResult<()> {
                 entities_with_action,
                 "auto-backfill pass completed",
             );
+            // Successful top-level pass — stamp regardless of
+            // per-entity row counters. The Settings card surfaces
+            // row-level failures separately via the live outcome.
+            stamp_last_run_at(&pool).await;
         }
         Err(err) => {
             tracing::warn!(error = %err, "auto-backfill pass failed");

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -1,8 +1,16 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertCircle,
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   CloudOff,
   Loader2,
   RefreshCw,
@@ -11,36 +19,37 @@ import {
 } from "lucide-react";
 import {
   syncBackfillGetEnabled,
+  syncBackfillGetHeartbeatInterval,
+  syncBackfillGetStatus,
   syncBackfillNow,
   syncBackfillSetEnabled,
+  syncBackfillSetHeartbeatInterval,
   syncDigestCheck,
+  syncDigestCheckDetailed,
   type BackfillOutcome,
+  type SyncDigestDetailed,
   type SyncDigestOutcome,
   type SyncDigestReport,
 } from "../../../lib/tauri/sync";
 
 /**
- * Settings → Diagnostics → "Sync status" card (RFC-003 Phase B.3).
+ * Settings → Diagnostics → "Sync status" card (RFC-003 Phase B
+ * polish).
  *
- * Surface the digest_check + backfill commands the B.1/B.2 PRs
- * shipped so users can see whether their local state matches the
- * server's + trigger reconciliation when it doesn't.
+ * Surface the digest_check + backfill commands the B.1/B.2/B.3 PRs
+ * shipped, plus the polish round:
  *
- * The card is intentionally read-only beyond two action buttons —
- * no continuous polling, no background heartbeat. Triggers:
+ * - "Last sync: X ago" subtitle hydrated from `sync_backfill_get_status`.
+ * - Per-entity drill-down with the divergent / missing-locally /
+ *   missing-remotely canonical_id + hash preview lists.
+ * - Configurable heartbeat cadence (15 min – 24 h) for the
+ *   background poll wired in `lib.rs::run`.
  *
- * - On mount: one digest_check pass (cheap, read-only).
- * - "Refresh" button: another digest_check.
- * - "Resync now" button: a backfill pass + automatic digest_check
- *   re-run after to surface the new state.
- *
- * Gating reasons surfaced (matches the backend's `Skipped { reason }`):
- *
- * - `offline` — user enabled offline mode.
- * - `sync_mode_local` — profile is set to Local mode.
- * - `not_configured` — no server URL or no JWT.
- * - `profile_canonical_id_missing` — profile hasn't been backfilled
- *   with its canonical id yet (drain task handles it on next pass).
+ * The card stays read-only beyond the action buttons + the two
+ * toggles — no continuous polling on this surface (the heartbeat
+ * task lives in the backend and fires `maybe_auto_backfill`
+ * independently); the timestamp self-refreshes every 30 s while
+ * the card is mounted so "5 min ago" doesn't go stale.
  */
 
 type CardState =
@@ -48,6 +57,27 @@ type CardState =
   | { kind: "ran"; reports: SyncDigestReport[] }
   | { kind: "skipped"; reason: string }
   | { kind: "error"; message: string };
+
+type DetailedEntry =
+  | { kind: "loading" }
+  | { kind: "ran"; diff: SyncDigestDetailed }
+  | { kind: "skipped"; reason: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Heartbeat cadence presets surfaced in the dropdown. Values
+ * match the `[15, 1440]` clamp the backend applies — picking from
+ * the list is always safe, the freeform path is reserved for
+ * future power-user tooling.
+ */
+const CADENCE_OPTIONS: ReadonlyArray<{ value: number; labelKey: string }> = [
+  { value: 15, labelKey: "settings.syncStatus.cadence.every15Min" },
+  { value: 30, labelKey: "settings.syncStatus.cadence.every30Min" },
+  { value: 60, labelKey: "settings.syncStatus.cadence.every1Hour" },
+  { value: 360, labelKey: "settings.syncStatus.cadence.every6Hours" },
+  { value: 720, labelKey: "settings.syncStatus.cadence.every12Hours" },
+  { value: 1440, labelKey: "settings.syncStatus.cadence.every24Hours" },
+] as const;
 
 export function SyncStatusCard() {
   const { t } = useTranslation();
@@ -65,6 +95,17 @@ export function SyncStatusCard() {
   // truth is "the call itself blew up". Cleared on every fresh
   // attempt so a successful retry hides the stale banner.
   const [backfillError, setBackfillError] = useState<string | null>(null);
+  const [lastRunAt, setLastRunAt] = useState<number | null>(null);
+  const [cadence, setCadence] = useState<number | null>(null);
+  const [cadenceBusy, setCadenceBusy] = useState(false);
+  // Re-render every 30 s so the "X min ago" subtitle stays in
+  // sync with wall-clock without polling the backend. Each tick
+  // bumps a counter `nowTick`; we don't store the actual
+  // timestamp because `formatRelativeTime` derives it from
+  // `Date.now()` at render time.
+  const [, setNowTick] = useState(0);
+  const [expandedEntity, setExpandedEntity] = useState<string | null>(null);
+  const [detailed, setDetailed] = useState<Record<string, DetailedEntry>>({});
 
   const refresh = useCallback(async () => {
     setState({ kind: "loading" });
@@ -81,26 +122,47 @@ export function SyncStatusCard() {
         message: err instanceof Error ? err.message : String(err),
       });
     }
+    // Re-hydrate the last-run timestamp too — a heartbeat tick
+    // could have fired between the user clicking Refresh and the
+    // status command returning.
+    try {
+      const status = await syncBackfillGetStatus();
+      setLastRunAt(status.last_run_at);
+    } catch {
+      // Best-effort; the subtitle just stays on its previous value.
+    }
+    // Detailed cache is now stale — drop it. Next expand triggers
+    // a fresh fetch.
+    setDetailed({});
+    setExpandedEntity(null);
   }, []);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       // `Promise.allSettled` so a digest_check failure doesn't
-      // strand `autoEnabled` at `null` for the rest of the
-      // session — the toggle would then be disabled because the
-      // checkbox gates on `autoEnabled === null` (loading). The
-      // two reads are independent backend calls; surface each
-      // outcome on its own state.
-      const [digestRes, enabledRes] = await Promise.allSettled([
-        syncDigestCheck(),
-        syncBackfillGetEnabled(),
-      ]);
+      // strand `autoEnabled` / `cadence` / `lastRunAt` at their
+      // initial null state — each of the four reads is
+      // independent backend-side; we surface each outcome on its
+      // own slice.
+      const [digestRes, enabledRes, statusRes, cadenceRes] =
+        await Promise.allSettled([
+          syncDigestCheck(),
+          syncBackfillGetEnabled(),
+          syncBackfillGetStatus(),
+          syncBackfillGetHeartbeatInterval(),
+        ]);
       if (cancelled) return;
 
       setAutoEnabled(
         enabledRes.status === "fulfilled" ? enabledRes.value : false,
       );
+      if (statusRes.status === "fulfilled") {
+        setLastRunAt(statusRes.value.last_run_at);
+      }
+      if (cadenceRes.status === "fulfilled") {
+        setCadence(cadenceRes.value);
+      }
 
       if (digestRes.status === "fulfilled") {
         const outcome = digestRes.value;
@@ -122,6 +184,15 @@ export function SyncStatusCard() {
     };
   }, []);
 
+  // 30 s relative-time tick. Cheap — one re-render every 30 s
+  // while the card is mounted; the rest of the tree is unaffected
+  // because `nowTick` only lives here. `setNowTick` is stable
+  // across renders so the empty dependency array is honest.
+  useEffect(() => {
+    const id = setInterval(() => setNowTick((n) => n + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
   const handleToggleAuto = useCallback(async (next: boolean) => {
     setAutoToggleBusy(true);
     try {
@@ -137,6 +208,19 @@ export function SyncStatusCard() {
       setBackfillError(err instanceof Error ? err.message : String(err));
     } finally {
       setAutoToggleBusy(false);
+    }
+  }, []);
+
+  const handleCadenceChange = useCallback(async (next: number) => {
+    setCadenceBusy(true);
+    try {
+      const stored = await syncBackfillSetHeartbeatInterval(next);
+      setCadence(stored);
+      setBackfillError(null);
+    } catch (err) {
+      setBackfillError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCadenceBusy(false);
     }
   }, []);
 
@@ -161,7 +245,40 @@ export function SyncStatusCard() {
     }
   }, [refresh]);
 
-  const overall = useOverallStatus(state);
+  const handleToggleExpand = useCallback(
+    (entity: string, inSync: boolean) => {
+      if (inSync) return;
+      setExpandedEntity((prev) => (prev === entity ? null : entity));
+      // Lazy-load the detailed diff on first expand. Don't re-fetch
+      // if we already have one in cache — `refresh` clears the
+      // cache so a manual Refresh re-hydrates.
+      if (detailed[entity] !== undefined) return;
+      setDetailed((prev) => ({ ...prev, [entity]: { kind: "loading" } }));
+      void (async () => {
+        try {
+          const outcome = await syncDigestCheckDetailed(entity);
+          setDetailed((prev) => ({
+            ...prev,
+            [entity]:
+              outcome.status === "ran"
+                ? { kind: "ran", diff: outcome.diff }
+                : { kind: "skipped", reason: outcome.reason },
+          }));
+        } catch (err) {
+          setDetailed((prev) => ({
+            ...prev,
+            [entity]: {
+              kind: "error",
+              message: err instanceof Error ? err.message : String(err),
+            },
+          }));
+        }
+      })();
+    },
+    [detailed],
+  );
+
+  const overall = useOverallStatus(state, lastRunAt);
 
   return (
     <div className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
@@ -222,7 +339,12 @@ export function SyncStatusCard() {
 
       {state.kind === "ran" && state.reports.length > 0 ? (
         <div className="mt-4 ml-9">
-          <EntityReportTable reports={state.reports} />
+          <EntityReportTable
+            reports={state.reports}
+            expandedEntity={expandedEntity}
+            detailed={detailed}
+            onToggle={handleToggleExpand}
+          />
         </div>
       ) : null}
 
@@ -244,10 +366,39 @@ export function SyncStatusCard() {
             onChange={(e) => void handleToggleAuto(e.target.checked)}
             aria-label={t("settings.syncStatus.autoToggleTitle") ?? undefined}
           />
-          <span className="relative w-10 h-6 bg-zinc-200 dark:bg-zinc-700 rounded-full peer-checked:bg-emerald-500 transition-colors peer-disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-500 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-white dark:peer-focus-visible:ring-offset-zinc-900">
+          <span className="relative w-10 h-6 bg-zinc-200 dark:bg-zinc-700 rounded-full peer-checked:bg-emerald-600 transition-colors peer-disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-500 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-white dark:peer-focus-visible:ring-offset-zinc-900">
             <span className="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-4" />
           </span>
         </label>
+      </div>
+
+      <div className="mt-3 ml-9 flex items-center justify-between gap-3 text-xs">
+        <div className="min-w-0">
+          <label
+            htmlFor="sync-cadence-select"
+            className="font-medium text-zinc-700 dark:text-zinc-200"
+          >
+            {t("settings.syncStatus.cadenceTitle")}
+          </label>
+          <div className="text-zinc-400">
+            {t("settings.syncStatus.cadenceSubtitle")}
+          </div>
+        </div>
+        <select
+          id="sync-cadence-select"
+          value={cadence ?? 60}
+          disabled={
+            cadence === null || cadenceBusy || autoEnabled !== true
+          }
+          onChange={(e) => void handleCadenceChange(Number(e.target.value))}
+          className="shrink-0 px-3 py-1.5 rounded-lg border border-zinc-200 bg-white text-xs text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {CADENCE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {t(opt.labelKey)}
+            </option>
+          ))}
+        </select>
       </div>
     </div>
   );
@@ -258,8 +409,12 @@ interface OverallStatus {
   subtitle: (t: ReturnType<typeof useTranslation>["t"]) => string;
 }
 
-function useOverallStatus(state: CardState): OverallStatus {
+function useOverallStatus(
+  state: CardState,
+  lastRunAt: number | null,
+): OverallStatus {
   return useMemo<OverallStatus>(() => {
+    const lastSyncSuffix = formatLastSyncSuffix(lastRunAt);
     switch (state.kind) {
       case "loading":
         return {
@@ -292,26 +447,30 @@ function useOverallStatus(state: CardState): OverallStatus {
             icon: (
               <CheckCircle2
                 size={20}
-                className="text-emerald-500 shrink-0"
+                className="text-emerald-600 dark:text-emerald-400 shrink-0"
                 aria-hidden="true"
               />
             ),
-            subtitle: (t) => t("settings.syncStatus.subtitleAllInSync"),
+            subtitle: (t) =>
+              joinSubtitle(t("settings.syncStatus.subtitleAllInSync"), lastSyncSuffix(t)),
           };
         }
         return {
           icon: (
             <AlertCircle
               size={20}
-              className="text-amber-500 shrink-0"
+              className="text-amber-600 dark:text-amber-400 shrink-0"
               aria-hidden="true"
             />
           ),
           subtitle: (t) =>
-            t("settings.syncStatus.subtitleOutOfSync", {
-              outOfSync: total - inSync,
-              total,
-            }),
+            joinSubtitle(
+              t("settings.syncStatus.subtitleOutOfSync", {
+                outOfSync: total - inSync,
+                total,
+              }),
+              lastSyncSuffix(t),
+            ),
         };
       }
       case "skipped": {
@@ -344,7 +503,7 @@ function useOverallStatus(state: CardState): OverallStatus {
           icon: (
             <AlertCircle
               size={20}
-              className="text-rose-500 shrink-0"
+              className="text-rose-600 dark:text-rose-400 shrink-0"
               aria-hidden="true"
             />
           ),
@@ -352,69 +511,283 @@ function useOverallStatus(state: CardState): OverallStatus {
             t("settings.syncStatus.error", { message: state.message }),
         };
     }
-  }, [state]);
+  }, [state, lastRunAt]);
 }
 
-function EntityReportTable({ reports }: { reports: SyncDigestReport[] }) {
+interface EntityReportTableProps {
+  reports: SyncDigestReport[];
+  expandedEntity: string | null;
+  detailed: Record<string, DetailedEntry>;
+  onToggle: (entity: string, inSync: boolean) => void;
+}
+
+function EntityReportTable({
+  reports,
+  expandedEntity,
+  detailed,
+  onToggle,
+}: EntityReportTableProps) {
   const { t } = useTranslation();
   return (
     <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
       <table className="w-full text-xs">
         <thead className="bg-zinc-50 dark:bg-zinc-800/50 text-zinc-500 dark:text-zinc-400">
           <tr>
-            <th className="px-3 py-2 text-left font-medium">
+            <th scope="col" className="w-6 px-2 py-2" aria-hidden="true" />
+            <th scope="col" className="px-3 py-2 text-left font-medium">
               {t("settings.syncStatus.col.entity")}
             </th>
-            <th className="px-3 py-2 text-center font-medium">
+            <th scope="col" className="px-3 py-2 text-center font-medium">
               {t("settings.syncStatus.col.state")}
             </th>
-            <th className="px-3 py-2 text-right font-medium">
+            <th scope="col" className="px-3 py-2 text-right font-medium">
               {t("settings.syncStatus.col.missingLocally")}
             </th>
-            <th className="px-3 py-2 text-right font-medium">
+            <th scope="col" className="px-3 py-2 text-right font-medium">
               {t("settings.syncStatus.col.missingRemotely")}
             </th>
-            <th className="px-3 py-2 text-right font-medium">
+            <th scope="col" className="px-3 py-2 text-right font-medium">
               {t("settings.syncStatus.col.divergent")}
             </th>
           </tr>
         </thead>
         <tbody className="divide-y divide-zinc-200 dark:divide-zinc-700">
-          {reports.map((r) => (
-            <tr key={r.entity}>
-              <td className="px-3 py-2 font-mono text-zinc-700 dark:text-zinc-200">
-                {r.entity}
-              </td>
-              <td className="px-3 py-2 text-center">
-                {r.in_sync ? (
-                  <span
-                    className="inline-flex items-center text-emerald-600 dark:text-emerald-400"
-                    title={t("settings.syncStatus.inSync") ?? undefined}
-                  >
-                    <CheckCircle2 size={14} aria-hidden="true" />
-                  </span>
-                ) : (
-                  <span
-                    className="inline-flex items-center text-amber-600 dark:text-amber-400"
-                    title={t("settings.syncStatus.outOfSync") ?? undefined}
-                  >
-                    <AlertCircle size={14} aria-hidden="true" />
-                  </span>
-                )}
-              </td>
-              <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
-                {r.missing_locally}
-              </td>
-              <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
-                {r.missing_remotely}
-              </td>
-              <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
-                {r.divergent}
-              </td>
-            </tr>
-          ))}
+          {reports.map((r) => {
+            const expanded = expandedEntity === r.entity;
+            const expandable = !r.in_sync;
+            return (
+              <ExpandableRow
+                key={r.entity}
+                report={r}
+                expanded={expanded}
+                expandable={expandable}
+                detailed={detailed[r.entity]}
+                onToggle={() => onToggle(r.entity, r.in_sync)}
+              />
+            );
+          })}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+interface ExpandableRowProps {
+  report: SyncDigestReport;
+  expanded: boolean;
+  expandable: boolean;
+  detailed: DetailedEntry | undefined;
+  onToggle: () => void;
+}
+
+function ExpandableRow({
+  report: r,
+  expanded,
+  expandable,
+  detailed,
+  onToggle,
+}: ExpandableRowProps) {
+  const { t } = useTranslation();
+  const interactive = expandable
+    ? "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/40"
+    : "";
+  return (
+    <>
+      <tr
+        className={`group ${interactive}`}
+        onClick={expandable ? onToggle : undefined}
+        aria-expanded={expandable ? expanded : undefined}
+      >
+        <td className="px-2 py-2 text-zinc-400">
+          {expandable ? (
+            expanded ? (
+              <ChevronDown size={14} aria-hidden="true" />
+            ) : (
+              <ChevronRight size={14} aria-hidden="true" />
+            )
+          ) : null}
+        </td>
+        <td className="px-3 py-2 font-mono text-zinc-700 dark:text-zinc-200">
+          {r.entity}
+        </td>
+        <td className="px-3 py-2 text-center">
+          {r.in_sync ? (
+            <span
+              className="inline-flex items-center text-emerald-600 dark:text-emerald-400"
+              title={t("settings.syncStatus.inSync") ?? undefined}
+            >
+              <CheckCircle2 size={14} aria-hidden="true" />
+            </span>
+          ) : (
+            <span
+              className="inline-flex items-center text-amber-600 dark:text-amber-400"
+              title={t("settings.syncStatus.outOfSync") ?? undefined}
+            >
+              <AlertCircle size={14} aria-hidden="true" />
+            </span>
+          )}
+        </td>
+        <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
+          {r.missing_locally}
+        </td>
+        <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
+          {r.missing_remotely}
+        </td>
+        <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-200">
+          {r.divergent}
+        </td>
+      </tr>
+      {expanded ? (
+        <tr>
+          <td
+            colSpan={6}
+            className="px-3 py-3 bg-zinc-50/50 dark:bg-zinc-800/30"
+          >
+            <DetailedPanel entry={detailed} />
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Maximum number of canonical_ids rendered per bucket in the
+ * drill-down panel. The backend already caps at 100; the UI
+ * shows the first 20 to keep the panel scannable, with a
+ * "+N more" footer surfacing the rest of the cap.
+ */
+const DRILLDOWN_PER_BUCKET_LIMIT = 20;
+
+function DetailedPanel({ entry }: { entry: DetailedEntry | undefined }) {
+  const { t } = useTranslation();
+  if (entry === undefined || entry.kind === "loading") {
+    return (
+      <div className="flex items-center space-x-2 text-zinc-500 dark:text-zinc-400">
+        <Loader2 size={12} className="animate-spin" aria-hidden="true" />
+        <span>{t("settings.syncStatus.drilldown.loading")}</span>
+      </div>
+    );
+  }
+  if (entry.kind === "skipped") {
+    return (
+      <div className="text-zinc-500 dark:text-zinc-400">
+        {t(`settings.syncStatus.reason.${entry.reason}`, {
+          defaultValue: t("settings.syncStatus.reasonGeneric", {
+            reason: entry.reason,
+          }),
+        })}
+      </div>
+    );
+  }
+  if (entry.kind === "error") {
+    return (
+      <div className="text-rose-600 dark:text-rose-400">
+        {t("settings.syncStatus.drilldown.error", { message: entry.message })}
+      </div>
+    );
+  }
+  const d = entry.diff;
+  const buckets: Array<{
+    titleKey: string;
+    rows: Array<{
+      canonical_id: string;
+      local_hash: string;
+      remote_hash: string;
+    }>;
+    total: number;
+  }> = [
+    {
+      titleKey: "settings.syncStatus.drilldown.missingLocally",
+      rows: d.missing_locally.map((m) => ({
+        canonical_id: m.canonical_id,
+        local_hash: "",
+        remote_hash: m.payload_hash,
+      })),
+      total: d.missing_locally_total,
+    },
+    {
+      titleKey: "settings.syncStatus.drilldown.missingRemotely",
+      rows: d.missing_remotely.map((m) => ({
+        canonical_id: m.canonical_id,
+        local_hash: m.local_payload_hash,
+        remote_hash: m.remote_payload_hash,
+      })),
+      total: d.missing_remotely_total,
+    },
+    {
+      titleKey: "settings.syncStatus.drilldown.divergent",
+      rows: d.divergent.map((m) => ({
+        canonical_id: m.canonical_id,
+        local_hash: m.local_payload_hash,
+        remote_hash: m.remote_payload_hash,
+      })),
+      total: d.divergent_total,
+    },
+  ];
+  const nonEmpty = buckets.filter((b) => b.rows.length > 0);
+  if (nonEmpty.length === 0) {
+    return (
+      <div className="text-zinc-500 dark:text-zinc-400">
+        {t("settings.syncStatus.drilldown.empty")}
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {nonEmpty.map((b) => (
+        <DrilldownBucket
+          key={b.titleKey}
+          title={t(b.titleKey)}
+          rows={b.rows}
+          total={b.total}
+        />
+      ))}
+    </div>
+  );
+}
+
+function DrilldownBucket({
+  title,
+  rows,
+  total,
+}: {
+  title: string;
+  rows: Array<{ canonical_id: string; local_hash: string; remote_hash: string }>;
+  total: number;
+}) {
+  const { t } = useTranslation();
+  const shown = rows.slice(0, DRILLDOWN_PER_BUCKET_LIMIT);
+  const remaining = total - shown.length;
+  return (
+    <div>
+      <div className="text-xs font-semibold text-zinc-600 dark:text-zinc-300 mb-1">
+        {title}{" "}
+        <span className="font-normal text-zinc-400">({total})</span>
+      </div>
+      <ul className="space-y-0.5 text-[11px] font-mono text-zinc-600 dark:text-zinc-400">
+        {shown.map((row, idx) => (
+          <li key={`${row.canonical_id}-${idx}`} className="flex gap-2">
+            <span className="truncate" title={row.canonical_id}>
+              {row.canonical_id}
+            </span>
+            {row.local_hash || row.remote_hash ? (
+              <span className="shrink-0 text-zinc-400 dark:text-zinc-500">
+                {row.local_hash ? row.local_hash.slice(0, 8) : "—"}
+                {" / "}
+                {row.remote_hash ? row.remote_hash.slice(0, 8) : "—"}
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+      {remaining > 0 ? (
+        <div className="mt-1 text-[11px] text-zinc-400 dark:text-zinc-500">
+          {t("settings.syncStatus.drilldown.moreNotShown", {
+            count: remaining,
+          })}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -451,4 +824,41 @@ function BackfillOutcomeSummary({ outcome }: { outcome: BackfillOutcome }) {
       {t("settings.syncStatus.backfillSummary", totals)}
     </span>
   );
+}
+
+/**
+ * Format the "Last sync: X ago" suffix for the subtitle. Returns
+ * a function so the i18n `t` is captured at render time (the
+ * `useOverallStatus` hook receives a stale `t` otherwise).
+ */
+function formatLastSyncSuffix(
+  lastRunAt: number | null,
+): (t: ReturnType<typeof useTranslation>["t"]) => string {
+  if (lastRunAt === null) {
+    return (t) => t("settings.syncStatus.lastSyncNever");
+  }
+  // Recompute relative buckets at render time so the 30 s tick
+  // can re-render with fresh values.
+  const ageMs = Date.now() - lastRunAt;
+  if (ageMs < 60_000) {
+    return (t) => t("settings.syncStatus.lastSyncJustNow");
+  }
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 60) {
+    return (t) =>
+      t("settings.syncStatus.lastSyncMinutesAgo", { count: minutes });
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return (t) => t("settings.syncStatus.lastSyncHoursAgo", { count: hours });
+  }
+  const days = Math.floor(hours / 24);
+  return (t) => t("settings.syncStatus.lastSyncDaysAgo", { count: days });
+}
+
+/** Join the in-sync / out-of-sync summary with the optional
+ *  "Last sync: X ago" suffix. Skips the separator when the
+ *  suffix is empty (no last_run_at). */
+function joinSubtitle(base: string, suffix: string): string {
+  return suffix ? `${base} · ${suffix}` : base;
 }

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -112,7 +112,14 @@ export function SyncStatusCard() {
   // bumps a counter `nowTick`; we don't store the actual
   // timestamp because `formatRelativeTime` derives it from
   // `Date.now()` at render time.
-  const [, setNowTick] = useState(0);
+  // `nowTick` is the dep that drags the "X min ago" suffix's
+  // memo invalidation. We don't read the value directly — only
+  // its identity matters — but stripping it with `[, setNowTick]`
+  // would prevent passing it to `useOverallStatus` below, and
+  // the memo there would never see a change to re-run
+  // `formatLastSyncSuffix(lastRunAt)` (which samples `Date.now()`
+  // at call time).
+  const [nowTick, setNowTick] = useState(0);
   const [expandedEntity, setExpandedEntity] = useState<string | null>(null);
   const [detailed, setDetailed] = useState<Record<string, DetailedEntry>>({});
   // Generation counter bumped on every `refresh()` so in-flight
@@ -307,7 +314,7 @@ export function SyncStatusCard() {
     [detailed],
   );
 
-  const overall = useOverallStatus(state, lastRunAt);
+  const overall = useOverallStatus(state, lastRunAt, nowTick);
 
   return (
     <div className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
@@ -442,8 +449,15 @@ interface OverallStatus {
 function useOverallStatus(
   state: CardState,
   lastRunAt: number | null,
+  nowTick: number,
 ): OverallStatus {
   return useMemo<OverallStatus>(() => {
+    // Touch `nowTick` so `react-hooks/exhaustive-deps` doesn't
+    // strip it from the dep list. The value itself is unused —
+    // its identity is the signal that the 30 s `setInterval` in
+    // the parent has bumped wall-clock and the suffix needs to
+    // re-sample `Date.now()`.
+    void nowTick;
     const lastSyncSuffix = formatLastSyncSuffix(lastRunAt);
     switch (state.kind) {
       case "loading":
@@ -541,7 +555,11 @@ function useOverallStatus(
             t("settings.syncStatus.error", { message: state.message }),
         };
     }
-  }, [state, lastRunAt]);
+    // `nowTick` enters the dep list so the 30 s `setInterval`
+    // in the parent invalidates this memo and `formatLastSyncSuffix`
+    // re-samples `Date.now()` — without it, the suffix stays
+    // pinned to whatever wall-clock the previous render saw.
+  }, [state, lastRunAt, nowTick]);
 }
 
 interface EntityReportTableProps {

--- a/src/components/views/settings/SyncStatusCard.tsx
+++ b/src/components/views/settings/SyncStatusCard.tsx
@@ -2,7 +2,9 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -98,6 +100,13 @@ export function SyncStatusCard() {
   const [lastRunAt, setLastRunAt] = useState<number | null>(null);
   const [cadence, setCadence] = useState<number | null>(null);
   const [cadenceBusy, setCadenceBusy] = useState(false);
+  // Mirrors the backend's `state.backfill_lock` snapshot —
+  // surfaced by `sync_backfill_get_status` and refreshed on
+  // mount + after every `refresh()`. Used to disable the Resync
+  // button while a heartbeat / mode-flip pass is mid-flight so
+  // the user can't queue a redundant click that would surface
+  // `AlreadyRunning` on return.
+  const [serverInProgress, setServerInProgress] = useState(false);
   // Re-render every 30 s so the "X min ago" subtitle stays in
   // sync with wall-clock without polling the backend. Each tick
   // bumps a counter `nowTick`; we don't store the actual
@@ -106,9 +115,25 @@ export function SyncStatusCard() {
   const [, setNowTick] = useState(0);
   const [expandedEntity, setExpandedEntity] = useState<string | null>(null);
   const [detailed, setDetailed] = useState<Record<string, DetailedEntry>>({});
+  // Generation counter bumped on every `refresh()` so in-flight
+  // `syncDigestCheckDetailed` requests started before the user
+  // clicked Refresh can't repopulate the freshly-cleared cache
+  // with stale data. Each request captures the current value
+  // and drops its result if a newer generation is active by
+  // the time it resolves.
+  const detailedGenRef = useRef(0);
 
   const refresh = useCallback(async () => {
+    // Invalidate any in-flight detailed fetches BEFORE wiping the
+    // cache so a request started pre-refresh can't repopulate it
+    // with stale member lists. The bump is observed by the
+    // closures captured in `handleToggleExpand`.
+    detailedGenRef.current += 1;
     setState({ kind: "loading" });
+    // Detailed cache is now stale — drop it. Next expand triggers
+    // a fresh fetch (gated on the new generation).
+    setDetailed({});
+    setExpandedEntity(null);
     try {
       const outcome: SyncDigestOutcome = await syncDigestCheck();
       if (outcome.status === "skipped") {
@@ -122,19 +147,16 @@ export function SyncStatusCard() {
         message: err instanceof Error ? err.message : String(err),
       });
     }
-    // Re-hydrate the last-run timestamp too — a heartbeat tick
-    // could have fired between the user clicking Refresh and the
-    // status command returning.
+    // Re-hydrate the last-run timestamp + in-progress flag too —
+    // a heartbeat tick could have fired between the user clicking
+    // Refresh and the status command returning.
     try {
       const status = await syncBackfillGetStatus();
       setLastRunAt(status.last_run_at);
+      setServerInProgress(status.in_progress);
     } catch {
       // Best-effort; the subtitle just stays on its previous value.
     }
-    // Detailed cache is now stale — drop it. Next expand triggers
-    // a fresh fetch.
-    setDetailed({});
-    setExpandedEntity(null);
   }, []);
 
   useEffect(() => {
@@ -159,6 +181,7 @@ export function SyncStatusCard() {
       );
       if (statusRes.status === "fulfilled") {
         setLastRunAt(statusRes.value.last_run_at);
+        setServerInProgress(statusRes.value.in_progress);
       }
       if (cadenceRes.status === "fulfilled") {
         setCadence(cadenceRes.value);
@@ -253,10 +276,15 @@ export function SyncStatusCard() {
       // if we already have one in cache — `refresh` clears the
       // cache so a manual Refresh re-hydrates.
       if (detailed[entity] !== undefined) return;
+      // Capture the current generation so a `refresh()` mid-fetch
+      // can invalidate this result on return rather than letting
+      // it land into a freshly-cleared cache.
+      const gen = detailedGenRef.current;
       setDetailed((prev) => ({ ...prev, [entity]: { kind: "loading" } }));
       void (async () => {
         try {
           const outcome = await syncDigestCheckDetailed(entity);
+          if (gen !== detailedGenRef.current) return;
           setDetailed((prev) => ({
             ...prev,
             [entity]:
@@ -265,6 +293,7 @@ export function SyncStatusCard() {
                 : { kind: "skipped", reason: outcome.reason },
           }));
         } catch (err) {
+          if (gen !== detailedGenRef.current) return;
           setDetailed((prev) => ({
             ...prev,
             [entity]: {
@@ -323,7 +352,8 @@ export function SyncStatusCard() {
             disabled={
               state.kind !== "ran" ||
               state.reports.every((r) => r.in_sync) ||
-              backfilling
+              backfilling ||
+              serverInProgress
             }
             className="flex items-center space-x-2 px-4 py-2 rounded-xl bg-emerald-600 text-sm font-medium text-white hover:bg-emerald-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
@@ -589,13 +619,30 @@ function ExpandableRow({
 }: ExpandableRowProps) {
   const { t } = useTranslation();
   const interactive = expandable
-    ? "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/40"
+    ? "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/40 focus-visible:outline-none focus-visible:bg-zinc-100 dark:focus-visible:bg-zinc-800/60"
     : "";
+  // Keyboard handler so the chevron-row is reachable + activatable
+  // without a mouse. We deliberately leave `role="row"` on the `<tr>`
+  // (the implicit ARIA role of a `tr`) rather than swap to
+  // `role="button"`: overriding it would break the table's
+  // accessible tree (every row should expose a `row` role for
+  // assistive tech to grok the grid structure). `aria-expanded`
+  // + the visible chevron carry the "expandable button" affordance
+  // for screen readers.
+  const handleKeyDown = (e: KeyboardEvent<HTMLTableRowElement>) => {
+    if (!expandable) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onToggle();
+    }
+  };
   return (
     <>
       <tr
         className={`group ${interactive}`}
         onClick={expandable ? onToggle : undefined}
+        onKeyDown={expandable ? handleKeyDown : undefined}
+        tabIndex={expandable ? 0 : undefined}
         aria-expanded={expandable ? expanded : undefined}
       >
         <td className="px-2 py-2 text-zinc-400">

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1515,7 +1515,31 @@
       },
       "backfillError": "فشل: {{message}}",
       "autoToggleTitle": "المزامنة التلقائية",
-      "autoToggleSubtitle": "تشغيل مزامنة عند الإقلاع وعند التبديل إلى الوضع الهجين"
+      "autoToggleSubtitle": "تشغيل مزامنة عند الإقلاع وعند التبديل إلى الوضع الهجين",
+      "cadenceTitle": "تواتر الخلفية",
+      "cadenceSubtitle": "الفاصل الزمني بين المزامنات التلقائية",
+      "cadence": {
+        "every15Min": "كل 15 دقيقة",
+        "every30Min": "كل 30 دقيقة",
+        "every1Hour": "كل ساعة",
+        "every6Hours": "كل 6 ساعات",
+        "every12Hours": "كل 12 ساعة",
+        "every24Hours": "مرة في اليوم"
+      },
+      "lastSyncNever": "لم تتم المزامنة مطلقاً",
+      "lastSyncJustNow": "للتو",
+      "lastSyncMinutesAgo": "قبل {{count}} دقيقة",
+      "lastSyncHoursAgo": "قبل {{count}} ساعة",
+      "lastSyncDaysAgo": "قبل {{count}} يوم",
+      "drilldown": {
+        "loading": "جاري تحميل التفاصيل…",
+        "error": "خطأ: {{message}}",
+        "empty": "لا توجد تفاصيل",
+        "missingLocally": "مفقود محلياً",
+        "missingRemotely": "مفقود عن بُعد",
+        "divergent": "متباين",
+        "moreNotShown": "+ {{count}} غير معروضة"
+      }
     },
     "visualizer": {
       "title": "محلل الصوت البصري",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1511,7 +1511,31 @@
       },
       "backfillError": "Fehlgeschlagen: {{message}}",
       "autoToggleTitle": "Auto-Sync",
-      "autoToggleSubtitle": "Führt beim Start und beim Wechsel in den Hybrid-Modus eine Synchronisation durch"
+      "autoToggleSubtitle": "Führt beim Start und beim Wechsel in den Hybrid-Modus eine Synchronisation durch",
+      "cadenceTitle": "Hintergrund-Kadenz",
+      "cadenceSubtitle": "Zeit zwischen automatischen Synchronisierungen",
+      "cadence": {
+        "every15Min": "Alle 15 Minuten",
+        "every30Min": "Alle 30 Minuten",
+        "every1Hour": "Stündlich",
+        "every6Hours": "Alle 6 Stunden",
+        "every12Hours": "Alle 12 Stunden",
+        "every24Hours": "Einmal täglich"
+      },
+      "lastSyncNever": "Nie synchronisiert",
+      "lastSyncJustNow": "Gerade eben",
+      "lastSyncMinutesAgo": "Vor {{count}} Min",
+      "lastSyncHoursAgo": "Vor {{count}} Std",
+      "lastSyncDaysAgo": "Vor {{count}} T",
+      "drilldown": {
+        "loading": "Details werden geladen…",
+        "error": "Fehler: {{message}}",
+        "empty": "Keine Details verfügbar",
+        "missingLocally": "Lokal fehlend",
+        "missingRemotely": "Entfernt fehlend",
+        "divergent": "Abweichend",
+        "moreNotShown": "+ {{count}} weitere nicht angezeigt"
+      }
     },
     "visualizer": {
       "title": "Audio-Visualizer",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1532,7 +1532,7 @@
         "error": "Fehler: {{message}}",
         "empty": "Keine Details verfügbar",
         "missingLocally": "Lokal fehlend",
-        "missingRemotely": "Entfernt fehlend",
+        "missingRemotely": "Remote fehlend",
         "divergent": "Abweichend",
         "moreNotShown": "+ {{count}} weitere nicht angezeigt"
       }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1511,7 +1511,31 @@
       },
       "backfillError": "Failed: {{message}}",
       "autoToggleTitle": "Auto sync",
-      "autoToggleSubtitle": "Runs a pass on boot and when switching to Hybrid mode"
+      "autoToggleSubtitle": "Runs a pass on boot and when switching to Hybrid mode",
+      "cadenceTitle": "Background cadence",
+      "cadenceSubtitle": "Time between automatic sync passes",
+      "cadence": {
+        "every15Min": "Every 15 minutes",
+        "every30Min": "Every 30 minutes",
+        "every1Hour": "Every hour",
+        "every6Hours": "Every 6 hours",
+        "every12Hours": "Every 12 hours",
+        "every24Hours": "Once a day"
+      },
+      "lastSyncNever": "Never synced",
+      "lastSyncJustNow": "Just now",
+      "lastSyncMinutesAgo": "{{count}} min ago",
+      "lastSyncHoursAgo": "{{count}} h ago",
+      "lastSyncDaysAgo": "{{count}} d ago",
+      "drilldown": {
+        "loading": "Loading details…",
+        "error": "Error: {{message}}",
+        "empty": "No details to show",
+        "missingLocally": "Missing locally",
+        "missingRemotely": "Missing remotely",
+        "divergent": "Divergent",
+        "moreNotShown": "+ {{count}} more not shown"
+      }
     },
     "visualizer": {
       "title": "Audio visualizer",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1511,7 +1511,31 @@
       },
       "backfillError": "Error: {{message}}",
       "autoToggleTitle": "Sincronización automática",
-      "autoToggleSubtitle": "Ejecuta una pasada al arrancar y al cambiar al modo Híbrido"
+      "autoToggleSubtitle": "Ejecuta una pasada al arrancar y al cambiar al modo Híbrido",
+      "cadenceTitle": "Cadencia en segundo plano",
+      "cadenceSubtitle": "Tiempo entre sincronizaciones automáticas",
+      "cadence": {
+        "every15Min": "Cada 15 minutos",
+        "every30Min": "Cada 30 minutos",
+        "every1Hour": "Cada hora",
+        "every6Hours": "Cada 6 horas",
+        "every12Hours": "Cada 12 horas",
+        "every24Hours": "Una vez al día"
+      },
+      "lastSyncNever": "Nunca sincronizado",
+      "lastSyncJustNow": "Justo ahora",
+      "lastSyncMinutesAgo": "Hace {{count}} min",
+      "lastSyncHoursAgo": "Hace {{count}} h",
+      "lastSyncDaysAgo": "Hace {{count}} d",
+      "drilldown": {
+        "loading": "Cargando detalles…",
+        "error": "Error: {{message}}",
+        "empty": "Nada que mostrar",
+        "missingLocally": "Falta local",
+        "missingRemotely": "Falta remoto",
+        "divergent": "Divergente",
+        "moreNotShown": "+ {{count}} más no mostrados"
+      }
     },
     "visualizer": {
       "title": "Visualizador de audio",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1562,7 +1562,31 @@
       },
       "backfillError": "Échec : {{message}}",
       "autoToggleTitle": "Synchronisation automatique",
-      "autoToggleSubtitle": "Lance un passage au démarrage et lors du passage en mode Hybride"
+      "autoToggleSubtitle": "Lance un passage au démarrage et lors du passage en mode Hybride",
+      "cadenceTitle": "Cadence en arrière-plan",
+      "cadenceSubtitle": "Intervalle entre deux synchronisations automatiques",
+      "cadence": {
+        "every15Min": "Toutes les 15 minutes",
+        "every30Min": "Toutes les 30 minutes",
+        "every1Hour": "Toutes les heures",
+        "every6Hours": "Toutes les 6 heures",
+        "every12Hours": "Toutes les 12 heures",
+        "every24Hours": "Une fois par jour"
+      },
+      "lastSyncNever": "Jamais synchronisé",
+      "lastSyncJustNow": "À l'instant",
+      "lastSyncMinutesAgo": "Il y a {{count}} min",
+      "lastSyncHoursAgo": "Il y a {{count}} h",
+      "lastSyncDaysAgo": "Il y a {{count}} j",
+      "drilldown": {
+        "loading": "Chargement des détails…",
+        "error": "Erreur : {{message}}",
+        "empty": "Aucun détail à afficher",
+        "missingLocally": "Manquant local",
+        "missingRemotely": "Manquant distant",
+        "divergent": "Divergent",
+        "moreNotShown": "+ {{count}} de plus non affichés"
+      }
     },
     "visualizer": {
       "title": "Visualiseur audio",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1523,7 +1523,31 @@
       },
       "backfillError": "विफल: {{message}}",
       "autoToggleTitle": "स्वचालित सिंक",
-      "autoToggleSubtitle": "बूट पर और हाइब्रिड मोड में स्विच करने पर एक पास चलाता है"
+      "autoToggleSubtitle": "बूट पर और हाइब्रिड मोड में स्विच करने पर एक पास चलाता है",
+      "cadenceTitle": "पृष्ठभूमि लय",
+      "cadenceSubtitle": "स्वचालित सिंक के बीच का अंतराल",
+      "cadence": {
+        "every15Min": "हर 15 मिनट",
+        "every30Min": "हर 30 मिनट",
+        "every1Hour": "हर घंटे",
+        "every6Hours": "हर 6 घंटे",
+        "every12Hours": "हर 12 घंटे",
+        "every24Hours": "दिन में एक बार"
+      },
+      "lastSyncNever": "कभी सिंक नहीं किया",
+      "lastSyncJustNow": "अभी-अभी",
+      "lastSyncMinutesAgo": "{{count}} मिनट पहले",
+      "lastSyncHoursAgo": "{{count}} घंटे पहले",
+      "lastSyncDaysAgo": "{{count}} दिन पहले",
+      "drilldown": {
+        "loading": "विवरण लोड हो रहे हैं…",
+        "error": "त्रुटि: {{message}}",
+        "empty": "दिखाने के लिए कोई विवरण नहीं",
+        "missingLocally": "स्थानीय रूप से अनुपस्थित",
+        "missingRemotely": "सर्वर पर अनुपस्थित",
+        "divergent": "भिन्न",
+        "moreNotShown": "+ {{count}} और नहीं दिखाए गए"
+      }
     },
     "gapless": {
       "title": "गैपलेस प्लेबैक",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1511,7 +1511,31 @@
       },
       "backfillError": "Gagal: {{message}}",
       "autoToggleTitle": "Sinkronisasi otomatis",
-      "autoToggleSubtitle": "Menjalankan pass saat boot dan saat beralih ke mode Hybrid"
+      "autoToggleSubtitle": "Menjalankan pass saat boot dan saat beralih ke mode Hybrid",
+      "cadenceTitle": "Kecepatan latar",
+      "cadenceSubtitle": "Interval antar sinkronisasi otomatis",
+      "cadence": {
+        "every15Min": "Setiap 15 menit",
+        "every30Min": "Setiap 30 menit",
+        "every1Hour": "Setiap jam",
+        "every6Hours": "Setiap 6 jam",
+        "every12Hours": "Setiap 12 jam",
+        "every24Hours": "Sekali sehari"
+      },
+      "lastSyncNever": "Belum pernah disinkronkan",
+      "lastSyncJustNow": "Baru saja",
+      "lastSyncMinutesAgo": "{{count}} mnt lalu",
+      "lastSyncHoursAgo": "{{count}} j lalu",
+      "lastSyncDaysAgo": "{{count}} h lalu",
+      "drilldown": {
+        "loading": "Memuat detail…",
+        "error": "Kesalahan: {{message}}",
+        "empty": "Tidak ada detail",
+        "missingLocally": "Hilang di lokal",
+        "missingRemotely": "Hilang di server",
+        "divergent": "Divergen",
+        "moreNotShown": "+ {{count}} lainnya tak ditampilkan"
+      }
     },
     "visualizer": {
       "title": "Visualizer audio",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1511,7 +1511,31 @@
       },
       "backfillError": "Errore: {{message}}",
       "autoToggleTitle": "Sincronizzazione automatica",
-      "autoToggleSubtitle": "Esegue una passata all'avvio e al passaggio alla modalità Ibrida"
+      "autoToggleSubtitle": "Esegue una passata all'avvio e al passaggio alla modalità Ibrida",
+      "cadenceTitle": "Cadenza in background",
+      "cadenceSubtitle": "Intervallo tra sincronizzazioni automatiche",
+      "cadence": {
+        "every15Min": "Ogni 15 minuti",
+        "every30Min": "Ogni 30 minuti",
+        "every1Hour": "Ogni ora",
+        "every6Hours": "Ogni 6 ore",
+        "every12Hours": "Ogni 12 ore",
+        "every24Hours": "Una volta al giorno"
+      },
+      "lastSyncNever": "Mai sincronizzato",
+      "lastSyncJustNow": "Adesso",
+      "lastSyncMinutesAgo": "{{count}} min fa",
+      "lastSyncHoursAgo": "{{count}} h fa",
+      "lastSyncDaysAgo": "{{count}} g fa",
+      "drilldown": {
+        "loading": "Caricamento dettagli…",
+        "error": "Errore: {{message}}",
+        "empty": "Nessun dettaglio",
+        "missingLocally": "Mancante in locale",
+        "missingRemotely": "Mancante in remoto",
+        "divergent": "Divergente",
+        "moreNotShown": "+ {{count}} altri non visualizzati"
+      }
     },
     "visualizer": {
       "title": "Visualizzatore audio",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1470,7 +1470,31 @@
       },
       "backfillError": "失敗: {{message}}",
       "autoToggleTitle": "自動同期",
-      "autoToggleSubtitle": "起動時とハイブリッドモード切替時に同期を実行します"
+      "autoToggleSubtitle": "起動時とハイブリッドモード切替時に同期を実行します",
+      "cadenceTitle": "バックグラウンド間隔",
+      "cadenceSubtitle": "自動同期の間隔",
+      "cadence": {
+        "every15Min": "15 分ごと",
+        "every30Min": "30 分ごと",
+        "every1Hour": "1 時間ごと",
+        "every6Hours": "6 時間ごと",
+        "every12Hours": "12 時間ごと",
+        "every24Hours": "1 日 1 回"
+      },
+      "lastSyncNever": "同期されていません",
+      "lastSyncJustNow": "たった今",
+      "lastSyncMinutesAgo": "{{count}} 分前",
+      "lastSyncHoursAgo": "{{count}} 時間前",
+      "lastSyncDaysAgo": "{{count}} 日前",
+      "drilldown": {
+        "loading": "詳細を読み込み中…",
+        "error": "エラー: {{message}}",
+        "empty": "表示する詳細はありません",
+        "missingLocally": "ローカルに不足",
+        "missingRemotely": "サーバーに不足",
+        "divergent": "不一致",
+        "moreNotShown": "他 {{count}} 件非表示"
+      }
     },
     "gapless": {
       "title": "ギャップレス再生",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1523,7 +1523,31 @@
       },
       "backfillError": "실패: {{message}}",
       "autoToggleTitle": "자동 동기화",
-      "autoToggleSubtitle": "부팅 시 그리고 하이브리드 모드로 전환할 때 동기화를 실행합니다"
+      "autoToggleSubtitle": "부팅 시 그리고 하이브리드 모드로 전환할 때 동기화를 실행합니다",
+      "cadenceTitle": "백그라운드 주기",
+      "cadenceSubtitle": "자동 동기화 간격",
+      "cadence": {
+        "every15Min": "15분마다",
+        "every30Min": "30분마다",
+        "every1Hour": "1시간마다",
+        "every6Hours": "6시간마다",
+        "every12Hours": "12시간마다",
+        "every24Hours": "하루 한 번"
+      },
+      "lastSyncNever": "동기화된 적 없음",
+      "lastSyncJustNow": "방금 전",
+      "lastSyncMinutesAgo": "{{count}}분 전",
+      "lastSyncHoursAgo": "{{count}}시간 전",
+      "lastSyncDaysAgo": "{{count}}일 전",
+      "drilldown": {
+        "loading": "세부 정보 불러오는 중…",
+        "error": "오류: {{message}}",
+        "empty": "표시할 세부 정보 없음",
+        "missingLocally": "로컬에 없음",
+        "missingRemotely": "원격에 없음",
+        "divergent": "불일치",
+        "moreNotShown": "{{count}}개 더 표시되지 않음"
+      }
     },
     "gapless": {
       "title": "갭리스 재생",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1511,7 +1511,31 @@
       },
       "backfillError": "Mislukt: {{message}}",
       "autoToggleTitle": "Automatische sync",
-      "autoToggleSubtitle": "Voert een pass uit bij het opstarten en bij overschakeling naar Hybride"
+      "autoToggleSubtitle": "Voert een pass uit bij het opstarten en bij overschakeling naar Hybride",
+      "cadenceTitle": "Achtergrondfrequentie",
+      "cadenceSubtitle": "Tijd tussen automatische synchronisaties",
+      "cadence": {
+        "every15Min": "Elke 15 minuten",
+        "every30Min": "Elke 30 minuten",
+        "every1Hour": "Elk uur",
+        "every6Hours": "Elke 6 uur",
+        "every12Hours": "Elke 12 uur",
+        "every24Hours": "Eén keer per dag"
+      },
+      "lastSyncNever": "Nooit gesynchroniseerd",
+      "lastSyncJustNow": "Zojuist",
+      "lastSyncMinutesAgo": "{{count}} min geleden",
+      "lastSyncHoursAgo": "{{count}} u geleden",
+      "lastSyncDaysAgo": "{{count}} d geleden",
+      "drilldown": {
+        "loading": "Details laden…",
+        "error": "Fout: {{message}}",
+        "empty": "Geen details",
+        "missingLocally": "Lokaal ontbrekend",
+        "missingRemotely": "Op afstand ontbrekend",
+        "divergent": "Afwijkend",
+        "moreNotShown": "+ {{count}} meer niet getoond"
+      }
     },
     "visualizer": {
       "title": "Audio-visualizer",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1532,7 +1532,7 @@
         "error": "Fout: {{message}}",
         "empty": "Geen details",
         "missingLocally": "Lokaal ontbrekend",
-        "missingRemotely": "Op afstand ontbrekend",
+        "missingRemotely": "Extern ontbrekend",
         "divergent": "Afwijkend",
         "moreNotShown": "+ {{count}} meer niet getoond"
       }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1543,8 +1543,8 @@
         "loading": "Carregando detalhes…",
         "error": "Erro: {{message}}",
         "empty": "Sem detalhes",
-        "missingLocally": "Faltando localmente",
-        "missingRemotely": "Faltando no servidor",
+        "missingLocally": "Faltando local",
+        "missingRemotely": "Faltando remoto",
         "divergent": "Divergente",
         "moreNotShown": "+ {{count}} mais não exibidos"
       }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1523,7 +1523,31 @@
       },
       "backfillError": "Falhou: {{message}}",
       "autoToggleTitle": "Sincronização automática",
-      "autoToggleSubtitle": "Executa uma passada na inicialização e ao mudar para o modo Híbrido"
+      "autoToggleSubtitle": "Executa uma passada na inicialização e ao mudar para o modo Híbrido",
+      "cadenceTitle": "Cadência em segundo plano",
+      "cadenceSubtitle": "Intervalo entre sincronizações automáticas",
+      "cadence": {
+        "every15Min": "A cada 15 minutos",
+        "every30Min": "A cada 30 minutos",
+        "every1Hour": "A cada hora",
+        "every6Hours": "A cada 6 horas",
+        "every12Hours": "A cada 12 horas",
+        "every24Hours": "Uma vez por dia"
+      },
+      "lastSyncNever": "Nunca sincronizado",
+      "lastSyncJustNow": "Agora mesmo",
+      "lastSyncMinutesAgo": "Há {{count}} min",
+      "lastSyncHoursAgo": "Há {{count}} h",
+      "lastSyncDaysAgo": "Há {{count}} d",
+      "drilldown": {
+        "loading": "Carregando detalhes…",
+        "error": "Erro: {{message}}",
+        "empty": "Sem detalhes",
+        "missingLocally": "Faltando localmente",
+        "missingRemotely": "Faltando no servidor",
+        "divergent": "Divergente",
+        "moreNotShown": "+ {{count}} mais não exibidos"
+      }
     },
     "gapless": {
       "title": "Reprodução contínua",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1523,7 +1523,31 @@
       },
       "backfillError": "Falhou: {{message}}",
       "autoToggleTitle": "Sincronização automática",
-      "autoToggleSubtitle": "Executa uma passagem ao iniciar e ao mudar para o modo Híbrido"
+      "autoToggleSubtitle": "Executa uma passagem ao iniciar e ao mudar para o modo Híbrido",
+      "cadenceTitle": "Cadência em segundo plano",
+      "cadenceSubtitle": "Intervalo entre sincronizações automáticas",
+      "cadence": {
+        "every15Min": "A cada 15 minutos",
+        "every30Min": "A cada 30 minutos",
+        "every1Hour": "A cada hora",
+        "every6Hours": "A cada 6 horas",
+        "every12Hours": "A cada 12 horas",
+        "every24Hours": "Uma vez por dia"
+      },
+      "lastSyncNever": "Nunca sincronizado",
+      "lastSyncJustNow": "Agora mesmo",
+      "lastSyncMinutesAgo": "Há {{count}} min",
+      "lastSyncHoursAgo": "Há {{count}} h",
+      "lastSyncDaysAgo": "Há {{count}} d",
+      "drilldown": {
+        "loading": "Carregando detalhes…",
+        "error": "Erro: {{message}}",
+        "empty": "Sem detalhes",
+        "missingLocally": "Faltando localmente",
+        "missingRemotely": "Faltando no servidor",
+        "divergent": "Divergente",
+        "moreNotShown": "+ {{count}} mais não exibidos"
+      }
     },
     "gapless": {
       "title": "Reprodução contínua",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1553,7 +1553,31 @@
       },
       "backfillError": "Сбой: {{message}}",
       "autoToggleTitle": "Автосинхронизация",
-      "autoToggleSubtitle": "Запускает проход при загрузке и при переключении в гибридный режим"
+      "autoToggleSubtitle": "Запускает проход при загрузке и при переключении в гибридный режим",
+      "cadenceTitle": "Фоновая частота",
+      "cadenceSubtitle": "Интервал между автоматическими синхронизациями",
+      "cadence": {
+        "every15Min": "Каждые 15 минут",
+        "every30Min": "Каждые 30 минут",
+        "every1Hour": "Каждый час",
+        "every6Hours": "Каждые 6 часов",
+        "every12Hours": "Каждые 12 часов",
+        "every24Hours": "Раз в день"
+      },
+      "lastSyncNever": "Никогда не синхронизировалось",
+      "lastSyncJustNow": "Только что",
+      "lastSyncMinutesAgo": "{{count}} мин назад",
+      "lastSyncHoursAgo": "{{count}} ч назад",
+      "lastSyncDaysAgo": "{{count}} д назад",
+      "drilldown": {
+        "loading": "Загрузка деталей…",
+        "error": "Ошибка: {{message}}",
+        "empty": "Нет данных",
+        "missingLocally": "Отсутствует локально",
+        "missingRemotely": "Отсутствует на сервере",
+        "divergent": "Расхождение",
+        "moreNotShown": "+ ещё {{count}} не показано"
+      }
     },
     "visualizer": {
       "title": "Аудио-визуализатор",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1511,7 +1511,31 @@
       },
       "backfillError": "Başarısız: {{message}}",
       "autoToggleTitle": "Otomatik senkronizasyon",
-      "autoToggleSubtitle": "Açılışta ve Hibrit moda geçişte bir geçiş çalıştırır"
+      "autoToggleSubtitle": "Açılışta ve Hibrit moda geçişte bir geçiş çalıştırır",
+      "cadenceTitle": "Arka plan sıklığı",
+      "cadenceSubtitle": "Otomatik senkronizasyonlar arası süre",
+      "cadence": {
+        "every15Min": "15 dakikada bir",
+        "every30Min": "30 dakikada bir",
+        "every1Hour": "Saatte bir",
+        "every6Hours": "6 saatte bir",
+        "every12Hours": "12 saatte bir",
+        "every24Hours": "Günde bir"
+      },
+      "lastSyncNever": "Hiç senkronize edilmedi",
+      "lastSyncJustNow": "Az önce",
+      "lastSyncMinutesAgo": "{{count}} dk önce",
+      "lastSyncHoursAgo": "{{count}} sa önce",
+      "lastSyncDaysAgo": "{{count}} g önce",
+      "drilldown": {
+        "loading": "Ayrıntılar yükleniyor…",
+        "error": "Hata: {{message}}",
+        "empty": "Ayrıntı yok",
+        "missingLocally": "Yerelde eksik",
+        "missingRemotely": "Uzakta eksik",
+        "divergent": "Sapma",
+        "moreNotShown": "+ {{count}} daha gösterilmiyor"
+      }
     },
     "visualizer": {
       "title": "Ses görselleştirici",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1470,7 +1470,31 @@
       },
       "backfillError": "失败：{{message}}",
       "autoToggleTitle": "自动同步",
-      "autoToggleSubtitle": "在启动时和切换至混合模式时运行一次同步"
+      "autoToggleSubtitle": "在启动时和切换至混合模式时运行一次同步",
+      "cadenceTitle": "后台同步频率",
+      "cadenceSubtitle": "自动同步之间的间隔",
+      "cadence": {
+        "every15Min": "每 15 分钟",
+        "every30Min": "每 30 分钟",
+        "every1Hour": "每小时",
+        "every6Hours": "每 6 小时",
+        "every12Hours": "每 12 小时",
+        "every24Hours": "每天一次"
+      },
+      "lastSyncNever": "尚未同步",
+      "lastSyncJustNow": "刚刚",
+      "lastSyncMinutesAgo": "{{count}} 分钟前",
+      "lastSyncHoursAgo": "{{count}} 小时前",
+      "lastSyncDaysAgo": "{{count}} 天前",
+      "drilldown": {
+        "loading": "正在加载详细信息…",
+        "error": "错误:{{message}}",
+        "empty": "无详细信息",
+        "missingLocally": "本地缺失",
+        "missingRemotely": "远端缺失",
+        "divergent": "不一致",
+        "moreNotShown": "另有 {{count}} 项未显示"
+      }
     },
     "gapless": {
       "title": "无缝播放",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1470,7 +1470,31 @@
       },
       "backfillError": "失敗：{{message}}",
       "autoToggleTitle": "自動同步",
-      "autoToggleSubtitle": "在啟動時和切換至混合模式時執行一次同步"
+      "autoToggleSubtitle": "在啟動時和切換至混合模式時執行一次同步",
+      "cadenceTitle": "背景同步頻率",
+      "cadenceSubtitle": "自動同步間隔",
+      "cadence": {
+        "every15Min": "每 15 分鐘",
+        "every30Min": "每 30 分鐘",
+        "every1Hour": "每小時",
+        "every6Hours": "每 6 小時",
+        "every12Hours": "每 12 小時",
+        "every24Hours": "每天一次"
+      },
+      "lastSyncNever": "尚未同步",
+      "lastSyncJustNow": "剛剛",
+      "lastSyncMinutesAgo": "{{count}} 分鐘前",
+      "lastSyncHoursAgo": "{{count}} 小時前",
+      "lastSyncDaysAgo": "{{count}} 天前",
+      "drilldown": {
+        "loading": "正在載入詳細資訊…",
+        "error": "錯誤:{{message}}",
+        "empty": "沒有詳細資訊",
+        "missingLocally": "本機缺少",
+        "missingRemotely": "遠端缺少",
+        "divergent": "不一致",
+        "moreNotShown": "另有 {{count}} 項未顯示"
+      }
     },
     "gapless": {
       "title": "無縫播放",

--- a/src/lib/tauri/sync.ts
+++ b/src/lib/tauri/sync.ts
@@ -110,3 +110,119 @@ export function syncBackfillGetEnabled(): Promise<boolean> {
 export function syncBackfillSetEnabled(enabled: boolean): Promise<boolean> {
   return invoke<boolean>("sync_backfill_set_enabled", { enabled });
 }
+
+/**
+ * Snapshot of the backfill task surfaced to the Settings card.
+ * Powers the "Last sync: X ago" affordance and the disabled state
+ * on the manual button while a pass is mid-flight.
+ */
+export interface SyncBackfillStatus {
+  /** Epoch milliseconds of the last successful backfill pass,
+   * or `null` when none has ever run on this profile. */
+  last_run_at: number | null;
+  /** `true` when a pass is currently holding the per-state lock. */
+  in_progress: boolean;
+}
+
+/**
+ * Read the persisted "last successful backfill" timestamp + the
+ * live in-progress state. Cheap (one SELECT + one non-blocking
+ * `try_lock`), called on mount + after the manual button completes.
+ */
+export function syncBackfillGetStatus(): Promise<SyncBackfillStatus> {
+  return invoke<SyncBackfillStatus>("sync_backfill_get_status");
+}
+
+/**
+ * Read the per-profile heartbeat cadence (minutes between automatic
+ * background passes). Clamped server-side to the documented
+ * 15-1440 range so a malformed stored value can't crash the UI.
+ */
+export function syncBackfillGetHeartbeatInterval(): Promise<number> {
+  return invoke<number>("sync_backfill_get_heartbeat_interval");
+}
+
+/**
+ * Persist the per-profile heartbeat cadence (minutes). The backend
+ * clamps to the [15, 1440] range and echoes the stored value so the
+ * UI hydrates with whatever actually landed in the row.
+ */
+export function syncBackfillSetHeartbeatInterval(
+  minutes: number,
+): Promise<number> {
+  return invoke<number>("sync_backfill_set_heartbeat_interval", { minutes });
+}
+
+/**
+ * Hex-encoded `(canonical_id, payload_hash)` pair returned by the
+ * detailed digest endpoint. Used by the drill-down panel to show
+ * which specific rows the two replicas disagree on.
+ *
+ * For the `missing_remotely` and `divergent` buckets, the
+ * desktop's `local_payload_hash` is populated. For `divergent`,
+ * the server's `remote_payload_hash` is also present so the UI
+ * can render a side-by-side hash preview.
+ */
+export interface SyncDigestDivergentMember {
+  canonical_id: string;
+  /** Hex-encoded local payload_hash. Empty string when the member
+   * is absent locally (i.e. `missing_locally` direction handled by
+   * the sibling `SyncDigestRemoteMember`). */
+  local_payload_hash: string;
+  /** Hex-encoded server payload_hash. Empty string when the member
+   * is absent remotely (`missing_remotely` direction). */
+  remote_payload_hash: string;
+}
+
+/**
+ * Hex-encoded `(canonical_id, payload_hash)` pair from the server's
+ * digest response — used to surface the `missing_locally` bucket,
+ * where only the remote side has the row.
+ */
+export interface SyncDigestRemoteMember {
+  canonical_id: string;
+  /** Hex-encoded BLAKE3-256 payload_hash from the server. */
+  payload_hash: string;
+}
+
+/**
+ * Per-entity detailed digest diff — full member-level lists for
+ * the drill-down panel. Each bucket is truncated server-side to
+ * 100 entries so the IPC stays bounded; the `*_total` fields carry
+ * the un-truncated count so the UI can render "+N more".
+ */
+export interface SyncDigestDetailed {
+  entity: string;
+  in_sync: boolean;
+  local_version: number;
+  remote_version: number;
+  missing_locally: SyncDigestRemoteMember[];
+  missing_locally_total: number;
+  missing_remotely: SyncDigestDivergentMember[];
+  missing_remotely_total: number;
+  divergent: SyncDigestDivergentMember[];
+  divergent_total: number;
+}
+
+/**
+ * Outcome of [`syncDigestCheckDetailed`]. Mirrors the summary
+ * variant's shape so the UI can render gating reasons (offline /
+ * local mode / unconfigured) with the same code path.
+ */
+export type SyncDigestDetailedOutcome =
+  | { status: "ran"; diff: SyncDigestDetailed }
+  | { status: "skipped"; reason: string };
+
+/**
+ * Run a detailed digest check for a single entity. Returns the
+ * full member lists for the three diff buckets, truncated to 100
+ * entries per bucket. The Settings card calls this when the user
+ * expands a row in the summary table.
+ */
+export function syncDigestCheckDetailed(
+  entity: string,
+): Promise<SyncDigestDetailedOutcome> {
+  return invoke<SyncDigestDetailedOutcome>("sync_digest_check_detailed", {
+    entity,
+  });
+}


### PR DESCRIPTION
## Summary

Closes Phase B of the RFC-003 sync v2 rollout by surfacing the operator affordances the previous PRs (#247–#252) didn't have room for. **5 of the 6 planned polish items** ship here; item 4 (TrackTable pulled-backfill tooltip) is deferred as a follow-up because it requires dropping the \`is_available = 1\` filter from every track repository query — a larger behavioural change than fits this polish PR.

Items:

1. **\`Last sync: X ago\` subtitle** — \`profile_setting['sync.backfill.last_run_at']\` stamped after every successful pass (manual or auto); new \`sync_backfill_get_status\` Tauri command + \`Promise.allSettled\` mount hydration + 30 s self-refresh while the card is open.
2. **Background heartbeat poll** — new \`sync::backfill::heartbeat\` task spawned from \`lib.rs::run\`, fires \`maybe_auto_backfill\` every \`sync.backfill.heartbeat_interval_min\` minutes (default 60, clamped \`[15, 1440]\`); cadence re-read at every tick so a Settings change applies without restart.
3. **Per-entity drill-down** — new \`sync_digest_check_detailed\` Tauri command returns the full \`DigestDiff\` for one entity, with each bucket truncated to 100 entries + an un-truncated total. Settings card renders chevron-expandable rows showing the first 20 canonical_ids + 8-char hash hex previews per non-empty bucket.
5. **Cadence dropdown** — 6 presets (15 min → 24 h) in the Settings card, disabled when the auto-toggle is off.
6. **WCAG AA contrast tweaks** — status icons \`emerald-500\` → \`emerald-600 dark:emerald-400\`, \`amber-500\` → \`amber-600\`, error subtitle \`rose-600 dark:rose-400\`. Auto-toggle track \`peer-checked:bg-emerald-500\` → \`peer-checked:bg-emerald-600\`.

i18n: \`settings.syncStatus.*\` block extended with the new keys, propagated natively to all 17 locales.

## Test plan

- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets\` clean
- [x] \`cargo test --manifest-path src-tauri/Cargo.toml --workspace\` — 351 passing (baseline preserved)
- [x] \`bun typecheck\` clean
- [x] \`bun lint\` clean
- [x] Manual: enable auto-sync → verify \`last_run_at\` updates in subtitle after a manual Resync
- [x] Manual: click a row out_of_sync → drill-down panel renders the 3 buckets with hex previews
- [x] Manual: switch cadence from 60 min → 15 min → verify next heartbeat tick fires sooner
- [x] Manual: dark-mode contrast against \`bg-surface-dark-elevated\` on the status icons

## Hors-scope (filed as follow-ups)

- **Item 4** (TrackTable \`Awaiting local file\` tooltip) — needs \`is_available = 1\` dropped from \`SqliteTrackRepository::{list,list_in_playlist,list_liked,search_fts,list_ids_in_source}\` + an \`is_pulled_backfill\` discriminator threaded through \`TrackListItem\`. Larger UX/repository change than this PR's surface area.
- **\`sync.backfill.last_outcome\` persistence** — \`BackfillOutcome\` stays in-memory; on reload the per-entity counts are gone but \`last_run_at\` survives. Acceptable v1 trade-off.

## RFC-003 context

This closes the Phase B polish work outlined in the post-v1.5.0 monorepo + sync v2 sprint memory. After merge: backlog issues (#229, #201, #208, #230), then back to roadmap step 2 (UI refonte).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

- **Nouvelles fonctionnalités**
  - Synchronisation automatique en arrière-plan avec cadence configurable (toutes les 15 min à 24 h) et enregistrement de la dernière exécution réussie.
  - Statut de backfill enrichi : dernier passage (timestamp) et indicateur “en cours”.
  - Vérification “digest” détaillée par entité, avec résultats tronqués et raisons d’ignoré lorsque pertinent.

- **Améliorations UI**
  - SyncStatusCard : affichage “Last sync”, sélection de cadence, drill-down par entité avec “+ N”.
  - “Resync now” indisponible aussi quand une synchro distante est en cours.

- **Localisations**
  - Nouvelles clés i18n pour cadence, dernier sync et drill-down (mise à jour multi-langues).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->