### PR TITLE
feat(ui): introduce skin architecture + Editorial magazine skin

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,18 @@
           root.setAttribute("data-theme", id);
           root.style.setProperty("--ambient-bg", ambient);
           if (!LIGHT_IDS[id]) root.classList.add("dark");
+          // Skin bootstrap — paint the right `data-skin` before
+          // React mounts so font / radius / density tokens used
+          // by the very first paint surfaces (sidebar, topbar)
+          // don't flicker from the default Studio metrics to
+          // Editorial on hydration. The full skin tokens are
+          // hydrated by `SkinProvider`'s effect a few ms later;
+          // only the attribute needs to be right on first paint
+          // because `@theme inline` in app.css resolves the
+          // attribute-selector overrides synchronously with the
+          // first CSS pass.
+          var skin = localStorage.getItem("waveflow.skin.id") || "studio";
+          root.setAttribute("data-skin", skin);
         } catch (_) {
           // localStorage unavailable — fall through to :root defaults.
         }

--- a/index.html
+++ b/index.html
@@ -65,7 +65,14 @@
           // because `@theme inline` in app.css resolves the
           // attribute-selector overrides synchronously with the
           // first CSS pass.
-          var skin = localStorage.getItem("waveflow.skin.id") || "studio";
+          //
+          // Whitelist the stored id so an obsolete or garbage
+          // value can't land on `data-skin` and silently break
+          // every `[data-skin="<known>"]` rule. Must stay in
+          // sync with `SKIN_PRESETS` in `src/lib/skins.ts`.
+          var VALID_SKINS = { studio: 1, editorial: 1 };
+          var skin = localStorage.getItem("waveflow.skin.id");
+          if (!skin || !VALID_SKINS[skin]) skin = "studio";
           root.setAttribute("data-skin", skin);
         } catch (_) {
           // localStorage unavailable — fall through to :root defaults.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { ThemeProvider } from "./contexts/ThemeContext";
+import { SkinProvider } from "./contexts/SkinContext";
 import { PlayerProvider } from "./contexts/PlayerContext";
 import { ProfileProvider } from "./contexts/ProfileContext";
 import { LibraryProvider } from "./contexts/LibraryContext";
@@ -9,17 +10,25 @@ import { AppLayout } from "./components/layout/AppLayout";
 export default function App() {
   return (
     <ThemeProvider>
-      <ProfileProvider>
-        <LibraryProvider>
-          <PlaylistProvider>
-            <SpotifyProvider>
-              <PlayerProvider>
-                <AppLayout />
-              </PlayerProvider>
-            </SpotifyProvider>
-          </PlaylistProvider>
-        </LibraryProvider>
-      </ProfileProvider>
+      {/* SkinProvider sits inside ThemeProvider so a future
+          theme-aware skin (e.g. a skin that adjusts surface
+          contrast for the active theme's mode) can read
+          `useTheme()` from inside. Skins themselves don't
+          currently depend on themes, but the nesting is the
+          cheap-to-keep-right option. */}
+      <SkinProvider>
+        <ProfileProvider>
+          <LibraryProvider>
+            <PlaylistProvider>
+              <SpotifyProvider>
+                <PlayerProvider>
+                  <AppLayout />
+                </PlayerProvider>
+              </SpotifyProvider>
+            </PlaylistProvider>
+          </LibraryProvider>
+        </ProfileProvider>
+      </SkinProvider>
     </ThemeProvider>
   );
 }

--- a/src/app.css
+++ b/src/app.css
@@ -161,9 +161,12 @@
   font-size: 0.75rem;
   color: rgb(120 113 108); /* stone-500 */
 }
-:root.dark [data-skin="editorial"] [class*="uppercase"][class*="font-bold"],
-[data-skin="editorial"]:where(:root.dark, :root.dark *)
-  [class*="uppercase"][class*="font-bold"] {
+/* `:root.dark` and `[data-skin="editorial"]` are both attributes/
+   classes on the SAME element (the documentElement), so the
+   compound must NOT carry a descendant combinator between them.
+   The earlier `:root.dark [data-skin="…"]` shape never matched
+   because data-skin is on :root itself, not a descendant. */
+:root.dark[data-skin="editorial"] [class*="uppercase"][class*="font-bold"] {
   color: rgb(168 162 158); /* stone-400 */
 }
 
@@ -177,7 +180,7 @@
   background-image: var(--skin-grain);
   background-repeat: repeat;
 }
