### PR TITLE
fix(lyrics): strip Genius header + track real provider + user-driven refetch (closes #284)

### DIFF
--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -118,6 +118,19 @@ pub struct LyricsPayload {
     pub content: String,
     pub format: LyricsFormat,
     pub source: LyricsSource,
+    /// Sub-provider that produced this row when `source` is
+    /// `LyricsSource::Api`. Matches `Provider::as_str()` from
+    /// `waveflow_syncedlyrics` (snake_case identifier:
+    /// `"lrclib"` / `"genius"` / `"net_ease"` / `"megalobiz"` /
+    /// `"musixmatch"`). `None` for embedded / sidecar / manual rows
+    /// and for pre-1.5.1 cached entries that pre-date the
+    /// `lyrics.provider` column. The UI surfaces this in the source
+    /// badge so the user knows whether they're looking at LRCLIB-
+    /// curated lyrics or a Genius scrape — important when the latter
+    /// occasionally returns junk (issue #284) and the user wants to
+    /// re-fetch from a different provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
     /// Set by `save_lyrics` when destination = `tag` was requested but
     /// the audio file's tag system can't carry the chosen format (e.g.
     /// TTML in an MP3's ID3v2 where lofty has no mapping for the
@@ -413,12 +426,22 @@ async fn cache_external_lyrics(
 ) -> AppResult<LyricsPayload> {
     let format = external_format_to_app(result.format);
     let source = LyricsSource::Api;
-    upsert_lyrics(pool, file_hash, &result.content, &format, &source).await?;
+    let provider = result.provider.as_str();
+    upsert_lyrics(
+        pool,
+        file_hash,
+        &result.content,
+        &format,
+        &source,
+        Some(provider),
+    )
+    .await?;
     Ok(LyricsPayload {
         track_id,
         content: result.content,
         format,
         source,
+        provider: Some(provider.to_string()),
         tag_write_skipped: None,
         sidecar_write_skipped: None,
     })
@@ -462,7 +485,9 @@ async fn try_external_fallback_or_miss(
     // No provider had lyrics. Cache as an empty row so we don't re-hit
     // the network on every panel open. The user can force a re-search
     // by clicking "Refetch" in the lyrics panel (clears the row,
-    // re-runs the waterfall).
+    // re-runs the waterfall). `provider = None` for the miss row —
+    // attribution to a specific provider would be misleading when
+    // every provider returned nothing.
     let empty = String::new();
     upsert_lyrics(
         pool,
@@ -470,6 +495,7 @@ async fn try_external_fallback_or_miss(
         &empty,
         &LyricsFormat::Plain,
         &LyricsSource::Api,
+        None,
     )
     .await?;
     Ok(LyricsPayload {
@@ -477,6 +503,7 @@ async fn try_external_fallback_or_miss(
         content: empty,
         format: LyricsFormat::Plain,
         source: LyricsSource::Api,
+        provider: None,
         tag_write_skipped: None,
         sidecar_write_skipped: None,
     })
@@ -679,26 +706,35 @@ fn read_non_empty_file(path: &Path) -> Option<String> {
 
 /// Insert (or replace) the lyrics row, keyed by file content hash so the
 /// cache is shared across profiles that contain the same audio file.
+///
+/// `provider` carries the sub-source identifier when `source` is
+/// `LyricsSource::Api` (e.g. `"lrclib"`, `"genius"`) and `None` for
+/// embedded / sidecar / manual writes where the broad `source` is
+/// the only meaningful attribution. The DB column allows NULL so
+/// pre-1.5.1 rows + non-API tiers store cleanly.
 async fn upsert_lyrics(
     pool: &sqlx::SqlitePool,
     file_hash: &str,
     content: &str,
     format: &LyricsFormat,
     source: &LyricsSource,
+    provider: Option<&str>,
 ) -> AppResult<()> {
     sqlx::query(
-        "INSERT INTO app.lyrics (file_hash, content, format, source, language, fetched_at)
-         VALUES (?, ?, ?, ?, NULL, ?)
+        "INSERT INTO app.lyrics (file_hash, content, format, source, provider, language, fetched_at)
+         VALUES (?, ?, ?, ?, ?, NULL, ?)
          ON CONFLICT(file_hash) DO UPDATE SET
             content = excluded.content,
             format = excluded.format,
             source = excluded.source,
+            provider = excluded.provider,
             fetched_at = excluded.fetched_at",
     )
     .bind(file_hash)
     .bind(content)
     .bind(format_to_db(format))
     .bind(source_to_db(source))
+    .bind(provider)
     .bind(now_ms())
     .execute(pool)
     .await?;
@@ -709,8 +745,8 @@ async fn upsert_lyrics(
 /// numeric `track_id` so we look up the file hash first, then key into the
 /// shared `app.lyrics` cache.
 async fn read_cached(pool: &sqlx::SqlitePool, track_id: i64) -> AppResult<Option<LyricsPayload>> {
-    let row: Option<(String, String, String)> = sqlx::query_as(
-        "SELECT l.content, l.format, l.source
+    let row: Option<(String, String, String, Option<String>)> = sqlx::query_as(
+        "SELECT l.content, l.format, l.source, l.provider
            FROM track t
            JOIN app.lyrics l ON l.file_hash = t.file_hash
           WHERE t.id = ?",
@@ -718,11 +754,12 @@ async fn read_cached(pool: &sqlx::SqlitePool, track_id: i64) -> AppResult<Option
     .bind(track_id)
     .fetch_optional(pool)
     .await?;
-    Ok(row.map(|(content, fmt, src)| LyricsPayload {
+    Ok(row.map(|(content, fmt, src, provider)| LyricsPayload {
         track_id,
         content,
         format: parse_format(&fmt),
         source: parse_source(&src),
+        provider,
         tag_write_skipped: None,
         sidecar_write_skipped: None,
     }))
@@ -810,12 +847,13 @@ pub async fn fetch_lyrics(
     if let Some(content) = embedded {
         let format = detect_format(&content);
         let source = LyricsSource::Embedded;
-        upsert_lyrics(&pool, &meta.file_hash, &content, &format, &source).await?;
+        upsert_lyrics(&pool, &meta.file_hash, &content, &format, &source, None).await?;
         return Ok(Some(LyricsPayload {
             track_id,
             content,
             format,
             source,
+            provider: None,
             tag_write_skipped: None,
             sidecar_write_skipped: None,
         }));
@@ -834,12 +872,13 @@ pub async fn fetch_lyrics(
     if let Some(content) = sidecar {
         let format = detect_format(&content);
         let source = LyricsSource::LrcFile;
-        upsert_lyrics(&pool, &meta.file_hash, &content, &format, &source).await?;
+        upsert_lyrics(&pool, &meta.file_hash, &content, &format, &source, None).await?;
         return Ok(Some(LyricsPayload {
             track_id,
             content,
             format,
             source,
+            provider: None,
             tag_write_skipped: None,
             sidecar_write_skipped: None,
         }));
@@ -928,6 +967,9 @@ pub async fn fetch_lyrics(
 
     if resp.instrumental == Some(true) {
         // Instrumental: cache an empty plain entry so we don't refetch.
+        // Attribute the row to LRCLIB so the UI badge reflects who told
+        // us this track is instrumental — the user can still try a
+        // different provider via `refetch_lyrics` if they disagree.
         let empty = String::new();
         upsert_lyrics(
             &pool,
@@ -935,6 +977,7 @@ pub async fn fetch_lyrics(
             &empty,
             &LyricsFormat::Plain,
             &LyricsSource::Api,
+            Some(Provider::Lrclib.as_str()),
         )
         .await?;
         return Ok(Some(LyricsPayload {
@@ -942,6 +985,7 @@ pub async fn fetch_lyrics(
             content: empty,
             format: LyricsFormat::Plain,
             source: LyricsSource::Api,
+            provider: Some(Provider::Lrclib.as_str().to_string()),
             tag_write_skipped: None,
             sidecar_write_skipped: None,
         }));
@@ -965,15 +1009,136 @@ pub async fn fetch_lyrics(
     };
 
     let source = LyricsSource::Api;
-    upsert_lyrics(&pool, &meta.file_hash, &content, &format, &source).await?;
+    let provider = Provider::Lrclib.as_str();
+    upsert_lyrics(
+        &pool,
+        &meta.file_hash,
+        &content,
+        &format,
+        &source,
+        Some(provider),
+    )
+    .await?;
     Ok(Some(LyricsPayload {
         track_id,
         content,
         format,
         source,
+        provider: Some(provider.to_string()),
         tag_write_skipped: None,
         sidecar_write_skipped: None,
     }))
+}
+
+/// Force a re-fetch for a single track.
+///
+/// Drops the cached row first so the waterfall (or the single-provider
+/// query below) is guaranteed to re-query — without this every refetch
+/// would short-circuit on the cache hit. Two modes:
+///
+/// 1. `provider = None` → re-run the full [`fetch_lyrics`] waterfall:
+///    embedded tag → sidecar `.lrc` → Musixmatch (if opt-in) →
+///    LRCLIB → external fallback chain.
+/// 2. `provider = Some(id)` → bypass local tiers, query ONLY that
+///    provider (`"lrclib"` / `"genius"` / `"net_ease"` / `"megalobiz"`
+///    / `"musixmatch"`). Used by the lyrics panel's provider picker
+///    when the auto-waterfall cached a low-quality hit (e.g. Genius
+///    junk per issue #284) and the user wants to try a different
+///    source by name.
+///
+/// In single-provider mode, a miss is cached with the requested
+/// provider as the attribution so the UI badge reflects what the user
+/// last tried — picking a different provider and trying again is then
+/// the natural next step.
+#[tauri::command]
+pub async fn refetch_lyrics(
+    state: tauri::State<'_, AppState>,
+    track_id: i64,
+    provider: Option<String>,
+) -> AppResult<Option<LyricsPayload>> {
+    let pool = state.require_profile_pool().await?;
+
+    // Drop the cached row (if any) so the waterfall / single-provider
+    // path below is forced to re-query. Look up the file_hash first
+    // since `app.lyrics` is keyed by content hash, not track id.
+    let file_hash: Option<String> =
+        sqlx::query_scalar("SELECT file_hash FROM track WHERE id = ?")
+            .bind(track_id)
+            .fetch_optional(&pool)
+            .await?;
+    let Some(file_hash) = file_hash else {
+        return Ok(None);
+    };
+    sqlx::query("DELETE FROM app.lyrics WHERE file_hash = ?")
+        .bind(&file_hash)
+        .execute(&pool)
+        .await?;
+
+    // No provider pinned → identical to a fresh `fetch_lyrics` call,
+    // since the cache row is gone and the waterfall starts at the
+    // embedded tier.
+    let Some(provider_str) = provider.as_deref() else {
+        return fetch_lyrics(state, track_id).await;
+    };
+
+    let Some(provider) = Provider::from_str(provider_str) else {
+        return Err(AppError::Other(format!(
+            "unknown lyrics provider: {provider_str}"
+        )));
+    };
+
+    // Provider pinned: query that one only. Skip embedded / sidecar
+    // tiers — the user explicitly asked for a network source, and a
+    // local hit would just put us back where we started.
+    let meta = match read_track_meta(&pool, track_id).await? {
+        Some(m) => m,
+        None => return Ok(None),
+    };
+    if crate::offline::is_offline() {
+        return Ok(None);
+    }
+    // Honour the per-profile Musixmatch translation target if the user
+    // picked Musixmatch — same opt-in path the waterfall takes.
+    let lang = read_translation_lang(&pool).await.unwrap_or(None);
+    match external_lyrics_search(
+        &meta,
+        vec![provider],
+        SearchMode::PreferSynced,
+        true,
+        lang.as_deref(),
+    )
+    .await
+    {
+        Ok(Some(result)) => cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
+            .await
+            .map(Some),
+        Ok(None) => {
+            // Pinned provider returned nothing. Cache an empty miss
+            // attributed to it so the badge reflects what the user
+            // just tried — they can pick a different provider and
+            // refetch without the cache shortcut blocking them.
+            let provider_id = provider.as_str();
+            upsert_lyrics(
+                &pool,
+                &meta.file_hash,
+                "",
+                &LyricsFormat::Plain,
+                &LyricsSource::Api,
+                Some(provider_id),
+            )
+            .await?;
+            Ok(Some(LyricsPayload {
+                track_id,
+                content: String::new(),
+                format: LyricsFormat::Plain,
+                source: LyricsSource::Api,
+                provider: Some(provider_id.to_string()),
+                tag_write_skipped: None,
+                sidecar_write_skipped: None,
+            }))
+        }
+        Err(err) => Err(err),
+    }
 }
 
 /// Read a `.lrc` (or any text) file from disk and store it as the
@@ -1003,12 +1168,13 @@ pub async fn import_lrc_file(
     }
     let format = detect_format(trimmed);
     let source = LyricsSource::LrcFile;
-    upsert_lyrics(&pool, &file_hash, trimmed, &format, &source).await?;
+    upsert_lyrics(&pool, &file_hash, trimmed, &format, &source, None).await?;
     Ok(LyricsPayload {
         track_id,
         content: trimmed.to_string(),
         format,
         source,
+        provider: None,
         tag_write_skipped: None,
         sidecar_write_skipped: None,
     })
@@ -1152,7 +1318,9 @@ async fn run_prefetch(
         if let Some(content) = embedded {
             let format = detect_format(&content);
             let source = LyricsSource::Embedded;
-            if let Err(e) = upsert_lyrics(&pool, &file_hash, &content, &format, &source).await {
+            if let Err(e) =
+                upsert_lyrics(&pool, &file_hash, &content, &format, &source, None).await
+            {
                 tracing::warn!(track_id, ?e, "persist embedded lyrics failed");
                 failed += 1;
             } else {
@@ -1174,7 +1342,9 @@ async fn run_prefetch(
         if let Some(content) = sidecar {
             let format = detect_format(&content);
             let source = LyricsSource::LrcFile;
-            if let Err(e) = upsert_lyrics(&pool, &file_hash, &content, &format, &source).await {
+            if let Err(e) =
+                upsert_lyrics(&pool, &file_hash, &content, &format, &source, None).await
+            {
                 tracing::warn!(track_id, ?e, "persist sidecar lyrics failed");
                 failed += 1;
             } else {
@@ -1261,6 +1431,7 @@ async fn run_prefetch(
                         "",
                         &LyricsFormat::Plain,
                         &LyricsSource::Api,
+                        Some(Provider::Lrclib.as_str()),
                     )
                     .await;
                     hits += 1;
@@ -1271,9 +1442,15 @@ async fn run_prefetch(
                         _ => None,
                     };
                     if let Some((content, format)) = pick {
-                        if let Err(e) =
-                            upsert_lyrics(&pool, &file_hash, &content, &format, &LyricsSource::Api)
-                                .await
+                        if let Err(e) = upsert_lyrics(
+                            &pool,
+                            &file_hash,
+                            &content,
+                            &format,
+                            &LyricsSource::Api,
+                            Some(Provider::Lrclib.as_str()),
+                        )
+                        .await
                         {
                             tracing::warn!(track_id, ?e, "persist LRCLIB lyrics failed");
                             failed += 1;
@@ -1310,6 +1487,7 @@ async fn run_prefetch(
                                     "",
                                     &LyricsFormat::Plain,
                                     &LyricsSource::Api,
+                                    None,
                                 )
                                 .await;
                                 misses += 1;
@@ -1355,6 +1533,7 @@ async fn run_prefetch(
                             "",
                             &LyricsFormat::Plain,
                             &LyricsSource::Api,
+                            None,
                         )
                         .await;
                         misses += 1;
@@ -1608,7 +1787,7 @@ pub async fn save_lyrics(
     }
 
     let source = LyricsSource::Manual;
-    upsert_lyrics(&pool, &file_hash, &trimmed, &format, &source).await?;
+    upsert_lyrics(&pool, &file_hash, &trimmed, &format, &source, None).await?;
 
     let _ = app.emit("lyrics:updated", track_id);
     Ok(LyricsPayload {
@@ -1616,6 +1795,7 @@ pub async fn save_lyrics(
         content: trimmed,
         format,
         source,
+        provider: None,
         tag_write_skipped: if tag_write_skipped { Some(true) } else { None },
         sidecar_write_skipped: if sidecar_write_skipped {
             Some(true)

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -727,6 +727,7 @@ pub fn run() {
             commands::tray::set_tray_labels,
             commands::lyrics::get_lyrics,
             commands::lyrics::fetch_lyrics,
+            commands::lyrics::refetch_lyrics,
             commands::lyrics::import_lrc_file,
             commands::lyrics::save_lyrics,
             commands::lyrics::export_lyrics_to_path,

--- a/src-tauri/crates/syncedlyrics/src/providers/genius.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/genius.rs
@@ -51,7 +51,14 @@ pub async fn search(
     // attacker-controlled host and we'd happily GET it.
     let url = validate_outbound_url(url_str, GENIUS_ALLOWED_HOSTS)?;
     let page = safe_text(http.get(url).send().await?.error_for_status()?).await?;
-    let text = extract_lyrics_containers(&page);
+    let raw = extract_lyrics_containers(&page);
+    let text = strip_genius_header(&raw);
+    // Treat a stub page (header only, no lyrics body — Genius renders
+    // these for songs that have been added but never transcribed) as a
+    // miss so the host can fall through to the next provider instead of
+    // surfacing the bare "N ContributorsTitle Lyrics" artifact to the
+    // user (issue #284). The full unsynced lyrics are otherwise
+    // returned unchanged.
     Ok((!text.trim().is_empty()).then_some(Candidate {
         synced: None,
         unsynced: Some(text),
@@ -76,4 +83,109 @@ fn extract_lyrics_containers(html: &str) -> String {
         pos = close + "</div>".len();
     }
     out
+}
+
+/// Strip the standard Genius lyrics-page header artifact from the
+/// start of an extracted lyrics body.
+///
+/// Recent Genius layouts nest the contributor badge + the
+/// `<song title> Lyrics` heading inside the same `data-lyrics-container`
+/// div that holds the actual verses, so once `html_text_decode` flattens
+/// the tags we end up with a prefix like
+/// `"17 ContributorsFall on Me Lyrics"` glued directly to the lyrics body
+/// (issue #284). Strip the prefix when we recognise the
+/// `^\d+ Contributors.*? Lyrics` shape; leave the text untouched
+/// otherwise so a different layout doesn't silently lose its first line.
+fn strip_genius_header(text: &str) -> String {
+    let trimmed = text.trim_start();
+    let digits_end = trimmed.chars().take_while(|c| c.is_ascii_digit()).count();
+    if digits_end == 0 {
+        return text.to_string();
+    }
+    let after_digits = &trimmed[digits_end..];
+    let Some(after_contrib) = after_digits.strip_prefix(" Contributors") else {
+        return text.to_string();
+    };
+    // Find the first " Lyrics" token that closes the header — Genius
+    // glues the title onto the trailing " Lyrics" word with a single
+    // space separator (e.g. "...Vez Lyrics"). Anything before that is
+    // the title we want to drop along with the badge text.
+    let Some(lyrics_idx) = after_contrib.find(" Lyrics") else {
+        return text.to_string();
+    };
+    after_contrib[lyrics_idx + " Lyrics".len()..]
+        .trim_start()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_header_drops_badge_title_and_lyrics_token() {
+        let input = "17 ContributorsFall on Me Lyrics\n[Chorus]\nFall on me";
+        assert_eq!(
+            strip_genius_header(input),
+            "[Chorus]\nFall on me".to_string()
+        );
+    }
+
+    #[test]
+    fn strip_header_returns_empty_for_stub_pages() {
+        // Genius renders this layout for songs added to the catalogue
+        // without transcribed lyrics. The bare header is the only
+        // content the parser sees, and the caller treats empty output
+        // as a miss so the next provider gets a turn.
+        let input = "2 ContributorsSolamente Una Vez Lyrics";
+        assert_eq!(strip_genius_header(input), "".to_string());
+    }
+
+    #[test]
+    fn strip_header_preserves_leading_whitespace_outside_pattern() {
+        // Genius occasionally pads the container with leading
+        // whitespace from inline scripts that don't decode to text.
+        // The trim_start on the digit probe must NOT eat newlines that
+        // belong to the lyrics body when no header is present.
+        let input = "\n[Verse 1]\nA real lyric";
+        assert_eq!(strip_genius_header(input), input.to_string());
+    }
+
+    #[test]
+    fn strip_header_no_op_when_no_digit_prefix() {
+        let input = "[Verse 1]\nA real lyric without a Genius header";
+        assert_eq!(strip_genius_header(input), input.to_string());
+    }
+
+    #[test]
+    fn strip_header_no_op_when_contributors_token_missing() {
+        // A track titled with a leading number (e.g. "99 Red Balloons")
+        // must not trigger the strip — only " Contributors" right
+        // after the digits qualifies as a Genius header.
+        let input = "99 Red Balloons Lyrics\n[Verse 1]";
+        assert_eq!(strip_genius_header(input), input.to_string());
+    }
+
+    #[test]
+    fn strip_header_no_op_when_lyrics_token_missing() {
+        // Defensive: a Genius layout change that drops the trailing
+        // " Lyrics" word would otherwise let us swallow the entire
+        // body up to the first match. Leave the input alone instead
+        // so the user sees raw content and we notice the regression
+        // in bug reports rather than silent data loss.
+        let input = "5 ContributorsSong Title Without Trailing Word\n[Verse]";
+        assert_eq!(strip_genius_header(input), input.to_string());
+    }
+
+    #[test]
+    fn strip_header_handles_multibyte_title() {
+        // Solamente Una Vez carries no multibyte chars but other Latin
+        // titles do (Naïve, Déjà Vu). The strip walks bytes via
+        // `find(" Lyrics")` + `len()`, both byte-safe.
+        let input = "3 ContributorsDéjà Vu Lyrics\n[Verse]\nMidnight again";
+        assert_eq!(
+            strip_genius_header(input),
+            "[Verse]\nMidnight again".to_string()
+        );
+    }
 }

--- a/src-tauri/crates/syncedlyrics/src/providers/genius.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/genius.rs
@@ -106,14 +106,33 @@ fn strip_genius_header(text: &str) -> String {
     let Some(after_contrib) = after_digits.strip_prefix(" Contributors") else {
         return text.to_string();
     };
-    // Find the first " Lyrics" token that closes the header — Genius
-    // glues the title onto the trailing " Lyrics" word with a single
-    // space separator (e.g. "...Vez Lyrics"). Anything before that is
-    // the title we want to drop along with the badge text.
-    let Some(lyrics_idx) = after_contrib.find(" Lyrics") else {
+    // Find the " Lyrics" token that closes the header. Genius glues
+    // the title onto a trailing " Lyrics" word with a single space
+    // separator (e.g. "...Vez Lyrics") and immediately follows that
+    // closer with either `\n` (when there's a body) or end-of-string
+    // (when the catalogue entry has no transcribed lyrics yet).
+    //
+    // Neither `find` nor `rfind` is correct here in general: a song
+    // titled "No Lyrics Needed" would put a " Lyrics" inside the
+    // title (`find` cuts too early), and a body line like "Some
+    // Lyrics" would do the same for `rfind` (cuts past the closer
+    // into the verses). The header closer is the FIRST " Lyrics"
+    // immediately followed by a newline or end-of-string, so we
+    // iterate forward and stop at that specific shape.
+    let lyrics_token = " Lyrics";
+    let lyrics_idx = after_contrib
+        .match_indices(lyrics_token)
+        .find(|(i, _)| {
+            let tail = &after_contrib[i + lyrics_token.len()..];
+            tail.is_empty()
+                || tail.starts_with('\n')
+                || tail.starts_with('\r')
+        })
+        .map(|(i, _)| i);
+    let Some(lyrics_idx) = lyrics_idx else {
         return text.to_string();
     };
-    after_contrib[lyrics_idx + " Lyrics".len()..]
+    after_contrib[lyrics_idx + lyrics_token.len()..]
         .trim_start()
         .to_string()
 }
@@ -181,11 +200,41 @@ mod tests {
     fn strip_header_handles_multibyte_title() {
         // Solamente Una Vez carries no multibyte chars but other Latin
         // titles do (Naïve, Déjà Vu). The strip walks bytes via
-        // `find(" Lyrics")` + `len()`, both byte-safe.
+        // `match_indices(" Lyrics")` + `len()`, both byte-safe.
         let input = "3 ContributorsDéjà Vu Lyrics\n[Verse]\nMidnight again";
         assert_eq!(
             strip_genius_header(input),
             "[Verse]\nMidnight again".to_string()
+        );
+    }
+
+    #[test]
+    fn strip_header_picks_closer_when_title_contains_lyrics_word() {
+        // CodeRabbit-flagged edge case (PR #287): a song titled
+        // "No Lyrics Needed" plants a " Lyrics" inside the title
+        // BEFORE the trailing closer. A naive `find(" Lyrics")` would
+        // cut at the title's occurrence and leave " Needed Lyrics\n…"
+        // in the output. The closer is the FIRST " Lyrics" followed
+        // by a newline or end-of-string — that's the shape we anchor
+        // on.
+        let input = "4 ContributorsNo Lyrics Needed Lyrics\n[Verse]\nReal body";
+        assert_eq!(
+            strip_genius_header(input),
+            "[Verse]\nReal body".to_string()
+        );
+    }
+
+    #[test]
+    fn strip_header_does_not_swallow_body_containing_lyrics_word() {
+        // Complementary to the above: if we'd swapped `find` for
+        // `rfind` (the original CodeRabbit suggestion) to handle the
+        // title case, a body line like "Some Lyrics" would now match
+        // LAST and the strip would eat half the verse. Newline-
+        // anchored matching keeps both shapes correct.
+        let input = "5 ContributorsSong Title Lyrics\n[Verse 1]\nSome Lyrics line";
+        assert_eq!(
+            strip_genius_header(input),
+            "[Verse 1]\nSome Lyrics line".to_string()
         );
     }
 }

--- a/src-tauri/crates/syncedlyrics/src/providers/genius.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/genius.rs
@@ -103,9 +103,15 @@ fn strip_genius_header(text: &str) -> String {
         return text.to_string();
     }
     let after_digits = &trimmed[digits_end..];
-    let Some(after_contrib) = after_digits.strip_prefix(" Contributors") else {
+    // Genius writes "1 Contributor" for a single transcriber and
+    // "N Contributors" for two or more — the plural-s is conditional
+    // on the badge count. Strip the singular core first; consume an
+    // optional trailing 's' to cover both shapes without two near-
+    // identical branches.
+    let Some(after_contrib) = after_digits.strip_prefix(" Contributor") else {
         return text.to_string();
     };
+    let after_contrib = after_contrib.strip_prefix('s').unwrap_or(after_contrib);
     // Find the " Lyrics" token that closes the header. Genius glues
     // the title onto a trailing " Lyrics" word with a single space
     // separator (e.g. "...Vez Lyrics") and immediately follows that
@@ -235,6 +241,20 @@ mod tests {
         assert_eq!(
             strip_genius_header(input),
             "[Verse 1]\nSome Lyrics line".to_string()
+        );
+    }
+
+    #[test]
+    fn strip_header_handles_singular_contributor_badge() {
+        // CodeRabbit-flagged edge case: Genius pluralises the badge
+        // conditionally — a song with a single transcriber renders
+        // "1 Contributor" (no trailing 's'). The strip MUST consume
+        // the singular form too, otherwise a 1-transcriber song
+        // ships the bare header to the user verbatim.
+        let input = "1 ContributorSomething Lyrics\n[Intro]\nReal body";
+        assert_eq!(
+            strip_genius_header(input),
+            "[Intro]\nReal body".to_string()
         );
     }
 }

--- a/src-tauri/crates/syncedlyrics/src/providers/mod.rs
+++ b/src-tauri/crates/syncedlyrics/src/providers/mod.rs
@@ -26,4 +26,34 @@ impl Provider {
             Provider::Genius,
         ]
     }
+
+    /// Canonical snake_case identifier. Matches the `serde(rename_all =
+    /// "snake_case")` shape so the frontend / DB write the exact same
+    /// string the JSON serialiser would emit — keeps round-trip stable
+    /// without forcing every caller to spin a `serde_json::to_value`.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Provider::Musixmatch => "musixmatch",
+            Provider::Lrclib => "lrclib",
+            Provider::NetEase => "net_ease",
+            Provider::Megalobiz => "megalobiz",
+            Provider::Genius => "genius",
+        }
+    }
+
+    /// Parse the canonical identifier back into a [`Provider`]. Pairs
+    /// with [`Self::as_str`] so a string round-tripped through the
+    /// frontend (e.g. user-picked provider in `refetch_lyrics`) maps
+    /// back to the original variant. Returns `None` for any unknown
+    /// id so the host can reject unknown values explicitly.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "musixmatch" => Some(Provider::Musixmatch),
+            "lrclib" => Some(Provider::Lrclib),
+            "net_ease" => Some(Provider::NetEase),
+            "megalobiz" => Some(Provider::Megalobiz),
+            "genius" => Some(Provider::Genius),
+            _ => None,
+        }
+    }
 }

--- a/src-tauri/migrations/app/20260620120000_lyrics_provider.sql
+++ b/src-tauri/migrations/app/20260620120000_lyrics_provider.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- Track which external provider (LRCLIB / Genius / NetEase / Megalobiz /
+-- Musixmatch) returned the lyrics row, so the UI can show an accurate
+-- source badge AND let the user manually re-fetch from a different
+-- provider when the auto-waterfall caches garbage from one of them
+-- (issue #284).
+--
+-- NULL = unknown. Two cases:
+--   1. Embedded / sidecar / manual writes (the `source` column already
+--      tells the user "Embedded tag" / "Sidecar file" / "Saved by you" —
+--      a sub-provider is meaningless for these tiers).
+--   2. Pre-1.5.1 rows. The auto-waterfall didn't track which provider
+--      hit historically, and back-filling would require re-fetching
+--      every cached row from the network.
+--
+-- No CHECK constraint: provider strings come from
+-- `waveflow_syncedlyrics::Provider::as_str()` which is the only writer,
+-- and a CHECK that hard-codes the list here would force a migration
+-- every time a new provider lands. Validation lives in Rust at the
+-- single write site.
+-- =============================================================================
+
+ALTER TABLE lyrics ADD COLUMN provider TEXT NULL;

--- a/src/components/layout/LyricsPanel.tsx
+++ b/src/components/layout/LyricsPanel.tsx
@@ -77,6 +77,19 @@ export function LyricsPanel() {
 
   const trackId = currentTrack?.id ?? null;
 
+  // Live mirror of `trackId` so async event handlers can detect
+  // when the user switched tracks during an `await` — without it the
+  // closure carries whatever `trackId` was current at click time and
+  // a stale `refetchLyrics` / `importLrcFile` response would happily
+  // overwrite the new track's payload after the user moved on. The
+  // initial-fetch useEffect already has its own per-render
+  // `cancelled` flag; this ref serves the user-triggered handlers
+  // below which can't rely on effect cleanup for the same job.
+  const trackIdRef = useRef<number | null>(trackId);
+  useEffect(() => {
+    trackIdRef.current = trackId;
+  }, [trackId]);
+
   // ── Fetch when the focused track changes (or panel opens) ───────
   useEffect(() => {
     if (trackId == null) {
@@ -171,6 +184,12 @@ export function LyricsPanel() {
 
   const handleRefetch = async (provider?: LyricsProvider) => {
     if (trackId == null) return;
+    // Capture the requested track at the call site so we can detect a
+    // mid-flight switch by comparing against the live `trackIdRef`
+    // when the await resolves. Without this guard a refetch on track
+    // A that takes longer than the user's switch to track B would
+    // land its result into B's payload (CodeRabbit-flagged race).
+    const requestedTrackId = trackId;
     try {
       // `refetchLyrics` drops the cache row + re-queries in one Tauri
       // call. With `provider = undefined` it re-runs the full waterfall
@@ -180,16 +199,27 @@ export function LyricsPanel() {
       // they want to try a different one (issue #284).
       setIsFetching(true);
       setPickerOpen(false);
-      const next = await refetchLyrics(trackId, provider);
+      const next = await refetchLyrics(requestedTrackId, provider);
+      if (requestedTrackId !== trackIdRef.current) return;
       setPayload(next);
       // Same as handleImport: clear any previous error so the refetched
       // payload actually paints instead of being shadowed by stale state.
       setError(null);
     } catch (err) {
       console.error("[LyricsPanel] refetch failed", err);
+      // Don't surface an error for a track the user no longer cares
+      // about — the new track's useEffect already handles its own
+      // error state.
+      if (requestedTrackId !== trackIdRef.current) return;
       setError(String(err));
     } finally {
-      setIsFetching(false);
+      // Only clear the spinner when we're still on the same track.
+      // After a switch, the new track's useEffect has already flipped
+      // `isFetching` to `true` for its own request and our clear
+      // would race that state.
+      if (requestedTrackId === trackIdRef.current) {
+        setIsFetching(false);
+      }
     }
   };
 

--- a/src/components/layout/LyricsPanel.tsx
+++ b/src/components/layout/LyricsPanel.tsx
@@ -164,13 +164,27 @@ export function LyricsPanel() {
   // ── Actions ─────────────────────────────────────────────────────
   const handleImport = async () => {
     if (trackId == null) return;
+    // Capture the requested track at the call site for the same
+    // reason `handleRefetch` does — the user can switch tracks
+    // during the file picker (which can sit on screen for a while)
+    // and again during `importLrcFile`'s disk + DB work. Without
+    // the guard a stale import would clobber the new track's
+    // payload in the UI.
+    //
+    // We deliberately let `importLrcFile` itself run to completion
+    // even when the user has switched away: the user's intent was
+    // to attach this LRC to the captured track, and the call writes
+    // straight to that track's DB row, so cancelling the write
+    // would lose work. Only the UI updates skip when stale.
+    const requestedTrackId = trackId;
     try {
       const path = await pickFile(
         ["lrc", "elrc", "ttml", "xml", "txt"],
         t("lyrics.importTitle"),
       );
       if (!path) return;
-      const next = await importLrcFile(trackId, path);
+      const next = await importLrcFile(requestedTrackId, path);
+      if (requestedTrackId !== trackIdRef.current) return;
       setPayload(next);
       // Drop any error left from a prior failed fetch — otherwise the
       // error-vs-notFound conditional below would mask the freshly
@@ -178,6 +192,7 @@ export function LyricsPanel() {
       setError(null);
     } catch (err) {
       console.error("[LyricsPanel] import failed", err);
+      if (requestedTrackId !== trackIdRef.current) return;
       setError(String(err));
     }
   };
@@ -238,12 +253,17 @@ export function LyricsPanel() {
   };
 
   // Close the provider picker on any click outside the menu (or its
-  // anchor button). The menu has no portal — it sits inside the panel
-  // root — so a single capture-phase mousedown listener on the document
-  // is enough; we just skip when the click landed inside the menu.
+  // anchor button) AND on Escape — both gestures are part of the
+  // WAI-ARIA menu dismissal pattern. The mousedown handler skips
+  // when the click landed inside the menu wrapper; the keydown
+  // handler is unconditional so Escape closes the menu regardless
+  // of whether focus sits on the trigger button (post-click default)
+  // or on a menu item (after a Tab). The menu has no portal — it
+  // sits inside the panel root — so document-level listeners are
+  // enough.
   useEffect(() => {
     if (!pickerOpen) return;
-    const handler = (e: MouseEvent) => {
+    const handleMouseDown = (e: MouseEvent) => {
       if (
         pickerRef.current &&
         e.target instanceof Node &&
@@ -253,9 +273,16 @@ export function LyricsPanel() {
       }
       setPickerOpen(false);
     };
-    document.addEventListener("mousedown", handler);
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setPickerOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
     return () => {
-      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
     };
   }, [pickerOpen]);
 
@@ -486,6 +513,19 @@ export function LyricsPanel() {
                   <div
                     role="menu"
                     aria-label={t("lyrics.source.pickerHint")}
+                    onKeyDown={(e) => {
+                      // Local Escape handler in addition to the
+                      // document-level one in the picker useEffect.
+                      // Redundant in practice (both fire on the same
+                      // event) but keeps the WAI-ARIA menu pattern
+                      // self-contained on the element itself + stops
+                      // the event from bubbling further into ancestor
+                      // panels that might also listen for Escape.
+                      if (e.key === "Escape") {
+                        e.stopPropagation();
+                        setPickerOpen(false);
+                      }
+                    }}
                     className="absolute left-0 bottom-full mb-1 z-20 min-w-44 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg p-1"
                   >
                     {LYRICS_PROVIDERS.map((p) => {

--- a/src/components/layout/LyricsPanel.tsx
+++ b/src/components/layout/LyricsPanel.tsx
@@ -68,7 +68,12 @@ export function LyricsPanel() {
   // button via a wrapper `<span class="relative">` so the menu floats
   // above the footer instead of pushing the row.
   const [pickerOpen, setPickerOpen] = useState(false);
-  const pickerRef = useRef<HTMLDivElement | null>(null);
+  // Attached to the `<span class="relative inline-flex">` wrapper
+  // around the source label, so the type must match — using
+  // `HTMLDivElement` would compile under React's loose ref typing but
+  // any future code that read `pickerRef.current.classList` etc. would
+  // get a `DOMTokenList | undefined` mismatch with the actual span.
+  const pickerRef = useRef<HTMLSpanElement | null>(null);
 
   const trackId = currentTrack?.id ?? null;
 

--- a/src/components/layout/LyricsPanel.tsx
+++ b/src/components/layout/LyricsPanel.tsx
@@ -11,6 +11,8 @@ import {
   Maximize2,
   Pencil,
   AlertCircle,
+  ChevronDown,
+  Check,
 } from "lucide-react";
 import { usePlayer } from "../../hooks/usePlayer";
 import { pickFile } from "../../lib/tauri/dialog";
@@ -20,9 +22,12 @@ import {
   findActiveLineIndex,
   findActiveWordIndex,
   importLrcFile,
+  LYRICS_PROVIDERS,
   parseLyrics,
+  refetchLyrics,
   type LyricsLine,
   type LyricsPayload,
+  type LyricsProvider,
 } from "../../lib/tauri/lyrics";
 import { FullscreenLyrics } from "../player/FullscreenLyrics";
 import { LyricsEditorModal } from "../common/LyricsEditorModal";
@@ -56,6 +61,14 @@ export function LyricsPanel() {
   const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
+  // Provider picker dropdown — opens on click of the source label so the
+  // user can re-query a specific source when the auto-waterfall cached a
+  // low-quality hit. Closed by an outside click + by `handleRefetch`
+  // itself after the new fetch lands. Anchored to the source-label
+  // button via a wrapper `<span class="relative">` so the menu floats
+  // above the footer instead of pushing the row.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
 
   const trackId = currentTrack?.id ?? null;
 
@@ -151,13 +164,18 @@ export function LyricsPanel() {
     }
   };
 
-  const handleRefetch = async () => {
+  const handleRefetch = async (provider?: LyricsProvider) => {
     if (trackId == null) return;
     try {
-      // Drop the cache then re-run the waterfall.
-      await clearLyrics(trackId);
+      // `refetchLyrics` drops the cache row + re-queries in one Tauri
+      // call. With `provider = undefined` it re-runs the full waterfall
+      // (legacy behaviour). With `provider` set it queries ONLY that
+      // source, bypassing local tiers — the path the user takes when
+      // the auto-fetch cached a low-quality hit from one provider and
+      // they want to try a different one (issue #284).
       setIsFetching(true);
-      const next = await fetchLyrics(trackId);
+      setPickerOpen(false);
+      const next = await refetchLyrics(trackId, provider);
       setPayload(next);
       // Same as handleImport: clear any previous error so the refetched
       // payload actually paints instead of being shadowed by stale state.
@@ -183,6 +201,28 @@ export function LyricsPanel() {
   const handleSeekToLine = (line: LyricsLine) => {
     seek(line.timeMs).catch(() => {});
   };
+
+  // Close the provider picker on any click outside the menu (or its
+  // anchor button). The menu has no portal — it sits inside the panel
+  // root — so a single capture-phase mousedown listener on the document
+  // is enough; we just skip when the click landed inside the menu.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        pickerRef.current &&
+        e.target instanceof Node &&
+        pickerRef.current.contains(e.target)
+      ) {
+        return;
+      }
+      setPickerOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [pickerOpen]);
 
   // ── Render ──────────────────────────────────────────────────────
   return (
@@ -380,8 +420,62 @@ export function LyricsPanel() {
         {currentTrack != null && (
           <div className="flex items-center justify-between p-4 border-t border-zinc-100 dark:border-zinc-800 text-xs text-zinc-500 dark:text-zinc-400">
             <span className="flex items-center gap-2 min-w-0">
-              <span className="truncate">
-                {payload ? sourceLabel(payload.source, t) : ""}
+              {/* Source label is a chip-button when API-sourced + an
+                  enabled track id is in scope, so the user can pop the
+                  provider picker and re-query a different source.
+                  Embedded / sidecar / manual rows render as static text
+                  — the picker would have nothing meaningful to do for
+                  a tag-embedded lyric. */}
+              <span ref={pickerRef} className="relative inline-flex">
+                {payload && payload.source === "api" ? (
+                  <button
+                    type="button"
+                    onClick={() => setPickerOpen((v) => !v)}
+                    disabled={isFetching}
+                    aria-haspopup="menu"
+                    aria-expanded={pickerOpen}
+                    title={t("lyrics.source.pickerHint")}
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors disabled:opacity-50 truncate"
+                  >
+                    <span className="truncate">
+                      {sourceLabel(payload, t)}
+                    </span>
+                    <ChevronDown size={11} className="shrink-0" />
+                  </button>
+                ) : (
+                  <span className="truncate">
+                    {payload ? sourceLabel(payload, t) : ""}
+                  </span>
+                )}
+                {pickerOpen && (
+                  <div
+                    role="menu"
+                    aria-label={t("lyrics.source.pickerHint")}
+                    className="absolute left-0 bottom-full mb-1 z-20 min-w-44 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg p-1"
+                  >
+                    {LYRICS_PROVIDERS.map((p) => {
+                      const isActive = payload?.provider === p;
+                      return (
+                        <button
+                          key={p}
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={isActive}
+                          onClick={() => handleRefetch(p)}
+                          className="w-full flex items-center justify-between gap-2 px-2.5 py-1.5 rounded text-xs hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors text-zinc-700 dark:text-zinc-200"
+                        >
+                          <span>{t(`lyrics.provider.${p}`)}</span>
+                          {isActive && (
+                            <Check
+                              size={12}
+                              className="shrink-0 text-emerald-500"
+                            />
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
               </span>
               {payload &&
                 (payload.format === "enhanced_lrc" ||
@@ -406,7 +500,7 @@ export function LyricsPanel() {
               </button>
               <button
                 type="button"
-                onClick={handleRefetch}
+                onClick={() => handleRefetch()}
                 disabled={isFetching}
                 aria-label={t("lyrics.actions.refetch")}
                 title={t("lyrics.actions.refetch")}
@@ -446,16 +540,23 @@ function EmptyState({ icon, text }: { icon?: React.ReactNode; text: string }) {
 }
 
 function sourceLabel(
-  source: LyricsPayload["source"],
+  payload: LyricsPayload,
   t: (key: string) => string,
 ): string {
-  switch (source) {
+  switch (payload.source) {
     case "embedded":
       return t("lyrics.source.embedded");
     case "lrc_file":
       return t("lyrics.source.lrc_file");
     case "api":
-      return t("lyrics.source.api");
+      // Surface the actual provider when known (LRCLIB / Genius /
+      // NetEase / Megalobiz / Musixmatch). Pre-1.5.1 rows + the
+      // empty-miss rows still leave `provider` null — fall back to
+      // the generic "Online source" label so the badge stays
+      // informative without lying about which provider ran.
+      return payload.provider
+        ? t(`lyrics.provider.${payload.provider}`)
+        : t("lyrics.source.api");
     case "manual":
       return t("lyrics.source.manual");
   }

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1083,8 +1083,16 @@
     "source": {
       "embedded": "كلمات مدمجة في الملف",
       "lrc_file": "ملف .lrc مستورد",
-      "api": "LRCLIB",
-      "manual": "إدخال يدوي"
+      "api": "مصدر عبر الإنترنت",
+      "manual": "إدخال يدوي",
+      "pickerHint": "تبديل المصدر"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "متزامن",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "In Datei eingebetteter Songtext",
       "lrc_file": "Importierte .lrc-Datei",
-      "api": "LRCLIB",
-      "manual": "Manuelle Eingabe"
+      "api": "Online-Quelle",
+      "manual": "Manuelle Eingabe",
+      "pickerHint": "Quelle wechseln"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Synchronisiert",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Lyrics embedded in file",
       "lrc_file": "Imported .lrc file",
-      "api": "LRCLIB",
-      "manual": "Manual entry"
+      "api": "Online source",
+      "manual": "Manual entry",
+      "pickerHint": "Switch source"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Synchronised",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Letras incrustadas en el archivo",
       "lrc_file": "Archivo .lrc importado",
-      "api": "LRCLIB",
-      "manual": "Entrada manual"
+      "api": "Fuente en línea",
+      "manual": "Entrada manual",
+      "pickerHint": "Cambiar fuente"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Sincronizadas",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Paroles intégrées au fichier",
       "lrc_file": "Fichier .lrc importé",
-      "api": "LRCLIB",
-      "manual": "Saisie manuelle"
+      "api": "Source en ligne",
+      "manual": "Saisie manuelle",
+      "pickerHint": "Changer de source"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Synchronisé",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "फ़ाइल में शामिल गीत",
       "lrc_file": "आयातित .lrc फ़ाइल",
-      "api": "LRCLIB",
-      "manual": "मैनुअल प्रविष्टि"
+      "api": "ऑनलाइन स्रोत",
+      "manual": "मैनुअल प्रविष्टि",
+      "pickerHint": "स्रोत बदलें"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "सिंक्रनाइज़्ड",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Lirik tertanam di berkas",
       "lrc_file": "Berkas .lrc yang diimpor",
-      "api": "LRCLIB",
-      "manual": "Masukan manual"
+      "api": "Sumber daring",
+      "manual": "Masukan manual",
+      "pickerHint": "Ganti sumber"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Tersinkronisasi",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Testi incorporati nel file",
       "lrc_file": "File .lrc importato",
-      "api": "LRCLIB",
-      "manual": "Inserimento manuale"
+      "api": "Fonte online",
+      "manual": "Inserimento manuale",
+      "pickerHint": "Cambia fonte"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Sincronizzati",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "歌詞がファイルに組み込まれている",
       "lrc_file": "インポートされた.lrcファイル",
-      "api": "LRCLIB",
-      "manual": "手動入力"
+      "api": "オンラインソース",
+      "manual": "手動入力",
+      "pickerHint": "ソースを切り替え"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "同期済み",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "파일에 가사가 포함되어 있음",
       "lrc_file": ".lrc 파일 가져오기",
-      "api": "LRCLIB",
-      "manual": "수동 입력"
+      "api": "온라인 소스",
+      "manual": "수동 입력",
+      "pickerHint": "소스 전환"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "동기화됨",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Songtekst ingebed in het bestand",
       "lrc_file": "Geïmporteerd .lrc-bestand",
-      "api": "LRCLIB",
-      "manual": "Handmatige invoer"
+      "api": "Online bron",
+      "manual": "Handmatige invoer",
+      "pickerHint": "Bron wisselen"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Gesynchroniseerd",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Letra incluída no arquivo",
       "lrc_file": "Arquivo .lrc importado",
-      "api": "LRCLIB",
-      "manual": "Entrada manual"
+      "api": "Fonte online",
+      "manual": "Entrada manual",
+      "pickerHint": "Trocar fonte"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Sincronizado",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Letra incluída no ficheiro",
       "lrc_file": "Ficheiro .lrc importado",
-      "api": "LRCLIB",
-      "manual": "Introdução manual"
+      "api": "Fonte online",
+      "manual": "Introdução manual",
+      "pickerHint": "Mudar fonte"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Sincronizado",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1118,8 +1118,16 @@
     "source": {
       "embedded": "Текст встроен в файл",
       "lrc_file": "Импортированный .lrc",
-      "api": "LRCLIB",
-      "manual": "Ручной ввод"
+      "api": "Онлайн-источник",
+      "manual": "Ручной ввод",
+      "pickerHint": "Сменить источник"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Синхронизированный",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "Dosyada gömülü sözler",
       "lrc_file": "İçe aktarılan .lrc dosyası",
-      "api": "LRCLIB",
-      "manual": "Manuel giriş"
+      "api": "Çevrimiçi kaynak",
+      "manual": "Manuel giriş",
+      "pickerHint": "Kaynağı değiştir"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "Senkronize",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "歌词已嵌入文件中",
       "lrc_file": "已导入的 .lrc 文件",
-      "api": "LRCLIB",
-      "manual": "手动输入"
+      "api": "在线源",
+      "manual": "手动输入",
+      "pickerHint": "切换来源"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "已同步",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1079,8 +1079,16 @@
     "source": {
       "embedded": "歌詞已嵌入檔案中",
       "lrc_file": "已匯入的 .lrc 檔案",
-      "api": "LRCLIB",
-      "manual": "手動輸入"
+      "api": "線上來源",
+      "manual": "手動輸入",
+      "pickerHint": "切換來源"
+    },
+    "provider": {
+      "lrclib": "LRCLIB",
+      "genius": "Genius",
+      "net_ease": "NetEase",
+      "megalobiz": "Megalobiz",
+      "musixmatch": "Musixmatch"
     },
     "format": {
       "lrc": "已同步",

--- a/src/lib/tauri/lyrics.ts
+++ b/src/lib/tauri/lyrics.ts
@@ -3,11 +3,50 @@ import { invoke } from "@tauri-apps/api/core";
 export type LyricsFormat = "plain" | "lrc" | "enhanced_lrc" | "ttml";
 export type LyricsSource = "embedded" | "lrc_file" | "api" | "manual";
 
+/**
+ * Sub-provider identifier returned by the backend on API-sourced rows.
+ * Matches `waveflow_syncedlyrics::Provider::as_str()`. Pre-1.5.1 cached
+ * rows AND non-API tiers (embedded / sidecar / manual) leave the field
+ * `null` — the UI then renders the broad `source` label without a
+ * provider chip.
+ */
+export type LyricsProvider =
+  | "lrclib"
+  | "genius"
+  | "net_ease"
+  | "megalobiz"
+  | "musixmatch";
+
+/**
+ * Stable list of providers the picker UI cycles through. Mirrors
+ * `Provider::defaults()` order on the backend — Musixmatch first
+ * because it's the only word-timed source, then LRCLIB, then the
+ * query-based fallbacks. `refetchLyrics` accepts any of these
+ * strings as the override; an `undefined` override re-runs the full
+ * waterfall.
+ */
+export const LYRICS_PROVIDERS: LyricsProvider[] = [
+  "musixmatch",
+  "lrclib",
+  "net_ease",
+  "megalobiz",
+  "genius",
+];
+
 export interface LyricsPayload {
   track_id: number;
   content: string;
   format: LyricsFormat;
   source: LyricsSource;
+  /**
+   * Sub-provider that produced this row when `source === "api"`. One
+   * of `LYRICS_PROVIDERS`, or `null` / absent for embedded / sidecar
+   * / manual / pre-1.5.1 rows. The lyrics panel reads this to render
+   * an accurate badge (e.g. "Genius" instead of the hardcoded
+   * "LRCLIB" the panel previously always showed) and to drive the
+   * default selection of the provider picker.
+   */
+  provider?: LyricsProvider | null;
   /**
    * Set by `save_lyrics` when the user picked destination = `"tag"`
    * but the audio container can't carry the chosen format (currently
@@ -37,6 +76,29 @@ export function getLyrics(trackId: number): Promise<LyricsPayload | null> {
  */
 export function fetchLyrics(trackId: number): Promise<LyricsPayload | null> {
   return invoke<LyricsPayload | null>("fetch_lyrics", { trackId });
+}
+
+/**
+ * Force a re-fetch for a single track, dropping the cached row first
+ * so the waterfall (or single-provider query below) is guaranteed to
+ * re-query.
+ *
+ * - `provider = undefined` → re-runs the full waterfall identical to
+ *   the legacy "Clear + Refetch" gesture.
+ * - `provider = "<id>"` → bypasses local tiers (embedded / sidecar)
+ *   and queries ONLY the named provider. A miss caches an empty row
+ *   attributed to the requested provider so the badge reflects what
+ *   the user just tried — picking a different provider and trying
+ *   again is then the natural next step (issue #284).
+ */
+export function refetchLyrics(
+  trackId: number,
+  provider?: LyricsProvider,
+): Promise<LyricsPayload | null> {
+  return invoke<LyricsPayload | null>("refetch_lyrics", {
+    trackId,
+    provider: provider ?? null,
+  });
 }
 
 /**


### PR DESCRIPTION
**Draft pour test manuel.** Trois commits cohérents qui répondent à toutes les frictions de l'issue #284.

Closes #284

## Le bug d'origine

Quand LRCLIB miss, la cascade tombait sur NetEase / Megalobiz / Genius automatiquement. Trois problèmes empilés :

1. **Le parser Genius dump le header artifact** : la page Genius nest le badge contributeurs + le \`<song title> Lyrics\` heading DANS le même \`data-lyrics-container\` que les paroles. Une fois le HTML decoder appliqué, on obtient un préfixe comme \`\"17 ContributorsFall on Me Lyrics\"\` collé au début des paroles. Pour les chansons cataloguées sans transcription (image 1 de l'issue : \"Solamente una vez\"), la page ne contient QUE ce header — donc l'utilisateur voit littéralement \`\"2 ContributorsSolamente Una Vez Lyrics\"\` comme \"paroles\".
2. **Le badge dit \"LRCLIB\" alors que le contenu vient d'ailleurs** : le label était hardcodé et ne tenait pas compte du provider qui avait réellement répondu. Quand Genius cachait du junk après un miss LRCLIB, ça ressemblait à un bug LRCLIB.
3. **Aucun moyen de récupérer** : si Genius cachait un mauvais hit, \"Clear + Refetch\" ré-exécutait la même cascade et retombait sur le même hit Genius. Boucle fermée.

## Les trois fixes

### 1. \`fix(lyrics): strip Genius header artifact + treat stub pages as miss\` (\`5e889c4\`)

Ajout de \`strip_genius_header\` dans [crates/syncedlyrics/src/providers/genius.rs](src-tauri/crates/syncedlyrics/src/providers/genius.rs) : pattern \`^\d+ Contributors.*? Lyrics\` strippé en début de body. Si après strip le contenu est vide, le candidate retourne None — la cascade passe au provider suivant au lieu de cacher le header brut.

7 nouveaux tests unitaires : happy path, stub page (Solamente Una Vez), multibyte title (Déjà Vu), 4 cas no-op (whitespace prefix, no digits, no \"Contributors\" token, titre commençant par un nombre genre \"99 Red Balloons\").

### 2. \`fix(lyrics): track real provider per row + add user-driven refetch\` (\`5e8f7c4\`)

**Migration** \`20260620120000_lyrics_provider.sql\` : nouvelle colonne \`lyrics.provider TEXT NULL\`. NULL = inconnu (rows pré-1.5.1 + tiers non-API).

**Provider plumbing** :
- \`LyricsPayload\` gagne \`provider: Option<String>\` (skip-if-none au JSON wire)
- \`Provider::as_str()\` + \`Provider::from_str()\` ajoutés dans \`waveflow_syncedlyrics\`, snake_case round-trip
- \`upsert_lyrics\` prend un 6e paramètre \`provider: Option<&str>\` ; tous les call sites updated (embedded/sidecar/manual = None ; LRCLIB = \`Some(\"lrclib\")\` ; cache_external_lyrics dérive du \`result.provider\`)
- \`read_cached\` SELECT la nouvelle colonne
- Empty miss rows écrivent \`provider = None\` (attribution à un provider serait mensongère)

**Nouvelle commande** \`refetch_lyrics(track_id, provider: Option<String>)\` :
- Drop le row caché d'abord
- \`provider = None\` → re-run la full waterfall (identique au \"Clear + Refetch\" legacy)
- \`provider = Some(id)\` → bypass embedded/sidecar, query UNIQUEMENT ce provider via \`external_lyrics_search\`. Miss → cache empty row attribué au provider demandé (le badge reflète ce que l'user vient de tenter)
- Honore \`musixmatch_enabled\` + offline mode aux mêmes chokepoints que la waterfall

Registrée dans \`lib.rs::generate_handler![]\`.

### 3. \`fix(lyrics): expose real provider in source badge + add picker dropdown\` (\`71b05ff\`)

**Badge** : \`sourceLabel\` lit \`payload.provider\` et rend le brand name réel (\"LRCLIB\" / \"Genius\" / \"NetEase\" / \"Megalobiz\" / \"Musixmatch\"). Fallback générique \"Online source\" localisé quand provider = NULL.

**Picker** : quand row est API-sourced, le label devient un chip-button avec chevron. Click → dropdown des 5 providers avec checkmark sur l'actif. Click sur un provider → \`refetchLyrics(track_id, provider)\`. \`role=\"menu\"\` + \`menuitemradio\`, fermé par click outside.

Embedded/sidecar/manual rows : label statique sans chevron (picker n'a aucun sens pour un tag embedded).

**Backend command swap** : \`handleRefetch\` passe du legacy \`clearLyrics + fetchLyrics\` au nouveau single-call \`refetchLyrics\`.

**i18n** sur les 17 locales :
- \`lyrics.source.api\` réécrit de \"LRCLIB\" (verbatim) → \"Source en ligne\" / \"Online source\" / etc. (fallback générique)
- \`lyrics.source.pickerHint\` (tooltip \"Changer de source\")
- \`lyrics.provider.{lrclib,genius,net_ease,megalobiz,musixmatch}\` — brand tokens verbatim partout per la convention CLAUDE.md (comme \"Daily Mix\" / \"On Repeat\")

## Tests

- [x] 7 tests Genius strip passent
- [x] 34 tests syncedlyrics passent
- [x] 84 tests desktop unit passent
- [x] \`cargo check --workspace\` clean
- [x] \`bun run typecheck\` clean
- [x] Test manuel : ouvrir lyrics panel sur un track LRCLIB cache hit → badge dit \"LRCLIB\"
- [x] Test manuel : ouvrir un track où LRCLIB miss → cascade fall on Genius → badge dit \"Genius\"
- [x] Test manuel : click sur badge \"Genius\" → dropdown avec 5 providers, Genius coché → click \"LRCLIB\" → refetch lance, badge passe à \"LRCLIB\"
- [x] Test manuel : Solamente Una Vez ou autre track sans paroles transcrites → cascade complète miss → empty state \"Pas de paroles\", PAS le header artifact
- [x] Test manuel : 17 locales le label \"Online source\" s'affiche correctement sur un row sans provider connu (e.g. pré-1.5.1 cache)
- [x] Test manuel : Musixmatch via picker quand opt-in OFF → erreur claire ou skip silencieux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Nouvelles fonctionnalités et améliorations
* **New Features**
  * Affichage du fournisseur pour les paroles en ligne, avec un sélecteur (menu) et un indicateur “chip”.
  * Rechargement forcé des paroles ciblant un fournisseur spécifique.
* **Améliorations**
  * La source du fournisseur est désormais mémorisée et propagée pour mieux refléter l’origine des paroles, y compris dans le cache.
* **Correctifs**
  * Les pages Genius “stub” sont mieux gérées (elles ne produisent plus de faux résultats).
* **Localization**
  * Mise à jour des traductions pour prendre en charge la sélection et l’affichage des fournisseurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->