### PR TITLE
chore(lint): ignore .claude and .agents AI skill dirs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,10 @@ export default tseslint.config(
       "scripts/**",
       "secrets/**",
       "packaging/**",
+      // AI agent skills / tooling — not application code (Node globals,
+      // hook-shaped helpers) and not ours to lint.
+      ".claude/**",
+      ".agents/**",
       "**/*.config.ts",
       "**/*.config.js",
       "**/.commitlintrc.cjs",


### PR DESCRIPTION
## Problème

`bun run lint` (= CI ESLint) était **rouge sur main** : ~380 erreurs (`'process' is not defined` no-undef, `react-hooks/*`, etc.) provenant **uniquement** de `.claude/` (27 fichiers) et `.agents/` (27 fichiers). Ce sont des **skills/outils pour agents IA**, pas du code applicatif — globals Node, helpers en forme de hooks React. Le code du projet (`src/**`) était déjà clean.

## Fix

Ajout de `".claude/**"` et `".agents/**"` à l''`ignores` d''[eslint.config.js](eslint.config.js).

## Validation

`bun run lint` passe maintenant proprement (exit 0, zéro erreur/warning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Mise à jour de la configuration de linting pour exclure les dossiers de tooling et d'agents du processus de vérification du code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->