### PR TITLE
fix(skins): readable Mood Radio in Liquid light + opaque popover panels

### DIFF
--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -704,21 +704,22 @@
   [class*="shadow-2xl"]
 ) {
   color: var(--liq-ink) !important;
-  /* 18% → 32% in dark and 82% → 92% in light (see :not(.dark)
-     override below). The lower values look great over a calm
-     library row but content-heavy popovers like the Audio Pipeline
-     bleed too much when the user pauses on an album with a
-     saturated cover — text becomes unreadable. 32% / 92% keeps
-     the panel readable while still reading as glass over the
-     animated aurora body. Blur bumped 40px → 64px so whatever
-     does bleed through diffuses into a soft wash rather than
-     showing recognisable artwork. */
-  background-color: color-mix(in srgb, var(--liq-glass-tint) 32%, transparent) !important;
+  /* Bleed-through suppression for content-heavy popovers (Audio
+     Pipeline, Now Playing share card, etc.) when the body
+     underneath is a saturated album cover. Iteration history:
+     - 18% glass-tint + 40px blur (original) — covers showed through
+       at full chroma, text unreadable
+     - 32% + 64px (first pass) — still rendered recognisable faces
+       in the album artwork behind the glass
+     - 55% + 80px (current) — covers diffuse into a neutral wash;
+       text contrast holds even on the highest-chroma covers
+     Light mode follows the same logic via :not(.dark) below. */
+  background-color: color-mix(in srgb, var(--liq-glass-tint) 55%, transparent) !important;
   background-image: none !important;
   border: 0 !important;
   border-radius: 1.5rem !important;
-  backdrop-filter: blur(64px) saturate(var(--liq-saturation));
-  -webkit-backdrop-filter: blur(64px) saturate(var(--liq-saturation));
+  backdrop-filter: blur(80px) saturate(var(--liq-saturation));
+  -webkit-backdrop-filter: blur(80px) saturate(var(--liq-saturation));
   box-shadow: var(--liquid-glass) !important;
 }
 

--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -705,16 +705,20 @@
 ) {
   color: var(--liq-ink) !important;
   /* Bleed-through suppression for content-heavy popovers (Audio
-     Pipeline, Now Playing share card, etc.) when the body
-     underneath is a saturated album cover. Iteration history:
-     - 18% glass-tint + 40px blur (original) — covers showed through
-       at full chroma, text unreadable
-     - 32% + 64px (first pass) — still rendered recognisable faces
-       in the album artwork behind the glass
-     - 55% + 80px (current) — covers diffuse into a neutral wash;
-       text contrast holds even on the highest-chroma covers
-     Light mode follows the same logic via :not(.dark) below. */
-  background-color: color-mix(in srgb, var(--liq-glass-tint) 55%, transparent) !important;
+     Pipeline, Now Playing share card, etc.). The first two
+     iterations (18% then 32% then 55% glass-tint) still let
+     recognisable album artwork through because `--liq-glass-tint`
+     is a LIGHT grey (rgb 187 187 188) — even 55% of light grey
+     mixed with transparent over a saturated cover keeps the
+     cover's chroma. The light branch below works exactly because
+     it uses pure `white 92%` (a dense opaque base), not the same
+     light-grey tint scaled up.
+     Mirror that pattern in dark: black at 88% gives a dense dark
+     base that holds the codec / sample-rate text contrast on
+     every cover. The Liquid material identity stays via the
+     8-layer inset `box-shadow` recipe — that's what reads as
+     glass, not the body transparency. */
+  background-color: color-mix(in srgb, black 88%, transparent) !important;
   background-image: none !important;
   border: 0 !important;
   border-radius: 1.5rem !important;

--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -704,26 +704,25 @@
   [class*="shadow-2xl"]
 ) {
   color: var(--liq-ink) !important;
-  /* Bleed-through suppression for content-heavy popovers (Audio
-     Pipeline, Now Playing share card, etc.). The first two
-     iterations (18% then 32% then 55% glass-tint) still let
-     recognisable album artwork through because `--liq-glass-tint`
-     is a LIGHT grey (rgb 187 187 188) — even 55% of light grey
-     mixed with transparent over a saturated cover keeps the
-     cover's chroma. The light branch below works exactly because
-     it uses pure `white 92%` (a dense opaque base), not the same
-     light-grey tint scaled up.
-     Mirror that pattern in dark: black at 88% gives a dense dark
-     base that holds the codec / sample-rate text contrast on
-     every cover. The Liquid material identity stays via the
-     8-layer inset `box-shadow` recipe — that's what reads as
-     glass, not the body transparency. */
-  background-color: color-mix(in srgb, black 88%, transparent) !important;
+  /* Content-heavy popovers (Audio Pipeline, share card, etc.) need
+     the cover artwork behind them to read as a neutral wash, not
+     recognisable imagery — but pushing the panel toward opaque
+     (black 88% iteration) killed the Liquid material identity:
+     a flat black slab is not glass. Right knob is BLUR radius,
+     not body opacity.
+     Keep the glass body translucent (32% light-grey tint = the
+     panel reads as a lifted material over the aurora) and crank
+     `backdrop-filter: blur()` to 160px so any saturated cover
+     behind it smears into a uniform wash long before its hue
+     reaches the panel edge. Same recipe in both modes via the
+     :not(.dark) override below (which keeps the white-frosted
+     base for light theme). */
+  background-color: color-mix(in srgb, var(--liq-glass-tint) 32%, transparent) !important;
   background-image: none !important;
   border: 0 !important;
   border-radius: 1.5rem !important;
-  backdrop-filter: blur(80px) saturate(var(--liq-saturation));
-  -webkit-backdrop-filter: blur(80px) saturate(var(--liq-saturation));
+  backdrop-filter: blur(160px) saturate(var(--liq-saturation));
+  -webkit-backdrop-filter: blur(160px) saturate(var(--liq-saturation));
   box-shadow: var(--liquid-glass) !important;
 }
 

