### PR TITLE
fix(sync): use tauri::async_runtime::spawn from setup-context callers

### DIFF
--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -168,7 +168,12 @@ pub fn run() {
             // so this is safe to fire unconditionally — the helper
             // owns the gate logic.
             let boot_handle = app.handle().clone();
-            tokio::spawn(async move {
+            // `setup` runs OUTSIDE a tokio reactor, so a bare
+            // `tokio::spawn` panics with "no reactor running".
+            // `tauri::async_runtime::spawn` resolves to the Tauri-
+            // managed tokio runtime — same pattern `sync::drain::spawn`
+            // documents at its own spawn site.
+            tauri::async_runtime::spawn(async move {
                 use tauri::Manager;
                 let state = boot_handle.state::<state::AppState>();
                 if let Err(err) = sync::backfill::maybe_auto_backfill(state.inner()).await {

--- a/src-tauri/crates/app/src/sync/backfill/heartbeat.rs
+++ b/src-tauri/crates/app/src/sync/backfill/heartbeat.rs
@@ -35,14 +35,22 @@ use crate::state::AppState;
 
 use super::{maybe_auto_backfill, read_heartbeat_interval_min, HEARTBEAT_INTERVAL_DEFAULT_MIN};
 
-/// Spawn the heartbeat task on the global tokio runtime. Called
-/// once from `lib.rs::run` after [`AppState`] is managed.
+/// Spawn the heartbeat task on the Tauri-managed tokio runtime.
+/// Called once from `lib.rs::run` after [`AppState`] is managed.
+///
+/// MUST use `tauri::async_runtime::spawn` rather than `tokio::spawn`:
+/// Tauri's `setup` callback runs OUTSIDE a tokio reactor, so a bare
+/// `tokio::spawn` panics with "no reactor running" — same pattern
+/// `sync::drain::spawn` documents at its own spawn site. The async
+/// body itself can still call `tokio::time::sleep` because, once
+/// spawned on the Tauri runtime, the future executes inside the
+/// reactor.
 ///
 /// The task lives for the entire process lifetime; there's no
 /// stop signal because the runtime tears it down with the rest
 /// of the tokio runtime at shutdown.
 pub fn spawn(app: AppHandle) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         // First tick fires after the configured interval — the
         // boot-time pass in `lib.rs::run` covers the immediate
         // catch-up window, so the heartbeat doesn't need to race


### PR DESCRIPTION
## Summary

App panicked at boot:

\`\`\`
thread 'main' panicked at crates\app\src\lib.rs:171:13:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
\`\`\`

Two call sites used \`tokio::spawn\` directly from Tauri's \`setup\` callback. That callback runs OUTSIDE a tokio reactor, so the spawn macro can't find a runtime to register the future onto. \`sync::drain::spawn\` already documents the correct pattern at its own spawn site:

> setup runs OUTSIDE a tokio reactor, so a bare \`tokio::spawn\` panics with \"no reactor running\". \`tauri::async_runtime::spawn\` resolves to the [Tauri-managed runtime].

- \`lib.rs:171\` — boot-time \`maybe_auto_backfill\` (introduced in #252 Phase B close; never exercised in dev mode between merge and the polish PRs).
- \`sync::backfill::heartbeat::spawn\` — heartbeat task added in #253.

Both switched to \`tauri::async_runtime::spawn\`. The async bodies still call \`tokio::time::sleep\` — that's fine because once spawned on the Tauri runtime, the future runs inside a reactor.

Heartbeat doc-comment updated to flag the constraint.

## Test plan

- [x] \`cargo check --workspace --all-targets\` clean
- [x] Manual: \`bun run tauri dev\` boots without the reactor panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Corrections de bugs**
  * Amélioration de la stabilité du système de synchronisation automatique au démarrage et du processus de monitoring en arrière-plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->