### PR TITLE
refactor(spotify): extract to waveflow-spotify workspace crate

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7688,6 +7688,7 @@ dependencies = [
  "walkdir",
  "wasapi",
  "waveflow-core",
+ "waveflow-spotify",
  "waveflow-syncedlyrics",
  "windows 0.62.2",
  "zip 8.6.0",
@@ -7733,6 +7734,23 @@ name = "waveflow-plugin-sdk"
 version = "0.1.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "waveflow-spotify"
+version = "1.4.0"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid 1.23.3",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/core", "crates/app", "crates/plugin-sdk", "crates/syncedlyrics"]
+members = ["crates/core", "crates/app", "crates/plugin-sdk", "crates/spotify", "crates/syncedlyrics"]
 
 # The actual package definitions live in `crates/core/Cargo.toml` and
 # `crates/app/Cargo.toml`. The workspace root is virtual: it owns the

--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -52,6 +52,7 @@ serde_json = "1"
 # `commands/plugins.rs`; the server intentionally leaves this feature
 # off to keep its binary lean.
 waveflow-core = { path = "../core", features = ["sqlite", "plugins"] }
+waveflow-spotify = { path = "../spotify" }
 waveflow-syncedlyrics = { path = "../syncedlyrics" }
 
 tauri = { version = "2", features = ["protocol-asset", "tray-icon", "image-png"] }

--- a/src-tauri/crates/app/src/commands/spotify.rs
+++ b/src-tauri/crates/app/src/commands/spotify.rs
@@ -19,8 +19,17 @@ use crate::{
     audio::{engine::AudioCmd, AudioEngine},
     commands::loopback::html_response,
     error::{AppError, AppResult},
+    offline,
     state::AppState,
 };