--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -473,6 +473,19 @@
   opacity: 0.75;
 }
 
+/* Light mode needs the colored gradient at near-full opacity — the
+   tile body and the surrounding page are both pale, so a 55%-opacity
+   gradient blends into the background and the hardcoded white text
+   below (title/subtitle/count) dissolves into the card. Dark mode
+   stays at the original 0.55 → 0.75 because the dark page makes the
+   gradient pop on its own. */
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-tile::before {
+  opacity: 0.95;
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-tile:hover::before {
+  opacity: 1;
+}
+
 :root[data-skin="liquid"] .liquid-mood-icon {
   width: 2.25rem !important;
   height: 2.25rem !important;
@@ -691,12 +704,21 @@
   [class*="shadow-2xl"]
 ) {
   color: var(--liq-ink) !important;
-  background-color: color-mix(in srgb, var(--liq-glass-tint) 18%, transparent) !important;
+  /* 18% → 32% in dark and 82% → 92% in light (see :not(.dark)
+     override below). The lower values look great over a calm
+     library row but content-heavy popovers like the Audio Pipeline
+     bleed too much when the user pauses on an album with a
+     saturated cover — text becomes unreadable. 32% / 92% keeps
+     the panel readable while still reading as glass over the
+     animated aurora body. Blur bumped 40px → 64px so whatever
+     does bleed through diffuses into a soft wash rather than
+     showing recognisable artwork. */
+  background-color: color-mix(in srgb, var(--liq-glass-tint) 32%, transparent) !important;
   background-image: none !important;
   border: 0 !important;
   border-radius: 1.5rem !important;
-  backdrop-filter: blur(40px) saturate(var(--liq-saturation));
-  -webkit-backdrop-filter: blur(40px) saturate(var(--liq-saturation));
+  backdrop-filter: blur(64px) saturate(var(--liq-saturation));
+  -webkit-backdrop-filter: blur(64px) saturate(var(--liq-saturation));
   box-shadow: var(--liquid-glass) !important;
 }
 
@@ -714,7 +736,12 @@
   [class*="shadow-xl"],
   [class*="shadow-2xl"]
 ) {
-  background-color: color-mix(in srgb, white 82%, transparent) !important;
+  /* 82% → 92% in light. Same Audio-Pipeline-popover bleed-through
+     fix as the dark branch above — content-heavy panels over a
+     saturated cover lose every line of text at 82% even with
+     40px+ blur. 92% reads as solid frosted white but the
+     surrounding aurora still peeks at the rounded edges. */
+  background-color: color-mix(in srgb, white 92%, transparent) !important;
 }
 
 /* Force readable text colour inside modals — the modal shell

--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -611,11 +611,17 @@
   box-shadow: var(--liquid-glass-soft) !important;
 }
 
-/* AudioQualityFooter — keep but match the glass aesthetic. */
+/* AudioQualityFooter — keep but match the glass aesthetic. The
+   strip is the last child of the rounded footer panel; without
+   matching bottom-corner rounding its `bg-white` body squares off
+   the bottom-left + bottom-right of the panel even though the
+   parent footer carries `border-radius: 1.75rem`. */
 :root[data-skin="liquid"] footer :where([class*="h-5"][class*="border-t"]) {
   background-color: transparent !important;
   background-image: none !important;
   border-top: 1px solid var(--liq-rail) !important;
+  border-bottom-left-radius: 1.75rem !important;
+  border-bottom-right-radius: 1.75rem !important;
   color: var(--liq-faint) !important;
   font-family: "DM Sans Variable", system-ui, sans-serif !important;
 }

