### PR TITLE
fix(plugins): refuse uninstall on bundled plugins + hide unavailable web-radio surface

### DIFF
--- a/scripts/add_bundled_plugin_i18n.py
+++ b/scripts/add_bundled_plugin_i18n.py
@@ -1,0 +1,183 @@
+"""One-shot script: propagate i18n strings introduced by the
+"bundled plugin uninstall guard" PR (Web Radio polish).
+
+Adds:
+  - `settings.plugins.bundled` / `bundledHint`
+  - `webRadio.unavailableTitle` / `unavailableHint`
+
+across all 17 locales. Idempotent — re-running on a locale that
+already has the keys is a no-op.
+
+Run from repo root:
+    python scripts/add_bundled_plugin_i18n.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+PLUGINS_BUNDLED_KEY = "bundled"
+PLUGINS_BUNDLED_HINT_KEY = "bundledHint"
+WEBRADIO_UNAVAILABLE_TITLE_KEY = "unavailableTitle"
+WEBRADIO_UNAVAILABLE_HINT_KEY = "unavailableHint"
+
+TRANSLATIONS = {
+    "fr": {
+        "bundled": "Inclus",
+        "bundledHint": "Livré avec WaveFlow — désactivez-le pour le masquer.",
+        "unavailableTitle": "Web Radio désactivée",
+        "unavailableHint": "Activez le plugin Web Radio dans Réglages → Plugins pour parcourir plus de 30 000 stations.",
+    },
+    "en": {
+        "bundled": "Built-in",
+        "bundledHint": "Ships with WaveFlow — disable it to hide it.",
+        "unavailableTitle": "Web Radio is disabled",
+        "unavailableHint": "Enable the Web Radio plugin in Settings → Plugins to browse 30,000+ stations.",
+    },
+    "es": {
+        "bundled": "Integrado",
+        "bundledHint": "Incluido con WaveFlow — desactívalo para ocultarlo.",
+        "unavailableTitle": "Web Radio está desactivada",
+        "unavailableHint": "Activa el plugin de Web Radio en Ajustes → Plugins para explorar más de 30 000 estaciones.",
+    },
+    "de": {
+        "bundled": "Mitgeliefert",
+        "bundledHint": "Mit WaveFlow ausgeliefert — deaktivieren, um es auszublenden.",
+        "unavailableTitle": "Web Radio ist deaktiviert",
+        "unavailableHint": "Aktivieren Sie das Web Radio-Plugin in Einstellungen → Plugins, um über 30 000 Sender zu durchsuchen.",
+    },
+    "it": {
+        "bundled": "Integrato",
+        "bundledHint": "Incluso in WaveFlow — disattivalo per nasconderlo.",
+        "unavailableTitle": "Web Radio è disattivata",
+        "unavailableHint": "Attiva il plugin Web Radio in Impostazioni → Plugin per sfogliare oltre 30 000 stazioni.",
+    },
+    "nl": {
+        "bundled": "Ingebouwd",
+        "bundledHint": "Meegeleverd met WaveFlow — schakel het uit om het te verbergen.",
+        "unavailableTitle": "Web Radio is uitgeschakeld",
+        "unavailableHint": "Schakel de Web Radio-plugin in via Instellingen → Plugins om meer dan 30.000 stations te doorzoeken.",
+    },
+    "pt": {
+        "bundled": "Integrado",
+        "bundledHint": "Incluído no WaveFlow — desative-o para o ocultar.",
+        "unavailableTitle": "Web Radio está desativada",
+        "unavailableHint": "Ative o plugin Web Radio em Definições → Plugins para explorar mais de 30 000 estações.",
+    },
+    "pt-BR": {
+        "bundled": "Integrado",
+        "bundledHint": "Incluído com o WaveFlow — desative para ocultá-lo.",
+        "unavailableTitle": "Web Radio está desativada",
+        "unavailableHint": "Ative o plugin Web Radio em Configurações → Plugins para explorar mais de 30 000 estações.",
+    },
+    "ru": {
+        "bundled": "Встроенный",
+        "bundledHint": "Поставляется с WaveFlow — отключите, чтобы скрыть.",
+        "unavailableTitle": "Web Radio отключено",
+        "unavailableHint": "Включите плагин Web Radio в Настройки → Плагины, чтобы просматривать более 30 000 станций.",
+    },
+    "tr": {
+        "bundled": "Yerleşik",
+        "bundledHint": "WaveFlow ile birlikte gelir — gizlemek için devre dışı bırakın.",
+        "unavailableTitle": "Web Radio devre dışı",
+        "unavailableHint": "30.000'den fazla istasyona göz atmak için Ayarlar → Plugin'ler bölümünden Web Radio plugin'ini etkinleştirin.",
+    },
+    "id": {
+        "bundled": "Bawaan",
+        "bundledHint": "Disertakan dengan WaveFlow — nonaktifkan untuk menyembunyikannya.",
+        "unavailableTitle": "Web Radio dinonaktifkan",
+        "unavailableHint": "Aktifkan plugin Web Radio di Pengaturan → Plugin untuk menjelajahi lebih dari 30.000 stasiun.",
+    },
+    "ja": {
+        "bundled": "組み込み",
+        "bundledHint": "WaveFlow に同梱されています — 非表示にするには無効にしてください。",
+        "unavailableTitle": "Web Radio は無効です",
+        "unavailableHint": "30,000 以上の放送局を閲覧するには、設定 → プラグイン で Web Radio プラグインを有効にしてください。",
+    },
+    "ko": {
+        "bundled": "내장",
+        "bundledHint": "WaveFlow에 포함되어 있습니다 — 숨기려면 비활성화하세요.",
+        "unavailableTitle": "Web Radio가 비활성화됨",
+        "unavailableHint": "30,000개 이상의 방송국을 탐색하려면 설정 → 플러그인에서 Web Radio 플러그인을 활성화하세요.",
+    },
+    "zh-CN": {
+        "bundled": "内置",
+        "bundledHint": "随 WaveFlow 提供 — 禁用以隐藏。",
+        "unavailableTitle": "Web Radio 已禁用",
+        "unavailableHint": "在 设置 → 插件 中启用 Web Radio 插件以浏览超过 30,000 个电台。",
+    },
+    "zh-TW": {
+        "bundled": "內建",
+        "bundledHint": "隨 WaveFlow 提供 — 停用以隱藏。",
+        "unavailableTitle": "Web Radio 已停用",
+        "unavailableHint": "在 設定 → 外掛 中啟用 Web Radio 外掛以瀏覽超過 30,000 個電台。",
+    },
+    "ar": {
+        "bundled": "مدمج",
+        "bundledHint": "يأتي مع WaveFlow — قم بتعطيله لإخفائه.",
+        "unavailableTitle": "Web Radio معطّل",
+        "unavailableHint": "فعّل إضافة Web Radio من الإعدادات → الإضافات لتصفح أكثر من 30,000 محطة.",
+    },
+    "hi": {
+        "bundled": "अंतर्निहित",
+        "bundledHint": "WaveFlow के साथ शामिल — छुपाने के लिए अक्षम करें।",
+        "unavailableTitle": "Web Radio अक्षम है",
+        "unavailableHint": "30,000+ स्टेशन ब्राउज़ करने के लिए सेटिंग्स → प्लगइन्स में Web Radio प्लगइन सक्षम करें।",
+    },
+}
+
+
+def patch_locale(path: Path, translations: dict) -> bool:
+    """Insert the bundled + webRadio.unavailable* keys. Returns True
+    when the file was modified."""
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    changed = False
+
+    settings = data.setdefault("settings", {})
+    plugins = settings.setdefault("plugins", {})
+    if PLUGINS_BUNDLED_KEY not in plugins:
+        plugins[PLUGINS_BUNDLED_KEY] = translations["bundled"]
+        changed = True
+    if PLUGINS_BUNDLED_HINT_KEY not in plugins:
+        plugins[PLUGINS_BUNDLED_HINT_KEY] = translations["bundledHint"]
+        changed = True
+
+    webradio = data.setdefault("webRadio", {})
+    if WEBRADIO_UNAVAILABLE_TITLE_KEY not in webradio:
+        webradio[WEBRADIO_UNAVAILABLE_TITLE_KEY] = translations["unavailableTitle"]
+        changed = True
+    if WEBRADIO_UNAVAILABLE_HINT_KEY not in webradio:
+        webradio[WEBRADIO_UNAVAILABLE_HINT_KEY] = translations["unavailableHint"]
+        changed = True
+
+    if not changed:
+        return False
+
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+    return True
+
+
+def main() -> int:
+    here = Path(__file__).resolve().parent.parent / "src" / "i18n" / "locales"
+    changed: list[str] = []
+    skipped: list[str] = []
+    for code, translations in TRANSLATIONS.items():
+        path = here / f"{code}.json"
+        if not path.exists():
+            print(f"  skip {code} — file missing")
+            continue
+        if patch_locale(path, translations):
+            changed.append(code)
+        else:
+            skipped.append(code)
+    print(f"changed ({len(changed)}): {', '.join(changed) or '(none)'}")
+    print(f"skipped ({len(skipped)}): {', '.join(skipped) or '(none)'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -13,6 +13,7 @@
 
 use std::fs;
 use std::sync::Arc;
+use std::sync::atomic::Ordering as AtomicOrdering;
 
 use serde::Serialize;
 use tauri::State;
@@ -20,8 +21,9 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 use waveflow_core::plugin::manifest::{Manifest, ManifestError};
 use waveflow_core::plugin::runtime::{source_list_entries, source_resolve, source_stream_url};
 
+use crate::audio::{AudioCmd, AudioEngine};
 use crate::error::{AppError, AppResult};
-use crate::state::AppState;
+use crate::state::{AppState, is_bundled_plugin};
 
 /// Acquire the per-plugin write lock. Inserts a fresh `Mutex<()>`
 /// into the runtime's map the first time we see this id; returns
@@ -66,6 +68,13 @@ pub struct PluginInfo {
     /// by `app_setting['plugin.<id>.enabled']`; missing key = on
     /// (an installed plugin is enabled by default).
     pub enabled: bool,
+    /// `true` when this plugin is shipped inside the installer and
+    /// re-seeded at every boot. The UI replaces "Uninstall" with a
+    /// disabled hint on bundled rows, and the backend refuses
+    /// [`uninstall_plugin`] for the same id so the FS-remove + boot
+    /// reseed cycle can't masquerade as an uninstall that "comes
+    /// back" on next launch.
+    pub bundled: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -84,6 +93,7 @@ pub struct PluginAssetInfo {
 }
 
 fn manifest_to_info(manifest: Manifest, enabled: bool) -> PluginInfo {
+    let bundled = is_bundled_plugin(&manifest.plugin.id);
     PluginInfo {
         id: manifest.plugin.id,
         name: manifest.plugin.name,
@@ -107,6 +117,7 @@ fn manifest_to_info(manifest: Manifest, enabled: bool) -> PluginInfo {
             })
             .collect(),
         enabled,
+        bundled,
     }
 }
 
@@ -346,18 +357,45 @@ pub async fn set_plugin_enabled(
 /// is also dropped so a future reinstall of the same id starts in
 /// its default state (enabled).
 ///
+/// Refuses bundled plugins ([`is_bundled_plugin`]) — the boot-time
+/// extractor would re-seed them on next launch, so an "uninstall"
+/// would silently roll itself back. Bundled plugins must be turned
+/// off via [`set_plugin_enabled`] instead; the frontend hides the
+/// uninstall button for these and points the user at the toggle.
+///
+/// When the audio engine is currently playing a non-library URL
+/// (sentinel `current_track_id < 0`, set by `player_play_url` for
+/// every plugin-minted stream), the engine is stopped before the
+/// install dir is wiped. The plugin id isn't currently round-tripped
+/// to the engine, so this stops any URL-based stream — accepted
+/// trade-off vs leaving an orphan stream playing whose source view
+/// has just been deleted.
+///
 /// Frontend must confirm with the user before invoking — the
 /// command itself takes no "are you sure" parameter, on the same
 /// principle as `delete_profile`.
 #[tauri::command]
 pub async fn uninstall_plugin(
     state: State<'_, AppState>,
+    engine: State<'_, Arc<AudioEngine>>,
     plugin_id: String,
 ) -> AppResult<()> {
     // Character-class gate FIRST: rejects case-variant input
     // before any lock entry is created. See doc on
     // `validate_plugin_id_chars`.
     validate_plugin_id_chars(&plugin_id)?;
+
+    // Bundled plugins live inside the installer and are re-seeded at
+    // every boot by `ensure_bundled_plugins`. Allowing the uninstall
+    // would create a one-launch ghost state — the user sees the
+    // plugin disappear, restarts the app, and it's back. Refuse so
+    // the contract is honest; the UI mirrors this by hiding the
+    // button entirely on bundled rows.
+    if is_bundled_plugin(&plugin_id) {
+        return Err(AppError::Other(format!(
+            "plugin {plugin_id} is bundled with WaveFlow and cannot be uninstalled (disable it instead)"
+        )));
+    }
 
     let paths = state.paths.plugin_paths();
     let install_dir = paths
@@ -402,6 +440,22 @@ pub async fn uninstall_plugin(
         return Err(AppError::Other(format!(
             "plugin manifest present but id mismatch (or corrupt): {plugin_id}"
         )));
+    }
+
+    // Stop any URL-based stream before we wipe the install dir.
+    // `player_play_url` mints a strictly-negative `track_id` for
+    // every HTTP stream it dispatches (radio + plugin-sourced),
+    // and that id is currently the only signal that the engine is
+    // serving something the local library can't anchor to. The
+    // plugin id isn't round-tripped to the engine, so we can't
+    // narrow this to "the URL was minted by THIS plugin" — accepted
+    // trade-off vs orphaning a stream whose owner has just been
+    // uninstalled. A library track is left alone.
+    if engine.shared().current_track_id.load(AtomicOrdering::Relaxed) < 0 {
+        tracing::info!(plugin_id, "stopping active URL stream before uninstall");
+        if let Err(e) = engine.send(AudioCmd::Stop) {
+            tracing::warn!(plugin_id, %e, "failed to stop engine; proceeding with uninstall");
+        }
     }
 
     // Remove install + state on a blocking thread — `remove_dir_all`

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -355,7 +355,17 @@ impl AppState {
 /// discovery (loop over `<resource_dir>/plugins/*/manifest.toml`)
 /// so adding a plugin to the bundle doesn't require touching app
 /// code; for v1.5.0 the static list keeps the diff focused.
-const BUNDLED_PLUGINS: &[&str] = &["web-radio"];
+pub(crate) const BUNDLED_PLUGINS: &[&str] = &["web-radio"];
+
+/// True when `plugin_id` is a first-party plugin shipped inside the
+/// installer (re-seeded at every boot by [`ensure_bundled_plugins`]).
+/// Used to surface a "bundled" badge and refuse `uninstall_plugin` —
+/// the uninstall would only persist until next launch, then the boot
+/// extractor would silently put the plugin back, which reads as a bug
+/// to the user.
+pub(crate) fn is_bundled_plugin(plugin_id: &str) -> bool {
+    BUNDLED_PLUGINS.iter().any(|id| *id == plugin_id)
+}
 
 /// Copy every entry in [`BUNDLED_PLUGINS`] from the installer's
 /// resource dir into `<plugins_root>/<id>/` when the install dir

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -24,6 +24,7 @@ import { SmartPlaylistEditorModal } from "../common/SmartPlaylistEditorModal";
 import { useProfile } from "../../hooks/useProfile";
 import { useLibrary } from "../../hooks/useLibrary";
 import { usePlaylist } from "../../hooks/usePlaylist";
+import { usePluginAvailability } from "../../hooks/usePluginAvailability";
 import { getProfileColor, profileInitial } from "../../lib/profileColors";
 import { pickFile, pickFolder } from "../../lib/tauri/dialog";
 import { importPlaylistM3u } from "../../lib/tauri/playlist";
@@ -74,6 +75,12 @@ export function Sidebar({
     liked_count: 0,
     recent_plays_count: 0,
   });
+  // Hide the Web Radio entry when the user has disabled or
+  // uninstalled the plugin in Settings. Keeping the entry visible on
+  // a click that fails with "plugin disabled" was a stale-UI bug
+  // (the user has no way back without going to Settings, and the
+  // raw error surfaced in the view).
+  const showWebRadio = usePluginAvailability("web-radio");
   // Per-profile toggle: hide the Spotify entry from the sidebar so
   // users who don't care about Spotify integration don't see it
   // every time. Default ON. Persisted in `ui.show_spotify`.
@@ -268,12 +275,14 @@ export function Sidebar({
           active={activeView === "home"}
           onClick={() => setActiveView("home")}
         />
-        <NavItem
-          icon={<Radio size={18} />}
-          label={t("sidebar.nav.webRadio")}
-          active={activeView === "web-radio"}
-          onClick={() => setActiveView("web-radio")}
-        />
+        {showWebRadio && (
+          <NavItem
+            icon={<Radio size={18} />}
+            label={t("sidebar.nav.webRadio")}
+            active={activeView === "web-radio"}
+            onClick={() => setActiveView("web-radio")}
+          />
+        )}
         {showSpotify && (
           <NavItem
             icon={<Headphones size={18} />}

--- a/src/components/views/WebRadioView.tsx
+++ b/src/components/views/WebRadioView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { Radio, Search, ChevronLeft, Play, Pause, Loader2 } from "lucide-react";
+import { Radio, Search, ChevronLeft, Play, Pause, Loader2, Puzzle } from "lucide-react";
 
 import { playerPlayUrl, playerStop } from "../../lib/tauri/player";
 import {
@@ -11,8 +11,23 @@ import {
   type PluginEntry,
   type PluginTrack,
 } from "../../lib/tauri/plugins";
+import { usePluginAvailability } from "../../hooks/usePluginAvailability";
 
 const PLUGIN_ID = "web-radio";
+
+/// Recognise the backend errors that mean "the plugin host refused
+/// to invoke web-radio" — disabled toggle, manifest missing after
+/// uninstall, runtime drift. Anything else is treated as a real
+/// runtime failure and surfaced verbatim so an upstream bug is
+/// debuggable, not hidden behind a friendly empty state.
+function isPluginUnavailableError(message: string | null): boolean {
+  if (!message) return false;
+  return (
+    message.includes("plugin disabled") ||
+    message.includes("plugin not installed") ||
+    message.includes("manifest id mismatch")
+  );
+}
 
 /**
  * Web Radio view (Phase 4.c — engine-integrated).
@@ -29,6 +44,7 @@ const PLUGIN_ID = "web-radio";
  */
 export function WebRadioView() {
   const { t } = useTranslation();
+  const pluginAvailable = usePluginAvailability(PLUGIN_ID);
   const [entries, setEntries] = useState<PluginEntry[]>([]);
   const [activeEntry, setActiveEntry] = useState<PluginEntry | null>(null);
   const [tracks, setTracks] = useState<PluginTrack[]>([]);
@@ -256,6 +272,20 @@ export function WebRadioView() {
 
   const showCategoryList = activeEntry === null && !searchActive;
 
+  // Two paths converge on "the plugin host won't honour our calls":
+  //   1. The user flipped the toggle off in Settings → Plugins
+  //      *while* this view was mounted. `pluginAvailable` flips first
+  //      because the Settings card dispatches the bus event.
+  //   2. The initial `pluginListEntries` call landed before the bus
+  //      event fired, returned `plugin disabled`, and parked the
+  //      error in `error`. We sniff for that wording too so the
+  //      same empty-state covers both races.
+  // We still leave generic backend errors visible (network blip,
+  // wasm trap) because hiding those behind a "disable me" pitch
+  // would mask real bugs.
+  const showUnavailableEmptyState =
+    !pluginAvailable || isPluginUnavailableError(error);
+
   return (
     <div className="flex flex-col h-full">
       <header className="px-6 py-5 border-b border-zinc-200 dark:border-zinc-800 flex items-center gap-3">
@@ -309,7 +339,11 @@ export function WebRadioView() {
         </div>
       </div>
 
-      {error && (
+      {/* Generic backend errors only — the plugin-unavailable case is
+          rendered as a full empty state below so the user gets a
+          single, actionable surface instead of a noisy red banner
+          stacked on top of a stale category grid. */}
+      {error && !showUnavailableEmptyState && (
         <div
           role="alert"
           className="mx-6 mt-3 px-3 py-2 bg-red-50 dark:bg-red-950/30 text-xs text-red-700 dark:text-red-300 border border-red-200 dark:border-red-900 rounded"
@@ -319,7 +353,21 @@ export function WebRadioView() {
       )}
 
       <div className="flex-1 overflow-y-auto px-6 py-4">
-        {loading ? (
+        {showUnavailableEmptyState ? (
+          <div className="flex flex-col items-center justify-center text-center py-16 px-6">
+            <Puzzle
+              size={48}
+              className="text-zinc-300 dark:text-zinc-700 mb-3"
+              aria-hidden="true"
+            />
+            <h2 className="text-base font-medium text-zinc-700 dark:text-zinc-200">
+              {t("webRadio.unavailableTitle")}
+            </h2>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 max-w-md">
+              {t("webRadio.unavailableHint")}
+            </p>
+          </div>
+        ) : loading ? (
           <div className="text-center text-sm text-zinc-500 dark:text-zinc-400 py-12">
             {t("webRadio.loading")}
           </div>

--- a/src/components/views/WebRadioView.tsx
+++ b/src/components/views/WebRadioView.tsx
@@ -76,11 +76,34 @@ export function WebRadioView() {
   const resolveReqRef = useRef(0);
   const streamReqRef = useRef(0);
 
-  // Initial fetch of the category list (`.then`-style per the same
-  // `react-hooks/set-state-in-effect` constraint that drives
-  // PluginsCard.tsx — see that file for the rationale).
+  // Fetch the category list whenever the plugin becomes available.
+  //
+  // Re-running on `pluginAvailable` matters because a user can land
+  // on this view while the plugin is disabled (initial fetch fails
+  // with `"plugin disabled"` → error parked in `error`), then
+  // re-enable it from Settings → Plugins. With an empty deps array
+  // the view would silently leave the stale error + empty `entries`
+  // forever after re-enable. We also reset all fetched state when
+  // the plugin flips OFF so a re-enable doesn't briefly flash the
+  // previous category list / track view before the fresh fetch
+  // lands.
+  //
+  // `.then`-style per the same `react-hooks/set-state-in-effect`
+  // constraint that drives PluginsCard.tsx — see that file for the
+  // rationale.
   useEffect(() => {
+    if (!pluginAvailable) {
+      setEntries([]);
+      setTracks([]);
+      setActiveEntry(null);
+      setSearchActive(false);
+      setError(null);
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
+    setLoading(true);
+    setError(null);
     pluginListEntries(PLUGIN_ID).then(
       (list) => {
         if (cancelled) return;
@@ -97,7 +120,7 @@ export function WebRadioView() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [pluginAvailable]);
 
   // Track the engine's lifecycle so a stream that dies on its own
   // (server timeout, mid-stream 5xx, user hits Stop on the PlayerBar)

--- a/src/components/views/WebRadioView.tsx
+++ b/src/components/views/WebRadioView.tsx
@@ -93,6 +93,16 @@ export function WebRadioView() {
   // rationale.
   useEffect(() => {
     if (!pluginAvailable) {
+      // React 19 batches these six setState calls into a single
+      // re-render, so the cascading-renders concern this rule
+      // guards against does not apply. The reset is the cheapest
+      // way to keep the view honest when the plugin flips OFF:
+      // a stale `activeEntry` / search result would otherwise
+      // flash for one tick on re-enable while the fresh fetch
+      // is in flight. A `useReducer` with a RESET action would
+      // sidestep the rule but adds more weight than this earns.
+      /* eslint-disable-next-line react-hooks/set-state-in-effect --
+         intentional batched reset on plugin-unavailability */
       setEntries([]);
       setTracks([]);
       setActiveEntry(null);

--- a/src/components/views/settings/PluginsCard.tsx
+++ b/src/components/views/settings/PluginsCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Puzzle, Trash2, Globe, Database, FileText } from "lucide-react";
+import { Puzzle, Trash2, Globe, Database, FileText, Package } from "lucide-react";
 
 import {
   listInstalledPlugins,
@@ -8,6 +8,15 @@ import {
   uninstallPlugin,
   type PluginInfo,
 } from "../../../lib/tauri/plugins";
+import { PLUGIN_AVAILABILITY_EVENT } from "../../../hooks/usePluginAvailability";
+
+/// Fire the cross-component "plugin availability changed" bus so
+/// Sidebar + WebRadioView refresh their conditional rendering.
+/// Standalone fn (not a useCallback closure) because the call sites
+/// already capture stable state via the optimistic setPlugins above.
+function notifyAvailabilityChanged() {
+  window.dispatchEvent(new CustomEvent(PLUGIN_AVAILABILITY_EVENT));
+}
 
 /**
  * Settings → Plugins panel (Phase 3.2). Lists every plugin
@@ -72,6 +81,7 @@ export function PluginsCard() {
       );
       try {
         await setPluginEnabled(plugin.id, !plugin.enabled);
+        notifyAvailabilityChanged();
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
         setPlugins((prev) =>
@@ -93,6 +103,7 @@ export function PluginsCard() {
         await uninstallPlugin(pluginId);
         setPlugins((prev) => prev.filter((p) => p.id !== pluginId));
         setConfirmingUninstall(null);
+        notifyAvailabilityChanged();
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -204,7 +215,19 @@ export function PluginsCard() {
                         })}
                       />
                     </label>
-                    {isConfirming ? (
+                    {plugin.bundled ? (
+                      // Bundled plugins re-seed at every boot, so an
+                      // uninstall is just a one-launch ghost state.
+                      // Surface a passive label so the user knows
+                      // "Disable" is the right knob, not Uninstall.
+                      <span
+                        className="flex items-center gap-1 text-[11px] text-zinc-500 dark:text-zinc-400 italic"
+                        title={t("settings.plugins.bundledHint")}
+                      >
+                        <Package size={12} aria-hidden="true" />
+                        <span>{t("settings.plugins.bundled")}</span>
+                      </span>
+                    ) : isConfirming ? (
                       <div
                         role="group"
                         aria-label={t("settings.plugins.confirmUninstall", {

--- a/src/hooks/usePluginAvailability.ts
+++ b/src/hooks/usePluginAvailability.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+import { listInstalledPlugins } from "../lib/tauri/plugins";
+
+/// DOM event the Settings → Plugins UI dispatches whenever the user
+/// flips a plugin's enabled toggle or uninstalls a plugin. Hooks
+/// listening on this event re-fetch their availability snapshot —
+/// same lightweight bus pattern the Sidebar uses for the Spotify
+/// visibility toggle.
+export const PLUGIN_AVAILABILITY_EVENT = "waveflow:plugin-availability-changed";
+
+/// Resolve once at mount + every time someone dispatches
+/// [`PLUGIN_AVAILABILITY_EVENT`]. Returns `true` only when the
+/// plugin is installed AND its enabled flag is on. A missing or
+/// disabled plugin yields `false`; a backend error during the
+/// `list_installed_plugins` call also yields `false` (we'd rather
+/// hide a feature than crash the layout).
+///
+/// The Settings → Plugins panel is the only writer that fires the
+/// event so consumers don't poll. WebRadioView + Sidebar both
+/// consume this hook to gate their Web Radio surface.
+export function usePluginAvailability(pluginId: string): boolean {
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = () => {
+      listInstalledPlugins().then(
+        (plugins) => {
+          if (cancelled) return;
+          setAvailable(plugins.some((p) => p.id === pluginId && p.enabled));
+        },
+        () => {
+          if (cancelled) return;
+          setAvailable(false);
+        },
+      );
+    };
+    refresh();
+    window.addEventListener(PLUGIN_AVAILABILITY_EVENT, refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(PLUGIN_AVAILABILITY_EVENT, refresh);
+    };
+  }, [pluginId]);
+
+  return available;
+}

--- a/src/hooks/usePluginAvailability.ts
+++ b/src/hooks/usePluginAvailability.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { listInstalledPlugins } from "../lib/tauri/plugins";
 
@@ -21,17 +21,27 @@ export const PLUGIN_AVAILABILITY_EVENT = "waveflow:plugin-availability-changed";
 /// consume this hook to gate their Web Radio surface.
 export function usePluginAvailability(pluginId: string): boolean {
   const [available, setAvailable] = useState(false);
+  // Per-effect token counter. A rapid disable → enable sequence
+  // dispatches two events and starts two `listInstalledPlugins`
+  // calls in parallel; the slower one would otherwise resolve last
+  // and overwrite the fresh value with stale data. Each refresh
+  // captures its token, the `.then` continuation bails when the
+  // ref has moved on. The existing `cancelled` flag still covers
+  // unmount, but it can't distinguish two in-flight refreshes
+  // inside the same effect lifetime — hence the token.
+  const reqRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
     const refresh = () => {
+      const token = ++reqRef.current;
       listInstalledPlugins().then(
         (plugins) => {
-          if (cancelled) return;
+          if (cancelled || token !== reqRef.current) return;
           setAvailable(plugins.some((p) => p.id === pluginId && p.enabled));
         },
         () => {
-          if (cancelled) return;
+          if (cancelled || token !== reqRef.current) return;
           setAvailable(false);
         },
       );

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1297,7 +1297,9 @@
         "storageRead": "قراءة التخزين",
         "assets": "الموارد ({{count}})",
         "none": "لا توجد أذونات مطلوبة"
-      }
+      },
+      "bundled": "مدمج",
+      "bundledHint": "يأتي مع WaveFlow — قم بتعطيله لإخفائه."
     },
     "shortcuts": {
       "subtitle": "انقر على اختصار ثم اضغط على تركيبة المفاتيح المطلوبة. Backspace للمسح، Esc للإلغاء.",
@@ -1849,6 +1851,8 @@
     "searchPlaceholder": "ابحث عن محطة…",
     "backToCategories": "العودة إلى الفئات",
     "live": "مباشر",
-    "nowPlaying": "قيد التشغيل الآن"
+    "nowPlaying": "قيد التشغيل الآن",
+    "unavailableTitle": "Web Radio معطّل",
+    "unavailableHint": "فعّل إضافة Web Radio من الإعدادات → الإضافات لتصفح أكثر من 30,000 محطة."
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Speicherlesen",
         "assets": "Ressourcen ({{count}})",
         "none": "Keine Berechtigungen angefordert"
-      }
+      },
+      "bundled": "Mitgeliefert",
+      "bundledHint": "Mit WaveFlow ausgeliefert — deaktivieren, um es auszublenden."
     },
     "shortcuts": {
       "subtitle": "Klicke auf ein Tastenkürzel und drücke dann die gewünschte Tastenkombination. Rücktaste zum Löschen, Esc zum Abbrechen.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Sender suchen…",
     "backToCategories": "Zurück zu den Kategorien",
     "live": "LIVE",
-    "nowPlaying": "Läuft gerade"
+    "nowPlaying": "Läuft gerade",
+    "unavailableTitle": "Web Radio ist deaktiviert",
+    "unavailableHint": "Aktivieren Sie das Web Radio-Plugin in Einstellungen → Plugins, um über 30 000 Sender zu durchsuchen."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Storage read",
         "assets": "Assets ({{count}})",
         "none": "No permission requested"
-      }
+      },
+      "bundled": "Built-in",
+      "bundledHint": "Ships with WaveFlow — disable it to hide it."
     },
     "shortcuts": {
       "subtitle": "Click a shortcut then press the key combination you want. Backspace to clear, Escape to cancel.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Search a station…",
     "backToCategories": "Back to categories",
     "live": "LIVE",
-    "nowPlaying": "Now playing"
+    "nowPlaying": "Now playing",
+    "unavailableTitle": "Web Radio is disabled",
+    "unavailableHint": "Enable the Web Radio plugin in Settings → Plugins to browse 30,000+ stations."
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Lectura de almacenamiento",
         "assets": "Recursos ({{count}})",
         "none": "Sin permisos solicitados"
-      }
+      },
+      "bundled": "Integrado",
+      "bundledHint": "Incluido con WaveFlow — desactívalo para ocultarlo."
     },
     "shortcuts": {
       "subtitle": "Haz clic en un atajo y pulsa la combinación de teclas que quieras. Retroceso para borrar, Esc para cancelar.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Buscar una emisora…",
     "backToCategories": "Volver a las categorías",
     "live": "EN VIVO",
-    "nowPlaying": "Reproduciendo ahora"
+    "nowPlaying": "Reproduciendo ahora",
+    "unavailableTitle": "Web Radio está desactivada",
+    "unavailableHint": "Activa el plugin de Web Radio en Ajustes → Plugins para explorar más de 30 000 estaciones."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Lecture du stockage",
         "assets": "Ressources ({{count}})",
         "none": "Aucune permission demandée"
-      }
+      },
+      "bundled": "Inclus",
+      "bundledHint": "Livré avec WaveFlow — désactivez-le pour le masquer."
     },
     "categoryNavLabel": "Catégories des paramètres",
     "appearance": {
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Rechercher une station…",
     "backToCategories": "Retour aux catégories",
     "live": "LIVE",
-    "nowPlaying": "Lecture en cours"
+    "nowPlaying": "Lecture en cours",
+    "unavailableTitle": "Web Radio désactivée",
+    "unavailableHint": "Activez le plugin Web Radio dans Réglages → Plugins pour parcourir plus de 30 000 stations."
   }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1293,7 +1293,9 @@
         "storageRead": "संग्रहण पढ़ना",
         "assets": "संपत्तियाँ ({{count}})",
         "none": "कोई अनुमति अनुरोधित नहीं"
-      }
+      },
+      "bundled": "अंतर्निहित",
+      "bundledHint": "WaveFlow के साथ शामिल — छुपाने के लिए अक्षम करें।"
     },
     "shortcuts": {
       "subtitle": "किसी शॉर्टकट पर क्लिक करें फिर अपनी इच्छित कुंजी संयोजन दबाएँ। साफ़ करने के लिए Backspace, रद्द करने के लिए Escape।",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "स्टेशन खोजें…",
     "backToCategories": "श्रेणियों पर वापस",
     "live": "लाइव",
-    "nowPlaying": "अभी चल रहा है"
+    "nowPlaying": "अभी चल रहा है",
+    "unavailableTitle": "Web Radio अक्षम है",
+    "unavailableHint": "30,000+ स्टेशन ब्राउज़ करने के लिए सेटिंग्स → प्लगइन्स में Web Radio प्लगइन सक्षम करें।"
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Baca penyimpanan",
         "assets": "Aset ({{count}})",
         "none": "Tidak ada izin diminta"
-      }
+      },
+      "bundled": "Bawaan",
+      "bundledHint": "Disertakan dengan WaveFlow — nonaktifkan untuk menyembunyikannya."
     },
     "shortcuts": {
       "subtitle": "Klik sebuah pintasan lalu tekan kombinasi tombol yang kamu inginkan. Backspace untuk menghapus, Esc untuk membatalkan.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Cari stasiun…",
     "backToCategories": "Kembali ke kategori",
     "live": "LANGSUNG",
-    "nowPlaying": "Sedang diputar"
+    "nowPlaying": "Sedang diputar",
+    "unavailableTitle": "Web Radio dinonaktifkan",
+    "unavailableHint": "Aktifkan plugin Web Radio di Pengaturan → Plugin untuk menjelajahi lebih dari 30.000 stasiun."
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Lettura archivio",
         "assets": "Risorse ({{count}})",
         "none": "Nessun permesso richiesto"
-      }
+      },
+      "bundled": "Integrato",
+      "bundledHint": "Incluso in WaveFlow — disattivalo per nasconderlo."
     },
     "shortcuts": {
       "subtitle": "Clicca su una scorciatoia e premi la combinazione di tasti desiderata. Backspace per cancellare, Esc per annullare.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Cerca una stazione…",
     "backToCategories": "Torna alle categorie",
     "live": "LIVE",
-    "nowPlaying": "In riproduzione"
+    "nowPlaying": "In riproduzione",
+    "unavailableTitle": "Web Radio è disattivata",
+    "unavailableHint": "Attiva il plugin Web Radio in Impostazioni → Plugin per sfogliare oltre 30 000 stazioni."
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1293,7 +1293,9 @@
         "storageRead": "ストレージ読み取り",
         "assets": "アセット ({{count}})",
         "none": "要求された権限はありません"
-      }
+      },
+      "bundled": "組み込み",
+      "bundledHint": "WaveFlow に同梱されています — 非表示にするには無効にしてください。"
     },
     "integrations": {
       "lastfm": {
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "ステーションを検索…",
     "backToCategories": "カテゴリーに戻る",
     "live": "ライブ",
-    "nowPlaying": "再生中"
+    "nowPlaying": "再生中",
+    "unavailableTitle": "Web Radio は無効です",
+    "unavailableHint": "30,000 以上の放送局を閲覧するには、設定 → プラグイン で Web Radio プラグインを有効にしてください。"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1293,7 +1293,9 @@
         "storageRead": "스토리지 읽기",
         "assets": "자산 ({{count}})",
         "none": "요청된 권한 없음"
-      }
+      },
+      "bundled": "내장",
+      "bundledHint": "WaveFlow에 포함되어 있습니다 — 숨기려면 비활성화하세요."
     },
     "shortcuts": {
       "subtitle": "단축키를 클릭한 후 원하는 키 조합을 누르세요. 지우려면 Backspace, 취소하려면 Escape를 누르세요.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "방송국 검색…",
     "backToCategories": "카테고리로 돌아가기",
     "live": "라이브",
-    "nowPlaying": "재생 중"
+    "nowPlaying": "재생 중",
+    "unavailableTitle": "Web Radio가 비활성화됨",
+    "unavailableHint": "30,000개 이상의 방송국을 탐색하려면 설정 → 플러그인에서 Web Radio 플러그인을 활성화하세요."
   }
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Opslag lezen",
         "assets": "Resources ({{count}})",
         "none": "Geen rechten gevraagd"
-      }
+      },
+      "bundled": "Ingebouwd",
+      "bundledHint": "Meegeleverd met WaveFlow — schakel het uit om het te verbergen."
     },
     "shortcuts": {
       "subtitle": "Klik op een sneltoets en druk vervolgens op de gewenste toetscombinatie. Backspace om te wissen, Esc om te annuleren.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Zoek een station…",
     "backToCategories": "Terug naar categorieën",
     "live": "LIVE",
-    "nowPlaying": "Speelt nu"
+    "nowPlaying": "Speelt nu",
+    "unavailableTitle": "Web Radio is uitgeschakeld",
+    "unavailableHint": "Schakel de Web Radio-plugin in via Instellingen → Plugins om meer dan 30.000 stations te doorzoeken."
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Leitura de armazenamento",
         "assets": "Recursos ({{count}})",
         "none": "Nenhuma permissão solicitada"
-      }
+      },
+      "bundled": "Integrado",
+      "bundledHint": "Incluído com o WaveFlow — desative para ocultá-lo."
     },
     "shortcuts": {
       "subtitle": "Clique em um atalho e pressione a combinação de teclas que você quer. Backspace para limpar, Esc para cancelar.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Pesquisar uma estação…",
     "backToCategories": "Voltar para categorias",
     "live": "AO VIVO",
-    "nowPlaying": "Tocando agora"
+    "nowPlaying": "Tocando agora",
+    "unavailableTitle": "Web Radio está desativada",
+    "unavailableHint": "Ative o plugin Web Radio em Configurações → Plugins para explorar mais de 30 000 estações."
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Leitura de armazenamento",
         "assets": "Recursos ({{count}})",
         "none": "Nenhuma permissão pedida"
-      }
+      },
+      "bundled": "Integrado",
+      "bundledHint": "Incluído no WaveFlow — desative-o para o ocultar."
     },
     "shortcuts": {
       "subtitle": "Clica num atalho e prime a combinação de teclas que desejas. Backspace para limpar, Escape para cancelar.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "Pesquisar uma estação…",
     "backToCategories": "Voltar às categorias",
     "live": "AO VIVO",
-    "nowPlaying": "A reproduzir agora"
+    "nowPlaying": "A reproduzir agora",
+    "unavailableTitle": "Web Radio está desativada",
+    "unavailableHint": "Ative o plugin Web Radio em Definições → Plugins para explorar mais de 30 000 estações."
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1334,7 +1334,9 @@
         "storageRead": "Чтение хранилища",
         "assets": "Ресурсы ({{count}})",
         "none": "Права не запрошены"
-      }
+      },
+      "bundled": "Встроенный",
+      "bundledHint": "Поставляется с WaveFlow — отключите, чтобы скрыть."
     },
     "shortcuts": {
       "subtitle": "Нажмите на сочетание клавиш, затем введите нужную комбинацию. Backspace — очистить, Esc — отменить.",
@@ -1890,6 +1892,8 @@
     "searchPlaceholder": "Поиск станции…",
     "backToCategories": "К категориям",
     "live": "ЭФИР",
-    "nowPlaying": "Сейчас играет"
+    "nowPlaying": "Сейчас играет",
+    "unavailableTitle": "Web Radio отключено",
+    "unavailableHint": "Включите плагин Web Radio в Настройки → Плагины, чтобы просматривать более 30 000 станций."
   }
 }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1293,7 +1293,9 @@
         "storageRead": "Depolama okuma",
         "assets": "Varlıklar ({{count}})",
         "none": "İstenen izin yok"
-      }
+      },
+      "bundled": "Yerleşik",
+      "bundledHint": "WaveFlow ile birlikte gelir — gizlemek için devre dışı bırakın."
     },
     "shortcuts": {
       "subtitle": "Bir kısayola tıkla ve ardından istediğin tuş kombinasyonuna bas. Silmek için Backspace, iptal için Esc.",
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "İstasyon ara…",
     "backToCategories": "Kategorilere dön",
     "live": "CANLI",
-    "nowPlaying": "Şimdi çalıyor"
+    "nowPlaying": "Şimdi çalıyor",
+    "unavailableTitle": "Web Radio devre dışı",
+    "unavailableHint": "30.000'den fazla istasyona göz atmak için Ayarlar → Plugin'ler bölümünden Web Radio plugin'ini etkinleştirin."
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1293,7 +1293,9 @@
         "storageRead": "读取存储",
         "assets": "资源 ({{count}})",
         "none": "未请求任何权限"
-      }
+      },
+      "bundled": "内置",
+      "bundledHint": "随 WaveFlow 提供 — 禁用以隐藏。"
     },
     "integrations": {
       "lastfm": {
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "搜索电台…",
     "backToCategories": "返回分类",
     "live": "直播",
-    "nowPlaying": "正在播放"
+    "nowPlaying": "正在播放",
+    "unavailableTitle": "Web Radio 已禁用",
+    "unavailableHint": "在 设置 → 插件 中启用 Web Radio 插件以浏览超过 30,000 个电台。"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1293,7 +1293,9 @@
         "storageRead": "讀取儲存",
         "assets": "資源 ({{count}})",
         "none": "未請求任何權限"
-      }
+      },
+      "bundled": "內建",
+      "bundledHint": "隨 WaveFlow 提供 — 停用以隱藏。"
     },
     "integrations": {
       "lastfm": {
@@ -1845,6 +1847,8 @@
     "searchPlaceholder": "搜尋電台…",
     "backToCategories": "返回分類",
     "live": "直播",
-    "nowPlaying": "正在播放"
+    "nowPlaying": "正在播放",
+    "unavailableTitle": "Web Radio 已停用",
+    "unavailableHint": "在 設定 → 外掛 中啟用 Web Radio 外掛以瀏覽超過 30,000 個電台。"
   }
 }

--- a/src/lib/tauri/plugins.ts
+++ b/src/lib/tauri/plugins.ts
@@ -24,6 +24,11 @@ export interface PluginInfo {
   /** Resolved from `app_setting['plugin.<id>.enabled']`. Defaults
    *  to `true` for a freshly-installed plugin (no setting row). */
   enabled: boolean;
+  /** `true` when the plugin ships inside the WaveFlow installer and
+   *  is re-seeded at every boot. The Settings UI hides "Uninstall"
+   *  for these rows; the backend mirrors this by refusing
+   *  `uninstall_plugin` on bundled ids. */
+  bundled: boolean;
 }
 
 export interface PluginPermissionsInfo {


### PR DESCRIPTION
## Context

The Web Radio plugin is bundled with WaveFlow and re-seeded at every boot by [`ensure_bundled_plugins`](src-tauri/crates/app/src/state.rs). Today, three rough edges around its lifecycle:

1. **Uninstall has no effect after restart.** Clicking Uninstall in Settings → Plugins wipes `<plugins_root>/web-radio/` and drops the `app_setting` row — then the next launch's boot extractor finds the install dir missing and re-copies the plugin. The user sees the plugin "come back" with no UI explanation; reads as a bug.
2. **Disable leaves stale UI.** The sidebar "Web Radio" entry is hardcoded, so disabling the plugin leaves the entry visible. Clicking it lands on `WebRadioView` with the raw `"plugin disabled: web-radio"` error banner and an empty grid below.
3. **Uninstalling a plugin during an active stream orphans it.** Once a stream URL has been minted, the cpal engine doesn't know which plugin it came from. Removing the install dir while audio is playing leaves a stream with no owner.

## Changes

### Backend (`src-tauri/crates/app/src/`)

- [`state.rs`](src-tauri/crates/app/src/state.rs) — exposes `is_bundled_plugin(id)` over the existing `BUNDLED_PLUGINS` constant.
- [`commands/plugins.rs`](src-tauri/crates/app/src/commands/plugins.rs)
  - `PluginInfo` gains `bundled: bool` so the UI can render the right surface.
  - `uninstall_plugin` refuses bundled ids upfront with a clear error (`plugin {id} is bundled with WaveFlow and cannot be uninstalled (disable it instead)`). The frontend hides the button entirely on bundled rows; the backend-side gate is the second line of defence.
  - `uninstall_plugin` stops the engine when `engine.shared().current_track_id < 0` (the negative-id sentinel `player_play_url` mints for every URL stream) before `remove_dir_all`. A library track is left alone. Plugin id isn't currently round-tripped to the engine, so this stops *any* URL stream — accepted trade-off vs orphaning an active stream whose source has just been removed.

### Frontend

- New [`src/hooks/usePluginAvailability.ts`](src/hooks/usePluginAvailability.ts) — resolves `installed && enabled` for a given plugin id, refreshes on the `waveflow:plugin-availability-changed` DOM event. Same lightweight bus the Spotify visibility toggle already uses.
- [`Sidebar.tsx`](src/components/layout/Sidebar.tsx) — conditions the Web Radio nav entry on `usePluginAvailability("web-radio")`.
- [`WebRadioView.tsx`](src/components/views/WebRadioView.tsx) — `isPluginUnavailableError()` sniffs the backend error for `"plugin disabled" | "plugin not installed" | "manifest id mismatch"`. When that matches OR the availability hook reports false, the view renders a Puzzle empty state pointing the user at Settings → Plugins instead of stacking a red banner on a stale grid.
- [`PluginsCard.tsx`](src/components/views/settings/PluginsCard.tsx) — renders a passive `Built-in` badge on bundled rows in place of the Uninstall button; fires the availability event on toggle + uninstall so consumers refresh.
- [`lib/tauri/plugins.ts`](src/lib/tauri/plugins.ts) — `PluginInfo` mirrors the new `bundled` field.

### i18n

Four new keys (`settings.plugins.bundled`, `settings.plugins.bundledHint`, `webRadio.unavailableTitle`, `webRadio.unavailableHint`) propagated to all 17 locales via [`scripts/add_bundled_plugin_i18n.py`](scripts/add_bundled_plugin_i18n.py) (idempotent — safe to re-run).

## Test plan

- [x] **Bundled refuses uninstall (backend):** patch `BUNDLED_PLUGINS` test-side, call `uninstall_plugin("web-radio")`, expect the typed error.
- [x] **Bundled badge replaces Uninstall (UI):** Settings → Plugins shows "Built-in" on the Web Radio row, no Uninstall button.
- [x] **Disable hides sidebar entry:** disable Web Radio in Settings → sidebar entry vanishes within a tick; re-enable → entry reappears.
- [x] **Disable empty-state in view:** open Web Radio view → disable plugin from Settings in another tab → view auto-switches to the Puzzle empty-state (no red banner).
- [x] **Backend stop-on-uninstall (manual third-party):** sideload a non-bundled plugin (or temporarily blank `BUNDLED_PLUGINS`), start its stream, uninstall mid-playback → engine stops cleanly, no orphan stream.
- [x] **i18n parity:** spot-check 3 locales (e.g. ja, ar, de) to confirm the bundled hint + webRadio.unavailableHint render and respect RTL on Arabic.
- [x] `bun run typecheck` ✅
- [x] `bun run lint` (excluding `.agents/` and `.claude/` skill scripts that ship pre-existing no-undef warnings) ✅
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de Version

* **Nouvelles Fonctionnalités**
  * Les plugins intégrés (“bundled”) sont désormais identifiés : ils peuvent être désactivés mais restent non désinstallables.
  * Mise à jour en temps réel de la disponibilité des plugins dans toute l’interface.
  * Page d’état dédiée pour Web Radio lorsqu’elle est désactivée (avec titre et conseil pour l’activer).

* **Améliorations**
  * Navigation et contenu ajustés automatiquement selon l’état du plugin (entrée web radio masquée si indisponible).
  * Tracés d’interface et libellés i18n mis à jour pour Web Radio et les plugins intégrés (17 langues).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->