### PR TITLE
fix(settings): portal language dropdown to escape Lounge/Liquid stacking trap

### DIFF
--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -318,6 +318,10 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
     const handleKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setIsOpen(false);
+        // Return focus to the trigger so keyboard users stay anchored
+        // to where they opened the listbox from. Matches WAI-ARIA APG
+        // for combobox/listbox dismissal via Escape.
+        triggerRef.current?.focus();
       }
     };
 
@@ -405,6 +409,13 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
   const handleSelect = (code: string) => {
     onSelect(code);
     setIsOpen(false);
+    // Same restoration as the Escape branch: a deliberate option pick
+    // (mouse click or Enter/Space) lands the keyboard caret back on
+    // the trigger so the user can keep tabbing forward from where
+    // they were. Click-outside is intentionally NOT mirrored here —
+    // there the user explicitly aimed at something else, and stealing
+    // focus back to the trigger would override that intent.
+    triggerRef.current?.focus();
   };
 
   return (

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -403,6 +403,17 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
     } else if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       handleSelect(SUPPORTED_LANGUAGES[index].code);
+    } else if (event.key === "Tab") {
+      // Dismiss the listbox and let the browser's default Tab action
+      // continue from the trigger's position in tab order. Focus is
+      // moved synchronously to the trigger before this handler
+      // returns; the un-prevented Tab default then advances from
+      // there, so Tab lands on the next focusable element AFTER the
+      // trigger and Shift+Tab lands on the previous one. Without this
+      // shim, Tab from a portaled option escapes through document.body
+      // and the keyboard caret falls off the end of tab order.
+      setIsOpen(false);
+      triggerRef.current?.focus();
     }
   };
 

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
   ArrowLeft,
@@ -277,7 +278,16 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(0);
+  // Viewport-relative coordinates for the portaled listbox. Captured
+  // once per open from the trigger's bounding rect; closed on scroll
+  // or resize so a stale position never paints.
+  const [position, setPosition] = useState<{
+    top: number;
+    right: number;
+  } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const normalizedCurrentCode = normalizeSupportedLanguageCode(currentCode);
 
@@ -285,15 +295,22 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
     SUPPORTED_LANGUAGES.find((lang) => lang.code === normalizedCurrentCode) ??
     SUPPORTED_LANGUAGES[0];
 
-  // Click-outside + Escape handling
+  // Click-outside + Escape handling. The listbox is portaled to
+  // document.body to escape the parent stacking context (the Lounge +
+  // Liquid skins paint Settings cards through `backdrop-filter`, which
+  // by spec creates a new stacking context and traps `z-index` of any
+  // descendant — so the dropdown rendered as an absolute child landed
+  // visually behind the cards below it). Click-outside therefore has
+  // to whitelist the portaled listbox too, otherwise clicking an
+  // option dismisses the menu before its onClick handler runs.
   useEffect(() => {
     if (!isOpen) return;
 
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
+      const target = event.target as Node;
+      const inTrigger = containerRef.current?.contains(target);
+      const inListbox = listboxRef.current?.contains(target);
+      if (!inTrigger && !inListbox) {
         setIsOpen(false);
       }
     };
@@ -312,6 +329,21 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
     };
   }, [isOpen]);
 