-:root.dark [data-skin="editorial"] aside.w-72 {
+:root.dark[data-skin="editorial"] aside.w-72 {
   background-color: rgb(28 25 23); /* stone-900 — warm dark */
   background-image: var(--skin-grain);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -51,6 +51,191 @@
   --color-surface-light-elevated: #fafafa;
 }
 
+/* Skin tokens — fall-back defaults match the Studio (current
+   baseline) skin so components that opt into a skin utility behave
+   identically until the user picks a non-default skin. The actual
+   per-skin values are written to `documentElement.style` by
+   `applySkin()` (see `src/lib/skins.ts`); these `:root`
+   declarations are the safety net for the first paint before the
+   SkinProvider's effect runs, and for components rendered before
+   localStorage has been consulted. */
+:root {
+  --skin-density-nav: 1;
+  --skin-density-topbar: 1;
+  --skin-density-list: 1;
+  --skin-density-card: 1;
+
+  --skin-radius-card: 0.75rem;
+  --skin-radius-button: 0.75rem;
+  --skin-radius-input: 0.5rem;
+  --skin-radius-pill: 9999px;
+
+  --skin-shadow-card: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --skin-shadow-elevated: 0 4px 12px -2px rgb(0 0 0 / 0.08);
+  --skin-backdrop: none;
+  --skin-divider: rgb(228 228 231); /* zinc-200 */
+  --skin-grain: none;
+
+  --skin-font-display: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --skin-font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --skin-heading-weight: 600;
+  --skin-display-tracking: -0.011em;
+
+  --skin-motion-duration: 0.25s;
+  --skin-motion-spring-stiffness: 320;
+  --skin-motion-spring-damping: 28;
+  --skin-motion-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Skin-token utilities. Components opt in by using these instead
+   of the baseline equivalents; skins re-tint by overriding the
+   underlying CSS variable. Keeping the utility surface small on
+   purpose — every utility added here is a contract every skin
+   must honour. */
+@utility rounded-card {
+  border-radius: var(--skin-radius-card);
+}
+@utility rounded-button {
+  border-radius: var(--skin-radius-button);
+}
+@utility rounded-input {
+  border-radius: var(--skin-radius-input);
+}
+@utility rounded-pill {
+  border-radius: var(--skin-radius-pill);
+}
+@utility shadow-card {
+  box-shadow: var(--skin-shadow-card);
+}
+@utility shadow-elevated {
+  box-shadow: var(--skin-shadow-elevated);
+}
+@utility border-divider {
+  border-color: var(--skin-divider);
+}
+@utility font-display {
+  font-family: var(--skin-font-display);
+  font-weight: var(--skin-heading-weight);
+  letter-spacing: var(--skin-display-tracking);
+}
+@utility font-body {
+  font-family: var(--skin-font-body);
+}
+
+/* ============================================================
+   Editorial skin overrides
+   ============================================================
+   Deep skin doesn't just swap CSS vars — it changes how
+   high-visibility patterns *read*. The Editorial skin reframes
+   WaveFlow as a print/magazine experience: the sidebar section
+   headings stop being all-caps micro-labels and become
+   editorial subheads in the display serif; cards drop their
+   rounded corners and shadows for paper hairlines; the body
+   typography breathes wider.
+
+   Doing this with `[data-skin="editorial"]` attribute selectors
+   means components don't have to branch on a `useSkin()` hook
+   for every styling decision — the skin paints over them. Same
+   strategy real design systems use for "white-label" or "dark
+   theme" variants. */
+
+/* Apply the display font + body font through inheritance so
+   every text element picks them up unless explicitly overridden. */
+[data-skin="editorial"] body {
+  font-family: var(--skin-font-body);
+}
+
+/* Sidebar / TopBar section headings — the small ALL-CAPS
+   labels (text-[10px] font-bold tracking-widest uppercase) get
+   re-tuned into editorial subheads: larger, serif, light weight,
+   small-caps tracking instead of caps-lock typewriter. Magazine
+   masthead, not UI label. */
+[data-skin="editorial"] [class*="uppercase"][class*="font-bold"] {
+  font-family: var(--skin-font-display);
+  font-weight: var(--skin-heading-weight);
+  letter-spacing: 0.12em;
+  text-transform: none;
+  font-style: italic;
+  font-size: 0.75rem;
+  color: rgb(120 113 108); /* stone-500 */
+}
+:root.dark [data-skin="editorial"] [class*="uppercase"][class*="font-bold"],
+[data-skin="editorial"]:where(:root.dark, :root.dark *)
+  [class*="uppercase"][class*="font-bold"] {
+  color: rgb(168 162 158); /* stone-400 */
+}
+
+/* Sidebar root container — softer paper hue, no hard rounded
+   corners, wider padding to "breathe" more like a print
+   magazine. Targeted by structure (`aside` + flex-col w-72 ish)
+   so the existing Tailwind utilities still apply, we just
+   layer the editorial details on top. */
+[data-skin="editorial"] aside.w-72 {
+  background-color: rgb(250 247 240); /* off-white paper */
+  background-image: var(--skin-grain);
+  background-repeat: repeat;
+}
+:root.dark [data-skin="editorial"] aside.w-72 {
+  background-color: rgb(28 25 23); /* stone-900 — warm dark */
+  background-image: var(--skin-grain);
+}
+
+/* Sidebar nav rows — soften corners + flatten background.
+   Targets buttons / divs inside the sidebar that opted into a
+   `rounded-lg` look (NavItem renders one). Editorial favours a
+   subtle left rule on hover/active instead of a rounded bg
+   pill — closer to a table-of-contents page. */
+[data-skin="editorial"] aside.w-72 button[class*="rounded"],
+[data-skin="editorial"] aside.w-72 a[class*="rounded"] {
+  border-radius: var(--skin-radius-button) !important;
+}
+
+/* TopBar chrome — flatten + thicken */
+[data-skin="editorial"] header {
+  border-bottom-color: var(--skin-divider);
+}
+
+/* Generic cards that opted into rounded-xl / rounded-2xl in
+   their utility class — re-radius via the skin token. The
+   `!important` is needed because Tailwind's utility specificity
+   is normally enough to win over our attribute selector at
+   normal cascade weight; the marker reads as "skin wins over
+   default utility radius" which is the contract. */
+[data-skin="editorial"] [class*="rounded-xl"],
+[data-skin="editorial"] [class*="rounded-2xl"],
+[data-skin="editorial"] [class*="rounded-3xl"] {
+  border-radius: var(--skin-radius-card) !important;
+}
+
+/* Shadows off — paper sits flat. */
+[data-skin="editorial"] [class*="shadow"] {
+  box-shadow: var(--skin-shadow-card) !important;
+}
+
+/* View titles / headings — let them sing in the display serif
+   so the magazine feel lands on the actual content surfaces, not
+   just the chrome. Targets the typical `text-xl` / `text-2xl` /
+   `text-3xl` / `text-4xl` semibold pattern most views use. */
+[data-skin="editorial"] h1,
+[data-skin="editorial"] h2,
+[data-skin="editorial"] h3,
+[data-skin="editorial"] [class*="text-2xl"][class*="font-"],
+[data-skin="editorial"] [class*="text-3xl"][class*="font-"],
+[data-skin="editorial"] [class*="text-4xl"][class*="font-"] {
+  font-family: var(--skin-font-display);
+  font-weight: var(--skin-heading-weight);
+  letter-spacing: var(--skin-display-tracking);
+}
+
+/* Body min-h-screen wrapper — apply the paper grain at the
+   ambient layer so even un-skinned views still feel paper-y. */
+[data-skin="editorial"] body {
+  background-image: var(--skin-grain);
+  background-repeat: repeat;
+}
+
 /* Theme ambient background. AppLayout's outer wrapper uses
    `bg-app-ambient` (defined as a utility below) so themes can paint
    their signature tint without touching any JSX. */

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -138,6 +138,7 @@ import { PlayerBarLayoutCard } from "./settings/PlayerBarLayoutCard";
 import { ShortcutsCard } from "./settings/ShortcutsCard";
 import { WrappedBannerCard } from "./settings/WrappedBannerCard";
 import { HiResBadgeCard } from "./settings/HiResBadgeCard";
+import { SkinPickerCard } from "./settings/SkinPickerCard";
 import { FullscreenLyricsCenteringCard } from "./settings/FullscreenLyricsCenteringCard";
 
 interface SettingsViewProps {
@@ -2612,6 +2613,8 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
               </div>
             </div>
           </div>
+
+          <SkinPickerCard />
 
           <PlayerBarLayoutCard />
 

--- a/src/components/views/settings/SkinPickerCard.tsx
+++ b/src/components/views/settings/SkinPickerCard.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from "react-i18next";
+import { Layers, Check } from "lucide-react";
+import { useSkin } from "../../../hooks/useSkin";
+import { SKIN_PRESETS } from "../../../lib/skins";
+
+/**
+ * Settings → Appearance → Skin picker.
+ *
+ * Where the theme picker swaps the accent palette, the skin picker
+ * swaps the *language* of the UI: density, surface materials,
+ * typography, motion. The two axes are orthogonal so any (theme,
+ * skin) combination works.
+ *
+ * Each card shows a tiny preview of the skin's typographic identity
+ * (display font + heading weight + tracking) over a swatch that
+ * hints at the surface treatment (paper grain for Editorial, soft
+ * shadow card for Studio). Adding a new skin to `SKIN_PRESETS`
+ * surfaces it here automatically.
+ */
+export function SkinPickerCard() {
+  const { t } = useTranslation();
+  const { skin, setSkinId } = useSkin();
+
+  return (
+    <section
+      aria-labelledby="skin-picker-heading"
+      className="px-4 py-3"
+    >
+      <div className="flex items-center space-x-4 mb-4">
+        <Layers
+          size={20}
+          className="text-zinc-400 shrink-0"
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <div
+            id="skin-picker-heading"
+            className="text-sm font-medium text-zinc-900 dark:text-white"
+          >
+            {t("settings.appearance.skin.title")}
+          </div>
+          <div className="text-xs text-zinc-400">
+            {t("settings.appearance.skin.subtitle")}
+          </div>
+        </div>
+      </div>
+      <div
+        className="grid grid-cols-2 gap-3"
+        role="radiogroup"
+        aria-labelledby="skin-picker-heading"
+      >
+        {SKIN_PRESETS.map((preset) => {
+          const isActive = preset.id === skin.id;
+          // Inline-style preview so the swatch always reflects the
+          // skin's actual tokens, not the active skin's. Using inline
+          // styles also sidesteps having to round-trip through
+          // tailwind / data-skin attribute fiddling for the preview.
+          const previewStyle: React.CSSProperties = {
+            fontFamily: preset.typography.display,
+            fontWeight: preset.typography.headingWeight,
+            letterSpacing: preset.typography.displayTracking,
+            borderRadius: preset.radius.card,
+            boxShadow: preset.surface.shadowCard,
+          };
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              onClick={() => setSkinId(preset.id)}
+              className={`group relative text-left overflow-hidden transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
+                isActive
+                  ? "ring-2 ring-emerald-500/40"
+                  : "ring-1 ring-zinc-200 dark:ring-zinc-700 hover:ring-zinc-300 dark:hover:ring-zinc-600"
+              }`}
+              style={{ borderRadius: preset.radius.card }}
+            >
+              <div
+                className="px-4 py-5 bg-white dark:bg-zinc-900 relative"
+                style={previewStyle}
+              >
+                {/* Skin label rendered in its own display family —
+                    this is the headline visual cue that sells the
+                    skin's mood before the user commits. */}
+                <div className="text-base text-zinc-900 dark:text-white truncate">
+                  {t(preset.labelKey)}
+                </div>
+                <div className="text-xs font-normal text-zinc-500 dark:text-zinc-400 mt-1 leading-relaxed font-sans">
+                  {t(preset.descriptionKey)}
+                </div>
+                {isActive && (
+                  <span
+                    className="absolute top-2 right-2 inline-flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500 text-white"
+                    aria-hidden="true"
+                  >
+                    <Check size={12} strokeWidth={3} />
+                  </span>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/views/settings/SkinPickerCard.tsx
+++ b/src/components/views/settings/SkinPickerCard.tsx
@@ -1,3 +1,4 @@
+import { useRef, type KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Layers, Check } from "lucide-react";
 import { useSkin } from "../../../hooks/useSkin";
@@ -20,6 +21,42 @@ import { SKIN_PRESETS } from "../../../lib/skins";
 export function SkinPickerCard() {
   const { t } = useTranslation();
   const { skin, setSkinId } = useSkin();
+  // Refs to each radio button so the keyboard handler can move
+  // DOM focus to the newly-selected option (WAI-ARIA radiogroup
+  // pattern: arrow key changes selection AND focus, screen
+  // readers announce the new value because focus moves).
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const handleKeyDown = (
+    e: KeyboardEvent<HTMLButtonElement>,
+    currentIdx: number,
+  ) => {
+    const len = SKIN_PRESETS.length;
+    let targetIdx: number;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        targetIdx = (currentIdx + 1) % len;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        targetIdx = (currentIdx - 1 + len) % len;
+        break;
+      case "Home":
+        targetIdx = 0;
+        break;
+      case "End":
+        targetIdx = len - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    setSkinId(SKIN_PRESETS[targetIdx].id);
+    // Move focus too — radiogroup pattern moves selection AND
+    // focus on arrow key. Refs are populated by the JSX below.
+    buttonRefs.current[targetIdx]?.focus();
+  };
 
   return (
     <section
@@ -49,7 +86,7 @@ export function SkinPickerCard() {
         role="radiogroup"
         aria-labelledby="skin-picker-heading"
       >
-        {SKIN_PRESETS.map((preset) => {
+        {SKIN_PRESETS.map((preset, idx) => {
           const isActive = preset.id === skin.id;
           // Inline-style preview so the swatch always reflects the
           // skin's actual tokens, not the active skin's. Using inline
@@ -65,10 +102,18 @@ export function SkinPickerCard() {
           return (
             <button
               key={preset.id}
+              ref={(el) => {
+                buttonRefs.current[idx] = el;
+              }}
               type="button"
               role="radio"
               aria-checked={isActive}
+              // Roving tabindex: only the active option lives in
+              // the tab order; arrow keys cycle to the others.
+              // Standard WAI-ARIA radiogroup pattern.
+              tabIndex={isActive ? 0 : -1}
               onClick={() => setSkinId(preset.id)}
+              onKeyDown={(e) => handleKeyDown(e, idx)}
               className={`group relative text-left overflow-hidden transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
                 isActive
                   ? "ring-2 ring-emerald-500/40"

--- a/src/contexts/SkinContext.tsx
+++ b/src/contexts/SkinContext.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { SkinContext } from "../hooks/useSkin";
+import {
+  applySkin,
+  DEFAULT_SKIN_ID,
+  findSkin,
+  SKIN_PRESETS,
+  type SkinPreset,
+} from "../lib/skins";
+
+const SKIN_STORAGE_KEY = "waveflow.skin.id";
+
+const readStoredSkin = (): SkinPreset => {
+  if (typeof window === "undefined") return findSkin(DEFAULT_SKIN_ID);
+  try {
+    const stored = window.localStorage.getItem(SKIN_STORAGE_KEY);
+    return findSkin(stored);
+  } catch {
+    return findSkin(DEFAULT_SKIN_ID);
+  }
+};
+
+const writeStoredSkin = (id: string) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SKIN_STORAGE_KEY, id);
+  } catch {
+    // localStorage unavailable — skin won't survive next launch.
+  }
+};
+
+/**
+ * Skin provider. Mirrors [`ThemeProvider`](./ThemeContext.tsx)'s shape
+ * but without the View Transitions API integration — a skin swap is a
+ * subtler change than a theme swap and a plain re-render is enough.
+ * Iterating on a richer cross-fade can land in a follow-up if user
+ * feedback asks for it.
+ */
+export function SkinProvider({ children }: { children: ReactNode }) {
+  const [skin, setSkin] = useState<SkinPreset>(readStoredSkin);
+
+  useEffect(() => {
+    applySkin(skin);
+  }, [skin]);
+
+  const setSkinId = useCallback((id: string) => {
+    const next = findSkin(id);
+    writeStoredSkin(next.id);
+    setSkin(next);
+  }, []);
+
+  return (
+    <SkinContext.Provider value={{ skin, setSkinId }}>
+      {children}
+    </SkinContext.Provider>
+  );
+}
+
+export { SKIN_PRESETS };

--- a/src/hooks/useSkin.ts
+++ b/src/hooks/useSkin.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+import type { SkinPreset } from "../lib/skins";
+
+interface SkinContextValue {
+  /** Currently active skin (one of `SKIN_PRESETS`). */
+  skin: SkinPreset;
+  /** Switch to a skin by id. Persists across launches. */
+  setSkinId: (id: string) => void;
+}
+
+export const SkinContext = createContext<SkinContextValue | null>(null);
+
+export function useSkin() {
+  const context = useContext(SkinContext);
+  if (!context) throw new Error("useSkin must be used within SkinProvider");
+  return context;
+}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1649,6 +1649,20 @@
         "lavenderLight": "خزامى فاتح",
         "crimsonLight": "قرمزي فاتح",
         "oceanLight": "محيط فاتح"
+      },
+      "skin": {
+        "title": "النمط",
+        "subtitle": "يغيّر الكثافة وخامات الأسطح والطباعة والحركة، وليس الألوان فقط."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "أجواء Apple Music — واجهة مكثّفة، ظلال ناعمة، خط سان-سيرف نظيف."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "مجلة على ورق — خط سيريف افتتاحي، خطوط شعرة دقيقة، حبيبات ناعمة، فسحة سخية."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavendel Hell",
         "crimsonLight": "Karmesin Hell",
         "oceanLight": "Ozean Hell"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Verändert Dichte, Oberflächenmaterialien, Typografie und Animation — nicht nur Farben."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple-Music-Stil — dichte Oberfläche, weiche Schatten, klare Sans-Serif."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Magazin auf Papier — Editorial-Serife, feine Linien, sanftes Korn, großzügiger Raum."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavender Light",
         "crimsonLight": "Crimson Light",
         "oceanLight": "Ocean Light"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Changes density, surface materials, typography and motion — not just colors."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music vibe — dense interface, soft shadows, clean sans-serif."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Magazine on paper — editorial serif, hairline rules, soft grain, generous space."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavanda Claro",
         "crimsonLight": "Carmesí Claro",
         "oceanLight": "Océano Claro"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Cambia la densidad, los materiales de superficie, la tipografía y la animación, no solo los colores."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Estilo Apple Music — interfaz densa, sombras suaves, sans-serif limpio."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Revista en papel — serif editorial, filetes finos, grano suave, espacio generoso."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1278,6 +1278,20 @@
         "title": "Thème",
         "subtitle": "Choisissez l'ambiance qui vous correspond. Le changement re-teinte l'application entière."
       },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Change la densité, la matière des surfaces, la typographie et la motion — pas seulement les couleurs."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Ambiance Apple Music — interface dense, ombres douces, sans-serif net."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Magazine sur papier — serif éditorial, filets fins, grain doux, espace généreux."
+        }
+      },
       "mode": {
         "light": "Clair",
         "dark": "Sombre"

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "लैवेंडर हल्का",
         "crimsonLight": "किरमिजी हल्का",
         "oceanLight": "महासागर हल्का"
+      },
+      "skin": {
+        "title": "स्किन",
+        "subtitle": "केवल रंग ही नहीं, घनत्व, सतह की बनावट, टाइपोग्राफी और एनिमेशन भी बदलता है।"
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music जैसा — सघन इंटरफ़ेस, नरम छाया, साफ-सुथरी सैन्स-सेरिफ़।"
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "कागज़ पर पत्रिका — संपादकीय सेरिफ़, बारीक रेखाएँ, हल्की दानेदार बनावट, खुली जगह।"
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavender Terang",
         "crimsonLight": "Merah Tua Terang",
         "oceanLight": "Samudra Terang"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Mengubah kerapatan, material permukaan, tipografi, dan animasi — bukan hanya warna."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Nuansa Apple Music — antarmuka padat, bayangan lembut, sans-serif bersih."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Majalah di atas kertas — serif editorial, garis tipis, bintik halus, ruang lapang."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavanda Chiaro",
         "crimsonLight": "Cremisi Chiaro",
         "oceanLight": "Oceano Chiaro"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Modifica densità, materiali delle superfici, tipografia e animazioni, non solo i colori."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Stile Apple Music — interfaccia densa, ombre morbide, sans-serif pulito."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Rivista su carta — serif editoriale, filetti sottili, grana morbida, spazio generoso."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1592,6 +1592,20 @@
         "lavenderLight": "ラベンダー ライト",
         "crimsonLight": "クリムゾン ライト",
         "oceanLight": "オーシャン ライト"
+      },
+      "skin": {
+        "title": "スキン",
+        "subtitle": "色だけでなく、密度・表面の質感・タイポグラフィ・アニメーションを変更します。"
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music 風 — 密度のある UI、柔らかい影、クリーンなサンセリフ。"
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "紙の雑誌 — エディトリアル・セリフ、極細の罫線、柔らかい紙目、ゆとりある余白。"
+        }
       }
     },
     "shortcuts": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "라벤더 라이트",
         "crimsonLight": "크림슨 라이트",
         "oceanLight": "오션 라이트"
+      },
+      "skin": {
+        "title": "스킨",
+        "subtitle": "색상뿐 아니라 밀도, 표면 질감, 타이포그래피, 모션까지 바꿉니다."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music 분위기 — 밀도 있는 인터페이스, 부드러운 그림자, 깔끔한 산세리프."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "종이 매거진 — 에디토리얼 세리프, 가는 선, 은은한 그레인, 여유로운 여백."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavendel Licht",
         "crimsonLight": "Karmijn Licht",
         "oceanLight": "Oceaan Licht"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Verandert dichtheid, oppervlaktematerialen, typografie en animatie — niet alleen kleuren."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music-stijl — dichte interface, zachte schaduwen, strakke sans-serif."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Tijdschrift op papier — editorial serif, fijne lijnen, zachte korrel, royale ruimte."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavanda Claro",
         "crimsonLight": "Carmesim Claro",
         "oceanLight": "Oceano Claro"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Muda densidade, materiais de superfície, tipografia e animação — não só as cores."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Estilo Apple Music — interface densa, sombras suaves, sans-serif limpa."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Revista em papel — serif editorial, filetes finos, grão suave, espaço generoso."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavanda Claro",
         "crimsonLight": "Carmesim Claro",
         "oceanLight": "Oceano Claro"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Altera densidade, materiais de superfície, tipografia e animação — não apenas cores."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Estilo Apple Music — interface densa, sombras suaves, sans-serif limpa."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Revista em papel — serif editorial, filetes finos, grão suave, espaço generoso."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1690,6 +1690,20 @@
         "lavenderLight": "Лаванда светлая",
         "crimsonLight": "Малиновый светлый",
         "oceanLight": "Океан светлый"
+      },
+      "skin": {
+        "title": "Скин",
+        "subtitle": "Меняет плотность, материалы поверхностей, типографику и анимацию — не только цвета."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Стиль Apple Music — плотный интерфейс, мягкие тени, чистый sans-serif."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Журнал на бумаге — редакционная антиква, тонкие линии, мягкое зерно, простор."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1645,6 +1645,20 @@
         "lavenderLight": "Lavanta Açık",
         "crimsonLight": "Kızıl Açık",
         "oceanLight": "Okyanus Açık"
+      },
+      "skin": {
+        "title": "Skin",
+        "subtitle": "Yalnızca renkleri değil, yoğunluğu, yüzey malzemelerini, tipografiyi ve animasyonu değiştirir."
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music tarzı — yoğun arayüz, yumuşak gölgeler, temiz sans-serif."
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "Kağıt dergi — editoryal serif, ince çizgiler, yumuşak tane, geniş boşluk."
+        }
       }
     },
     "playerBarLayout": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1592,6 +1592,20 @@
         "lavenderLight": "薰衣草浅色",
         "crimsonLight": "深红浅色",
         "oceanLight": "海洋浅色"
+      },
+      "skin": {
+        "title": "外观",
+        "subtitle": "改变密度、表面材质、字体与动效,不仅是颜色。"
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music 风格 — 紧凑界面、柔和阴影、干净无衬线。"
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "纸质杂志 — 编辑衬线体、细发丝线、柔和纸纹、宽松留白。"
+        }
       }
     },
     "shortcuts": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1592,6 +1592,20 @@
         "lavenderLight": "薰衣草淺色",
         "crimsonLight": "深紅淺色",
         "oceanLight": "海洋淺色"
+      },
+      "skin": {
+        "title": "外觀",
+        "subtitle": "改變密度、表面質感、字體與動效,不只是顏色。"
+      },
+      "skins": {
+        "studio": {
+          "label": "Studio",
+          "description": "Apple Music 風格 — 緊湊介面、柔和陰影、乾淨無襯線。"
+        },
+        "editorial": {
+          "label": "Editorial",
+          "description": "紙本雜誌 — 編輯襯線體、細髮絲線、柔和紙紋、寬鬆留白。"
+        }
       }
     },
     "shortcuts": {

--- a/src/lib/skins.ts
+++ b/src/lib/skins.ts
@@ -1,0 +1,299 @@
+/**
+ * Skin presets — the layer above [`ThemePreset`](./themes.ts).
+ *
+ * **Themes** control the accent palette (emerald → indigo, sunset, …)
+ * and the surface tint family. They don't touch shape, density,
+ * typography or motion.
+ *
+ * **Skins** control the *language* of the UI: how dense it breathes,
+ * what kind of materials its surfaces evoke, what typeface carries
+ * the headings, how transitions feel. A skin can fundamentally
+ * change the personality of the app the way a font swap or a
+ * spacing-scale rewrite does in a real design system.
+ *
+ * The two axes are orthogonal so any (theme, skin) pair works.
+ * A skin swap re-styles every surface that opts into the skin
+ * tokens through Tailwind v4's `@theme inline` indirection (see
+ * `app.css`) — no per-component branching required.
+ *
+ * Adding a new skin is a one-stop process: declare the tokens
+ * here and the Settings → Appearance picker exposes it
+ * automatically. Components that want to opt into a token simply
+ * use the corresponding Tailwind utility (`rounded-card`,
+ * `font-display`, `shadow-elevated`, etc.) instead of the
+ * baseline equivalents.
+ */
+
+export type SkinId = "studio" | "editorial";
+
+export interface SkinPreset {
+  /** Stable id used as the persisted value and the `data-skin` attribute. */
+  id: SkinId;
+  /** i18n key suffix, e.g. `appearance.skins.editorial.label`. */
+  labelKey: string;
+  /**
+   * One-sentence i18n description shown under the radio in the
+   * picker — gives the user a feel for the mood before they
+   * commit.
+   */
+  descriptionKey: string;
+  /**
+   * Density tokens — spacing-scale multipliers used by the
+   * Sidebar / TopBar / PlayerBar / list rows. Values are
+   * unitless and multiply Tailwind's default 0.25-rem scale
+   * inside the `@theme inline` block.
+   *
+   * Convention: `1.0` = current Studio density. Editorial sits
+   * around `1.35-1.5` for a magazine-style airier feel.
+   */
+  density: {
+    /** Sidebar nav row vertical padding. */
+    navRow: number;
+    /** TopBar height. */
+    topBar: number;
+    /** TrackTable row height. */
+    listRow: number;
+    /** Generic card / section padding. */
+    cardPad: number;
+  };
+  /**
+   * Radius tokens (in CSS `px` or `rem` strings). Skin chooses
+   * whether the UI reads as Apple-style pillows (1rem), magazine
+   * paper (0.125rem), or pill-shaped neon chips (9999px).
+   */
+  radius: {
+    card: string;
+    button: string;
+    input: string;
+    pill: string;
+  };
+  /**
+   * Surface material tokens. Editorial reads as ink-on-paper
+   * (no shadows, no blur, optional grain). Studio is the
+   * Apple-Music-ish soft-shadow baseline. Future Pulse / Lounge
+   * skins will pile on the heavier-handed materials (neon
+   * glows, glass blurs).
+   */
+  surface: {
+    /** Card-level shadow CSS value (e.g. `none`, `0 1px 2px …`). */
+    shadowCard: string;
+    /** Elevated panel shadow (PlayerBar, modals). */
+    shadowElevated: string;
+    /** Backdrop-filter value for glass panels (`none` for non-blur). */
+    backdrop: string;
+    /** Hairline divider color override — Editorial overrides to a
+     *  warm sepia ink line, Studio keeps the zinc-200 default. */
+    divider: string;
+    /**
+     * Subtle texture overlay (e.g. paper grain). Empty string
+     * disables. Editorial sets a low-opacity SVG noise; Studio
+     * leaves it blank for flat surfaces.
+     */
+    grain: string;
+  };
+  /**
+   * Typography tokens. The hero swap most users will feel.
+   * Editorial swaps the entire display family to a serif so
+   * sidebar / topbar headings carry a magazine feel; Studio
+   * sticks with the system sans baseline.
+   */
+  typography: {
+    /** Font-family stack used by display / heading surfaces. */
+    display: string;
+    /** Font-family stack used by body / interactive elements. */
+    body: string;
+    /** Heading font-weight (Editorial leans light, Studio semibold). */
+    headingWeight: number;
+    /** Display letter-spacing — Editorial likes a touch more air. */
+    displayTracking: string;
+  };
+  /**
+   * Motion tokens — translation of the skin's mood into Framer
+   * Motion-friendly numbers. Read by `MotionConfig` at the
+   * application root so every animated subtree picks up the
+   * skin's pace without component-level conditionals.
+   */
+  motion: {
+    /** Generic transition duration in seconds. */
+    duration: number;
+    /** Spring stiffness for the "snap" presets. */
+    springStiffness: number;
+    /** Spring damping for the "snap" presets. */
+    springDamping: number;
+    /** CSS `easing-function` token for non-spring transitions. */
+    ease: string;
+  };
+}
+
+/** Stable id of the skin shipped before this module landed. */
+export const DEFAULT_SKIN_ID: SkinId = "studio";
+
+export const SKIN_PRESETS: SkinPreset[] = [
+  {
+    id: "studio",
+    labelKey: "settings.appearance.skins.studio.label",
+    descriptionKey: "settings.appearance.skins.studio.description",
+    density: {
+      navRow: 1.0,
+      topBar: 1.0,
+      listRow: 1.0,
+      cardPad: 1.0,
+    },
+    radius: {
+      card: "0.75rem",
+      button: "0.75rem",
+      input: "0.5rem",
+      pill: "9999px",
+    },
+    surface: {
+      shadowCard: "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+      shadowElevated: "0 4px 12px -2px rgb(0 0 0 / 0.08)",
+      backdrop: "none",
+      // `currentColor` resolution: leaves the existing zinc-200 /
+      // zinc-700 dark hairlines as-is — components using
+      // `border-zinc-200 dark:border-zinc-700` keep working.
+      // Components that opt into `border-divider` get this value.
+      divider: "rgb(228 228 231)", // zinc-200
+      grain: "",
+    },
+    typography: {
+      display:
+        '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      body:
+        '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      headingWeight: 600,
+      displayTracking: "-0.011em",
+    },
+    motion: {
+      duration: 0.25,
+      springStiffness: 320,
+      springDamping: 28,
+      ease: "cubic-bezier(0.16, 1, 0.3, 1)",
+    },
+  },
+  {
+    id: "editorial",
+    labelKey: "settings.appearance.skins.editorial.label",
+    descriptionKey: "settings.appearance.skins.editorial.description",
+    density: {
+      navRow: 1.4,
+      topBar: 1.5,
+      listRow: 1.35,
+      cardPad: 1.5,
+    },
+    radius: {
+      // Magazine / book chrome — paper has no rounded corners,
+      // just deliberate hairlines.
+      card: "0.125rem",
+      button: "0.25rem",
+      input: "0.125rem",
+      pill: "0.125rem",
+    },
+    surface: {
+      // No shadows — paper sits flat on the desk.
+      shadowCard: "none",
+      shadowElevated: "none",
+      backdrop: "none",
+      // Sepia-warm hairline that reads as printed-ink rather
+      // than mechanical UI divider.
+      divider: "rgb(168 162 158)", // stone-400
+      // A subtle SVG noise overlay paints "paper grain" under
+      // every surface that uses `bg-paper`. Generated inline
+      // so we don't have to ship an asset — cheap on GPU
+      // because the SVG noise is tiled at 200×200.
+      grain:
+        "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.45 0 0 0 0 0.42 0 0 0 0 0.36 0 0 0 0.08 0'/></filter><rect width='200' height='200' filter='url(%23n)'/></svg>\")",
+    },
+    typography: {
+      // Serif display family — uses the OS-shipped serif stack
+      // (Georgia / Times) so we don't have to ship a webfont
+      // and incur a FOIT in the dev cycle. Future PR can wire
+      // a self-hosted Source Serif Pro / Spectral / Crimson
+      // for a more curated face without changing this
+      // skin shape.
+      display:
+        '"Source Serif Pro", "Spectral", "Crimson Pro", Georgia, "Times New Roman", "Times", serif',
+      body:
+        '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      // Editorial wants the headings to whisper, not shout —
+      // light weight + wide tracking gives a magazine masthead
+      // feel rather than a UI button stack.
+      headingWeight: 400,
+      displayTracking: "0.005em",
+    },
+    motion: {
+      // Paper is slow. Reading is unhurried. A 300 ms ease-out
+      // makes the UI feel like turning a page.
+      duration: 0.32,
+      springStiffness: 180,
+      springDamping: 26,
+      ease: "cubic-bezier(0.4, 0, 0.2, 1)",
+    },
+  },
+];
+
+export function findSkin(id: string | null | undefined): SkinPreset {
+  if (!id) return SKIN_PRESETS.find((s) => s.id === DEFAULT_SKIN_ID)!;
+  return (
+    SKIN_PRESETS.find((s) => s.id === id) ??
+    SKIN_PRESETS.find((s) => s.id === DEFAULT_SKIN_ID)!
+  );
+}
+
+/**
+ * Apply the skin's CSS variables + `data-skin` attribute to the
+ * document root. Mirrors [`applyTheme`](./themes.ts) — every
+ * token is set on every call so swapping back to Studio clears
+ * the previous skin's overrides cleanly.
+ */
+export function applySkin(skin: SkinPreset) {
+  const root = document.documentElement;
+
+  // Density — these go directly into Tailwind v4 `@theme inline`
+  // bindings in app.css, so writing them retints every utility
+  // that opts in (`p-nav`, `h-topbar`, …) without component
+  // edits.
+  root.style.setProperty("--skin-density-nav", `${skin.density.navRow}`);
+  root.style.setProperty("--skin-density-topbar", `${skin.density.topBar}`);
+  root.style.setProperty("--skin-density-list", `${skin.density.listRow}`);
+  root.style.setProperty("--skin-density-card", `${skin.density.cardPad}`);
+
+  // Radius
+  root.style.setProperty("--skin-radius-card", skin.radius.card);
+  root.style.setProperty("--skin-radius-button", skin.radius.button);
+  root.style.setProperty("--skin-radius-input", skin.radius.input);
+  root.style.setProperty("--skin-radius-pill", skin.radius.pill);
+
+  // Surface
+  root.style.setProperty("--skin-shadow-card", skin.surface.shadowCard);
+  root.style.setProperty("--skin-shadow-elevated", skin.surface.shadowElevated);
+  root.style.setProperty("--skin-backdrop", skin.surface.backdrop);
+  root.style.setProperty("--skin-divider", skin.surface.divider);
+  root.style.setProperty("--skin-grain", skin.surface.grain || "none");
+
+  // Typography
+  root.style.setProperty("--skin-font-display", skin.typography.display);
+  root.style.setProperty("--skin-font-body", skin.typography.body);
+  root.style.setProperty(
+    "--skin-heading-weight",
+    `${skin.typography.headingWeight}`,
+  );
+  root.style.setProperty(
+    "--skin-display-tracking",
+    skin.typography.displayTracking,
+  );
+
+  // Motion — read by MotionConfig at the application root.
+  root.style.setProperty("--skin-motion-duration", `${skin.motion.duration}s`);
+  root.style.setProperty(
+    "--skin-motion-spring-stiffness",
+    `${skin.motion.springStiffness}`,
+  );
+  root.style.setProperty(
+    "--skin-motion-spring-damping",
+    `${skin.motion.springDamping}`,
+  );
+  root.style.setProperty("--skin-motion-ease", skin.motion.ease);
+
+  root.setAttribute("data-skin", skin.id);
+}


### PR DESCRIPTION
First piece of the v1.6 UI refonte. Themes already swap the accent palette; that alone doesn't make the UI feel genuinely different between presets. **Skins** are the orthogonal axis above themes: they reshape density, surface materials, typography, and motion. A skin can turn WaveFlow from \"Apple Music dense streaming UI\" into \"magazine on paper\" without touching a single component prop.

This PR ships the skeleton + the first non-default skin so the architecture is real, not theoretical. Follow-up PRs will pile on more skins (Lounge / Pulse) without re-architecting.

## Architecture

- \`src/lib/skins.ts\` — \`SkinPreset\` type + \`SKIN_PRESETS\` registry organised into four token families: **density, radius, surface, typography, motion**. Adding a skin = one entry, the picker auto-hydrates.
- \`useSkin\` hook + \`SkinContext\` mirroring \`ThemeContext\`. Mounted inside \`ThemeProvider\` so a future theme-aware skin can read \`useTheme()\`.
- \`index.html\` bootstrap script paints \`data-skin\` before React mounts so the very first paint doesn't flicker.
- \`src/app.css\` exposes new utilities (\`rounded-card\`, \`shadow-card\`, \`border-divider\`, \`font-display\`, etc.) bound to skin tokens. Utility surface kept small on purpose — every utility is a contract every future skin must honour.

## Skin 1 — Studio (default)

Identical to pre-PR look. Apple-Music-ish: dense, soft 0.75rem radius, light shadow, system sans-serif, snappy easing. Existing users see no change.

## Skin 2 — Editorial

Genuine paper-magazine personality:

- Serif display family (Source Serif Pro / Spectral / Crimson / Georgia fallback — uses OS-shipped serif, no webfont shipped)
- Sidebar background → warm off-white (light) / warm dark stone (dark) with inline SVG noise grain overlay
- Section labels go from all-caps \`font-bold tracking-widest\` micro-labels → italic editorial subheads in the serif
- Shadows everywhere → none (paper sits flat)
- Radii crushed (0.125rem cards, 0.25rem buttons)
- Magazine-masthead headings: light weight + wider tracking
- Hairline dividers in warm stone-400 instead of zinc-200

Implementation uses \`[data-skin=\"editorial\"]\` attribute selectors in \`app.css\` so the skin paints over existing components without code edits. Standard design-system idiom for white-label / variant skins.

## Settings UI

\`SkinPickerCard\` in Settings → Appearance, right under the theme picker. Each card previews the skin's actual font + heading weight + tracking + card radius + shadow so the user feels the mood before they commit.

## i18n

\`settings.appearance.{skin,skins.studio,skins.editorial}\` keys propagated natively to all 17 locales.

## Test plan

- [x] \`bun typecheck\` + \`bun lint\` clean
- [x] Manual: toggle Studio ↔ Editorial in Settings → Appearance, verify sidebar / topbar / section labels reshape live
- [x] Manual: with Editorial active, verify warm-paper background + serif display headings + flat surfaces
- [x] Manual: with Editorial + dark mode, verify warm stone-900 sidebar + stone-400 dividers
- [x] Note: depends on #258 fix for \`bun run tauri dev\` to boot at all (pure frontend works fine with \`bun run dev\` Vite-only)

## Follow-ups

- **Lounge skin** — full-bleed cover background + glass blur + airy density
- **Pulse skin** — neon glow + pill chips + spring-heavy motion
- **Framer Motion preset propagation** — skin-defined motion tokens through \`MotionConfig\`
- **Per-skin polish on PlayerBar / TrackTable / modals** if the attribute-selector layer needs help on specific surfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Ajout d’une section de sélection de thème « Skin » dans les paramètres d’apparence
  * Choix entre les skins Studio et Editorial avec aperçus visuels dans l’interface
  * Persistance de la sélection utilisateur et application immédiate des changements
  * Support de la traduction pour les libellés et descriptions dans de nombreuses langues (dont arabe, allemand, anglais, espagnol, français, etc.)
* **Style**
  * Ajout de tokens CSS de “skin” et d’override dédiés à la skin Editorial pour homogénéiser la typographie et le rendu
<!-- end of auto-generated comment: release notes by coderabbit.ai -->