### PR TITLE
fix(library): resolve local artist.jpg for Various Artists folder

### DIFF
--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -79,9 +79,9 @@ Hash-addressed via BLAKE3 into the shared `artwork/<hash>.{jpg,png,webp,…}` ca
 
 Resolution priority in [`commands/browse.rs::get_artist_detail`](../../src-tauri/crates/app/src/commands/browse.rs) is now: **local sidecar → Deezer cache → live Deezer fetch** (last skipped when offline). [`ArtistDetailView`](../../src/components/views/ArtistDetailView.tsx) prefers `artwork_path` over `picture_path` and refuses to clobber a local image with a late-arriving Deezer response.
 
-The `"Various Artists"` sentinel is explicitly excluded so a compilation folder never inherits a stray album cover as an artist photo.
+The `"Various Artists"` sentinel is skipped by the per-track pass because it's an *album* artist — it's written to `album.artist_id` (never to `track_artist`), so the per-track join can't reach it. It's handled separately by [`scanner::link_va_artist_image`](../../src-tauri/crates/core/src/scanner/upserts.rs), which resolves a curated `Various Artists/artist.jpg` (or `Various Artists.jpg`) via the album relationship (issue #292). Because `extract_artist_image` only matches an explicit artist-named sidecar — never a generic `cover.jpg` / `folder.jpg` — VA still never inherits a stray album cover. The helper runs at the end of every scan (after `merge_implicit_compilations`) and inside the rescan below.
 
-For libraries scanned before the feature shipped, [`commands/scan.rs::rescan_local_artist_images`](../../src-tauri/crates/app/src/commands/scan.rs) (exposed as **Settings → Library → Local artist images**) walks every `artist WHERE artwork_id IS NULL` and probes up to 16 tracks per artist with `extract_artist_image`, stopping at the first hit. Already-linked rows are filtered out at the SQL level, so the rescan is cheap to re-run.
+For libraries scanned before the feature shipped, [`commands/scan.rs::rescan_local_artist_images`](../../src-tauri/crates/app/src/commands/scan.rs) (exposed as **Settings → Library → Local artist images**) walks every `artist WHERE artwork_id IS NULL` and probes up to 16 tracks per artist with `extract_artist_image`, stopping at the first hit (plus a dedicated VA pass via the album relationship). Already-linked rows are filtered out at the SQL level, so the rescan is cheap to re-run.
 
 ### Manual override
 

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -1088,9 +1088,11 @@ pub async fn rescan_local_artist_images(
     // sentinel never appears in (it's an album artist) — resolve its
     // sidecar via the album relationship instead (issue #292). The
     // rows query above already excluded VA via `canonical_name != ?`.
-    if link_va_artist_image(&mut tx, &artwork_dir).await? {
+    if let Some(linked) = link_va_artist_image(&mut tx, &artwork_dir).await? {
         summary.considered += 1;
-        summary.linked += 1;
+        if linked {
+            summary.linked += 1;
+        }
     }
 
     tx.commit().await?;

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -14,7 +14,8 @@ use walkdir::WalkDir;
 use waveflow_core::scanner::{
     extract_album_artist, extract_artist_image, extract_compilation_flag, extract_cover,
     extract_folder_cover, extract_musical_key, extract_rating, file_type_label, hash_file,
-    link_local_artist_image, maybe_link_artist_images, merge_implicit_compilations, now_millis,
+    link_local_artist_image, link_va_artist_image, maybe_link_artist_images,
+    merge_implicit_compilations, now_millis,
     split_artist_name, upsert_album, upsert_artist, upsert_artist_list, upsert_artwork,
     upsert_genre, ExtractedFile, AUDIO_EXTENSIONS, VARIOUS_ARTISTS_LABEL,
 };
@@ -958,6 +959,20 @@ pub(crate) async fn scan_folder_inner(
         tracing::warn!(?err, "merge_implicit_compilations failed (non-fatal)");
     }
 
+    // VA is an album artist (never in `track_artist`), so the per-track
+    // `maybe_link_artist_images` pass above can't reach it — resolve a
+    // curated `Various Artists/artist.jpg` via the album relationship here
+    // (issue #292). Runs after the merge so a freshly promoted VA row is
+    // covered. Non-fatal: a missing sidecar is the common case.
+    match pool.acquire().await {
+        Ok(mut conn) => {
+            if let Err(err) = link_va_artist_image(&mut conn, artwork_dir).await {
+                tracing::warn!(?err, "link_va_artist_image failed (non-fatal)");
+            }
+        }
+        Err(err) => tracing::warn!(?err, "link_va_artist_image: acquire failed (non-fatal)"),
+    }
+
     tracing::info!(
         folder_id,
         library_id,
@@ -1067,6 +1082,15 @@ pub async fn rescan_local_artist_images(
                 tx_count = 0;
             }
         }
+    }
+
+    // The main loop joins `track_artist`, which the "Various Artists"
+    // sentinel never appears in (it's an album artist) — resolve its
+    // sidecar via the album relationship instead (issue #292). The
+    // rows query above already excluded VA via `canonical_name != ?`.
+    if link_va_artist_image(&mut tx, &artwork_dir).await? {
+        summary.considered += 1;
+        summary.linked += 1;
     }
 
     tx.commit().await?;

--- a/src-tauri/crates/core/src/scanner/mod.rs
+++ b/src-tauri/crates/core/src/scanner/mod.rs
@@ -30,7 +30,8 @@ pub use extract::{
 };
 #[cfg(feature = "sqlite")]
 pub use upserts::{
-    link_local_artist_image, maybe_link_artist_images, merge_implicit_compilations, now_millis,
+    link_local_artist_image, link_va_artist_image, maybe_link_artist_images,
+    merge_implicit_compilations, now_millis,
     resolve_album_artist, split_artist_name, upsert_album, upsert_artist, upsert_artist_list,
     upsert_artwork, upsert_genre, VARIOUS_ARTISTS_LABEL,
 };

--- a/src-tauri/crates/core/src/scanner/upserts.rs
+++ b/src-tauri/crates/core/src/scanner/upserts.rs
@@ -372,12 +372,14 @@ pub async fn maybe_link_artist_images(
 /// a random album cover to VA. Idempotent: skips when no VA row exists and
 /// (via the `artwork_id IS NULL` filter + [`link_local_artist_image`]'s own
 /// guard) when VA already has artwork from a manual upload or earlier scan.
-/// Returns `true` when a sidecar image was found and linked, `false`
-/// otherwise (no VA row, VA already has artwork, or no sidecar present).
+/// Returns `None` when there's no eligible VA candidate (no VA row, or VA
+/// already has artwork), so callers don't count it as "considered". Returns
+/// `Some(true)` when an eligible VA was linked to a sidecar, `Some(false)`
+/// when an eligible VA had no sidecar to link.
 pub async fn link_va_artist_image(
     conn: &mut sqlx::SqliteConnection,
     artwork_dir: &Path,
-) -> CoreResult<bool> {
+) -> CoreResult<Option<bool>> {
     let va_canon = canonical_name(VARIOUS_ARTISTS_LABEL);
     let va_id: Option<i64> =
         sqlx::query_scalar("SELECT id FROM artist WHERE canonical_name = ? AND artwork_id IS NULL")
@@ -385,7 +387,7 @@ pub async fn link_va_artist_image(
             .fetch_optional(&mut *conn)
             .await?;
     let Some(va_id) = va_id else {
-        return Ok(false);
+        return Ok(None);
     };
 
     // VA tracks are linked through their album, not `track_artist`.
@@ -402,10 +404,10 @@ pub async fn link_va_artist_image(
     for (path,) in paths {
         if let Some(cover) = extract_artist_image(Path::new(&path), &va_canon, artwork_dir) {
             link_local_artist_image(&mut *conn, va_id, &cover).await?;
-            return Ok(true);
+            return Ok(Some(true));
         }
     }
-    Ok(false)
+    Ok(Some(false))
 }
 
 /// Post-scan pass that promotes "tagless" same-title album rows into a

--- a/src-tauri/crates/core/src/scanner/upserts.rs
+++ b/src-tauri/crates/core/src/scanner/upserts.rs
@@ -318,8 +318,9 @@ pub async fn link_local_artist_image(
 /// artist image from `track_path`. Idempotent — artists that already have
 /// an `artwork_id` are skipped by [`link_local_artist_image`].
 ///
-/// Skips the "Various Artists" sentinel: a compilation folder never holds
-/// a meaningful artist photo and we'd just pin a random album cover to it.
+/// Skips the "Various Artists" sentinel here because VA is an *album*
+/// artist (it never appears in `track_artist`); its sidecar image is
+/// resolved separately via the album relationship in [`link_va_artist_image`].
 pub async fn maybe_link_artist_images(
     conn: &mut sqlx::SqliteConnection,
     artist_raw: Option<&str>,
@@ -352,6 +353,59 @@ pub async fn maybe_link_artist_images(
         }
     }
     Ok(())
+}
+
+/// Resolve a sidecar artist image for the "Various Artists" sentinel.
+///
+/// VA is an *album* artist — it's written to `album.artist_id` by
+/// [`upsert_album`] / [`merge_implicit_compilations`] and never appears in
+/// `track_artist` — so the per-track [`maybe_link_artist_images`] pass can't
+/// reach it. A user who curates a `Various Artists/` folder and drops an
+/// `artist.jpg` (or `Various Artists.jpg`) at its root legitimately wants
+/// that photo on the VA page (issue #292); we resolve it here via the album
+/// relationship instead.
+///
+/// Safe to run unconditionally: [`extract_artist_image`] only matches an
+/// explicit artist-named sidecar (an `artist` / `performer` / `band` stem,
+/// or a stem whose canonical form equals the artist name) — never a generic
+/// `cover` / `folder` / `front` album cover — so this can't accidentally pin
+/// a random album cover to VA. Idempotent: skips when no VA row exists and
+/// (via the `artwork_id IS NULL` filter + [`link_local_artist_image`]'s own
+/// guard) when VA already has artwork from a manual upload or earlier scan.
+/// Returns `true` when a sidecar image was found and linked, `false`
+/// otherwise (no VA row, VA already has artwork, or no sidecar present).
+pub async fn link_va_artist_image(
+    conn: &mut sqlx::SqliteConnection,
+    artwork_dir: &Path,
+) -> CoreResult<bool> {
+    let va_canon = canonical_name(VARIOUS_ARTISTS_LABEL);
+    let va_id: Option<i64> =
+        sqlx::query_scalar("SELECT id FROM artist WHERE canonical_name = ? AND artwork_id IS NULL")
+            .bind(&va_canon)
+            .fetch_optional(&mut *conn)
+            .await?;
+    let Some(va_id) = va_id else {
+        return Ok(false);
+    };
+
+    // VA tracks are linked through their album, not `track_artist`.
+    let paths: Vec<(String,)> = sqlx::query_as(
+        "SELECT t.file_path FROM track t
+           JOIN album a ON a.id = t.album_id
+          WHERE a.artist_id = ? AND t.is_available = 1
+          LIMIT 16",
+    )
+    .bind(va_id)
+    .fetch_all(&mut *conn)
+    .await?;
+
+    for (path,) in paths {
+        if let Some(cover) = extract_artist_image(Path::new(&path), &va_canon, artwork_dir) {
+            link_local_artist_image(&mut *conn, va_id, &cover).await?;
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Post-scan pass that promotes "tagless" same-title album rows into a


### PR DESCRIPTION
## Problème

Closes #292.

Un dossier **"Various Artists"** custom avec un `artist.jpg` local n'affiche jamais son image — alors que tous les autres artistes custom fonctionnent. Cause : `"Various Artists"` est un *album artist* sentinelle, écrit dans `album.artist_id` et **jamais** dans `track_artist`. Or les deux chemins de résolution d'image locale s'appuient sur `track_artist` :

- `maybe_link_artist_images` (scan-time) itère sur `track_artist` **et** skippait explicitement VA.
- `rescan_local_artist_images` (backfill) joint `track_artist` **et** excluait VA en SQL.

VA ne pouvait donc jamais récupérer son image, peu importe le nombre de rescans — d'où le workaround manuel du reporter. Le commentaire qui justifiait le skip ("épinglerait une pochette random") était factuellement faux : `extract_artist_image` ne matche que `artist.jpg`/`performer`/`band` ou `<nom canonique>.jpg`, jamais un `cover.jpg`/`folder.jpg` générique.

## Fix

- Nouveau helper `scanner::link_va_artist_image` qui résout le sidecar de VA **via la relation album** (`album.artist_id = va_id`), avec le même garde `artwork_id IS NULL` (respecte un upload manuel / image déjà liée).
- Câblé à chaque scan après `merge_implicit_compilations` (couvre une VA fraîchement promue) et dans `rescan_local_artist_images` (Settings → Library → Local artist images).
- Commentaire trompeur corrigé + doc `docs/features/library.md` mise à jour.

## Test

- `cargo check --workspace` + `cargo clippy --workspace` propres.
- `cargo test -p waveflow-core --lib scanner` : 8/8 verts.
- Pas de harness de test DB dans ce module (les tests scanner existants ne couvrent que les fonctions FS pures, déjà testées) — cohérent avec la convention.

L'utilisateur peut relancer **Settings → Library → Local artist images** pour récupérer son image, ou attendre le prochain scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Amélioration de la gestion des images locales pour les compilations **“Various Artists”** lors de la détection et du **rescannage** de la bibliothèque musicale.
  * Le système tente désormais de retrouver et d’associer une image d’artiste de manière plus fiable pour ce cas spécial, sans interrompre le scan en cas d’échec.

* **Documentation**
  * Mise à jour de la documentation pour expliquer précisément le traitement dédié de **“Various Artists”** et le comportement lors du rescannage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->