### PR TITLE
fix(locales): fr _zero plurals + zh-CN/zh-TW CJK punctuation cleanup

### DIFF
--- a/scripts/fix_locales_mechanical.py
+++ b/scripts/fix_locales_mechanical.py
@@ -1,0 +1,189 @@
+"""Mechanical i18n cleanup — cluster 3 (post-validator pass-2).
+
+Two systemic bugs the AI validator surfaced after #268 + #269 landed:
+
+1. **fr `_zero` keys at singular instead of plural.** French grammar
+   requires a plural noun after `0` (unlike English, where `0 track`
+   is singular). The first JSON authoring pass borrowed the English
+   plural rules and parked every `_zero` form at singular, which the
+   validator caught across ~25 keys.
+
+2. **zh-CN + zh-TW half-width ASCII punctuation inside CJK text.**
+   CJK conventions use full-width `，` `：` `（` `）` between Chinese
+   characters; the source JSON drifted to half-width `,` `:` `(` `)`
+   in many places. The validator flagged this in both Chinese
+   locales.
+
+Idempotent — re-running on already-clean files is a no-op. Returns
+non-zero only when a locale file the script expected isn't on disk.
+
+Run from repo root:
+    python scripts/fix_locales_mechanical.py
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# --- Section 1 — French `_zero` pluralisation ------------------------
+
+# Map of singular → plural noun stems. The script walks every leaf
+# string whose key ends with `_zero` and, when the value starts with
+# the singular stem, rewrites it to the plural. Stems that the
+# validator did NOT flag (idiomatic alternatives like `"Aucun résultat"`
+# or `"Rien à supprimer"`) are deliberately absent from this map so
+# the script leaves them alone.
+FR_ZERO_FIXES = {
+    "0 titre": "0 titres",
+    "0 album": "0 albums",
+    "0 artiste": "0 artistes",
+    "0 genre": "0 genres",
+    "0 dossier": "0 dossiers",
+    "0 écoute": "0 écoutes",
+    "0 minute de musique": "0 minutes de musique",
+    "0 jour d'affilée": "0 jours d'affilée",
+    "0 sélectionné": "0 sélectionnés",
+}
+
+
+def walk(obj, path=""):
+    """Recursively yield (dotted-path, value) for every leaf string."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield from walk(v, f"{path}.{k}" if path else k)
+    elif isinstance(obj, str):
+        yield path, obj
+
+
+def set_path(data, dotted, value):
+    cursor = data
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        cursor = cursor[part]
+    cursor[parts[-1]] = value
+
+
+def fix_fr_plurals(data) -> int:
+    """Walk the loaded fr.json tree and apply the singular→plural map
+    to every `_zero` leaf. Returns the number of keys mutated."""
+    fixed = 0
+    for path, value in list(walk(data)):
+        if not path.endswith("_zero"):
+            continue
+        new_value = FR_ZERO_FIXES.get(value)
+        if new_value is None or new_value == value:
+            continue
+        set_path(data, path, new_value)
+        fixed += 1
+    return fixed
+
+
+# --- Section 2 — CJK punctuation -------------------------------------
+
+# `一-鿿` is the CJK Unified Ideographs block — enough for
+# both zh-CN and zh-TW common ideographs. Half-width punctuation that
+# appears in a CJK context should be replaced with the full-width
+# variant.
+CJK = r"[一-鿿]"
+
+# Patterns we touch unconditionally when both sides are CJK. The
+# question / bang variants also fire when the punctuation lands at
+# end-of-string after a CJK character — those still belong in
+# full-width form even when not followed by more CJK content.
+_COMMA_RE = re.compile(rf"(?<={CJK}),(?={CJK})")
+_COLON_RE = re.compile(rf"(?<={CJK}):(?={CJK})")
+_QMARK_RE = re.compile(rf"(?<={CJK})\?(?={CJK}|$)")
+_BANG_RE = re.compile(rf"(?<={CJK})!(?={CJK}|$)")
+
+# Parentheses: only convert paired `(content)` when the LEFT outer
+# neighbour is CJK AND the content is purely CJK (no Latin, no digits,
+# no braces). That keeps `(A = {{a}})` and `(A → Z)` style annotations
+# at half-width — those are the CJK convention for Latin/expression
+# annotations.
+_PAREN_RE = re.compile(rf"({CJK})\(([^()]*)\)")
+
+
+def _paren_replace(match: re.Match) -> str:
+    before = match.group(1)
+    content = match.group(2)
+    has_cjk = re.search(CJK, content) is not None
+    has_non_cjk = re.search(r"[A-Za-z0-9{}→]", content) is not None
+    if has_cjk and not has_non_cjk:
+        return f"{before}（{content}）"
+    return match.group(0)
+
+
+def fix_cjk_punctuation(data) -> int:
+    """Walk a CJK locale tree and replace half-width punctuation
+    occurring in CJK contexts with the full-width variant. Returns
+    the number of leaf strings touched."""
+    touched = 0
+    for path, value in list(walk(data)):
+        new_value = _COMMA_RE.sub("，", value)
+        new_value = _COLON_RE.sub("：", new_value)
+        new_value = _QMARK_RE.sub("？", new_value)
+        new_value = _BANG_RE.sub("！", new_value)
+        new_value = _PAREN_RE.sub(_paren_replace, new_value)
+        if new_value != value:
+            set_path(data, path, new_value)
+            touched += 1
+    return touched
+
+
+# --- Wire it ---------------------------------------------------------
+
+def patch_locale(path: Path, code: str) -> int:
+    """Apply the appropriate fixer(s) for `code` to the file at
+    `path`. Returns the number of leaf strings mutated, or -1 if
+    `code` has no scheduled fixes."""
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if code == "fr":
+        touched = fix_fr_plurals(data)
+    elif code in ("zh-CN", "zh-TW"):
+        touched = fix_cjk_punctuation(data)
+    else:
+        return -1
+    if touched == 0:
+        return 0
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+    return touched
+
+
+def main() -> int:
+    here = Path(__file__).resolve().parent.parent / "src" / "i18n" / "locales"
+    sys.stdout.reconfigure(encoding="utf-8")
+    changed: list[tuple[str, int]] = []
+    skipped: list[str] = []
+    missing: list[str] = []
+    for code in ("fr", "zh-CN", "zh-TW"):
+        path = here / f"{code}.json"
+        if not path.exists():
+            missing.append(code)
+            continue
+        touched = patch_locale(path, code)
+        if touched > 0:
+            changed.append((code, touched))
+        else:
+            skipped.append(code)
+    changed_summary = (
+        ", ".join(f"{code} ({n})" for code, n in changed) if changed else "(none)"
+    )
+    print(f"changed ({len(changed)}): {changed_summary}")
+    print(f"skipped ({len(skipped)}): {', '.join(skipped) or '(none)'}")
+    if missing:
+        print(
+            f"missing ({len(missing)}): {', '.join(missing)} — "
+            "expected locale file(s) not found",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fix_locales_mechanical.py
+++ b/scripts/fix_locales_mechanical.py
@@ -97,21 +97,39 @@ _COLON_RE = re.compile(rf"(?<={CJK}):(?={CJK})")
 _QMARK_RE = re.compile(rf"(?<={CJK})\?(?={CJK}|$)")
 _BANG_RE = re.compile(rf"(?<={CJK})!(?={CJK}|$)")
 
-# Parentheses: only convert paired `(content)` when the LEFT outer
-# neighbour is CJK AND the content is purely CJK (no Latin, no digits,
-# no braces). That keeps `(A = {{a}})` and `(A → Z)` style annotations
-# at half-width — those are the CJK convention for Latin/expression
-# annotations.
-_PAREN_RE = re.compile(rf"({CJK})\(([^()]*)\)")
+# Parentheses run TWO directions to enforce the same convention:
+#
+# 1. Half-width → full-width when the paren follows CJK AND the
+#    content inside is purely CJK. Keeps `(A = {{a}})` and
+#    `(A → Z)` style annotations at half-width — that's the CJK
+#    convention for Latin/expression parentheticals.
+# 2. Full-width → half-width when the paren content carries any
+#    Latin / digit / template-variable character. Cleans up
+#    pre-existing strings like `（MP3、FLAC、ALAC、…）` or
+#    `（{{count}} 个字段）` where the original authoring pass used
+#    full-width parens around mixed content. Same rule as above,
+#    just applied in the opposite direction.
+_PAREN_HW_RE = re.compile(rf"({CJK})\(([^()]*)\)")
+_PAREN_FW_RE = re.compile(r"（([^（）]*)）")
+
+# Anything that disqualifies content from full-width parens.
+_PAREN_NON_CJK = re.compile(r"[A-Za-z0-9{}/=→]")
 
 
-def _paren_replace(match: re.Match) -> str:
+def _paren_hw_to_fw(match: re.Match) -> str:
     before = match.group(1)
     content = match.group(2)
     has_cjk = re.search(CJK, content) is not None
-    has_non_cjk = re.search(r"[A-Za-z0-9{}→]", content) is not None
+    has_non_cjk = _PAREN_NON_CJK.search(content) is not None
     if has_cjk and not has_non_cjk:
         return f"{before}（{content}）"
+    return match.group(0)
+
+
+def _paren_fw_to_hw(match: re.Match) -> str:
+    content = match.group(1)
+    if _PAREN_NON_CJK.search(content):
+        return f"({content})"
     return match.group(0)
 
 
@@ -125,7 +143,8 @@ def fix_cjk_punctuation(data) -> int:
         new_value = _COLON_RE.sub("：", new_value)
         new_value = _QMARK_RE.sub("？", new_value)
         new_value = _BANG_RE.sub("！", new_value)
-        new_value = _PAREN_RE.sub(_paren_replace, new_value)
+        new_value = _PAREN_HW_RE.sub(_paren_hw_to_fw, new_value)
+        new_value = _PAREN_FW_RE.sub(_paren_fw_to_hw, new_value)
         if new_value != value:
             set_path(data, path, new_value)
             touched += 1
@@ -136,10 +155,18 @@ def fix_cjk_punctuation(data) -> int:
 
 def patch_locale(path: Path, code: str) -> int:
     """Apply the appropriate fixer(s) for `code` to the file at
-    `path`. Returns the number of leaf strings mutated, or -1 if
-    `code` has no scheduled fixes."""
-    with path.open("r", encoding="utf-8") as fh:
-        data = json.load(fh)
+    `path`. Returns the number of leaf strings mutated, -1 if `code`
+    has no scheduled fixes, or -2 when the file failed to parse as
+    JSON (caller treats this as fatal alongside `missing`)."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as err:
+        print(
+            f"  parse error in {path}: line {err.lineno} col {err.colno}: {err.msg}",
+            file=sys.stderr,
+        )
+        return -2
     if code == "fr":
         touched = fix_fr_plurals(data)
     elif code in ("zh-CN", "zh-TW"):
@@ -160,13 +187,16 @@ def main() -> int:
     changed: list[tuple[str, int]] = []
     skipped: list[str] = []
     missing: list[str] = []
+    unparseable: list[str] = []
     for code in ("fr", "zh-CN", "zh-TW"):
         path = here / f"{code}.json"
         if not path.exists():
             missing.append(code)
             continue
         touched = patch_locale(path, code)
-        if touched > 0:
+        if touched == -2:
+            unparseable.append(code)
+        elif touched > 0:
             changed.append((code, touched))
         else:
             skipped.append(code)
@@ -181,8 +211,13 @@ def main() -> int:
             "expected locale file(s) not found",
             file=sys.stderr,
         )
