### PR TITLE
fix(ui): portal dropdowns trapped by backdrop-filter skins

### DIFF
--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -1856,28 +1856,34 @@ function AlbumGrid({
           );
         })}
       </div>
-      {contextMenu && (
-        <div
-          role="menu"
-          style={{ top: contextMenu.y, left: contextMenu.x }}
-          className="fixed z-100 min-w-48 rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-surface-dark-elevated dark:shadow-black/40 overflow-hidden animate-fade-in py-1"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              const id = contextMenu.albumId;
-              setContextMenu(null);
-              onChangeCover(id);
-            }}
-            className="w-full flex items-center space-x-2 px-3 py-2 text-left text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700/30 transition-colors"
+      {contextMenu &&
+        createPortal(
+          // Portaled to <body>: the menu uses viewport `fixed` coords,
+          // but an ancestor album card gets a `backdrop-filter` under
+          // the Lounge / Liquid skins, which would otherwise become the
+          // containing block and trap / mis-stack the menu.
+          <div
+            role="menu"
+            style={{ top: contextMenu.y, left: contextMenu.x }}
+            className="fixed z-100 min-w-48 rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-surface-dark-elevated dark:shadow-black/40 overflow-hidden animate-fade-in py-1"
+            onClick={(e) => e.stopPropagation()}
           >
-            <ImageIcon size={14} />
-            <span>{t("library.changeCover")}</span>
-          </button>
-        </div>
-      )}
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                const id = contextMenu.albumId;
+                setContextMenu(null);
+                onChangeCover(id);
+              }}
+              className="w-full flex items-center space-x-2 px-3 py-2 text-left text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700/30 transition-colors"
+            >
+              <ImageIcon size={14} />
+              <span>{t("library.changeCover")}</span>
+            </button>
+          </div>,
+          document.body,
+        )}
     </>
   );
 }

