### PR TITLE
WIP — fix(skins): Liquid light contrast pass (Mood Radio + About + scan)

### DIFF
--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -478,12 +478,32 @@
    gradient blends into the background and the hardcoded white text
    below (title/subtitle/count) dissolves into the card. Dark mode
    stays at the original 0.55 → 0.75 because the dark page makes the
-   gradient pop on its own. */
+   gradient pop on its own.
+   We ALSO need to bump the gradient internal alphas from 0.55 → 1.0
+   in light mode — the ::before opacity bump alone wasn't enough
+   because the two alphas multiply (0.55 × 0.95 = 0.52, basically
+   unchanged from 0.55). Solid-alpha gradients give the saturated
+   cards that white text actually reads on. */
 :root[data-skin="liquid"]:not(.dark) .liquid-mood-tile::before {
   opacity: 0.95;
 }
 :root[data-skin="liquid"]:not(.dark) .liquid-mood-tile:hover::before {
   opacity: 1;
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-focus::before {
+  background: linear-gradient(135deg, rgb(99 102 241), rgb(37 99 235));
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-chill::before {
+  background: linear-gradient(135deg, rgb(245 158 11), rgb(217 119 6));
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-workout::before {
+  background: linear-gradient(135deg, rgb(244 63 94), rgb(219 39 119));
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-party::before {
+  background: linear-gradient(135deg, rgb(168 85 247), rgb(217 70 239));
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-sleep::before {
+  background: linear-gradient(135deg, rgb(8 145 178), rgb(30 64 175));
 }
 
 :root[data-skin="liquid"] .liquid-mood-icon {
@@ -786,6 +806,51 @@
   .dark\:text-white,
   .dark\:text-zinc-100,
   .dark\:text-zinc-200
+) {
+  color: var(--liq-ink) !important;
+}
+
+/* Light-mode `.text-white` neutralization. Components like AboutView's
+   hero ship `<div className="... bg-linear-to-br from-zinc-900 ...
+   text-white">` — the dark gradient body keeps white text readable
+   in Studio. Liquid light mode keeps the same `text-white` on those
+   elements while the surrounding aurora bleeds through, and the
+   inherited white propagates down to every text child → invisible.
+   Remap `.text-white` to `--liq-ink` (dark in light, near-white in
+   dark, so it stays white when it should). The `:not(...)` chain
+   excludes elements that ALSO carry a saturated colored background
+   (emerald pills, action buttons, mood tiles) where the white is
+   intentional. */
+:root[data-skin="liquid"]:not(.dark) :where(.text-white):not(
+  [class*="bg-emerald"]
+):not(
+  [class*="bg-violet"]
+):not(
+  [class*="bg-indigo"]
+):not(
+  [class*="bg-blue-5"]
+):not(
+  [class*="bg-blue-6"]
+):not(
+  [class*="bg-purple"]
+):not(
+  [class*="bg-fuchsia"]
+):not(
+  [class*="bg-pink"]
+):not(
+  [class*="bg-rose"]
+):not(
+  [class*="bg-amber"]
+):not(
+  [class*="bg-orange"]
+):not(
+  [class*="bg-sky"]
+):not(
+  [class*="bg-cyan"]
+):not(
+  .liquid-mood-tile
+):not(
+  .liquid-mood-tile *
 ) {
   color: var(--liq-ink) !important;
 }

--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -484,26 +484,42 @@
    because the two alphas multiply (0.55 × 0.95 = 0.52, basically
    unchanged from 0.55). Solid-alpha gradients give the saturated
    cards that white text actually reads on. */
+/* Paint the gradient DIRECTLY on the tile element (not the ::before
+   pseudo) for the light variant. The pseudo route was fragile in
+   three ways:
+   - it sits behind the tile body at z-index -1 and depends on the
+     parent's stacking context staying as expected,
+   - the `opacity` transition (240ms) on the pseudo races with
+     theme/skin re-application during profile load — `.dark` can flip
+     on briefly while the DB row is being read by ThemeContext, and
+     the `:not(.dark)` rule stops matching → cards fade to the
+     0.55-alpha gradient and look white,
+   - view transitions snapshot the paint at the moment of click; if
+     the snapshot caught the wrong state the tile stays pale until
+     the transition tears down.
+   Painting on the element itself bypasses all three traps — the
+   tile renders as a saturated colored surface from the first paint,
+   and stays that way regardless of cascade ordering, .dark flips,
+   or view-transition snapshots. We also `display: none` the ::before
+   so the two layers don't double-stack and re-introduce the flicker
+   when the user picks an interactive state mid-transition. */
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-focus {
+  background-image: linear-gradient(135deg, rgb(99 102 241), rgb(37 99 235)) !important;
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-chill {
+  background-image: linear-gradient(135deg, rgb(245 158 11), rgb(217 119 6)) !important;
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-workout {
+  background-image: linear-gradient(135deg, rgb(244 63 94), rgb(219 39 119)) !important;
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-party {
+  background-image: linear-gradient(135deg, rgb(168 85 247), rgb(217 70 239)) !important;
+}
+:root[data-skin="liquid"]:not(.dark) .liquid-mood-sleep {
+  background-image: linear-gradient(135deg, rgb(8 145 178), rgb(30 64 175)) !important;
+}
 :root[data-skin="liquid"]:not(.dark) .liquid-mood-tile::before {
-  opacity: 0.95;
-}
-:root[data-skin="liquid"]:not(.dark) .liquid-mood-tile:hover::before {
-  opacity: 1;
-}
-:root[data-skin="liquid"]:not(.dark) .liquid-mood-focus::before {
-  background: linear-gradient(135deg, rgb(99 102 241), rgb(37 99 235));
-}
-:root[data-skin="liquid"]:not(.dark) .liquid-mood-chill::before {
-  background: linear-gradient(135deg, rgb(245 158 11), rgb(217 119 6));
-}
-:root[data-skin="liquid"]:not(.dark) .liquid-mood-workout::before {
-  background: linear-gradient(135deg, rgb(244 63 94), rgb(219 39 119));
-}
-:root[data-skin="liquid"]:not(.dark) .liquid-mood-party::before {
-  background: linear-gradient(135deg, rgb(168 85 247), rgb(217 70 239));
-}
-:root[data-skin="liquid"]:not(.dark) .liquid-mood-sleep::before {
-  background: linear-gradient(135deg, rgb(8 145 178), rgb(30 64 175));
+  display: none;
 }
 
 :root[data-skin="liquid"] .liquid-mood-icon {


### PR DESCRIPTION
> **Status: draft / WIP** — first attempt landed and reverted on main, opening this PR to iterate without churning the changelog.

## Symptoms (Liquid light skin, after v1.5.0 ship)

1. **Mood Radio tiles** — cards render as faint pastels (Focus / Chill / Workout / Party / Sleep). Hardcoded white text dissolves into the pale tile bg.
2. **About hero** — \"WaveFlow\" wordmark, \"Cross-platform HD music player\" subtitle, \"Developed by WaveFlow Team\" footer all paint grey-on-grey because the dark gradient body gets neutralised by the Liquid surface chain and the inherited \`text-white\` propagates down to every child.

## First-pass attempt (cherry-picked from debc42f)

- **Mood Radio**: bumped the 5 mood gradients' internal alphas from 0.55 → 1.0 in \`:not(.dark)\` so the colored ::before layer fully saturates (the previous fix only bumped \`opacity: 0.55 → 0.95\` on the pseudo, but the gradient stops themselves still ran at 0.55 alpha — net 0.52, basically unchanged).
- **About hero**: added a \`.text-white\` → \`--liq-ink\` neutralisation in \`:not(.dark)\` mode, excluding 12 colored-bg utility prefixes (bg-emerald / bg-violet / bg-indigo / bg-blue-5 / bg-blue-6 / bg-purple / bg-fuchsia / bg-pink / bg-rose / bg-amber / bg-orange / bg-sky / bg-cyan) plus the mood tile container so intentional white pills (v1.5.0 emerald badge, action chips) keep their contrast.

## Why this isn't enough yet

User-tested in the live app and reported:
- Mood Radio tiles **still pale** despite the gradient alpha bump → suspect the tile body's \`backdrop-filter\` + \`z-index: -1\` of \`::before\` is stacking the gradient behind the glass tint at a paint layer that gets blurred / occluded
- About text **still grey-on-grey** → the \`.text-white\` override doesn't catch every descendant; some text uses \`text-zinc-400\` (subtitle) and \`text-zinc-500\` (license meta + Developed by) which Liquid does map but to \`--liq-muted\` which is rgb(102 102 106) — still low contrast against light glass

## Next iterations to try

- [ ] Move Mood Radio gradient to the tile's own \`background-image\` (not ::before) to bypass the z-index / backdrop-filter interaction
- [ ] Add a \`isolation: isolate\` on the tile so the ::before stacks correctly
- [ ] Tighten Liquid-light text colors: \`text-zinc-400\` → darker than \`--liq-muted\` (currently 102 102 106 ≈ 40% lightness); maybe rgb(63 63 70) or use \`--liq-ink\` for body copy
- [ ] Audit the About hero specifically — its dark gradient body should NOT be neutralised by Liquid surface rules at all (the design intent is dark block); add a \`:not(.about-hero)\` carve-out or move the hero to a skin-aware token
- [ ] Same audit for \`text-zinc-500\` (used by the v1.5.0 pill metadata + license line)

## Test plan

- [ ] Liquid light: Mood Radio tiles fully saturated, white text reads cleanly
- [ ] Liquid light: About hero shows dark text on light glass OR white text on dark hero (pick one and commit)
- [ ] Liquid dark: all unchanged
- [ ] Studio / Editorial / Lounge / Pulse: no regression
- [ ] AboutView keyboard nav + screen reader still OK