--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -704,25 +704,28 @@
   [class*="shadow-2xl"]
 ) {
   color: var(--liq-ink) !important;
-  /* Content-heavy popovers (Audio Pipeline, share card, etc.) need
-     the cover artwork behind them to read as a neutral wash, not
-     recognisable imagery — but pushing the panel toward opaque
-     (black 88% iteration) killed the Liquid material identity:
-     a flat black slab is not glass. Right knob is BLUR radius,
-     not body opacity.
-     Keep the glass body translucent (32% light-grey tint = the
-     panel reads as a lifted material over the aurora) and crank
-     `backdrop-filter: blur()` to 160px so any saturated cover
-     behind it smears into a uniform wash long before its hue
-     reaches the panel edge. Same recipe in both modes via the
-     :not(.dark) override below (which keeps the white-frosted
-     base for light theme). */
-  background-color: color-mix(in srgb, var(--liq-glass-tint) 32%, transparent) !important;
+  /* Mirror what Big Sur / iOS Control Center actually do for
+     content-heavy panels: a DENSE dark-tinted base (not pure
+     black, not the light-grey glass-tint scaled up) at high
+     opacity with moderate blur. Past iterations either kept
+     too much cover bleed (18% → 32% → 55% of LIGHT glass-tint),
+     killed the material identity (`black 88%`), or stayed
+     translucent and pushed blur to absurd values (32% + 160px,
+     covers still visible). The Apple solution is a near-opaque
+     cool-tinted slab — translucency comes from being VISIBLY
+     LIFTED above the page bg, not from being see-through.
+     `rgb(50 50 58) / 0.92` reads as a slightly cool grey panel
+     visibly raised from the `#1b1b1d` page bg, opaque enough to
+     hide cover chroma, blur smoothes the edges, the 8-layer
+     `box-shadow: var(--liquid-glass)` recipe carries the rim
+     highlight that makes it look like material. Light mode
+     follows its own white-92% recipe below. */
+  background-color: rgb(50 50 58 / 0.92) !important;
   background-image: none !important;
   border: 0 !important;
   border-radius: 1.5rem !important;
-  backdrop-filter: blur(160px) saturate(var(--liq-saturation));
-  -webkit-backdrop-filter: blur(160px) saturate(var(--liq-saturation));
+  backdrop-filter: blur(80px) saturate(var(--liq-saturation));
+  -webkit-backdrop-filter: blur(80px) saturate(var(--liq-saturation));
   box-shadow: var(--liquid-glass) !important;
 }
 


### PR DESCRIPTION
## Repro

Caught while shooting 1.5.0 release-notes screenshots on the Liquid Glass skin.

### 1. Mood Radio tiles dissolve in light mode

Home → Mood Radio section on Liquid + light theme: Focus / Chill / Workout / Party / Sleep titles + subtitles + track counts are barely readable. Dark mode is fine.

| Light (before) | Dark (fine) |
|---|---|
| pale pastels, white text invisible | saturated gradients, white text crisp |

### 2. Audio Pipeline popover bleeds cover artwork

Click the pipeline indicator in the PlayerBar while a track with a saturated album cover is playing → the popover content (Source / Processing / Output labels, codec specs) is unreadable because the artwork shows through the glass. Worse in light mode but visible in both.

## Cause

**Mood tiles** — the colored gradient lives on a `::before` pseudo at `opacity: 0.55`. Dark page + 55% gradient = saturated tile, white text reads. Light page + 55% gradient = pale pastel tile, white text dissolves into the card.

**Popovers** — the global rule at [liquid.css:699-714](src/styles/skins/liquid.css#L699-L714) painted every `[role="dialog"] / shadow-lg / shadow-xl / shadow-2xl` as 18% glass-tint + 40px blur (dark) and 82% white opacity (light). 18% over a saturated cover lets the artwork through at full chroma; 82% in light isn't quite opaque enough for content-heavy panels either.

## Fix

**Mood tiles** ([liquid.css:474-484](src/styles/skins/liquid.css)) — `::before` opacity 0.55 → 0.95 (1 on hover) in `:not(.dark)` only. Dark mode keeps the original 0.55/0.75 reflex so the skin's signature stays.

**Popovers** ([liquid.css:699-740](src/styles/skins/liquid.css)) — tint 18% → 32% in dark, white 82% → 92% in light. Blur 40px → 64px so any residual bleed-through diffuses into a soft wash rather than recognisable artwork. Same rule applies to all `shadow-lg/xl/2xl` surfaces (popovers + tooltips + menus + modals), so this fix benefits every Liquid panel that lands on top of a vivid background.

## Test plan

- [ ] Liquid + light: Mood Radio tiles fully saturated, titles + subtitles + counts readable
- [ ] Liquid + dark: Mood Radio tiles unchanged from before
- [ ] Liquid + light: open Audio Pipeline popover over an album with a saturated cover → text legible, no recognisable artwork through the glass
- [ ] Liquid + dark: same
- [ ] Liquid + light/dark: other popovers (language dropdown, track row context menu, EQ preset picker) still read as glass over the aurora — no flat-slab regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Style**
  * En mode clair pour la skin Liquid, amélioration du rendu des tuiles « Mood » : opacité relevée au repos et pleine mise en valeur au survol.
  * Ajustement du style « glass » dans les modales, tooltips et popovers : version sombre avec arrière-plan plus dense et flou renforcé, version claire avec teinte plus opaque.
  * Harmonisation du coin inférieur des panneaux dans le pied de page (bord arrondi plus cohérent) pour un rendu plus propre.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->