-        return 1
-    return 0
+    if unparseable:
+        print(
+            f"unparseable ({len(unparseable)}): {', '.join(unparseable)} — "
+            "JSON parse failed (see lines above)",
+            file=sys.stderr,
+        )
+    return 1 if (missing or unparseable) else 0
 
 
 if __name__ == "__main__":

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -153,7 +153,7 @@
       "folder": "Dossier"
     },
     "library": {
-      "tracksCount_zero": "0 titre",
+      "tracksCount_zero": "0 titres",
       "tracksCount_one": "{{count}} titre",
       "tracksCount_other": "{{count}} titres",
       "createLibraryAria": "Créer une nouvelle bibliothèque",
@@ -162,10 +162,10 @@
         "label": "Sélection de la bibliothèque",
         "header": "Bibliothèques",
         "countLine": "{{tracks}} · {{albums}}",
-        "tracks_zero": "0 titre",
+        "tracks_zero": "0 titres",
         "tracks_one": "{{count}} titre",
         "tracks_other": "{{count}} titres",
-        "albums_zero": "0 album",
+        "albums_zero": "0 albums",
         "albums_one": "{{count}} album",
         "albums_other": "{{count}} albums",
         "see": "Voir",
@@ -186,7 +186,7 @@
       "importDialogTitle": "Importer une playlist M3U",
       "liked": "Titres aimés",
       "recent": "Récemment joués",
-      "emptySubtext_zero": "0 titre",
+      "emptySubtext_zero": "0 titres",
       "emptySubtext_one": "{{count}} titre",
       "emptySubtext_other": "{{count}} titres"
     },
