### PR TITLE
fix(skins): preserve Liquid mood tile gradient from shadow-lg capture

### DIFF
--- a/src/styles/skins/liquid.css
+++ b/src/styles/skins/liquid.css
@@ -701,14 +701,29 @@
    SmartPlaylistEditor). Without all three, the modal we miss
    keeps its raw `bg-white dark:bg-surface-dark-elevated` and
    reads as a flat dark slab instead of glass — every internal
-   text + tinted button then fights the wrong bg. */
+   text + tinted button then fights the wrong bg.
+
+   `:not(.liquid-mood-tile)` excludes the Mood Radio tiles whose
+   button carries `hover:shadow-lg` — that substring matches
+   `[class*="shadow-lg"]` and would otherwise paint a near-opaque
+   white-92% (light) / cool-grey-92% (dark) slab over the
+   colored gradient `.liquid-mood-tile::before` paints, bleaching
+   every tile down to a faintly-tinted white card. The
+   `.liquid-mood-tile` rule above has the same specificity
+   (0,2,1) so source order would otherwise let this modal rule
+   win.
+
+   Studio / Editorial / Lounge / Pulse skin tiles don't need an
+   exclusion — none of them paint a base bg via a `.liquid-*`
+   class so the substring capture lands on a tile that already
+   carries its own gradient, with no conflict. */
 :root[data-skin="liquid"] :where(
   [role="dialog"],
   [role="tooltip"],
   [class*="shadow-lg"],
   [class*="shadow-xl"],
   [class*="shadow-2xl"]
-) {
+):not(.liquid-mood-tile) {
   color: var(--liq-ink) !important;
   /* Mirror what Big Sur / iOS Control Center actually do for
      content-heavy panels: a DENSE dark-tinted base (not pure
@@ -748,7 +763,7 @@
   [class*="shadow-lg"],
   [class*="shadow-xl"],
   [class*="shadow-2xl"]
-) {
+):not(.liquid-mood-tile) {
   /* 82% → 92% in light. Same Audio-Pipeline-popover bleed-through
      fix as the dark branch above — content-heavy panels over a
      saturated cover lose every line of text at 82% even with


### PR DESCRIPTION
## Summary

- Excludes `.liquid-mood-tile` from both `[class*="shadow-lg"]` modal-capture rules in [src/styles/skins/liquid.css](src/styles/skins/liquid.css) so the Mood Radio tiles' colored `::before` gradient survives in Liquid + light theme on release builds.
- No JSX change — the tile button still ships `hover:shadow-lg` for its hover elevation, which is what triggered the false-positive capture.

## Root cause

The "modals / popovers" rule substring-matches `[class*="shadow-lg"]` to repaint Tailwind popovers as Big-Sur frosted material. The Mood Radio tile button in [MoodRadioGrid.tsx](src/components/views/home/MoodRadioGrid.tsx) carries `hover:shadow-lg`, which the matcher catches — so in light mode every tile inherits `background-color: color-mix(white 92%, transparent) !important`, drowning the gradient.

Specificity tie at `(0,2,1)` on both `.liquid-mood-tile` and the modal rule; source order broke the tie in favour of the (later) modal rule deterministically in release builds (Lightning CSS reorder), while Vite's dev CSS injection happened to preserve the `.liquid-mood-tile` rule's precedence — hence "works in dev, broken in release".

## Test plan

- [x] `bun run tauri build` → install → switch to Liquid skin + a light theme (Émeraude / Lavender / Sunset) → Mood Radio tiles show the colored gradient again, text readable.
- [x] Dark Liquid theme unchanged (mood tiles already worked there).
- [x] No regression on actual popovers / modals (`AudioPipelinePopover`, `MoreActionsMenu`, `SmartPlaylistEditor`, settings dropdowns).

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Correction de l'apparence des tuiles Mood Radio - le gradient d'arrière-plan est désormais préservé et la lisibilité est améliorée dans le thème liquid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->