+  // Close on scroll/resize — the listbox uses fixed positioning derived
+  // from a snapshot of the trigger's rect, so any layout shift would
+  // leave it visually detached from the trigger. Closing is simpler
+  // (and matches native <select>) than re-measuring on every frame.
+  useEffect(() => {
+    if (!isOpen) return;
+    const close = () => setIsOpen(false);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [isOpen]);
+
   // Keep keyboard focus on the highlighted option when it changes
   useEffect(() => {
     if (isOpen) {
@@ -322,7 +354,18 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
   const handleTriggerClick = () => {
     setIsOpen((prev) => {
       if (!prev) {
-        // Opening: focus the currently selected option
+        // Opening: snapshot the trigger's viewport rect for the
+        // portaled listbox, then focus the currently selected option.
+        // `mt-2` (= 8px) keeps the visual gap the old absolute markup
+        // had; `right` is measured from the viewport edge to mirror
+        // the original `right-0` anchor.
+        const rect = triggerRef.current?.getBoundingClientRect();
+        if (rect) {
+          setPosition({
+            top: rect.bottom + 8,
+            right: window.innerWidth - rect.right,
+          });
+        }
         const initialIndex = Math.max(
           0,
           SUPPORTED_LANGUAGES.findIndex(
@@ -367,6 +410,7 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
   return (
     <div className="relative" ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
         onClick={handleTriggerClick}
         aria-haspopup="listbox"
@@ -381,39 +425,48 @@ function LanguageDropdown({ currentCode, onSelect }: LanguageDropdownProps) {
         />
       </button>
 
-      {isOpen && (
-        <ul
-          role="listbox"
-          aria-label={t("settings.language.title")}
-          className="absolute top-full right-0 mt-2 min-w-48 rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-surface-dark-elevated dark:shadow-black/40 overflow-hidden z-50 animate-fade-in py-1"
-        >
-          {SUPPORTED_LANGUAGES.map((lang, index) => {
-            const isSelected = lang.code === normalizedCurrentCode;
-            return (
-              <li key={lang.code} role="presentation">
-                <button
-                  ref={(el) => {
-                    optionRefs.current[index] = el;
-                  }}
-                  type="button"
-                  role="option"
-                  aria-selected={isSelected}
-                  onClick={() => handleSelect(lang.code)}
-                  onKeyDown={(event) => handleOptionKeyDown(event, index)}
-                  className={`w-full flex items-center justify-between px-4 py-2 text-sm text-left transition-colors focus:outline-none ${
-                    isSelected
-                      ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400"
-                      : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700/30 focus:bg-zinc-50 dark:focus:bg-zinc-700/30"
-                  }`}
-                >
-                  <span>{lang.nativeLabel}</span>
-                  {isSelected && <Check size={14} />}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      )}
+      {isOpen &&
+        position &&
+        createPortal(
+          <ul
+            ref={listboxRef}
+            role="listbox"
+            aria-label={t("settings.language.title")}
+            style={{
+              position: "fixed",
+              top: position.top,
+              right: position.right,
+            }}
+            className="min-w-48 rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-surface-dark-elevated dark:shadow-black/40 overflow-hidden z-[100] animate-fade-in py-1"
+          >
+            {SUPPORTED_LANGUAGES.map((lang, index) => {
+              const isSelected = lang.code === normalizedCurrentCode;
+              return (
+                <li key={lang.code} role="presentation">
+                  <button
+                    ref={(el) => {
+                      optionRefs.current[index] = el;
+                    }}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    onClick={() => handleSelect(lang.code)}
+                    onKeyDown={(event) => handleOptionKeyDown(event, index)}
+                    className={`w-full flex items-center justify-between px-4 py-2 text-sm text-left transition-colors focus:outline-none ${
+                      isSelected
+                        ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400"
+                        : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700/30 focus:bg-zinc-50 dark:focus:bg-zinc-700/30"
+                    }`}
+                  >
+                    <span>{lang.nativeLabel}</span>
+                    {isSelected && <Check size={14} />}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>,
+          document.body,
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Repro

Open **Settings → Library tab** on either the **Lounge** or **Liquid Glass** skin → click the language picker. The dropdown options paint behind the cards below it instead of floating above them.

| Lounge | Liquid Glass |
|---|---|
| (red glow theme) | (teal glass theme) |

Both show the same symptom: "Deutsch" peeks out, then the UI Zoom card stacks on top of the rest of the list.

## Cause

Both skins paint Settings cards through `backdrop-filter`:
- [`lounge.css:175-176`](src/styles/skins/lounge.css#L175-L176), [201-202](src/styles/skins/lounge.css#L201-L202), [230-231](src/styles/skins/lounge.css#L230-L231)
- [`liquid.css:308-309`](src/styles/skins/liquid.css#L308-L309), [358-359](src/styles/skins/liquid.css#L358-L359), [434-435](src/styles/skins/liquid.css#L434-L435)

Per CSS spec, **any element with `backdrop-filter` creates a new stacking context**. The dropdown's `z-50` therefore only stacked WITHIN its parent card's context — every subsequent card's own `backdrop-filter` stacking context then painted on top of it.

## Fix

Render the listbox via `createPortal` to `document.body` using fixed positioning derived from a snapshot of the trigger button's bounding rect. The portaled node escapes every ancestor stacking context, so the listbox now stacks against the document root rather than being trapped inside a `backdrop-filter` card.

Side touches required:
- `triggerRef` on the button so we can measure its rect on open
- `listboxRef` on the `<ul>` so click-outside whitelists the portaled subtree (without it, mousedown inside the dropdown trips the close-on-outside handler and dismisses the menu before the option's `onClick` fires)
- Close on scroll/resize since the fixed coords are a snapshot — matches native `<select>` behaviour and avoids re-measuring per frame

## Test plan

- [x] On Lounge skin: language dropdown options fully visible above all cards
- [x] On Liquid Glass skin: same
- [x] On Studio / Editorial / Pulse: no visual regression (dropdown still anchored correctly to the trigger)
- [x] Click an option → language changes + menu closes
- [x] Click outside the menu → closes
- [x] Escape → closes
- [x] Arrow Up/Down/Home/End keyboard nav still works
- [x] Scroll the Settings page while menu is open → menu closes (no detached floating list)
- [x] Resize window while menu is open → menu closes

## Follow-up (not in this PR)

Same stacking-context trap likely affects other dropdowns under Lounge/Liquid:
- [`PlaylistView.tsx:1327`](src/components/views/PlaylistView.tsx#L1327) — track-row context menu
- [`LibraryView.tsx:940`](src/components/views/LibraryView.tsx#L940) — track-row context menu
- [`EqualizerCard.tsx:197`](src/components/views/settings/EqualizerCard.tsx#L197) — preset picker

Worth porting the same pattern if reported. TopBar dropdowns sit at the top of the app so they're less likely to overlap backdrop-filter cards below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Améliorations

* **Améliorations**
  * Le sélecteur de langue s’affiche et se positionne de façon plus fiable, même dans des contextes complexes, grâce à un rendu plus adapté.
  * Il se ferme désormais aussi lors du défilement et du redimensionnement de la fenêtre.
  * Le comportement clavier et la gestion du focus sont renforcés : fermeture et restauration plus cohérentes après une sélection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->