@@ -203,7 +203,7 @@
       "title": "Playlists"
     },
     "myLibrary": {
-      "playlistSubtext_zero": "0 titre",
+      "playlistSubtext_zero": "0 titres",
       "playlistSubtext_one": "{{count}} titre",
       "playlistSubtext_other": "{{count}} titres"
     }
@@ -328,19 +328,19 @@
     "header": {
       "addFolder": "Ajouter un dossier",
       "subtext": {
-        "morceaux_zero": "0 titre",
+        "morceaux_zero": "0 titres",
         "morceaux_one": "{{count}} titre",
         "morceaux_other": "{{count}} titres",
-        "albums_zero": "0 album",
+        "albums_zero": "0 albums",
         "albums_one": "{{count}} album",
         "albums_other": "{{count}} albums",
-        "artistes_zero": "0 artiste",
+        "artistes_zero": "0 artistes",
         "artistes_one": "{{count}} artiste",
         "artistes_other": "{{count}} artistes",
-        "genres_zero": "0 genre",
+        "genres_zero": "0 genres",
         "genres_one": "{{count}} genre",
         "genres_other": "{{count}} genres",
-        "dossiers_zero": "0 dossier",
+        "dossiers_zero": "0 dossiers",
         "dossiers_one": "{{count}} dossier",
         "dossiers_other": "{{count}} dossiers"
       }
@@ -409,25 +409,25 @@
       "compact": "Compact"
     },
     "albumGrid": {
-      "trackCount_zero": "0 titre",
+      "trackCount_zero": "0 titres",
       "trackCount_one": "{{count}} titre",
       "trackCount_other": "{{count}} titres"
     },
     "artistList": {
-      "trackCount_zero": "0 titre",
+      "trackCount_zero": "0 titres",
       "trackCount_one": "{{count}} titre",
       "trackCount_other": "{{count}} titres",
-      "albumCount_zero": "0 album",
+      "albumCount_zero": "0 albums",
       "albumCount_one": "{{count}} album",
       "albumCount_other": "{{count}} albums"
     },
     "genreList": {
-      "trackCount_zero": "0 titre",
+      "trackCount_zero": "0 titres",
       "trackCount_one": "{{count}} titre",
       "trackCount_other": "{{count}} titres"
     },
     "folderList": {
-      "trackCount_zero": "0 titre",
+      "trackCount_zero": "0 titres",
       "trackCount_one": "{{count}} titre",
       "trackCount_other": "{{count}} titres",
       "lastScanned": "Scanné : {{date}}",
@@ -443,7 +443,7 @@
   "liked": {
     "badge": "Collection",
     "title": "Titres aimés",
-    "count_zero": "0 titre",
+    "count_zero": "0 titres",
     "count_one": "{{count}} titre",
     "count_other": "{{count}} titres",
     "emptyTitle": "Aucun titre aimé",
@@ -477,7 +477,7 @@
   "recent": {
     "badge": "Historique",
     "title": "Récemment joués",
-    "count_zero": "0 titre",
+    "count_zero": "0 titres",
     "count_one": "{{count}} titre",
     "count_other": "{{count}} titres",
     "emptyTitle": "Aucun titre récent",
@@ -504,7 +504,7 @@
       "totalPlays": "Écoutes",
       "totalTime": "Temps d'écoute",
       "uniqueTracks": "Titres uniques",
-      "uniqueArtists_zero": "0 artiste",
+      "uniqueArtists_zero": "0 artistes",
       "uniqueArtists_one": "{{count}} artiste",
       "uniqueArtists_other": "{{count}} artistes",
       "completionRate": "Taux d'écoute complète"
@@ -537,7 +537,7 @@
       "less": "Moins",
       "more": "Plus"
     },
-    "plays_zero": "0 écoute",
+    "plays_zero": "0 écoutes",
     "plays_one": "{{count}} écoute",
     "plays_other": "{{count}} écoutes"
   },
@@ -551,7 +551,7 @@
     "next": "Slide suivante",
     "yearPicker": "Choisir une année",
     "backToHome": "Retour à l'accueil",
-    "playsShort_zero": "0 écoute",
+    "playsShort_zero": "0 écoutes",
     "playsShort_one": "{{count}} écoute",
     "playsShort_other": "{{count}} écoutes",
     "empty": {
@@ -564,7 +564,7 @@
     },
     "minutes": {
       "eyebrow": "Vous avez écouté",
-      "subtitle_zero": "0 minute de musique",
+      "subtitle_zero": "0 minutes de musique",
       "subtitle_one": "{{count}} minute de musique",
       "subtitle_other": "{{count}} minutes de musique"
     },
@@ -604,7 +604,7 @@
     },
     "streak": {
       "eyebrow": "Votre plus longue série",
-      "daysLabel_zero": "0 jour d'affilée",
+      "daysLabel_zero": "0 jours d'affilée",
       "daysLabel_one": "{{count}} jour d'affilée",
       "daysLabel_other": "{{count}} jours d'affilée",
       "daysShort": "jours d'affilée",
@@ -709,7 +709,7 @@
   "queue": {
     "title": "File d'attente",
     "inactive": "INACTIF",
-    "count_zero": "0 titre",
+    "count_zero": "0 titres",
     "count_one": "{{count}} titre",
     "count_other": "{{count}} titres",
     "emptyTitle": "Rien à écouter",
@@ -804,7 +804,7 @@
   },
   "playlistView": {
     "badge": "Playlist",
-    "trackCount_zero": "0 titre",
+    "trackCount_zero": "0 titres",
     "trackCount_one": "{{count}} titre",
     "trackCount_other": "{{count}} titres",
     "actions": {
@@ -916,7 +916,7 @@
   },
   "selection": {
     "toolbarLabel": "Actions de sélection",
-    "count_zero": "0 sélectionné",
+    "count_zero": "0 sélectionnés",
     "count_one": "{{count}} sélectionné",
     "count_other": "{{count}} sélectionnés",
     "play": "Lecture",
@@ -930,7 +930,7 @@
     "badge": "Album",
     "playAll": "Tout lire",
     "shuffle": "Lecture aléatoire",
-    "trackCount_zero": "0 titre",
+    "trackCount_zero": "0 titres",
     "trackCount_one": "{{count}} titre",
     "trackCount_other": "{{count}} titres",
     "discHeader": "Disque {{number}}",
@@ -946,13 +946,13 @@
     "shuffle": "Lecture aléatoire",
     "discography": "Discographie",
     "allTracks": "Tous les titres",
-    "trackCount_zero": "0 titre",
+    "trackCount_zero": "0 titres",
     "trackCount_one": "{{count}} titre",
     "trackCount_other": "{{count}} titres",
-    "albumCount_zero": "0 album",
+    "albumCount_zero": "0 albums",
     "albumCount_one": "{{count}} album",
     "albumCount_other": "{{count}} albums",
-    "albumTrackCount_zero": "0 titre",
+    "albumTrackCount_zero": "0 titres",
     "albumTrackCount_one": "{{count}} titre",
     "albumTrackCount_other": "{{count}} titres",
     "emptyTitle": "Artiste introuvable",
@@ -977,7 +977,7 @@
     "badge": "Genre",
     "playAll": "Tout lire",
     "shuffle": "Lecture aléatoire",
-    "trackCount_zero": "0 titre",
+    "trackCount_zero": "0 titres",
     "trackCount_one": "{{count}} titre",
     "trackCount_other": "{{count}} titres",
     "emptyTitle": "Genre introuvable",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -132,8 +132,8 @@
       "unavailable": "资料暂不可用，请稍后再试。"
     },
     "lyrics": {
-      "title": "歌词保存在哪里?",
-      "description": "编辑歌词时,它们应该保存到何处?可在 设置 → 播放 中随时更改。",
+      "title": "歌词保存在哪里？",
+      "description": "编辑歌词时，它们应该保存到何处？可在 设置 → 播放 中随时更改。",
       "hint": "选择「Sidecar 文件」可让音频文件保持不变 — foobar2000 等播放器就是这样做的。"
     }
   },
@@ -307,7 +307,7 @@
       "regenerate": "重新生成",
       "regenerating": "生成中…",
       "emptyTitle": "暂无 Daily Mix",
-      "emptyDescription": "先听几首歌,然后点击重新生成以创建你的个性化合辑。",
+      "emptyDescription": "先听几首歌，然后点击重新生成以创建你的个性化合辑。",
       "label": "Daily Mix",
       "trackCount_one": "{{count}} 首",
       "trackCount_other": "{{count}} 首"
@@ -713,7 +713,7 @@
     "count_one": "{{count}} 首",
     "count_other": "{{count}} 首",
     "emptyTitle": "没什么可听的",
-    "emptyDescription": "从你的音乐库选取一首歌,加入播放队列。",
+    "emptyDescription": "从你的音乐库选取一首歌，加入播放队列。",
     "nowPlaying": "进行中",
     "upNext_zero": "接下来",
     "upNext_one": "接下来 · {{count}} 首",
@@ -1089,7 +1089,7 @@
     },
     "toast": {
       "tagWriteSkipped": "TTML 仅保留在缓存中（未写入音频标签）",
-      "sidecarWriteSkipped": "歌词已保存到数据库,但 TTML 无法放入 .lrc/.txt 文件。"
+      "sidecarWriteSkipped": "歌词已保存到数据库，但 TTML 无法放入 .lrc/.txt 文件。"
     }
   },
   "duplicates": {
@@ -1129,7 +1129,7 @@
       "album": "专辑包含",
       "year": "年份",
       "bpm": "BPM",
-      "durationMin": "时长(分钟)",
+      "durationMin": "时长（分钟）",
       "hiRes": "仅 Hi-Res",
       "liked": "仅已喜欢的曲目",
       "formats": "格式",
@@ -1152,8 +1152,8 @@
     "sortOptions": {
       "addedDesc": "最近添加",
       "addedAsc": "最早添加",
-      "yearDesc": "年份(降序)",
-      "yearAsc": "年份(升序)",
+      "yearDesc": "年份（降序）",
+      "yearAsc": "年份（升序）",
       "titleAsc": "标题(A → Z)",
       "artistAsc": "艺人(A → Z)",
       "random": "随机"
@@ -1205,7 +1205,7 @@
     "plainPlaceholder": "逐行输入歌词…",
     "linePlaceholder": "行文本",
     "capture": "捕获",
-    "captureHint": "开始播放后按空格(或捕获)将当前行锚定到播放点",
+    "captureHint": "开始播放后按空格（或捕获）将当前行锚定到播放点",
     "captureNow": "立即捕获",
     "recapture": "重新锚定到当前位置",
     "seekToLine": "跳转到该行",
@@ -1226,7 +1226,7 @@
     "captureHintWord": "空格 = 下一个词 · 回车 = 下一行 · Backspace = 撤销最后一个词",
     "notCaptured": "未捕获",
     "exportToFile": "保存到文件…",
-    "exportToFileHint": "将歌词导出为 .lrc 或 .txt 文件到您选择的位置,不会修改音频文件",
+    "exportToFileHint": "将歌词导出为 .lrc 或 .txt 文件到您选择的位置，不会修改音频文件",
     "exportedToFile": "已导出到 {{path}}",
     "destinationLabel": "歌词默认保存位置",
     "destination": {
@@ -1362,7 +1362,7 @@
       },
       "notifications": {
         "title": "曲目变更通知",
-        "subtitle": "每首曲目开始时显示系统通知(标题 + 艺人)。默认关闭。"
+        "subtitle": "每首曲目开始时显示系统通知（标题 + 艺人）。默认关闭。"
       }
     },
     "crossfade": {
@@ -1383,8 +1383,8 @@
     },
     "exclusive": {
       "title": "WASAPI 独占模式(Windows)",
-      "subtitle": "比特完美:绕过 Windows 混音器以提供无干扰输出。如果设备拒绝独占访问,则回退到共享模式。",
-      "fallback": "设备不接受独占模式,正在回退到共享模式。"
+      "subtitle": "比特完美：绕过 Windows 混音器以提供无干扰输出。如果设备拒绝独占访问，则回退到共享模式。",
+      "fallback": "设备不接受独占模式，正在回退到共享模式。"
     },
     "mono": {
       "title": "单声道",
@@ -1445,7 +1445,7 @@
     },
     "localArtistImages": {
       "title": "本地艺人图片",
-      "subtitle": "在音乐旁查找 artist.jpg(或 <名称>.jpg)文件,并将其用作艺人头像。",
+      "subtitle": "在音乐旁查找 artist.jpg(或 <名称>.jpg)文件，并将其用作艺人头像。",
       "action": "扫描",
       "done": "已为 {{considered}} 位艺人中的 {{linked}} 位关联本地图片"
     },
@@ -1641,7 +1641,7 @@
       },
       "skin": {
         "title": "外观",
-        "subtitle": "改变密度、表面材质、字体与动效,不仅是颜色。"
+        "subtitle": "改变密度、表面材质、字体与动效，不仅是颜色。"
       },
       "skins": {
         "studio": {
@@ -1654,7 +1654,7 @@
         },
         "lounge": {
           "label": "Lounge",
-          "description": "高级玻璃 — 专辑封面成为背景,半透明面板,缓慢过渡。"
+          "description": "高级玻璃 — 专辑封面成为背景，半透明面板，缓慢过渡。"
         },
         "pulse": {
           "label": "Pulse",
@@ -1713,7 +1713,7 @@
     },
     "smartCrossfade": {
       "title": "智能交叉淡化",
-      "subtitle": "自动跳过同一专辑内两首曲目间的淡化(适合概念专辑和现场录音)"
+      "subtitle": "自动跳过同一专辑内两首曲目间的淡化（适合概念专辑和现场录音）"
     },
     "showSpotify": {
       "title": "显示 Spotify 入口",
@@ -1808,11 +1808,11 @@
     },
     "fullscreenLyricsCentering": {
       "title": "全屏中将同步歌词居中",
-      "subtitle": "在全屏视图中将带时间戳的歌词居中对齐,与纯文本视图保持一致。"
+      "subtitle": "在全屏视图中将带时间戳的歌词居中对齐，与纯文本视图保持一致。"
     },
     "lyricsTranslation": {
       "title": "歌词翻译 (Musixmatch)",
-      "subtitle": "当 Musixmatch 提供翻译时,在每行 LRC 下方显示翻译",
+      "subtitle": "当 Musixmatch 提供翻译时，在每行 LRC 下方显示翻译",
       "off": "关闭"
     },
     "lyricsDestination": {
@@ -1843,11 +1843,11 @@
     "playlists": "播放列表",
     "emptyPlaylist": "此播放列表中没有可用的曲目(Spotify 可能不会公开本地文件或非你拥有的播放列表)。",
     "notConfiguredTitle": "注册你的 Spotify 应用",
-    "notConfiguredMessage": "Spotify 要求每个第三方应用在播放前必须注册一个免费的 Client ID。请在 Spotify Developer dashboard 创建一个,然后粘贴到 WaveFlow 的「设置 → 集成」。",
+    "notConfiguredMessage": "Spotify 要求每个第三方应用在播放前必须注册一个免费的 Client ID。请在 Spotify Developer dashboard 创建一个，然后粘贴到 WaveFlow 的「设置 → 集成」。",
     "openDashboard": "打开 Spotify Developer dashboard",
     "openSettings": "打开设置",
     "notConnectedTitle": "Spotify 未连接",
-    "notConnectedMessage": "你的 Client ID 已配置。请到「设置」登录 Spotify Premium 账户,以加载播放列表并开始播放。"
+    "notConnectedMessage": "你的 Client ID 已配置。请到「设置」登录 Spotify Premium 账户，以加载播放列表并开始播放。"
   },
   "share": {
     "title": "分享播放列表",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -17,7 +17,7 @@
   },
   "updater": {
     "available": {
-      "title": "有更新可用（版本{{version}}）",
+      "title": "有更新可用(版本{{version}})",
       "message": "WaveFlow 的新版本已准备就绪，可以安装了。",
       "action": "立即安装",
       "later": "稍后"
@@ -43,7 +43,7 @@
       "title": "重要：仅限本地音乐",
       "description": "WaveFlow 不是流媒体服务，它播放你设备上已有的文件。",
       "calloutTitle": "你需要知道",
-      "bulletOwn": "自带音乐库（MP3、FLAC、ALAC、OGG、DSD…）",
+      "bulletOwn": "自带音乐库(MP3、FLAC、ALAC、OGG、DSD…)",
       "bulletImport": "导入文件夹或拖放文件",
       "bulletScrobble": "连接 Last.fm，在后台 Scrobble 你的播放记录"
     },
@@ -222,9 +222,9 @@
         "reset": "重置",
         "hiRes": "高解析度",
         "likedOnly": "仅显示喜欢",
-        "year": "年份（从 → 到）",
-        "bpm": "BPM（从 → 到）",
-        "durationMin": "时长（分钟）（从 → 到）",
+        "year": "年份(从 → 到)",
+        "bpm": "BPM(从 → 到)",
+        "durationMin": "时长（分钟）(从 → 到)",
         "format": "格式",
         "genres": "流派"
       }
@@ -390,7 +390,7 @@
     "searchDeezer": "搜索Deezer",
     "localFile": "本地文件",
     "fetchMissingCovers": "找回所有缺失的封套",
-    "fetchingCovers": "正在获取封面…（{{current}} / {{total}}）",
+    "fetchingCovers": "正在获取封面…({{current}} / {{total}})",
     "fetchCoversResult": "已获取 {{count}} 张封套",
     "fetchCoversFailed": "封套获取失败",
     "table": {
@@ -639,7 +639,7 @@
     "sections": {
       "frameworkDesktop": "桌面框架",
       "frontend": "前端",
-      "backend": "后端（Rust）",
+      "backend": "后端(Rust)",
       "audio": "音频",
       "shortcuts": "键盘快捷键",
       "credits": "鸣谢",
@@ -852,7 +852,7 @@
     "title": "批量编辑标签",
     "subtitle": "已选择 {{count}} 首",
     "help": "勾选要应用到整个选择的字段。未勾选的字段保持每首曲目原值。",
-    "submit": "应用（{{count}} 个字段）",
+    "submit": "应用({{count}} 个字段)",
     "fields": {
       "artist": "艺人",
       "album": "专辑",
@@ -1232,7 +1232,7 @@
     "destination": {
       "tag": {
         "label": "嵌入标签",
-        "hint": "写入音频文件的 USLT/©lyr（兼容 foobar2000、iTunes…）。"
+        "hint": "写入音频文件的 USLT/©lyr(兼容 foobar2000、iTunes…)。"
       },
       "sidecar": {
         "label": "Sidecar 文件",
@@ -1371,7 +1371,7 @@
     },
     "dynamicCrossfade": {
       "title": "动态交叉淡化",
-      "subtitle": "根据曲目间的速度差调整淡化时长（BPM 未知时回退至固定交叉淡化）"
+      "subtitle": "根据曲目间的速度差调整淡化时长(BPM 未知时回退至固定交叉淡化)"
     },
     "normalize": {
       "title": "标准化音量",
@@ -1500,7 +1500,7 @@
       "inSync": "已同步",
       "outOfSync": "存在差异",
       "error": "错误：{{message}}",
-      "reasonGeneric": "已跳过（{{reason}}）",
+      "reasonGeneric": "已跳过({{reason}})",
       "reason": {
         "offline": "离线模式已启用",
         "sync_mode_local": "配置文件处于本地模式",
@@ -1508,7 +1508,7 @@
         "profile_canonical_id_missing": "等待首次同步"
       },
       "backfillAlreadyRunning": "已有同步在运行",
-      "backfillSkipped": "已跳过同步（{{reason}}）",
+      "backfillSkipped": "已跳过同步({{reason}})",
       "backfillSummary": "{{pushed}} 已发送 · {{pulled}} 已接收 · {{lww}} 已合并 · {{failed}} 失败",
       "col": {
         "entity": "实体",
@@ -1611,7 +1611,7 @@
     },
     "showAudioQualityFooter": {
       "title": "显示音频质量条",
-      "subtitle": "在播放栏下方显示技术详情（kHz、kbps、编解码、位深）。为保持播放栏轻巧，默认关闭。"
+      "subtitle": "在播放栏下方显示技术详情(kHz、kbps、编解码、位深)。为保持播放栏轻巧，默认关闭。"
     },
     "categoryNavLabel": "设置分类",
     "appearance": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -132,8 +132,8 @@
       "unavailable": "設定檔暫時無法使用，請稍後再試。"
     },
     "lyrics": {
-      "title": "歌詞要儲存在哪裡?",
-      "description": "編輯歌詞時,它們應該儲存到何處?可在 設定 → 播放 中隨時變更。",
+      "title": "歌詞要儲存在哪裡？",
+      "description": "編輯歌詞時，它們應該儲存到何處？可在 設定 → 播放 中隨時變更。",
       "hint": "選擇「Sidecar 檔案」可讓音訊檔保持不變 — foobar2000 等播放器就是這樣做的。"
     }
   },
@@ -307,7 +307,7 @@
       "regenerate": "重新產生",
       "regenerating": "產生中…",
       "emptyTitle": "還沒有 Daily Mix",
-      "emptyDescription": "先聽幾首歌,然後點擊重新產生來建立你的個人化合輯。",
+      "emptyDescription": "先聽幾首歌，然後點擊重新產生來建立你的個人化合輯。",
       "label": "Daily Mix",
       "trackCount_one": "{{count}} 首",
       "trackCount_other": "{{count}} 首"
@@ -702,7 +702,7 @@
       "title": "播放速度",
       "slider": "速度滑桿",
       "custom": "自訂速度",
-      "pitchHint": "音高隨速度變化(無時間拉伸)。"
+      "pitchHint": "音高隨速度變化（無時間拉伸）。"
     },
     "seek": "播放位置"
   },
@@ -713,7 +713,7 @@
     "count_one": "{{count}} 首",
     "count_other": "{{count}} 首",
     "emptyTitle": "沒什麼可聽的",
-    "emptyDescription": "從你的音樂庫中選取一首歌,加入播放佇列。",
+    "emptyDescription": "從你的音樂庫中選取一首歌，加入播放佇列。",
     "nowPlaying": "正在播放",
     "upNext_zero": "接下來",
     "upNext_one": "接下來 · {{count}} 首",
@@ -1089,7 +1089,7 @@
     },
     "toast": {
       "tagWriteSkipped": "TTML 僅保留在快取中（未寫入音訊標籤）",
-      "sidecarWriteSkipped": "歌詞已儲存到資料庫,但 TTML 無法放入 .lrc/.txt 檔案。"
+      "sidecarWriteSkipped": "歌詞已儲存到資料庫，但 TTML 無法放入 .lrc/.txt 檔案。"
     }
   },
   "duplicates": {
@@ -1129,7 +1129,7 @@
       "album": "專輯包含",
       "year": "年份",
       "bpm": "BPM",
-      "durationMin": "時長(分鐘)",
+      "durationMin": "時長（分鐘）",
       "hiRes": "僅 Hi-Res",
       "liked": "僅已喜歡的曲目",
       "formats": "格式",
@@ -1152,8 +1152,8 @@
     "sortOptions": {
       "addedDesc": "最近新增",
       "addedAsc": "最早新增",
-      "yearDesc": "年份(由新到舊)",
-      "yearAsc": "年份(由舊到新)",
+      "yearDesc": "年份（由新到舊）",
+      "yearAsc": "年份（由舊到新）",
       "titleAsc": "標題(A → Z)",
       "artistAsc": "藝人(A → Z)",
       "random": "隨機"
@@ -1205,7 +1205,7 @@
     "plainPlaceholder": "逐行輸入歌詞…",
     "linePlaceholder": "行文字",
     "capture": "擷取",
-    "captureHint": "開始播放後按空白鍵(或擷取)將目前行錨定到播放點",
+    "captureHint": "開始播放後按空白鍵（或擷取）將目前行錨定到播放點",
     "captureNow": "立即擷取",
     "recapture": "重新錨定到目前位置",
     "seekToLine": "跳到此行",
@@ -1226,7 +1226,7 @@
     "captureHintWord": "空格鍵 = 下一個字 · Enter = 下一行 · Backspace = 取消最後一個字",
     "notCaptured": "未擷取",
     "exportToFile": "儲存到檔案…",
-    "exportToFileHint": "將歌詞匯出為 .lrc 或 .txt 檔案至您選擇的位置,不會更動音訊檔案",
+    "exportToFileHint": "將歌詞匯出為 .lrc 或 .txt 檔案至您選擇的位置，不會更動音訊檔案",
     "exportedToFile": "已匯出至 {{path}}",
     "destinationLabel": "歌詞預設儲存位置",
     "destination": {
@@ -1293,7 +1293,7 @@
       "subtitle": "管理為 WaveFlow 新增來源、中繼資料或檢視的擴充功能。",
       "loading": "載入中…",
       "emptyTitle": "未安裝任何外掛",
-      "emptyHint": "手動安裝:將資料夾放在 <data>/waveflow/plugins/ 下。官方商店即將推出。",
+      "emptyHint": "手動安裝：將資料夾放在 <data>/waveflow/plugins/ 下。官方商店即將推出。",
       "byAuthor": "作者:{{author}}",
       "enabled": "已啟用",
       "disabled": "已停用",
@@ -1362,7 +1362,7 @@
       },
       "notifications": {
         "title": "曲目變更通知",
-        "subtitle": "每首曲目開始時顯示系統通知(標題 + 演出者)。預設關閉。"
+        "subtitle": "每首曲目開始時顯示系統通知（標題 + 演出者）。預設關閉。"
       }
     },
     "crossfade": {
@@ -1384,7 +1384,7 @@
     "exclusive": {
       "title": "WASAPI 獨佔模式(Windows)",
       "subtitle": "位元完美：繞過 Windows 混音器以提供無干擾輸出。如果裝置拒絕獨佔存取，則退回共用模式。",
-      "fallback": "裝置不接受獨佔模式,正在退回共享模式。"
+      "fallback": "裝置不接受獨佔模式，正在退回共享模式。"
     },
     "mono": {
       "title": "單聲道音訊",
@@ -1654,7 +1654,7 @@
         },
         "lounge": {
           "label": "Lounge",
-          "description": "高級玻璃 — 專輯封面成為背景,半透明面板,緩慢過渡。"
+          "description": "高級玻璃 — 專輯封面成為背景，半透明面板，緩慢過渡。"
         },
         "pulse": {
           "label": "Pulse",
@@ -1713,7 +1713,7 @@
     },
     "smartCrossfade": {
       "title": "智慧交叉淡化",
-      "subtitle": "自動跳過同一張專輯內兩首曲目間的淡化(適合概念專輯和現場錄音)"
+      "subtitle": "自動跳過同一張專輯內兩首曲目間的淡化（適合概念專輯和現場錄音）"
     },
     "showSpotify": {
       "title": "顯示 Spotify 入口",
@@ -1808,11 +1808,11 @@
     },
     "fullscreenLyricsCentering": {
       "title": "全螢幕中將同步歌詞置中",
-      "subtitle": "在全螢幕檢視中將帶時間戳的歌詞置中對齊,與純文字檢視保持一致。"
+      "subtitle": "在全螢幕檢視中將帶時間戳的歌詞置中對齊，與純文字檢視保持一致。"
     },
     "lyricsTranslation": {
       "title": "歌詞翻譯 (Musixmatch)",
-      "subtitle": "當 Musixmatch 有翻譯時,在每行 LRC 下方顯示翻譯",
+      "subtitle": "當 Musixmatch 有翻譯時，在每行 LRC 下方顯示翻譯",
       "off": "關閉"
     },
     "lyricsDestination": {
@@ -1843,11 +1843,11 @@
     "playlists": "播放清單",
     "emptyPlaylist": "此播放清單中沒有可用的曲目(Spotify 可能不會公開本機檔案或非你擁有的播放清單)。",
     "notConfiguredTitle": "註冊你的 Spotify 應用程式",
-    "notConfiguredMessage": "Spotify 要求每個第三方應用程式在播放前必須註冊一個免費的 Client ID。請在 Spotify Developer dashboard 建立一個,然後貼到 WaveFlow 的「設定 → 整合」。",
+    "notConfiguredMessage": "Spotify 要求每個第三方應用程式在播放前必須註冊一個免費的 Client ID。請在 Spotify Developer dashboard 建立一個，然後貼到 WaveFlow 的「設定 → 整合」。",
     "openDashboard": "開啟 Spotify Developer dashboard",
     "openSettings": "開啟設定",
     "notConnectedTitle": "Spotify 尚未連接",
-    "notConnectedMessage": "你的 Client ID 已設定。請至「設定」登入 Spotify Premium 帳號,以載入播放清單並開始播放。"
+    "notConnectedMessage": "你的 Client ID 已設定。請至「設定」登入 Spotify Premium 帳號，以載入播放清單並開始播放。"
   },
   "share": {
     "title": "分享播放清單",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -17,7 +17,7 @@
   },
   "updater": {
     "available": {
-      "title": "有更新可用（版本{{version}}）",
+      "title": "有更新可用(版本{{version}})",
       "message": "WaveFlow 的新版本已準備就緒，可供安裝。",
       "action": "立即安裝",
       "later": "稍後"
@@ -43,7 +43,7 @@
       "title": "重要：僅限本地音樂",
       "description": "WaveFlow 不是串流服務，它播放裝置上已有的檔案。",
       "calloutTitle": "你需要知道",
-      "bulletOwn": "自帶音樂庫（MP3、FLAC、ALAC、OGG、DSD…）",
+      "bulletOwn": "自帶音樂庫(MP3、FLAC、ALAC、OGG、DSD…)",
       "bulletImport": "匯入資料夾或拖放檔案",
       "bulletScrobble": "連接 Last.fm，在背景 Scrobble 你的播放紀錄"
     },
@@ -222,9 +222,9 @@
         "reset": "重設",
         "hiRes": "高解析度",
         "likedOnly": "僅顯示喜歡",
-        "year": "年份（從 → 至）",
-        "bpm": "BPM（從 → 至）",
-        "durationMin": "時長（分鐘）（從 → 至）",
+        "year": "年份(從 → 至)",
+        "bpm": "BPM(從 → 至)",
+        "durationMin": "時長（分鐘）(從 → 至)",
         "format": "格式",
         "genres": "類型"
       }
@@ -390,7 +390,7 @@
     "searchDeezer": "搜尋Deezer",
     "localFile": "本機檔案",
     "fetchMissingCovers": "找回所有遺失的封套",
-    "fetchingCovers": "正在取得封面…（{{current}} / {{total}}）",
+    "fetchingCovers": "正在取得封面…({{current}} / {{total}})",
     "fetchCoversResult": "已取得 {{count}} 張封套",
     "fetchCoversFailed": "封套取得失敗",
     "table": {
@@ -639,7 +639,7 @@
     "sections": {
       "frameworkDesktop": "桌面框架",
       "frontend": "前端",
-      "backend": "後端（Rust）",
+      "backend": "後端(Rust)",
       "audio": "音訊",
       "shortcuts": "鍵盤快捷鍵",
       "credits": "版權聲明",
@@ -852,7 +852,7 @@
     "title": "批次編輯標籤",
     "subtitle": "已選 {{count}} 首",
     "help": "勾選要套用到整個選取的欄位。未勾選的欄位保持每首曲目原值。",
-    "submit": "套用（{{count}} 個欄位）",
+    "submit": "套用({{count}} 個欄位)",
     "fields": {
       "artist": "藝人",
       "album": "專輯",
@@ -1371,7 +1371,7 @@
     },
     "dynamicCrossfade": {
       "title": "動態交叉淡化",
-      "subtitle": "依曲目間的速度差調整淡化時長（BPM 未知時回退至固定交叉淡化）"
+      "subtitle": "依曲目間的速度差調整淡化時長(BPM 未知時回退至固定交叉淡化)"
     },
     "normalize": {
       "title": "將音量調整至標準值",
@@ -1445,7 +1445,7 @@
     },
     "localArtistImages": {
       "title": "本地藝人圖片",
-      "subtitle": "在音樂旁尋找 artist.jpg（或 <名稱>.jpg）檔案，並將其用作藝人照片。",
+      "subtitle": "在音樂旁尋找 artist.jpg(或 <名稱>.jpg)檔案，並將其用作藝人照片。",
       "action": "掃描",
       "done": "已為 {{considered}} 位藝人中的 {{linked}} 位連結本地圖片"
     },
@@ -1500,7 +1500,7 @@
       "inSync": "已同步",
       "outOfSync": "存在差異",
       "error": "錯誤：{{message}}",
-      "reasonGeneric": "已略過（{{reason}}）",
+      "reasonGeneric": "已略過({{reason}})",
       "reason": {
         "offline": "離線模式已啟用",
         "sync_mode_local": "設定檔處於本機模式",
@@ -1508,7 +1508,7 @@
         "profile_canonical_id_missing": "等待首次同步"
       },
       "backfillAlreadyRunning": "已有同步正在執行",
-      "backfillSkipped": "已略過同步（{{reason}}）",
+      "backfillSkipped": "已略過同步({{reason}})",
       "backfillSummary": "{{pushed}} 已傳送 · {{pulled}} 已接收 · {{lww}} 已合併 · {{failed}} 失敗",
       "col": {
         "entity": "實體",
@@ -1611,7 +1611,7 @@
     },
     "showAudioQualityFooter": {
       "title": "顯示音訊品質列",
-      "subtitle": "在播放列下方顯示技術詳情（kHz、kbps、編解碼、位元深度）。為保持播放列輕巧，預設關閉。"
+      "subtitle": "在播放列下方顯示技術詳情(kHz、kbps、編解碼、位元深度)。為保持播放列輕巧，預設關閉。"
     },
     "categoryNavLabel": "設定分類",
     "appearance": {


### PR DESCRIPTION
## Context

Third translation-validation pass, this time targeting the systemic mechanical bugs that pass-2 surfaced after #268 + #269 landed. Two clusters:

### 1. French `_zero` keys at singular instead of plural

French grammar requires a plural noun after `0` — `0 titres`, not `0 titre`. The original JSON authoring pass borrowed English plural rules where `0 track` is singular. The validator caught ~30 keys reading wrong.

Fixed every leaf string whose key ends in \`_zero\` and whose value matched a known singular form (\`titre\`, \`album\`, \`artiste\`, \`genre\`, \`dossier\`, \`écoute\`, \`minute de musique\`, \`jour d'affilée\`, \`sélectionné\`). Idiomatic alternative phrasings (\`Aucun résultat\`, \`Rien à supprimer\`, \`À suivre\`, \`vide\`) are deliberately left alone — they're not "0 X" patterns and don't need pluralisation.

### 2. zh-CN + zh-TW half-width punctuation inside CJK text

Both Chinese locales had drifted to ASCII \`,\` \`:\` \`?\` \`(\` \`)\` between Chinese characters where CJK conventions require full-width \`，\` \`：\` \`？\` \`（\` \`）\`. The validator flagged this across many strings.

Context-sensitive walk:
- \`,\` \`:\` \`?\` \`!\` → full-width **only** when surrounded by CJK characters
- \`(content)\` → \`（content）\` **only** when the content is purely CJK

The second rule preserves intentional half-width Latin annotations like \`(A → Z)\` and \`(A = {{a}})\`, which the CJK style convention keeps half-width when the parenthetical wraps foreign script. Otherwise the script would over-convert and introduce regressions.

## Script

[\`scripts/fix_locales_mechanical.py\`](scripts/fix_locales_mechanical.py) — idempotent, exit non-zero only on missing locale files (same convention as \`fix_repeat_aria_labels.py\` and \`fix_skin_descriptions_i18n.py\`).

**Touched:** 30 fr keys, 22 zh-CN strings, 21 zh-TW strings.

## What's NOT in this PR

- **id pronoun consistency** (Anda/kamu mixing), **ar audio terms** (resample/downmix/pitch), **pt-BR strip vs track confusion**, **zh terminology drift** (Library/Profile/Genre/Cover) — these need per-locale judgment calls, not mechanical sweeps. Deferred to per-locale follow-ups or 1.6.0 community-contribution work.
- Brand tokens (\`Daily Mix\`, \`On Repeat\`, etc.) stay verbatim per the convention formalised in #268.

## Test plan

- [x] Switch through fr in Settings → confirm "0 titres", "0 albums" etc. render naturally
- [x] Switch through zh-CN → confirm `（分钟）`, `？` between CJK, etc. look right
- [x] zh-TW same spot check
- [x] Re-run \`bun secrets/validate-translations.mjs\` — fr plural bug + zh CJK punctuation findings should be gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Correction des libellés de pluralisation en français pour les compteurs (notamment le cas “0” dans les barres, sections Bibliothèque et vues détaillées).
  * Harmonisation de la ponctuation et de l’espacement en chinois (simplifié et traditionnel), avec ajustements des guillemets, séparateurs et parenthèses pour une typographie plus cohérente.
* **Chores**
  * Ajout d’un script autonome pour corriger automatiquement et de façon idempotente certaines dérives de traductions, avec rapport de traitement (modifiés/non modifiés).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->