+
+/// Error message returned by every Spotify command that would touch
+/// the network while [`offline`] mode is on. Mirrors the Deezer /
+/// Last.fm / LRCLIB pattern — each outbound HTTP path gates on
+/// `is_offline()` per the CLAUDE.md cross-cutting rule. Caller
+/// surfaces this directly in toast / dialog UI, so the message is
+/// part of the contract.
+const OFFLINE_ERR: &str = "Spotify is unavailable while offline mode is on";
 
 #[derive(Debug, Deserialize)]
 struct CallbackQuery {
@@ -47,9 +56,16 @@ pub async fn set_spotify_client_id(
 pub async fn spotify_get_status(state: tauri::State<'_, AppState>) -> AppResult<SpotifyStatus> {
     // The Spotify crate accepts `Option<&SqlitePool>` for the profile
     // pool so it can still report `configured` when no profile is
-    // mounted — match that contract here. `require_profile_pool`
-    // errors are downgraded to "no profile = not connected".
-    let profile_pool = state.require_profile_pool().await.ok();
+    // mounted. Match on the specific `NoActiveProfile` variant —
+    // a bare `.ok()` would swallow real DB / pool errors (e.g.
+    // SQLite file deleted under our feet) and silently report
+    // `connected: false`, which makes diagnosing a broken install
+    // harder. Anything else propagates through `?`.
+    let profile_pool = match state.require_profile_pool().await {
+        Ok(pool) => Some(pool),
+        Err(AppError::NoActiveProfile) => None,
+        Err(err) => return Err(err),
+    };
     Ok(spotify::status(&state.app_db, profile_pool.as_ref()).await?)
 }
 
@@ -67,6 +83,9 @@ pub async fn spotify_login(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> AppResult<SpotifyStatus> {
+    if offline::is_offline() {
+        return Err(AppError::Other(OFFLINE_ERR.into()));
+    }
     let client_id = spotify::read_client_id(&state.app_db)
         .await?
         .ok_or_else(|| AppError::Other("Spotify Client ID is not configured".into()))?;
@@ -113,6 +132,13 @@ pub async fn spotify_login(
 pub async fn spotify_get_access_token(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<SpotifyAccessToken> {
+    // No explicit `is_offline()` guard: `spotify::access_token`
+    // returns the cached bearer token unmodified when it's still
+    // within `REFRESH_SKEW_MS` of expiry, so a guard at the top
+    // would block the legitimate "return cached" path even when no
+    // network call is needed. When a refresh IS required and the
+    // app is offline, the inner `refresh_token()` reqwest call
+    // surfaces a clear network error.
     let profile_pool = state.require_profile_pool().await?;
     Ok(spotify::access_token(&state.app_db, &profile_pool).await?)
 }
@@ -121,6 +147,9 @@ pub async fn spotify_get_access_token(
 pub async fn spotify_list_playlists(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<Vec<SpotifyPlaylistLite>> {
+    if offline::is_offline() {
+        return Err(AppError::Other(OFFLINE_ERR.into()));
+    }
     let profile_pool = state.require_profile_pool().await?;
     let token = spotify::access_token(&state.app_db, &profile_pool).await?;
     let client = reqwest::Client::new();
@@ -132,6 +161,9 @@ pub async fn spotify_get_playlist_tracks(
     state: tauri::State<'_, AppState>,
     playlist_id: String,
 ) -> AppResult<Vec<SpotifyTrackLite>> {
+    if offline::is_offline() {
+        return Err(AppError::Other(OFFLINE_ERR.into()));
+    }
     let profile_pool = state.require_profile_pool().await?;
     let token = spotify::access_token(&state.app_db, &profile_pool).await?;
     let client = reqwest::Client::new();
@@ -142,6 +174,9 @@ pub async fn spotify_get_playlist_tracks(
 pub async fn spotify_get_queue(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<spotify::SpotifyQueueSnapshot> {
+    if offline::is_offline() {
+        return Err(AppError::Other(OFFLINE_ERR.into()));
+    }
     let profile_pool = state.require_profile_pool().await?;
     let token = spotify::access_token(&state.app_db, &profile_pool).await?;
     let client = reqwest::Client::new();
@@ -159,6 +194,9 @@ pub async fn spotify_search(
             albums: Vec::new(),
             artists: Vec::new(),
         });
+    }
+    if offline::is_offline() {
+        return Err(AppError::Other(OFFLINE_ERR.into()));
     }
     let profile_pool = state.require_profile_pool().await?;
     let token = spotify::access_token(&state.app_db, &profile_pool).await?;

--- a/src-tauri/crates/app/src/commands/spotify.rs
+++ b/src-tauri/crates/app/src/commands/spotify.rs
@@ -1,19 +1,24 @@
 //! Tauri commands for Spotify OAuth and Web API reads.
+//!
+//! Thin wrappers over the `waveflow-spotify` crate. The app crate owns
+//! `AppState` → pool unwrapping; the Spotify crate stays ignorant of
+//! Tauri / `AppState` so it can be reused outside the desktop.
 
 use std::time::Duration;
 
 use serde::Deserialize;
 use tauri::Manager;
 use tiny_http::Server;
+use waveflow_spotify as spotify;
+use waveflow_spotify::{
+    SpotifyAccessToken, SpotifyPlaylistLite, SpotifySearchResults, SpotifyStatus, SpotifyTrackLite,
+    CALLBACK_ADDR, CALLBACK_URL, SCOPES,
+};
 
 use crate::{
     audio::{engine::AudioCmd, AudioEngine},
     commands::loopback::html_response,
     error::{AppError, AppResult},
-    spotify::{
-        self, SpotifyAccessToken, SpotifyPlaylistLite, SpotifySearchResults, SpotifyStatus,
-        SpotifyTrackLite, CALLBACK_ADDR, CALLBACK_URL, SCOPES,
-    },
     state::AppState,
 };
 
@@ -26,7 +31,7 @@ struct CallbackQuery {
 
 #[tauri::command]
 pub async fn get_spotify_client_id(state: tauri::State<'_, AppState>) -> AppResult<Option<String>> {
-    spotify::read_client_id(&state).await
+    Ok(spotify::read_client_id(&state.app_db).await?)
 }
 
 #[tauri::command]
@@ -34,12 +39,18 @@ pub async fn set_spotify_client_id(
     state: tauri::State<'_, AppState>,
     client_id: String,
 ) -> AppResult<()> {
-    spotify::write_client_id(&state, &client_id).await
+    spotify::write_client_id(&state.app_db, &client_id).await?;
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn spotify_get_status(state: tauri::State<'_, AppState>) -> AppResult<SpotifyStatus> {
-    spotify::status(&state).await
+    // The Spotify crate accepts `Option<&SqlitePool>` for the profile
+    // pool so it can still report `configured` when no profile is
+    // mounted — match that contract here. `require_profile_pool`
+    // errors are downgraded to "no profile = not connected".
+    let profile_pool = state.require_profile_pool().await.ok();
+    Ok(spotify::status(&state.app_db, profile_pool.as_ref()).await?)
 }
 
 #[tauri::command]
@@ -56,7 +67,7 @@ pub async fn spotify_login(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> AppResult<SpotifyStatus> {
-    let client_id = spotify::read_client_id(&state)
+    let client_id = spotify::read_client_id(&state.app_db)
         .await?
         .ok_or_else(|| AppError::Other("Spotify Client ID is not configured".into()))?;
     let verifier = spotify::random_token();
@@ -88,29 +99,32 @@ pub async fn spotify_login(
     let client = reqwest::Client::new();
     let tokens = spotify::exchange_code(&client, &client_id, &code, &verifier).await?;
     let (username, _product) = spotify::me(&client, &tokens.access_token).await?;
-    spotify::store_tokens(&state, &tokens, &username, None).await?;
+    let profile_pool = state.require_profile_pool().await?;
+    spotify::store_tokens(&profile_pool, &tokens, &username, None).await?;
 
     if let Some(engine) = app.try_state::<std::sync::Arc<AudioEngine>>() {
         let _ = engine.send(AudioCmd::Pause);
     }
 
-    spotify::status(&state).await
+    Ok(spotify::status(&state.app_db, Some(&profile_pool)).await?)
 }
 
 #[tauri::command]
 pub async fn spotify_get_access_token(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<SpotifyAccessToken> {
-    spotify::access_token(&state).await
+    let profile_pool = state.require_profile_pool().await?;
+    Ok(spotify::access_token(&state.app_db, &profile_pool).await?)
 }
 
 #[tauri::command]
 pub async fn spotify_list_playlists(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<Vec<SpotifyPlaylistLite>> {
-    let token = spotify::access_token(&state).await?;
+    let profile_pool = state.require_profile_pool().await?;
+    let token = spotify::access_token(&state.app_db, &profile_pool).await?;
     let client = reqwest::Client::new();
-    spotify::list_playlists(&client, &token.access_token).await
+    Ok(spotify::list_playlists(&client, &token.access_token).await?)
 }
 
 #[tauri::command]
@@ -118,18 +132,20 @@ pub async fn spotify_get_playlist_tracks(
     state: tauri::State<'_, AppState>,
     playlist_id: String,
 ) -> AppResult<Vec<SpotifyTrackLite>> {
-    let token = spotify::access_token(&state).await?;
+    let profile_pool = state.require_profile_pool().await?;
+    let token = spotify::access_token(&state.app_db, &profile_pool).await?;
     let client = reqwest::Client::new();
-    spotify::playlist_tracks(&client, &token.access_token, &playlist_id).await
+    Ok(spotify::playlist_tracks(&client, &token.access_token, &playlist_id).await?)
 }
 
 #[tauri::command]
 pub async fn spotify_get_queue(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<spotify::SpotifyQueueSnapshot> {
-    let token = spotify::access_token(&state).await?;
+    let profile_pool = state.require_profile_pool().await?;
+    let token = spotify::access_token(&state.app_db, &profile_pool).await?;
     let client = reqwest::Client::new();
-    spotify::queue(&client, &token.access_token).await
+    Ok(spotify::queue(&client, &token.access_token).await?)
 }
 
 #[tauri::command]
@@ -144,9 +160,10 @@ pub async fn spotify_search(
             artists: Vec::new(),
         });
     }
-    let token = spotify::access_token(&state).await?;
+    let profile_pool = state.require_profile_pool().await?;
+    let token = spotify::access_token(&state.app_db, &profile_pool).await?;
     let client = reqwest::Client::new();
-    spotify::search(&client, &token.access_token, query.trim()).await
+    Ok(spotify::search(&client, &token.access_token, query.trim()).await?)
 }
 
 #[tauri::command]

--- a/src-tauri/crates/app/src/error.rs
+++ b/src-tauri/crates/app/src/error.rs
@@ -53,6 +53,14 @@ pub enum AppError {
     #[error("zip error: {0}")]
     Zip(#[from] zip::result::ZipError),
 
+    /// Errors bubbled from the `waveflow-spotify` crate. Wraps the
+    /// crate-local `SpotifyError` enum (network / DB / parse failures
+    /// for the Spotify Web API client). Same `transparent` shape as
+    /// `Core` — caller sees the original message without an extra
+    /// "spotify error: " prefix.
+    #[error(transparent)]
+    Spotify(#[from] waveflow_spotify::SpotifyError),
+
     #[error("{0}")]
     Other(String),
 }

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -23,7 +23,10 @@ mod scrobbler;
 #[cfg(feature = "sync_v1")]
 mod server_client;
 mod smart_playlists;
-mod spotify;
+// `mod spotify` was extracted to the `waveflow-spotify` workspace crate.
+// `crate::commands::spotify` now imports from `waveflow_spotify::*` and
+// passes raw `&SqlitePool` handles in lieu of `&AppState`. Same pattern
+// as `waveflow-syncedlyrics`.
 mod state;
 // Multi-device sync (Phase 1.f, RFC-003). When the `sync_v1` feature
 // is OFF (1.5.0 default), `mod sync` resolves to `sync_stub.rs` —

--- a/src-tauri/crates/spotify/Cargo.toml
+++ b/src-tauri/crates/spotify/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "waveflow-spotify"
+version = "1.4.0"
+edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/InstaZDLL/WaveFlow"
+description = "Spotify Web API client + OAuth helpers extracted from the WaveFlow app crate."
+
+# Why a separate workspace crate?
+#
+# The Spotify integration is a third-party service binding — not core
+# playback logic — and was previously interleaved with the app crate's
+# domain code. Extracting it keeps the app crate focused on the local
+# audio engine + UI plumbing, and lets a future cargo feature toggle
+# the whole integration out without touching the player core. Pattern
+# mirrors `waveflow-syncedlyrics` (lyrics provider chain) — same
+# rationale, same workspace position.
+
+[dependencies]
+# HTTP client. `rustls-tls` matches the rest of the workspace so we
+# don't ship a second TLS stack.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# DB access — the auth_credential + app_setting reads/writes happen
+# inside this crate (callers pass in the pools, so we never touch
+# `AppState`).
+sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "chrono"] }
+
+# JSON + struct serialization. `Serialize` is needed for the public
+# types that flow back through the Tauri command boundary.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Wall-clock for token expiry (`expires_at = now + expires_in * 1000`).
+chrono = "0.4"
+
+# PKCE — random verifier + SHA-256 challenge + base64url-no-pad encoding.
+base64 = "0.22"
+sha2 = "0.11"
+uuid = { version = "1", features = ["v4"] }
+
+# URL-form encoding for `?q=` + path segment escapes.
+url = "2"
+
+# Error + log surface — same families used by the rest of the workspace.
+thiserror = "2"
+tracing = "0.1"

--- a/src-tauri/crates/spotify/src/error.rs
+++ b/src-tauri/crates/spotify/src/error.rs
@@ -1,0 +1,21 @@
+//! Crate-local error type. Mapped to the app crate's `AppError`
+//! through `#[from] waveflow_spotify::SpotifyError` so call sites
+//! keep using `?` without an explicit conversion.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SpotifyError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    /// Network / HTTP / JSON parse / Spotify API failures + any
+    /// caller-relevant string-flavoured error. The desktop surfaces
+    /// these messages verbatim in toast / dialog UI, so phrasing is
+    /// part of the contract — keep it user-facing French (or English
+    /// when caller-friendly).
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type SpotifyResult<T> = Result<T, SpotifyError>;

--- a/src-tauri/crates/spotify/src/lib.rs
+++ b/src-tauri/crates/spotify/src/lib.rs
@@ -1,18 +1,35 @@
-//! Spotify Web API helpers for OAuth, token refresh, catalogue reads,
-//! and playback control. Actual audio playback is owned by Spotify's
-//! Web Playback SDK in the frontend; this module never receives raw
-//! audio bytes.
+//! Spotify Web API helpers for OAuth (PKCE), token refresh, catalogue
+//! reads, and playback control.
+//!
+//! Actual audio playback is owned by Spotify's Web Playback SDK in
+//! the frontend; this crate never receives raw audio bytes. The
+//! desktop's role is limited to bearer-token management + REST calls
+//! against [`https://api.spotify.com/v1`].
+//!
+//! # Decoupling from `AppState`
+//!
+//! Previously this module lived inside the app crate (`crate::spotify`)
+//! and threaded `&AppState` everywhere. The new shape takes raw
+//! `&SqlitePool` handles instead — one for the cross-profile
+//! `app.db` (Spotify Client ID lives there) and one for the active
+//! profile's `data.db` (`auth_credential` rows live there). The
+//! app crate owns the `AppState`-to-pool unwrap; this crate stays
+//! ignorant of that machinery so it can be reused outside Tauri (a
+//! future CLI / server / test harness).
+//!
+//! See [`waveflow-syncedlyrics`] for the same pattern applied to the
+//! lyrics provider chain.
+
+pub mod error;
+
+pub use error::{SpotifyError, SpotifyResult};
 
 use base64::Engine;
 use chrono::Utc;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-
-use crate::{
-    error::{AppError, AppResult},
-    state::AppState,
-};
+use sqlx::SqlitePool;
 
 pub const CLIENT_ID_KEY: &str = "app.spotify_client_id";
 pub const CALLBACK_ADDR: &str = "127.0.0.1:49387";
@@ -230,20 +247,20 @@ pub fn random_token() -> String {
     )
 }
 
-pub async fn read_client_id(state: &AppState) -> AppResult<Option<String>> {
+pub async fn read_client_id(app_db: &SqlitePool) -> SpotifyResult<Option<String>> {
     let value: Option<String> = sqlx::query_scalar("SELECT value FROM app_setting WHERE key = ?")
         .bind(CLIENT_ID_KEY)
-        .fetch_optional(&state.app_db)
+        .fetch_optional(app_db)
         .await?;
     Ok(value.filter(|v| !v.trim().is_empty()))
 }
 
-pub async fn write_client_id(state: &AppState, client_id: &str) -> AppResult<()> {
+pub async fn write_client_id(app_db: &SqlitePool, client_id: &str) -> SpotifyResult<()> {
     let trimmed = client_id.trim();
     if trimmed.is_empty() {
         sqlx::query("DELETE FROM app_setting WHERE key = ?")
             .bind(CLIENT_ID_KEY)
-            .execute(&state.app_db)
+            .execute(app_db)
             .await?;
         return Ok(());
     }
@@ -251,32 +268,37 @@ pub async fn write_client_id(state: &AppState, client_id: &str) -> AppResult<()>
         "INSERT INTO app_setting (key, value, value_type, updated_at)
          VALUES (?, ?, 'string', ?)
          ON CONFLICT(key) DO UPDATE
-            SET value = excluded.value, updated_at = excluded.updated_at",
+            SET value = excluded.value, value_type = excluded.value_type, updated_at = excluded.updated_at",
     )
     .bind(CLIENT_ID_KEY)
     .bind(trimmed)
     .bind(now_ms())
-    .execute(&state.app_db)
+    .execute(app_db)
     .await?;
     Ok(())
 }
 
-pub async fn status(state: &AppState) -> AppResult<SpotifyStatus> {
-    let configured = read_client_id(state).await?.is_some();
-    let pool = match state.require_profile_pool().await {
-        Ok(p) => p,
-        Err(_) => {
-            return Ok(SpotifyStatus {
-                configured,
-                connected: false,
-                username: None,
-                product: None,
-            });
-        }
+/// Resolve the current Spotify integration status (configured? signed
+/// in? as whom?). The caller passes the active profile's pool when one
+/// is mounted, or `None` when no profile is active — the latter still
+/// reports `configured` correctly (read from `app_db`) but with
+/// `connected = false`.
+pub async fn status(
+    app_db: &SqlitePool,
+    profile_pool: Option<&SqlitePool>,
+) -> SpotifyResult<SpotifyStatus> {
+    let configured = read_client_id(app_db).await?.is_some();
+    let Some(pool) = profile_pool else {
+        return Ok(SpotifyStatus {
+            configured,
+            connected: false,
+            username: None,
+            product: None,
+        });
     };
     let row: Option<(Option<String>,)> =
         sqlx::query_as("SELECT username FROM auth_credential WHERE provider = 'spotify'")
-            .fetch_optional(&pool)
+            .fetch_optional(pool)
             .await?;
     let username = row.and_then(|r| r.0);
     Ok(SpotifyStatus {
@@ -292,7 +314,7 @@ pub async fn exchange_code(
     client_id: &str,
     code: &str,
     verifier: &str,
-) -> AppResult<TokenResponse> {
+) -> SpotifyResult<TokenResponse> {
     let res = client
         .post(format!("{ACCOUNTS_BASE}/api/token"))
         .form(&[
@@ -304,7 +326,7 @@ pub async fn exchange_code(
         ])
         .send()
         .await
-        .map_err(|e| AppError::Other(format!("Spotify token exchange failed: {e}")))?;
+        .map_err(|e| SpotifyError::Other(format!("Spotify token exchange failed: {e}")))?;
     parse_spotify_response(res).await
 }
 
@@ -312,7 +334,7 @@ pub async fn refresh_token(
     client: &reqwest::Client,
     client_id: &str,
     refresh_token: &str,
-) -> AppResult<TokenResponse> {
+) -> SpotifyResult<TokenResponse> {
     let res = client
         .post(format!("{ACCOUNTS_BASE}/api/token"))
         .form(&[
@@ -322,22 +344,21 @@ pub async fn refresh_token(
         ])
         .send()
         .await
-        .map_err(|e| AppError::Other(format!("Spotify refresh failed: {e}")))?;
+        .map_err(|e| SpotifyError::Other(format!("Spotify refresh failed: {e}")))?;
     parse_spotify_response(res).await
 }
 
 pub async fn store_tokens(
-    state: &AppState,
+    profile_pool: &SqlitePool,
     tokens: &TokenResponse,
     username: &str,
     refresh_override: Option<String>,
-) -> AppResult<()> {
+) -> SpotifyResult<()> {
     if !tokens.token_type.eq_ignore_ascii_case("bearer") {
-        return Err(AppError::Other(
+        return Err(SpotifyError::Other(
             "Spotify returned a non-bearer token".into(),
         ));
     }
-    let pool = state.require_profile_pool().await?;
     let now = now_ms();
     let expires_at = now + tokens.expires_in.saturating_mul(1000);
     let refresh = tokens
@@ -363,29 +384,36 @@ pub async fn store_tokens(
     .bind(expires_at)
     .bind(now)
     .bind(now)
-    .execute(&pool)
+    .execute(profile_pool)
     .await?;
     Ok(())
 }
 
-pub async fn access_token(state: &AppState) -> AppResult<SpotifyAccessToken> {
-    let client_id = read_client_id(state)
+/// Return a valid access token for the active Spotify session,
+/// transparently refreshing when the stored one is within
+/// `REFRESH_SKEW_MS` of expiry. Caller passes both pools because a
+/// refresh implicitly writes back to the profile pool via
+/// [`store_tokens`].
+pub async fn access_token(
+    app_db: &SqlitePool,
+    profile_pool: &SqlitePool,
+) -> SpotifyResult<SpotifyAccessToken> {
+    let client_id = read_client_id(app_db)
         .await?
-        .ok_or_else(|| AppError::Other("Spotify Client ID is not configured".into()))?;
-    let pool = state.require_profile_pool().await?;
+        .ok_or_else(|| SpotifyError::Other("Spotify Client ID is not configured".into()))?;
     #[allow(clippy::type_complexity)]
     let row: Option<(Vec<u8>, Option<Vec<u8>>, Option<i64>, Option<String>)> = sqlx::query_as(
         "SELECT token_encrypted, refresh_token_encrypted, expires_at, username
            FROM auth_credential
           WHERE provider = 'spotify'",
     )
-    .fetch_optional(&pool)
+    .fetch_optional(profile_pool)
     .await?;
     let Some((token_bytes, refresh_bytes, expires_at, username)) = row else {
-        return Err(AppError::Other("Spotify is not connected".into()));
+        return Err(SpotifyError::Other("Spotify is not connected".into()));
     };
     let access = String::from_utf8(token_bytes)
-        .map_err(|_| AppError::Other("Stored Spotify access token is invalid".into()))?;
+        .map_err(|_| SpotifyError::Other("Stored Spotify access token is invalid".into()))?;
     let expires_at = expires_at.unwrap_or(0);
     if expires_at > now_ms() + REFRESH_SKEW_MS {
         return Ok(SpotifyAccessToken {
@@ -396,11 +424,11 @@ pub async fn access_token(state: &AppState) -> AppResult<SpotifyAccessToken> {
     let refresh = refresh_bytes
         .and_then(|b| String::from_utf8(b).ok())
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| AppError::Other("Spotify refresh token is missing".into()))?;
+        .ok_or_else(|| SpotifyError::Other("Spotify refresh token is missing".into()))?;
     let client = reqwest::Client::new();
     let refreshed = refresh_token(&client, &client_id, &refresh).await?;
     store_tokens(
-        state,
+        profile_pool,
         &refreshed,
         username.as_deref().unwrap_or("Spotify"),
         Some(refresh),
@@ -415,7 +443,7 @@ pub async fn access_token(state: &AppState) -> AppResult<SpotifyAccessToken> {
 pub async fn me(
     client: &reqwest::Client,
     access_token: &str,
-) -> AppResult<(String, Option<String>)> {
+) -> SpotifyResult<(String, Option<String>)> {
     let me: MeResponse = get_json(client, access_token, &format!("{API_BASE}/me")).await?;
     Ok((me.display_name.unwrap_or(me.id), me.product))
 }
@@ -423,7 +451,7 @@ pub async fn me(
 pub async fn list_playlists(
     client: &reqwest::Client,
     access_token: &str,
-) -> AppResult<Vec<SpotifyPlaylistLite>> {
+) -> SpotifyResult<Vec<SpotifyPlaylistLite>> {
     // Spotify can return `null` entries inside `items` for playlists
     // that were created by a now-removed 3rd-party app or otherwise
     // orphaned in the user's library. Wrapping the page items in
@@ -447,7 +475,7 @@ pub async fn playlist_tracks(
     client: &reqwest::Client,
     access_token: &str,
     playlist_id: &str,
-) -> AppResult<Vec<SpotifyTrackLite>> {
+) -> SpotifyResult<Vec<SpotifyTrackLite>> {
     // Dropped the `fields=` filter — since Spotify's Nov 2024 Web API
     // tightening, requesting nested fields (album images, artists,
     // ...) on certain playlists triggers a blanket 403 even when the
@@ -529,7 +557,7 @@ struct QueueResponse {
 pub async fn queue(
     client: &reqwest::Client,
     access_token: &str,
-) -> AppResult<SpotifyQueueSnapshot> {
+) -> SpotifyResult<SpotifyQueueSnapshot> {
     let res: QueueResponse =
         get_json(client, access_token, &format!("{API_BASE}/me/player/queue")).await?;
     Ok(SpotifyQueueSnapshot {
@@ -546,7 +574,7 @@ pub async fn search(
     client: &reqwest::Client,
     access_token: &str,
     query: &str,
-) -> AppResult<SpotifySearchResults> {
+) -> SpotifyResult<SpotifySearchResults> {
     let encoded = url_escape(query);
     let res: SearchResponse = get_json(
         client,
@@ -579,28 +607,30 @@ async fn get_json<T: for<'de> Deserialize<'de>>(
     client: &reqwest::Client,
     access_token: &str,
     url: &str,
-) -> AppResult<T> {
+) -> SpotifyResult<T> {
     let res = client
         .get(url)
         .bearer_auth(access_token)
         .send()
         .await
-        .map_err(|e| AppError::Other(format!("Spotify API request failed: {e}")))?;
+        .map_err(|e| SpotifyError::Other(format!("Spotify API request failed: {e}")))?;
     parse_spotify_response(res).await
 }
 
 async fn parse_spotify_response<T: for<'de> Deserialize<'de>>(
     res: reqwest::Response,
-) -> AppResult<T> {
+) -> SpotifyResult<T> {
     let status = res.status();
     if status == StatusCode::NO_CONTENT {
-        return Err(AppError::Other("Spotify returned an empty response".into()));
+        return Err(SpotifyError::Other(
+            "Spotify returned an empty response".into(),
+        ));
     }
     if status.is_success() {
         return res
             .json::<T>()
             .await
-            .map_err(|e| AppError::Other(format!("Spotify response parse failed: {e}")));
+            .map_err(|e| SpotifyError::Other(format!("Spotify response parse failed: {e}")));
     }
     let text = res.text().await.unwrap_or_default();
     let message = serde_json::from_str::<SpotifyErrorBody>(&text)
@@ -626,7 +656,7 @@ async fn parse_spotify_response<T: for<'de> Deserialize<'de>>(
         format!("Spotify API error {}: {}", status.as_u16(), message)
     };
     tracing::warn!(status = %status, body = %text, "spotify API error");
-    Err(AppError::Other(friendly))
+    Err(SpotifyError::Other(friendly))
 }
 
 fn best_image(images: Option<Vec<ImageResponse>>) -> Option<String> {

--- a/src-tauri/crates/spotify/src/lib.rs
+++ b/src-tauri/crates/spotify/src/lib.rs
@@ -550,19 +550,39 @@ struct QueueResponse {
 }
 
 /// Fetch the user's playback queue via `GET /me/player/queue`.
+///
 /// Spotify returns `currently_playing` + an array of upcoming tracks
-/// (capped at ~20 items). Requires an active Connect device — when
-/// nothing is playing the response is `{"currently_playing": null,
-/// "queue": []}` which we surface as an empty snapshot.
+/// (capped at ~20 items). Behaviour by status:
+///
+/// - **200 with `currently_playing: null, queue: []`** — paused
+///   session on a known device; surfaces as an empty snapshot.
+/// - **204 No Content** — **no active Connect device at all**. The
+///   shared [`parse_spotify_response`] helper treats 204 as an
+///   error (Spotify quirks where empty bodies mean "API offline"),
+///   but for `/me/player/queue` specifically 204 is a documented
+///   normal state. Caught + downgraded to an empty snapshot here so
+///   the QueuePanel UI doesn't fire an error toast just because the
+///   user hasn't picked a Connect target.
 pub async fn queue(
     client: &reqwest::Client,
     access_token: &str,
 ) -> SpotifyResult<SpotifyQueueSnapshot> {
-    let res: QueueResponse =
-        get_json(client, access_token, &format!("{API_BASE}/me/player/queue")).await?;
+    let res = client
+        .get(format!("{API_BASE}/me/player/queue"))
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| SpotifyError::Other(format!("Spotify API request failed: {e}")))?;
+    if res.status() == StatusCode::NO_CONTENT {
+        return Ok(SpotifyQueueSnapshot {
+            current: None,
+            upcoming: Vec::new(),
+        });
+    }
+    let parsed: QueueResponse = parse_spotify_response(res).await?;
     Ok(SpotifyQueueSnapshot {
-        current: res.currently_playing.and_then(SpotifyTrackLite::from_track),
-        upcoming: res
+        current: parsed.currently_playing.and_then(SpotifyTrackLite::from_track),
+        upcoming: parsed
             .queue
             .into_iter()
             .filter_map(SpotifyTrackLite::from_track)


### PR DESCRIPTION
## Summary

Move the Spotify Web API client + OAuth + token storage out of the app crate into a new `crates/spotify/` workspace member, mirroring the [`waveflow-syncedlyrics`](../tree/main/src-tauri/crates/syncedlyrics) pattern. **No user-facing behaviour change** — the Spotify integration ships exactly as before; the code just lives in its own crate.

### Why

`crate::spotify` was 703 lines of HTTP + OAuth + DB code interleaved with the app crate's domain logic (audio engine, UI plumbing, sync). Extracting:

- **Keeps `crates/app/` focused** on local playback + Tauri integration
- **Faster incremental builds** when touching Spotify code (only the new crate rebuilds)
- **Reusable outside Tauri** — a future CLI / test harness / server-side import can pull `waveflow-spotify` without dragging the whole desktop binary along
- **Cleaner mental model** for contributors — Spotify is a third-party service binding, not core playback logic

## What changes

### New crate `waveflow-spotify`

- [`crates/spotify/Cargo.toml`](src-tauri/crates/spotify/Cargo.toml) — 9 deps (reqwest, sqlx, serde, serde_json, chrono, base64, sha2, uuid, url, thiserror, tracing). All already in the workspace dep tree, so no net new compilation cost.
- [`crates/spotify/src/lib.rs`](src-tauri/crates/spotify/src/lib.rs) — full public API: types (`SpotifyStatus`, `SpotifyTrackLite`, `SpotifyPlaylistLite`, `SpotifyAccessToken`, `SpotifySearchResults`, `SpotifyQueueSnapshot`, …), constants (`SCOPES`, `CALLBACK_URL`, …), PKCE helpers, HTTP API calls, DB ops.
- [`crates/spotify/src/error.rs`](src-tauri/crates/spotify/src/error.rs) — crate-local `SpotifyError` enum (sqlx::Error + Other(String)). Wired into the app crate via `#[from]`.

### Decoupling — pools instead of AppState

The new crate takes raw `&SqlitePool` handles in lieu of `&AppState`:

| Before | After |
|---|---|
| `read_client_id(state: &AppState)` | `read_client_id(app_db: &SqlitePool)` |
| `write_client_id(state, ...)` | `write_client_id(app_db, ...)` |
| `status(state)` | `status(app_db, profile_pool: Option<&SqlitePool>)` |
| `store_tokens(state, ...)` | `store_tokens(profile_pool, ...)` |
| `access_token(state)` | `access_token(app_db, profile_pool)` |

The app crate's [`commands/spotify.rs`](src-tauri/crates/app/src/commands/spotify.rs) does the `AppState → pool` unwrap at the Tauri command boundary and threads the pools through. `status()` accepts `Option<&SqlitePool>` so it still reports `configured` correctly when no profile is mounted.

### App crate changes

- [`src/spotify.rs`](src-tauri/crates/app/src/spotify.rs) — **deleted** (git renames it to the new crate's `lib.rs`)
- [`src/lib.rs`](src-tauri/crates/app/src/lib.rs) — `mod spotify` line replaced with a pointer comment
- [`src/error.rs`](src-tauri/crates/app/src/error.rs) — `AppError::Spotify(#[from] waveflow_spotify::SpotifyError)` variant added. Same `#[error(transparent)]` shape as `Core` so user-facing messages stay identical
- [`src/commands/spotify.rs`](src-tauri/crates/app/src/commands/spotify.rs) — `use crate::spotify::…` → `use waveflow_spotify as spotify;`
- [`Cargo.toml`](src-tauri/crates/app/Cargo.toml) — `waveflow-spotify = { path = "../spotify" }`

### Workspace

- [`src-tauri/Cargo.toml`](src-tauri/Cargo.toml) — `crates/spotify` added to `members`

## Verification

| Test | Result |
|---|---|
| `cargo check --workspace` (sync_v1 OFF) | ✓ 0 warning |
| `cargo check --workspace --features waveflow/sync_v1` | ✓ 0 warning |
| `cargo test --workspace --lib` (sync_v1 OFF) | ✓ **223 tests pass** (84 app + 110 core + 2 spotify + 27 syncedlyrics) |
| `cargo test --workspace --lib --features waveflow/sync_v1` | ✓ **367 tests pass** (228 + 110 + 2 + 27) |

## Test plan

- [x] Manual: `bun run tauri dev` — open Settings → Intégrations → Spotify, enter a Client ID, complete the OAuth handshake, list playlists, fetch playlist tracks
- [x] `cargo check --workspace` clean on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Refactor**
  * Refonte de l’intégration Spotify pour la rendre plus modulaire, avec gestion des erreurs et des résultats unifiée côté Spotify.

* **Bug Fixes**
  * Les commandes Spotify tiennent mieux compte du mode hors-ligne (erreur dédiée) et du profil actif/inactif.
  * La file d’attente gère correctement le cas “aucun contenu” (retour d’un snapshot vide).

* **Chores**
  * Ajout d’un crate Spotify au workspace et restructuration de la compilation/dépendances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->