### PR TITLE
chore(aur): sharper pkgdesc + 15 search keywords for AUR chips

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -7,14 +7,18 @@ arch=('x86_64')
 url='https://github.com/InstaZDLL/WaveFlow'
 license=('GPL-3.0-only')
 # AUR keywords show up as blue chips on the package page and drive
-# search discovery on aur.archlinux.org. makepkg --printsrcinfo
-# emits each entry as a `keywords = ...` line in .SRCINFO, which
-# the AUR web ingests on push. Mix of category terms (music-player,
-# audio-player), comparatives that match what people search for
-# (spotify-alternative, apple-music-alternative), local-first
-# differentiators (local-music, offline-music) and audiophile-cluster
-# (hi-res, dsd, flac, bit-perfect, replaygain).
-_keywords=(
+# search discovery on aur.archlinux.org. The field name is bare
+# `keywords` (no leading underscore) — variables prefixed with `_`
+# are a PKGBUILD convention for PRIVATE values that makepkg ignores
+# during `--printsrcinfo`, so `_keywords=(...)` would silently
+# render zero chips. `keywords` is one of the recognised optional
+# .SRCINFO fields; each array entry comes out as a `keywords = ...`
+# line that the AUR web ingests on push. Mix of category terms
+# (music-player, audio-player), comparatives that match what people
+# search for (spotify-alternative, apple-music-alternative),
+# local-first differentiators (local-music, offline-music) and
+# audiophile-cluster (hi-res, dsd, flac, bit-perfect, replaygain).
+keywords=(
   'music-player'
   'music'
   'audio-player'

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,10 +2,35 @@
 pkgname=waveflow-bin
 pkgver=0.1.0
 pkgrel=1
-pkgdesc='Local-first music player desktop app with a Spotify-inspired 3-panel UI'
+pkgdesc='Spotify for your local files - bit-perfect Hi-Res music player'
 arch=('x86_64')
 url='https://github.com/InstaZDLL/WaveFlow'
 license=('GPL-3.0-only')
+# AUR keywords show up as blue chips on the package page and drive
+# search discovery on aur.archlinux.org. makepkg --printsrcinfo
+# emits each entry as a `keywords = ...` line in .SRCINFO, which
+# the AUR web ingests on push. Mix of category terms (music-player,
+# audio-player), comparatives that match what people search for
+# (spotify-alternative, apple-music-alternative), local-first
+# differentiators (local-music, offline-music) and audiophile-cluster
+# (hi-res, dsd, flac, bit-perfect, replaygain).
+_keywords=(
+  'music-player'
+  'music'
+  'audio-player'
+  'spotify-alternative'
+  'apple-music-alternative'
+  'local-music'
+  'offline-music'
+  'audiophile'
+  'hi-res'
+  'lossless'
+  'flac'
+  'dsd'
+  'bit-perfect'
+  'replaygain'
+  'tauri'
+)
 depends=(
   'webkit2gtk-4.1'
   'gtk3'


### PR DESCRIPTION
## Problem

The WaveFlow AUR page sits flat against omniget-bin (and other competitors) on search results because:

1. **pkgdesc was a UX detail** — \"Local-first music player desktop app with a Spotify-inspired 3-panel UI\". Nobody types \"3-panel UI\" into AUR search. The Spotify reference was there but buried mid-sentence.
2. **Zero AUR keywords** — the blue chip row on the package page renders empty. Omniget-bin shows ~14 keywords (download-manager, downloader, hotmart-downloader, …) which drive a huge chunk of its discoverability.

## Fix

- **`pkgdesc`** → \"Spotify for your local files - bit-perfect Hi-Res music player\" (62 chars, well under the 80-char AUR cap). Spotify reference reads instantly for both casual users and audiophiles browsing the AUR.
- **`_keywords` array** → 15 entries grouped by intent:
  - Category: `music-player`, `music`, `audio-player`
  - Comparatives (high search volume): `spotify-alternative`, `apple-music-alternative`
  - Local-first differentiators: `local-music`, `offline-music`
  - Audiophile cluster: `audiophile`, `hi-res`, `lossless`, `flac`, `dsd`, `bit-perfect`, `replaygain`
  - Tech: `tauri`

`makepkg --printsrcinfo` writes each entry as a `keywords = ...` line in `.SRCINFO`. The `KSXGitHub/github-actions-deploy-aur` action used by [`aur.yml`](.github/workflows/aur.yml) regenerates the `.SRCINFO` before push, so the next release (v1.5.0) will deploy both changes to AUR automatically — no manual edit on aur.archlinux.org needed.

## Test plan

- [x] After v1.5.0 ships, visit https://aur.archlinux.org/packages/waveflow-bin
- [x] Description reads \"Spotify for your local files - bit-perfect Hi-Res music player\"
- [x] Keywords row visible with 15 blue chips
- [x] `yay -S waveflow-bin` still installs correctly (unaffected by metadata changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Mise à jour de la description du paquet pour mieux refléter les caractéristiques du lecteur Hi-Res de fichiers locaux
  * Amélioration des mots-clés d'empaquetage pour optimiser la découverte et la catégorisation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->