### PR TITLE
fix(1.5.1): mini-player white screen + Pulse halo leak in skin picker

### DIFF
--- a/src/MiniPlayerApp.tsx
+++ b/src/MiniPlayerApp.tsx
@@ -9,6 +9,12 @@ import { MiniPlayer } from "./components/views/MiniPlayer";
  * Library / Playlist contexts since the mini-player only displays
  * the current track + playback controls — no library browsing.
  *
+ * ProfileProvider sits OUTSIDE ThemeProvider because the per-profile
+ * theme work landed in #264 made `ThemeProvider` call `useProfile()`
+ * to scope theme choices per-profile. Without this nesting the
+ * mini boots into a white screen via the "must be used within
+ * ProfileProvider" throw — mirrors the main `App.tsx` nesting.
+ *
  * SpotifyProvider stays in because PlayerProvider calls useSpotify()
  * unconditionally (provider routing happens inside PlayerContext).
  * Without it the mini boots into a white screen via the "must be
@@ -20,14 +26,14 @@ import { MiniPlayer } from "./components/views/MiniPlayer";
  */
 export function MiniPlayerApp() {
   return (
-    <ThemeProvider>
-      <ProfileProvider>
+    <ProfileProvider>
+      <ThemeProvider>
         <SpotifyProvider>
           <PlayerProvider>
             <MiniPlayer />
           </PlayerProvider>
         </SpotifyProvider>
-      </ProfileProvider>
-    </ThemeProvider>
+      </ThemeProvider>
+    </ProfileProvider>
   );
 }

