### PR TITLE
fix(audio): report current track id on decode error during crossfade

### DIFF
--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -100,7 +100,6 @@ fn handle_playback_outcome(
     outcome: Result<(PlaybackEnd, u64, FinishedTrack), String>,
     shared: &SharedPlayback,
     app: &AppHandle,
-    requested_track_id: i64,
     analytics_tx: &UnboundedSender<AnalyticsMsg>,
     source_label: Option<String>,
 ) {
@@ -152,7 +151,17 @@ fn handle_playback_outcome(
                     message: err.clone(),
                 },
             );
-            transition_state(shared, app, PlayerState::Idle, Some(requested_track_id));
+            // Read the live `current_track_id` rather than the
+            // id passed in from the original `LoadAndPlay` /
+            // `LoadUrlAndPlay` command: `play_track`'s crossfade
+            // swap (and the gapless EOF hand-off) reassigns the
+            // active stream to a pre-fetched track and updates
+            // the atomic accordingly. Using the request id would
+            // surface the wrong track on the `player:state idle`
+            // emit when a decode error lands during the crossfade
+            // window (issue #229).
+            let failing_track_id = shared.current_track_id.load(Ordering::Acquire);
+            transition_state(shared, app, PlayerState::Idle, Some(failing_track_id));
         }
     }
 }
@@ -376,7 +385,6 @@ fn decoder_loop(
                     outcome,
                     &shared,
                     &app,
-                    track_id,
                     analytics_tx,
                     Some(path.display().to_string()),
                 );
@@ -502,7 +510,6 @@ fn decoder_loop(
                     outcome,
                     &shared,
                     &app,
-                    track_id,
                     analytics_tx,
                     Some(redacted),
                 );


### PR DESCRIPTION
Closes #229.

## Summary

`handle_playback_outcome`'s \`Err\` branch reported the original \`requested_track_id\` on its \`player:state idle\` emit, but during a crossfade \`play_track\` swaps the active stream to a pre-fetched track and the new id is what actually fails when its decode errors. Result: UI showed "track A error" when B was the casualty.

The issue's \"proper fix step 1\" (make the crossfade swap update \`shared.current_track_id\`) turned out to be already in place since the real-crossfade-DSP PR (\`b3bcf27\`) — both swap sites have been calling \`shared.current_track_id.store(stream.track_id)\` for a while. So the ~50-100 LOC estimate shrinks to the ~5-LOC reader fix CodeRabbit originally suggested on PR #228.

## Change

- \`handle_playback_outcome\`: drop the stale \`requested_track_id\` parameter, read \`shared.current_track_id.load(Ordering::Acquire)\` in the \`Err\` branch instead.
- Both call sites (\`LoadAndPlay\`, \`LoadUrlAndPlay\`) drop the 4th positional arg; \`track_id\` stays in scope for the initial \`shared.current_track_id.store(track_id)\` that runs before \`play_track\`.

## Test plan

- [x] \`cargo check --workspace --all-targets\` clean
- [x] \`cargo test --workspace\` — 351 passing (baseline preserved)
- [x] Manual: trigger a decode error mid-crossfade (e.g. corrupt the pre-fetched file's tag block) → verify \`player:state\` emit reports the failed track id, PlayerBar surfaces the right title

## Why no new tests

\`handle_playback_outcome\` is private to \`audio::decoder\`. Locking the contract would require either exposing it \`pub(crate)\` + mocking \`AppHandle\` / \`SharedPlayback\` / \`UnboundedSender\` (tauri's AppHandle has no usable mock) or rewriting against the public surface with a real cpal output thread. The change is a 1-line read swap whose correctness is anchored by the swap sites already storing into the atomic — defer the test harness work to v1.6 if the area churns again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correction de la gestion des erreurs lors de la lecture audio, notamment lors des transitions entre pistes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->