--- a/src/components/views/settings/EqualizerCard.tsx
+++ b/src/components/views/settings/EqualizerCard.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { ChevronDown } from "lucide-react";
 import {
@@ -39,7 +40,29 @@ export function EqualizerCard() {
   const [maxGain, setMaxGain] = useState(12);
   const [presets, setPresets] = useState<EqPresetEntry[]>([]);
   const [presetOpen, setPresetOpen] = useState(false);
+  // Viewport coords of the portaled preset menu (null until opened).
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(
+    null,
+  );
   const presetRef = useRef<HTMLDivElement>(null);
+  const presetBtnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Width of the portaled menu (keep in sync with the `w-44` class
+  // below) so we can clamp it inside the viewport.
+  const MENU_WIDTH = 176;
+
+  // Open the menu, pinning it to the trigger's current viewport rect.
+  // The menu is portaled to <body> (below) so a skin's backdrop-filter
+  // card can't trap it in a clipped / mis-stacked containing block.
+  const openPreset = useCallback(() => {
+    const rect = presetBtnRef.current?.getBoundingClientRect();
+    if (rect) {
+      const left = Math.min(rect.left, window.innerWidth - MENU_WIDTH - 8);
+      setMenuPos({ top: rect.bottom + 8, left: Math.max(8, left) });
+    }
+    setPresetOpen(true);
+  }, []);
 
   // Hydrate from backend at mount, then keep in sync via `player:eq`
   // broadcasts so a mutation from the player-bar popup (or any other
@@ -90,22 +113,34 @@ export function EqualizerCard() {
     return match?.key ?? "custom";
   }, [presets, bands]);
 
-  // Close the preset menu on outside click / Escape.
+  // Close the preset menu on outside click / Escape. The menu is
+  // portaled out of `presetRef`, so an outside click must miss BOTH the
+  // trigger wrapper and the menu itself. Scrolling / resizing detaches
+  // the fixed menu from the trigger, so close on those too.
   useEffect(() => {
     if (!presetOpen) return;
     const onClick = (e: MouseEvent) => {
-      if (presetRef.current && !presetRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (
+        !presetRef.current?.contains(target) &&
+        !menuRef.current?.contains(target)
+      ) {
         setPresetOpen(false);
       }
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setPresetOpen(false);
     };
+    const close = () => setPresetOpen(false);
     document.addEventListener("mousedown", onClick);
     document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
     return () => {
       document.removeEventListener("mousedown", onClick);
       document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
     };
   }, [presetOpen]);
 
@@ -181,8 +216,9 @@ export function EqualizerCard() {
               {t("settings.equalizer.presets")}
             </span>
             <button
+              ref={presetBtnRef}
               type="button"
-              onClick={() => setPresetOpen((v) => !v)}
+              onClick={() => (presetOpen ? setPresetOpen(false) : openPreset())}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 text-sm text-zinc-800 dark:text-zinc-200 transition-colors"
             >
               {t(`settings.equalizer.preset.${activePresetKey}`, {
@@ -193,26 +229,39 @@ export function EqualizerCard() {
               })}
               <ChevronDown size={14} className="text-zinc-400" />
             </button>
-            {presetOpen && (
-              <div className="absolute top-full left-22 mt-2 z-20 w-44 max-h-72 overflow-y-auto rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg">
-                {presets.map((p) => (
-                  <button
-                    key={p.key}
-                    type="button"
-                    onClick={() => handlePickPreset(p.key)}
-                    className={`w-full text-left px-3 py-2 text-sm transition-colors ${
-                      p.key === activePresetKey
-                        ? "bg-emerald-500 text-white"
-                        : "hover:bg-zinc-100 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-200"
-                    }`}
-                  >
-                    {t(`settings.equalizer.preset.${p.key}`, {
-                      defaultValue: p.key,
-                    })}
-                  </button>
-                ))}
-              </div>
-            )}
+            {presetOpen &&
+              menuPos &&
+              createPortal(
+                <div
+                  ref={menuRef}
+                  role="menu"
+                  style={{
+                    position: "fixed",
+                    top: menuPos.top,
+                    left: menuPos.left,
+                  }}
+                  className="z-100 w-44 max-h-72 overflow-y-auto rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg"
+                >
+                  {presets.map((p) => (
+                    <button
+                      key={p.key}
+                      type="button"
+                      role="menuitem"
+                      onClick={() => handlePickPreset(p.key)}
+                      className={`w-full text-left px-3 py-2 text-sm transition-colors ${
+                        p.key === activePresetKey
+                          ? "bg-emerald-500 text-white"
+                          : "hover:bg-zinc-100 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-200"
+                      }`}
+                    >
+                      {t(`settings.equalizer.preset.${p.key}`, {
+                        defaultValue: p.key,
+                      })}
+                    </button>
+                  ))}
+                </div>,
+                document.body,
+              )}
           </div>
           <button
             type="button"

--- a/src/components/views/settings/EqualizerCard.tsx
+++ b/src/components/views/settings/EqualizerCard.tsx
@@ -48,9 +48,10 @@ export function EqualizerCard() {
   const presetBtnRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Width of the portaled menu (keep in sync with the `w-44` class
-  // below) so we can clamp it inside the viewport.
+  // Dimensions of the portaled menu (keep in sync with the `w-44` /
+  // `max-h-72` classes below) so we can clamp it inside the viewport.
   const MENU_WIDTH = 176;
+  const MENU_MAX_HEIGHT = 288;
 
   // Open the menu, pinning it to the trigger's current viewport rect.
   // The menu is portaled to <body> (below) so a skin's backdrop-filter
@@ -58,8 +59,17 @@ export function EqualizerCard() {
   const openPreset = useCallback(() => {
     const rect = presetBtnRef.current?.getBoundingClientRect();
     if (rect) {
-      const left = Math.min(rect.left, window.innerWidth - MENU_WIDTH - 8);
-      setMenuPos({ top: rect.bottom + 8, left: Math.max(8, left) });
+      const left = Math.max(
+        8,
+        Math.min(rect.left, window.innerWidth - MENU_WIDTH - 8),
+      );
+      // Clamp vertically too — a trigger near the viewport bottom would
+      // otherwise push the menu off-screen below.
+      const top = Math.max(
+        8,
+        Math.min(rect.bottom + 8, window.innerHeight - MENU_MAX_HEIGHT - 8),
+      );
+      setMenuPos({ top, left });
     }
     setPresetOpen(true);
   }, []);

--- a/src/components/views/settings/EqualizerCard.tsx
+++ b/src/components/views/settings/EqualizerCard.tsx
@@ -141,16 +141,23 @@ export function EqualizerCard() {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setPresetOpen(false);
     };
-    const close = () => setPresetOpen(false);
+    // Capture-phase scroll catches scrolls anywhere — but the menu's own
+    // overflow-y-auto list scrolling must NOT close it; only an outside
+    // (page / panel) scroll detaches the fixed menu from its trigger.
+    const onScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      setPresetOpen(false);
+    };
+    const onResize = () => setPresetOpen(false);
     document.addEventListener("mousedown", onClick);
     document.addEventListener("keydown", onKey);
-    window.addEventListener("scroll", close, true);
-    window.addEventListener("resize", close);
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onResize);
     return () => {
       document.removeEventListener("mousedown", onClick);
       document.removeEventListener("keydown", onKey);
-      window.removeEventListener("scroll", close, true);
-      window.removeEventListener("resize", close);
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onResize);
     };
   }, [presetOpen]);
 
@@ -228,6 +235,9 @@ export function EqualizerCard() {
             <button
               ref={presetBtnRef}
               type="button"
+              aria-haspopup="menu"
+              aria-expanded={presetOpen}
+              aria-controls={presetOpen ? "eq-preset-menu" : undefined}
               onClick={() => (presetOpen ? setPresetOpen(false) : openPreset())}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 text-sm text-zinc-800 dark:text-zinc-200 transition-colors"
             >
@@ -244,6 +254,7 @@ export function EqualizerCard() {
               createPortal(
                 <div
                   ref={menuRef}
+                  id="eq-preset-menu"
                   role="menu"
                   style={{
                     position: "fixed",


### PR DESCRIPTION
## Résumé

Item **`[C2]`** du thème **C · Skins polish** ([Project v1.6.0](https://github.com/users/InstaZDLL/projects/2)) — audit stacking-trap, porter le pattern portal de PR #274 (dropdown langue) aux autres dropdowns.

Sous les skins **Lounge / Liquid**, les cartes ont un `backdrop-filter` qui crée un nouveau containing block + stacking context. Un dropdown rendu **dans l'arbre** y est piégé (clippé par `overflow`, ou rendu derrière une carte voisine).

## Audit

| Dropdown | État avant |
|---|---|
| PlaylistView track-row menu | ✅ déjà portalisé |
| LibraryView track-row menu | ✅ déjà portalisé |
| **LibraryView** menu album « changer cover » | ❌ `fixed` en arbre |
| **EqualizerCard** preset picker | ❌ `absolute` en arbre |

## Fix

- **EqualizerCard** : le menu preset passe par `createPortal(document.body)`, positionné en `fixed` sur le rect viewport du trigger. La détection outside-click vérifie maintenant **le trigger ET le menu portalisé** (sinon le portal hors `presetRef` fermerait au premier clic), et le menu se ferme au scroll / resize (un menu `fixed` se détache du trigger sinon). Clamp horizontal pour rester dans le viewport.
- **LibraryView** menu album : wrap en `createPortal(document.body)` — il utilisait déjà des coords viewport `fixed` (depuis l'event contextmenu), donc le portal suffit.

## Validation

`bun run typecheck` ✅ · `bun run lint` ✅. Pas de changement i18n / backend.

## Note

`[C1]` (glow Lounge depuis la cover) est laissé à une **passe visuelle interactive** — c'est du tuning d'opacité/teinte qui se juge à l'écran, pas à l'aveugle.

Milestone v1.6.0, thème C (1/2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Les menus contextuels des pochettes et des presets s’affichent désormais correctement au-dessus de l’interface, même avec certains thèmes/effets visuels.
  * Améliorations du comportement de fermeture : clic extérieur, défilement, redimensionnement et touche Échap, avec une gestion plus fiable des cas limites.
  * Le positionnement des menus est recalculé à l’ouverture et ajusté pour rester dans la zone visible de l’écran, avec une meilleure structure ARIA pour le menu des presets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->