--- a/src/components/views/AboutView.tsx
+++ b/src/components/views/AboutView.tsx
@@ -256,37 +256,45 @@ export function AboutView({ onNavigate }: AboutViewProps) {
         </div>
       </div>
 
-      {/* Hero Card */}
-      <div className="relative overflow-hidden rounded-3xl p-10 bg-linear-to-br from-zinc-900 to-zinc-800 text-white">
-        <div className="absolute top-0 right-0 text-[120px] font-black text-white/5 leading-none pr-8 pt-4 select-none">
+      {/* Hero Card — theme-aware so the light variant stays readable.
+          The original hero hardcoded a dark gradient + white text;
+          that worked on Studio Dark and on Studio Light (where the
+          dark surface deliberately contrasted with the page), but
+          Liquid Light's universal `rounded-3xl` glass override
+          (liquid.css:349) strips `background-image` and leaves the
+          dark text classes stranded on pale glass. Pairing every
+          colour with a `dark:` variant lets the hero render
+          correctly on every (theme × skin) combo. */}
+      <div className="relative overflow-hidden rounded-3xl p-10 bg-linear-to-br from-zinc-100 to-zinc-200 dark:from-zinc-900 dark:to-zinc-800 text-zinc-900 dark:text-white">
+        <div className="absolute top-0 right-0 text-[120px] font-black text-zinc-900/5 dark:text-white/5 leading-none pr-8 pt-4 select-none">
           {version}
         </div>
         <div className="relative z-10">
           <div className="flex items-center space-x-2 mb-2">
             <WaveFlowLogo className="w-8 h-8" />
             <h2 className="text-3xl font-black">
-              Wave<span className="text-emerald-400">Flow</span>
+              Wave<span className="text-emerald-600 dark:text-emerald-400">Flow</span>
             </h2>
           </div>
-          <p className="text-zinc-400 mb-4">{t("about.hero.subtitle")}</p>
+          <p className="text-zinc-600 dark:text-zinc-400 mb-4">{t("about.hero.subtitle")}</p>
           <div className="flex items-center space-x-3 mb-4">
             <span className="bg-emerald-500 text-white text-xs px-2.5 py-1 rounded-full font-semibold">
               v{version}
             </span>
-            <span className="text-zinc-500 text-sm">2026</span>
-            <span className="text-zinc-600">·</span>
-            <span className="text-zinc-500 text-sm">GPL-3.0 License</span>
+            <span className="text-zinc-600 dark:text-zinc-500 text-sm">2026</span>
+            <span className="text-zinc-400 dark:text-zinc-600">·</span>
+            <span className="text-zinc-600 dark:text-zinc-500 text-sm">GPL-3.0 License</span>
           </div>
           <button
             type="button"
-            className="flex items-center space-x-2 px-4 py-2 rounded-xl border border-zinc-700 bg-zinc-800 text-sm font-medium text-zinc-300 hover:bg-zinc-700 transition-colors"
+            className="flex items-center space-x-2 px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
           >
             <ExternalLink size={14} aria-hidden="true" />
             <span>{t("about.hero.checkUpdates")}</span>
           </button>
-          <p className="text-xs text-zinc-500 mt-4">
+          <p className="text-xs text-zinc-600 dark:text-zinc-500 mt-4">
             {t("about.hero.developedBy")}{" "}
-            <span className="font-semibold text-zinc-300">WaveFlow Team</span>
+            <span className="font-semibold text-zinc-800 dark:text-zinc-300">WaveFlow Team</span>
           </p>
         </div>
       </div>

--- a/src/components/views/settings/SkinPickerCard.tsx
+++ b/src/components/views/settings/SkinPickerCard.tsx
@@ -92,12 +92,20 @@ export function SkinPickerCard() {
           // skin's actual tokens, not the active skin's. Using inline
           // styles also sidesteps having to round-trip through
           // tailwind / data-skin attribute fiddling for the preview.
+          //
+          // `shadowCard` is intentionally NOT applied here: Pulse's
+          // neon halo (`0 0 24px -4px var(--accent-500)`) leaks
+          // visibly past the button's overflow-hidden clip, and at
+          // ~200×100 px the other skins' shadows are too subtle to
+          // read anyway. The skin's identity is already carried by
+          // the display font + heading weight + tracking + radius;
+          // chrome-scale shadows belong on real surfaces, not on
+          // thumbnail previews.
           const previewStyle: React.CSSProperties = {
             fontFamily: preset.typography.display,
             fontWeight: preset.typography.headingWeight,
             letterSpacing: preset.typography.displayTracking,
             borderRadius: preset.radius.card,
-            boxShadow: preset.surface.shadowCard,
           };
           return (
             <button


### PR DESCRIPTION
**WIP — patch bundle pour la 1.5.1.** Encore la race condition Liquid light (Mood Radio) à investiguer avant merge.

Closes #279
Closes #281

L'issue #280 (deux dossiers `plugins/web-radio/`) n'est PAS dans cette PR : c'est l'architecture standard Tauri NSIS où le bundle plugin vit sous `%LocalAppData%\WaveFlow\plugins\` (resource dir, read-only) et est copié au boot vers `%AppData%\Roaming\app.waveflow\waveflow\plugins\` (runtime). Le runtime charge toujours depuis Roaming. Pour l'éliminer il faudrait loader les plugins bundled directement depuis `BaseDirectory::Resource` — refactor du loader, mieux scopé pour 1.6.0.

## Bugs corrigés

### 1. Mini-player blanche depuis 1.5.0 (#279)

`ThemeProvider` appelle `useProfile()` depuis #264 (per-profile theme + skin storage), mais [`MiniPlayerApp.tsx`](src/MiniPlayerApp.tsx) était resté avec l'ancien ordre où `ThemeProvider` wrap `ProfileProvider`. React StrictMode catch le `"must be used within ProfileProvider"` throw → fenêtre blanche.

**Fix** (`985e4e5`) : remettre `ProfileProvider` en outer comme dans `App.tsx`.

### 2. Glow neon Pulse leak dans le skin picker (#281)

[`SkinPickerCard`](src/components/views/settings/SkinPickerCard.tsx) applique `preset.surface.shadowCard` en `boxShadow` inline sur la div interne. Pulse seul utilise une halo neon saturée (`0 0 24px -4px var(--accent-500)`) qui escape le clip `overflow-hidden` du bouton parent et bleed en bas de la card preview.

Les autres skins ont des shadows soit trop subtiles pour être visibles à ~200×100 px (Studio, Lounge), soit `none` (Editorial, Liquid). Le canal porte zéro signal utile pour 4 skins et un vrai bug pour le 5e.

**Fix** (`a066a17`) : drop `boxShadow` du `previewStyle`. L'identité du skin reste portée par la typographie + le radius — les shadows se révèlent au clic sur le vrai chrome.

### 3. About hero illisible en Liquid light

Le Hero hardcodait `bg-linear-to-br from-zinc-900 to-zinc-800 text-white` + classes `text-zinc-{300,400,500,600}` dark-only. Marchait sur Studio Light (gradient dark contraste avec la page), mais [`liquid.css:349`](src/styles/skins/liquid.css#L349) strip `background-image` sur tout `rounded-3xl` sous `main` pour appliquer son glass universel → texte dark stranded sur glass pâle, version watermark / subtitle / year / license / bouton tous invisibles.

**Fix** (`a802da9`) : paire chaque couleur avec un variant `dark:` pour que le hero rende correctement sur chaque combo (theme × skin).

## Bug à investiguer avant merge (blocker)

### Race condition Liquid light → Mood Radio tiles blanchissent

Pré-investigation : [`liquid.css:443-486`](src/styles/skins/liquid.css#L443-L486) — `.liquid-mood-tile::before` a opacity 0.55 par défaut + transition opacity 240ms, override à 0.95 quand `:not(.dark)` matche. Le double-effect pattern de `ThemeContext` (cache→DB) peut toggle `.dark` brièvement pendant un profile load, déclencher la transition opacity, et un second reapply pendant l'animation persiste l'état intermédiaire.

Trois itérations précédentes ont échoué (`debc42f` reverted, `a2c0cb4` WIP deleted) parce qu'elles patchaient le symptôme CSS, pas la race. À adresser à la source : court-circuiter `applyTheme` + `applySkin` quand cache et DB matchent.

## Test plan

- [x] `bun run typecheck` passe
- [x] Test manuel mini-player (clic immersive → fenêtre s'ouvre avec UI, pas white)
- [x] Test manuel Settings → Appearance, skin Pulse non-actif (pas de leak vert sous la card)
- [x] Test manuel About en Liquid light (texte lisible : subtitle, dates, bouton)
- [x] Test manuel About en Studio dark / Studio light / Editorial / Lounge / Pulse / Liquid dark (regression check)
- [x] Race condition Liquid light Mood Radio investigation + fix
- [x] Test manuel : Liquid light, switch profile plusieurs fois, vérifier Mood Radio reste coloré

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correction de la cohérence du thème clair/sombre dans la vue About pour une meilleure lisibilité

* **Style**
  * Optimisation du rendu visuel des aperçus de skins
  * Amélioration de la palette de couleurs pour une meilleure adaptation au thème sélectionné

<!-- end of auto-generated comment: release notes by coderabbit.ai -->