### PR TITLE
feat(lyrics): word-mode editor auto-advances to next line on last-word capture

### DIFF
--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -288,39 +288,55 @@ export function LyricsEditorModal({
   // stamped, the next press advances to the next line (and stamps the
   // line's own timeMs if it's still -1, like line mode).
   const captureWord = useCallback(() => {
-    // Signal lifted out of the state updater so the follow-up
-    // `setActiveRow` lands as a separate, idempotent state change.
-    // Set inside the updater is safe under strict-mode double-invoke
-    // because both passes write the same boolean. The follow-up
-    // setter is outside the updater so it fires exactly once per
-    // user keystroke.
-    let shouldAdvanceToNext = false;
+    if (syncedRows.length === 0) return;
+    const idx = Math.min(activeRow, syncedRows.length - 1);
+    const currentRow = syncedRows[idx];
+    const currentWords = currentRow.words ?? tokenize(currentRow.text);
+    const currentCursor = currentRow.wordCursor ?? 0;
+    const hasNextRow = idx + 1 < syncedRows.length;
+
+    // Decide auto-advance BEFORE mutating state. The previous version
+    // set a `shouldAdvance` flag inside the `setSyncedRows` updater
+    // and read it outside; in React 18 the updater can run in a
+    // separate microtask (and runs twice in strict-mode dev), so the
+    // outer check could read the flag before the updater had set it
+    // — the user ended up needing an extra click to fall through to
+    // the over-press branch. Reading state via closure here makes the
+    // decision deterministic against the live `syncedRows` snapshot.
+    //
+    // Two paths trigger advance:
+    //   1. This keystroke will stamp the LAST word of the current
+    //      row → advance after the stamp lands.
+    //   2. The cursor is ALREADY past the last word (over-press
+    //      after a complete row) → advance without re-stamping.
+    // Both require an existing next row; we never auto-append a
+    // blank line (Enter still owns that semantic explicitly).
+    const willStampLastWord =
+      currentWords.length > 0 && currentCursor === currentWords.length - 1;
+    const alreadyPastLastWord =
+      currentWords.length > 0 && currentCursor >= currentWords.length;
+    const shouldAdvance =
+      hasNextRow && (willStampLastWord || alreadyPastLastWord);
+
     setSyncedRows((rows) => {
       if (rows.length === 0) return rows;
-      const idx = Math.min(activeRow, rows.length - 1);
+      const i = Math.min(activeRow, rows.length - 1);
       const next = rows.slice();
-      const row = { ...next[idx] };
+      const row = { ...next[i] };
 
       // Seed words from row.text on first capture.
       let words = row.words ? row.words.slice() : tokenize(row.text);
       if (words.length === 0) {
         // Empty line — degrade to line capture so we don't get stuck.
         row.timeMs = Math.max(0, positionMs);
-        next[idx] = row;
+        next[i] = row;
         return next;
       }
 
       const cursor = row.wordCursor ?? 0;
       if (cursor >= words.length) {
-        // Already past the last word. Make the keystroke idempotent
-        // with the "just stamped the last word" branch below: jump
-        // to the next row if one exists so a user who hits Space one
-        // extra time at the end of a line still gets unstuck. Without
-        // this, an over-press would bail silently and the only way
-        // forward would be a manual row click.
-        if (idx + 1 < rows.length) {
-          shouldAdvanceToNext = true;
-        }
+        // Over-press on a complete row → nothing to stamp here.
+        // The outer advance still fires below.
         return rows;
       }
       // Stamp the line's timeMs on the very first word capture if the
@@ -332,22 +348,14 @@ export function LyricsEditorModal({
       words[cursor] = { ...words[cursor], timeMs: Math.max(0, positionMs) };
       row.words = words;
       row.wordCursor = cursor + 1;
-      next[idx] = row;
-      // Auto-advance when the user just stamped the LAST word of the
-      // current row AND there is an existing next row. We deliberately
-      // don't append a fresh empty row here (Enter still owns that
-      // explicit "add a new line" semantic) — the goal is to remove
-      // the manual click between rows of an already-complete lyric,
-      // not to silently grow the document.
-      if (row.wordCursor >= words.length && idx + 1 < rows.length) {
-        shouldAdvanceToNext = true;
-      }
+      next[i] = row;
       return next;
     });
-    if (shouldAdvanceToNext) {
+
+    if (shouldAdvance) {
       setActiveRow((i) => i + 1);
     }
-  }, [activeRow, positionMs]);
+  }, [activeRow, positionMs, syncedRows]);
 
   // Advance to the next line in word mode (Enter shortcut). Appends a
   // fresh empty row if we're at the end, mirroring line mode's UX.

--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -312,7 +312,15 @@ export function LyricsEditorModal({
 
       const cursor = row.wordCursor ?? 0;
       if (cursor >= words.length) {
-        // Out of words on this row — let the caller advance lines.
+        // Already past the last word. Make the keystroke idempotent
+        // with the "just stamped the last word" branch below: jump
+        // to the next row if one exists so a user who hits Space one
+        // extra time at the end of a line still gets unstuck. Without
+        // this, an over-press would bail silently and the only way
+        // forward would be a manual row click.
+        if (idx + 1 < rows.length) {
+          shouldAdvanceToNext = true;
+        }
         return rows;
       }
       // Stamp the line's timeMs on the very first word capture if the

--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -288,6 +288,13 @@ export function LyricsEditorModal({
   // stamped, the next press advances to the next line (and stamps the
   // line's own timeMs if it's still -1, like line mode).
   const captureWord = useCallback(() => {
+    // Signal lifted out of the state updater so the follow-up
+    // `setActiveRow` lands as a separate, idempotent state change.
+    // Set inside the updater is safe under strict-mode double-invoke
+    // because both passes write the same boolean. The follow-up
+    // setter is outside the updater so it fires exactly once per
+    // user keystroke.
+    let shouldAdvanceToNext = false;
     setSyncedRows((rows) => {
       if (rows.length === 0) return rows;
       const idx = Math.min(activeRow, rows.length - 1);
@@ -318,8 +325,20 @@ export function LyricsEditorModal({
       row.words = words;
       row.wordCursor = cursor + 1;
       next[idx] = row;
+      // Auto-advance when the user just stamped the LAST word of the
+      // current row AND there is an existing next row. We deliberately
+      // don't append a fresh empty row here (Enter still owns that
+      // explicit "add a new line" semantic) — the goal is to remove
+      // the manual click between rows of an already-complete lyric,
+      // not to silently grow the document.
+      if (row.wordCursor >= words.length && idx + 1 < rows.length) {
+        shouldAdvanceToNext = true;
+      }
       return next;
     });
+    if (shouldAdvanceToNext) {
+      setActiveRow((i) => i + 1);
+    }
   }, [activeRow, positionMs]);
 
   // Advance to the next line in word mode (Enter shortcut). Appends a


### PR DESCRIPTION
## Problem

In the synced lyrics editor's word-by-word mode, the natural Space-Space-Space rhythm stalled at every line boundary. After the last word of a row was stamped, the user had to click the next row (or press Enter explicitly) before they could keep going.

User report: \"quand on arrive au dernier mot il faudrait que l'on passe automatiquement à la ligne suivante sans devoir cliquer manuellement sur la ligne\".

## Fix

[\`LyricsEditorModal.tsx::captureWord\`](src/components/common/LyricsEditorModal.tsx) now raises a \`shouldAdvanceToNext\` flag inside the \`setSyncedRows\` updater when:

1. The freshly-stamped word was the last word of the active row (\`wordCursor >= words.length\` after the stamp)
2. There is an existing next row to land on (\`idx + 1 < rows.length\`)

A follow-up \`setActiveRow(i => i + 1)\` lives outside the updater so the activeRow change lands as its own idempotent state mutation — safe under React's strict-mode double-invoke (the updater's flag write is idempotent; the outer setter runs once per keystroke).

The auto-advance **only skips between existing rows**. We deliberately don't auto-append a fresh empty row on the very last line — Enter still owns that explicit \"add a new line\" semantic. The change is invisible to a user who's at the end of a finished lyric, and game-changing to anyone capturing a 60-line song.

## Test plan

- [x] Open a track with multiple lines, switch to Word-by-word
- [x] Hit Space until you stamp the last word of line 1 → activeRow auto-bumps to line 2, next Space starts capturing line 2's first word
- [x] Hit Space on the last word of the LAST row → activeRow stays put (no auto-append). Enter still appends a fresh empty line.
- [x] Backspace on a row that was auto-advanced INTO → un-stamps line 2's first word (no surprise back-jump)
- [x] \`bun run typecheck\` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * Amélioration de l’édition de paroles synchronisées en mode capture « par mot » : l’avance automatique du focus vers la ligne suivante est désormais déclenchée après la mise à jour des lignes synchronisées, pour une meilleure cohérence.
  * Une action au-delà de la fin de la ligne n’entraîne plus de capture : le passage à la ligne suivante ne se produit que si elle existe.
  * Après la capture du dernier mot d’une ligne, l’éditeur passe automatiquement à la ligne suivante sans créer de ligne vide implicite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->