### PR TITLE
perf(scan): ~4× faster first scan — cache the artist-image directory walk

### DIFF
--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -242,6 +242,16 @@ struct ScanTimings {
     /// `extract_db_ms` is the single-writer DB path vs the parallel
     /// extraction feeding it. Diagnostics only.
     db_us: AtomicU64,
+    /// Subset of `db_us` spent inside `maybe_link_artist_images` — the
+    /// per-track sidecar-artist-image walk (`fs::read_dir` of up to 3
+    /// ancestor dirs + a `canonical_name` per directory entry). On a
+    /// library with no local artist images this re-walks the same
+    /// folders for the same artists on every track, so it's the prime
+    /// suspect for the chunk of `db_ms_total` that the upsert
+    /// memoisation did NOT move. Diagnostics only — split out to
+    /// confirm before optimising (the SQL-lookup memo was measured to
+    /// barely dent `db_ms_total`, so guessing isn't enough).
+    link_us: AtomicU64,
 }
 
 /// Scan-scoped memo for the `artist` / `genre` lookups that otherwise
@@ -839,6 +849,7 @@ pub(crate) async fn scan_folder_inner(
                     .bind(existing_track_id)
                     .fetch_all(&mut *tx)
                     .await?;
+                    let t_link = Instant::now();
                     maybe_link_artist_images(
                         &mut tx,
                         Some(raw),
@@ -847,6 +858,9 @@ pub(crate) async fn scan_folder_inner(
                         artwork_dir,
                     )
                     .await?;
+                    timings
+                        .link_us
+                        .fetch_add(t_link.elapsed().as_micros() as u64, Ordering::Relaxed);
                 }
 
                 // Phase 4.d.0.3: emit a sync op ONLY when the skip
@@ -907,6 +921,7 @@ pub(crate) async fn scan_folder_inner(
                     .await?;
                 }
 
+                let t_link = Instant::now();
                 maybe_link_artist_images(
                     &mut tx,
                     extracted.artist.as_deref(),
@@ -915,6 +930,9 @@ pub(crate) async fn scan_folder_inner(
                     artwork_dir,
                 )
                 .await?;
+                timings
+                    .link_us
+                    .fetch_add(t_link.elapsed().as_micros() as u64, Ordering::Relaxed);
 
                 sqlx::query(
                     "UPDATE track SET
@@ -1033,6 +1051,7 @@ pub(crate) async fn scan_folder_inner(
                     .await?;
             }
 
+            let t_link = Instant::now();
             maybe_link_artist_images(
                 &mut tx,
                 extracted.artist.as_deref(),
@@ -1041,6 +1060,9 @@ pub(crate) async fn scan_folder_inner(
                 artwork_dir,
             )
             .await?;
+            timings
+                .link_us
+                .fetch_add(t_link.elapsed().as_micros() as u64, Ordering::Relaxed);
 
             let insert = sqlx::query(
                 "INSERT INTO track (
@@ -1212,6 +1234,8 @@ pub(crate) async fn scan_folder_inner(
         // this is the parallel extraction (hash + cover) the consumer
         // waited on.
         db_ms_total = timings.db_us.load(Ordering::Relaxed) / 1000,
+        // Subset of db_ms_total spent in the sidecar-artist-image walk.
+        link_ms_total = timings.link_us.load(Ordering::Relaxed) / 1000,
         "scan complete"
     );
 

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -18,7 +18,8 @@ use waveflow_core::scanner::{
     extract_folder_cover, extract_musical_key, extract_rating, file_type_label, hash_file,
     link_local_artist_image, link_va_artist_image, maybe_link_artist_images,
     merge_implicit_compilations, now_millis, split_artist_name, upsert_album, upsert_artist,
-    upsert_artwork, upsert_genre, ExtractedFile, AUDIO_EXTENSIONS, VARIOUS_ARTISTS_LABEL,
+    upsert_artwork, upsert_genre, ArtistImageScanCache, ExtractedFile, AUDIO_EXTENSIONS,
+    VARIOUS_ARTISTS_LABEL,
 };
 
 use crate::{
@@ -707,10 +708,11 @@ pub(crate) async fn scan_folder_inner(
     // `UpsertCache`. Lives for the loop's duration so every track on
     // the same album / by the same artist reuses the first resolution.
     let mut upsert_cache = UpsertCache::default();
-    // `(artist_id, parent dir)` pairs already run through the
-    // sidecar-artist-image walk — threaded into `maybe_link_artist_images`
-    // so it skips a repeat walk per artist (the single biggest scan cost).
-    let mut linked_artist_dirs: HashSet<(i64, PathBuf)> = HashSet::new();
+    // Per-scan memo for the sidecar-artist-image walk (the single
+    // biggest scan cost) — threaded into `maybe_link_artist_images`.
+    // Skips repeat `(artist, folder)` pairs AND caches each directory's
+    // `read_dir` so shared ancestor folders are read once.
+    let mut artist_image_cache = ArtistImageScanCache::default();
 
     while let Some((path, result)) = extraction_stream.next().await {
         processed += 1;
@@ -860,7 +862,7 @@ pub(crate) async fn scan_folder_inner(
                         &current_ids,
                         track_path,
                         artwork_dir,
-                        &mut linked_artist_dirs,
+                        &mut artist_image_cache,
                     )
                     .await?;
                     timings
@@ -933,7 +935,7 @@ pub(crate) async fn scan_folder_inner(
                     &artist_ids,
                     Path::new(&extracted.abs_path),
                     artwork_dir,
-                    &mut linked_artist_dirs,
+                    &mut artist_image_cache,
                 )
                 .await?;
                 timings
@@ -1064,7 +1066,7 @@ pub(crate) async fn scan_folder_inner(
                 &artist_ids,
                 Path::new(&extracted.abs_path),
                 artwork_dir,
-                &mut linked_artist_dirs,
+                &mut artist_image_cache,
             )
             .await?;
             timings

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -18,7 +18,7 @@ use waveflow_core::scanner::{
     extract_folder_cover, extract_musical_key, extract_rating, file_type_label, hash_file,
     link_local_artist_image, link_va_artist_image, maybe_link_artist_images,
     merge_implicit_compilations, now_millis, split_artist_name, upsert_album, upsert_artist,
-    upsert_artwork, upsert_genre, ArtistImageScanCache, ExtractedFile, AUDIO_EXTENSIONS,
+    upsert_artwork, ArtistImageScanCache, ExtractedFile, UpsertCache, AUDIO_EXTENSIONS,
     VARIOUS_ARTISTS_LABEL,
 };
 
@@ -253,90 +253,6 @@ struct ScanTimings {
     /// confirm before optimising (the SQL-lookup memo was measured to
     /// barely dent `db_ms_total`, so guessing isn't enough).
     link_us: AtomicU64,
-}
-
-/// Scan-scoped memo for the `artist` / `genre` lookups that otherwise
-/// fire one `SELECT … WHERE canonical_name = ?` per track. A 900-track
-/// library typically resolves to ~100 distinct artists and ~20 genres,
-/// so without this the consumer loop pays thousands of redundant
-/// single-writer round-trips — the dominant cost once the partial hash
-/// took hashing off the critical path (`db_ms_total` ≈ 99 % of
-/// `extract_db_ms`, measured).
-///
-/// Keyed on [`canonical_name`] exactly like [`upsert_artist`] /
-/// [`upsert_genre`] so a cache hit returns the same id the SELECT
-/// would. Ids stay valid across the loop's periodic `TX_BATCH` commits
-/// (the rows they point at are committed, never rolled back — any error
-/// aborts the whole scan and drops the cache with it). `album` is
-/// deliberately NOT memoised: [`upsert_album`] carries sticky
-/// compilation / album-artist backfill logic that must run per track.
-#[derive(Default)]
-struct UpsertCache {
-    artists: HashMap<String, i64>,
-    genres: HashMap<String, i64>,
-}
-
-impl UpsertCache {
-    /// Cached [`upsert_artist`]. Mirrors its trim → `canonical_name` →
-    /// empty-guard so the cache key matches the DB lookup key.
-    async fn artist(
-        &mut self,
-        conn: &mut sqlx::SqliteConnection,
-        raw_name: &str,
-    ) -> AppResult<Option<i64>> {
-        let canon = canonical_name(raw_name.trim());
-        if canon.is_empty() {
-            return Ok(None);
-        }
-        if let Some(&id) = self.artists.get(&canon) {
-            return Ok(Some(id));
-        }
-        let id = upsert_artist(conn, raw_name).await?;
-        if let Some(id) = id {
-            self.artists.insert(canon, id);
-        }
-        Ok(id)
-    }
-
-    /// Cached equivalent of [`upsert_artist_list`] — splits the raw
-    /// multi-artist string the same way, then resolves each through
-    /// [`Self::artist`].
-    async fn artist_list(
-        &mut self,
-        conn: &mut sqlx::SqliteConnection,
-        raw: &Option<String>,
-    ) -> AppResult<Vec<i64>> {
-        let Some(raw) = raw else {
-            return Ok(Vec::new());
-        };
-        let mut ids = Vec::new();
-        for name in split_artist_name(raw) {
-            if let Some(id) = self.artist(&mut *conn, &name).await? {
-                ids.push(id);
-            }
-        }
-        Ok(ids)
-    }
-
-    /// Cached [`upsert_genre`].
-    async fn genre(
-        &mut self,
-        conn: &mut sqlx::SqliteConnection,
-        raw_name: &str,
-    ) -> AppResult<Option<i64>> {
-        let canon = canonical_name(raw_name.trim());
-        if canon.is_empty() {
-            return Ok(None);
-        }
-        if let Some(&id) = self.genres.get(&canon) {
-            return Ok(Some(id));
-        }
-        let id = upsert_genre(conn, raw_name).await?;
-        if let Some(id) = id {
-            self.genres.insert(canon, id);
-        }
-        Ok(id)
-    }
 }
 
 fn extract_file(
@@ -587,32 +503,6 @@ pub(crate) async fn scan_folder_inner(
         .map(|(p, mtime, size)| (p, (mtime, size)))
         .collect();
 
-    // Probe map for the insert-vs-update decision in the consumer loop,
-    // pre-loaded ONCE instead of a `SELECT … WHERE library_id = ? AND
-    // file_path = ?` per extracted track (the per-track probe was a
-    // wasted round-trip on every brand-new file — always a miss — and
-    // those dominate a first scan). Keyed library-wide, NOT folder-
-    // scoped like `existing_meta`: a file already known under another
-    // folder of the same library must still resolve so the loop UPDATEs
-    // (and reassigns `folder_id`) instead of hitting the
-    // `UNIQUE(library_id, file_path)` constraint. No `is_available`
-    // filter — matches the old probe, so a vanished-then-restored track
-    // is found and flipped back to available. Snapshot-before-loop is
-    // safe: the walk yields distinct paths, so no row inserted earlier
-    // in THIS scan is ever probed later.
-    let probe_rows: Vec<(String, i64, i64, String, i64)> = sqlx::query_as(
-        "SELECT file_path, id, file_modified, file_hash, added_at
-           FROM track
-          WHERE library_id = ?",
-    )
-    .bind(library_id)
-    .fetch_all(pool)
-    .await?;
-    let existing_probe: HashMap<String, (i64, i64, String, i64)> = probe_rows
-        .into_iter()
-        .map(|(path, id, mtime, hash, added_at)| (path, (id, mtime, hash, added_at)))
-        .collect();
-
     let meta_load_ms = t_scan.elapsed().as_millis();
 
     let total_files = audio_files.len();
@@ -666,6 +556,38 @@ pub(crate) async fn scan_folder_inner(
     }
     let stat_ms = t_scan.elapsed().as_millis();
     let to_extract_count = to_extract.len();
+
+    // Probe map for the insert-vs-update decision in the consumer loop,
+    // pre-loaded ONCE instead of a `SELECT … WHERE library_id = ? AND
+    // file_path = ?` per extracted track (the per-track probe was a
+    // wasted round-trip on every brand-new file — always a miss — and
+    // those dominate a first scan). Built only when there's actually
+    // something to extract: a stat-skip rescan (everything unchanged)
+    // would otherwise pay a full library-wide load for nothing. Keyed
+    // library-wide, NOT folder-scoped like `existing_meta`: a file
+    // already known under another folder of the same library must still
+    // resolve so the loop UPDATEs (and reassigns `folder_id`) instead of
+    // hitting the `UNIQUE(library_id, file_path)` constraint. No
+    // `is_available` filter — matches the old probe, so a vanished-then-
+    // restored track is found and flipped back to available. Snapshot-
+    // before-loop is safe: the walk yields distinct paths, so no row
+    // inserted earlier in THIS scan is ever probed later.
+    let existing_probe: HashMap<String, (i64, i64, String, i64)> = if to_extract.is_empty() {
+        HashMap::new()
+    } else {
+        let probe_rows: Vec<(String, i64, i64, String, i64)> = sqlx::query_as(
+            "SELECT file_path, id, file_modified, file_hash, added_at
+               FROM track
+              WHERE library_id = ?",
+        )
+        .bind(library_id)
+        .fetch_all(pool)
+        .await?;
+        probe_rows
+            .into_iter()
+            .map(|(path, id, mtime, hash, added_at)| (path, (id, mtime, hash, added_at)))
+            .collect()
+    };
 
     // ─── Phase 2: Parallel extract + transactional DB writes ──────
     //
@@ -1156,7 +1078,16 @@ pub(crate) async fn scan_folder_inner(
         maybe_emit_progress(app_handle, folder_id, processed, total_files, &summary);
     }
 
+    // Time the final commit into `db_us` too — the periodic TX_BATCH
+    // commits are already counted inside the loop, so without this the
+    // last batch's commit (which can carry up to TX_BATCH rows of fsync)
+    // would be the one slice of DB cost `db_ms_total` silently omits.
+    let t_final_commit = Instant::now();
     tx.commit().await?;
+    timings.db_us.fetch_add(
+        t_final_commit.elapsed().as_micros() as u64,
+        Ordering::Relaxed,
+    );
     let extract_db_ms = t_scan.elapsed().as_millis();
 
     // Anything still in the map was on disk last time but isn't now.

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -234,6 +234,15 @@ fn extract_dsd_file(
 struct ScanTimings {
     hash_us: AtomicU64,
     tag_us: AtomicU64,
+    /// Wall time spent on the SERIAL per-track DB work in the consumer
+    /// loop (the `SELECT existing` probe + every `upsert_*` + the row
+    /// INSERT/UPDATE + the periodic `TX_BATCH` commit). Unlike
+    /// `hash_us` / `tag_us` — summed across the parallel extraction
+    /// tasks — this accrues on the single consumer task, so the total
+    /// is already wall-clock: it tells us directly how much of
+    /// `extract_db_ms` is the single-writer DB path vs the parallel
+    /// extraction feeding it. Diagnostics only.
+    db_us: AtomicU64,
 }
 
 fn extract_file(
@@ -593,6 +602,13 @@ pub(crate) async fn scan_folder_inner(
 
         // File is on disk → keep it out of the deletion sweep below.
         existing_meta.remove(&extracted.abs_path);
+
+        // Time the serial DB work for this track (probe + upserts +
+        // INSERT/UPDATE + the periodic commit). `existing_meta.remove`
+        // above is an in-memory HashMap op, negligible. No `continue`
+        // sits between here and the accumulate below, so one delta
+        // covers the whole iteration's DB cost.
+        let t_db = Instant::now();
 
         // Pulls `added_at` so we can preserve the row's original
         // "first import" timestamp on the wire — re-emits must NOT
@@ -994,6 +1010,10 @@ pub(crate) async fn scan_folder_inner(
             tx_count = 0;
         }
 
+        timings
+            .db_us
+            .fetch_add(t_db.elapsed().as_micros() as u64, Ordering::Relaxed);
+
         maybe_emit_progress(app_handle, folder_id, processed, total_files, &summary);
     }
 
@@ -1079,6 +1099,11 @@ pub(crate) async fn scan_folder_inner(
         total_ms = t_scan.elapsed().as_millis(),
         hash_cpu_ms_total = timings.hash_us.load(Ordering::Relaxed) / 1000,
         tag_cpu_ms_total = timings.tag_us.load(Ordering::Relaxed) / 1000,
+        // Serial single-writer DB time — already wall-clock (one
+        // consumer task). The slice of `extract_db_ms` NOT covered by
+        // this is the parallel extraction (hash + cover) the consumer
+        // waited on.
+        db_ms_total = timings.db_us.load(Ordering::Relaxed) / 1000,
         "scan complete"
     );
 

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -18,8 +18,7 @@ use waveflow_core::scanner::{
     extract_folder_cover, extract_musical_key, extract_rating, file_type_label, hash_file,
     link_local_artist_image, link_va_artist_image, maybe_link_artist_images,
     merge_implicit_compilations, now_millis, split_artist_name, upsert_album, upsert_artist,
-    upsert_artist_list, upsert_artwork, upsert_genre, ExtractedFile, AUDIO_EXTENSIONS,
-    VARIOUS_ARTISTS_LABEL,
+    upsert_artwork, upsert_genre, ExtractedFile, AUDIO_EXTENSIONS, VARIOUS_ARTISTS_LABEL,
 };
 
 use crate::{
@@ -243,6 +242,90 @@ struct ScanTimings {
     /// `extract_db_ms` is the single-writer DB path vs the parallel
     /// extraction feeding it. Diagnostics only.
     db_us: AtomicU64,
+}
+
+/// Scan-scoped memo for the `artist` / `genre` lookups that otherwise
+/// fire one `SELECT … WHERE canonical_name = ?` per track. A 900-track
+/// library typically resolves to ~100 distinct artists and ~20 genres,
+/// so without this the consumer loop pays thousands of redundant
+/// single-writer round-trips — the dominant cost once the partial hash
+/// took hashing off the critical path (`db_ms_total` ≈ 99 % of
+/// `extract_db_ms`, measured).
+///
+/// Keyed on [`canonical_name`] exactly like [`upsert_artist`] /
+/// [`upsert_genre`] so a cache hit returns the same id the SELECT
+/// would. Ids stay valid across the loop's periodic `TX_BATCH` commits
+/// (the rows they point at are committed, never rolled back — any error
+/// aborts the whole scan and drops the cache with it). `album` is
+/// deliberately NOT memoised: [`upsert_album`] carries sticky
+/// compilation / album-artist backfill logic that must run per track.
+#[derive(Default)]
+struct UpsertCache {
+    artists: HashMap<String, i64>,
+    genres: HashMap<String, i64>,
+}
+
+impl UpsertCache {
+    /// Cached [`upsert_artist`]. Mirrors its trim → `canonical_name` →
+    /// empty-guard so the cache key matches the DB lookup key.
+    async fn artist(
+        &mut self,
+        conn: &mut sqlx::SqliteConnection,
+        raw_name: &str,
+    ) -> AppResult<Option<i64>> {
+        let canon = canonical_name(raw_name.trim());
+        if canon.is_empty() {
+            return Ok(None);
+        }
+        if let Some(&id) = self.artists.get(&canon) {
+            return Ok(Some(id));
+        }
+        let id = upsert_artist(conn, raw_name).await?;
+        if let Some(id) = id {
+            self.artists.insert(canon, id);
+        }
+        Ok(id)
+    }
+
+    /// Cached equivalent of [`upsert_artist_list`] — splits the raw
+    /// multi-artist string the same way, then resolves each through
+    /// [`Self::artist`].
+    async fn artist_list(
+        &mut self,
+        conn: &mut sqlx::SqliteConnection,
+        raw: &Option<String>,
+    ) -> AppResult<Vec<i64>> {
+        let Some(raw) = raw else {
+            return Ok(Vec::new());
+        };
+        let mut ids = Vec::new();
+        for name in split_artist_name(raw) {
+            if let Some(id) = self.artist(&mut *conn, &name).await? {
+                ids.push(id);
+            }
+        }
+        Ok(ids)
+    }
+
+    /// Cached [`upsert_genre`].
+    async fn genre(
+        &mut self,
+        conn: &mut sqlx::SqliteConnection,
+        raw_name: &str,
+    ) -> AppResult<Option<i64>> {
+        let canon = canonical_name(raw_name.trim());
+        if canon.is_empty() {
+            return Ok(None);
+        }
+        if let Some(&id) = self.genres.get(&canon) {
+            return Ok(Some(id));
+        }
+        let id = upsert_genre(conn, raw_name).await?;
+        if let Some(id) = id {
+            self.genres.insert(canon, id);
+        }
+        Ok(id)
+    }
 }
 
 fn extract_file(
@@ -492,6 +575,33 @@ pub(crate) async fn scan_folder_inner(
         .into_iter()
         .map(|(p, mtime, size)| (p, (mtime, size)))
         .collect();
+
+    // Probe map for the insert-vs-update decision in the consumer loop,
+    // pre-loaded ONCE instead of a `SELECT … WHERE library_id = ? AND
+    // file_path = ?` per extracted track (the per-track probe was a
+    // wasted round-trip on every brand-new file — always a miss — and
+    // those dominate a first scan). Keyed library-wide, NOT folder-
+    // scoped like `existing_meta`: a file already known under another
+    // folder of the same library must still resolve so the loop UPDATEs
+    // (and reassigns `folder_id`) instead of hitting the
+    // `UNIQUE(library_id, file_path)` constraint. No `is_available`
+    // filter — matches the old probe, so a vanished-then-restored track
+    // is found and flipped back to available. Snapshot-before-loop is
+    // safe: the walk yields distinct paths, so no row inserted earlier
+    // in THIS scan is ever probed later.
+    let probe_rows: Vec<(String, i64, i64, String, i64)> = sqlx::query_as(
+        "SELECT file_path, id, file_modified, file_hash, added_at
+           FROM track
+          WHERE library_id = ?",
+    )
+    .bind(library_id)
+    .fetch_all(pool)
+    .await?;
+    let existing_probe: HashMap<String, (i64, i64, String, i64)> = probe_rows
+        .into_iter()
+        .map(|(path, id, mtime, hash, added_at)| (path, (id, mtime, hash, added_at)))
+        .collect();
+
     let meta_load_ms = t_scan.elapsed().as_millis();
 
     let total_files = audio_files.len();
@@ -583,6 +693,10 @@ pub(crate) async fn scan_folder_inner(
     let mut tx = pool.begin().await?;
     let mut tx_count: usize = 0;
     let mut processed: usize = summary.skipped as usize;
+    // Memo for artist / genre id lookups across the whole scan — see
+    // `UpsertCache`. Lives for the loop's duration so every track on
+    // the same album / by the same artist reuses the first resolution.
+    let mut upsert_cache = UpsertCache::default();
 
     while let Some((path, result)) = extraction_stream.next().await {
         processed += 1;
@@ -610,20 +724,14 @@ pub(crate) async fn scan_folder_inner(
         // covers the whole iteration's DB cost.
         let t_db = Instant::now();
 
-        // Pulls `added_at` so we can preserve the row's original
-        // "first import" timestamp on the wire — re-emits must NOT
-        // bump it (a peer device receiving a re-emit op for an
-        // existing track would otherwise see the file as "just
-        // added" in its `Recently added` view). Brand-new track
-        // path keeps using `now`.
-        let existing: Option<(i64, i64, String, i64)> = sqlx::query_as(
-            "SELECT id, file_modified, file_hash, added_at \
-               FROM track WHERE library_id = ? AND file_path = ?",
-        )
-        .bind(library_id)
-        .bind(&extracted.abs_path)
-        .fetch_optional(&mut *tx)
-        .await?;
+        // Insert-vs-update probe, served from the pre-loaded
+        // `existing_probe` map instead of a per-track SELECT. Carries
+        // `added_at` so we preserve the row's original "first import"
+        // timestamp on the wire — re-emits must NOT bump it (a peer
+        // device receiving a re-emit op for an existing track would
+        // otherwise see the file as "just added" in its `Recently
+        // added` view). Brand-new track path keeps using `now`.
+        let existing = existing_probe.get(&extracted.abs_path).cloned();
 
         if let Some((existing_track_id, mtime, ref hash, existing_added_at)) = existing {
             if mtime == extracted.modified_ms && hash == &extracted.hash {
@@ -767,7 +875,7 @@ pub(crate) async fn scan_folder_inner(
                 // Hash or mtime changed → full re-write of the track row
                 // and its many-to-many links. Falls through to the
                 // shared insert/update path below.
-                let artist_ids = upsert_artist_list(&mut tx, &extracted.artist).await?;
+                let artist_ids = upsert_cache.artist_list(&mut tx, &extracted.artist).await?;
                 let artist_id = artist_ids.first().copied();
                 let album_id = match &extracted.album {
                     Some(a) => {
@@ -784,7 +892,7 @@ pub(crate) async fn scan_folder_inner(
                     None => None,
                 };
                 let genre_id = match &extracted.genre {
-                    Some(g) => upsert_genre(&mut tx, g).await?,
+                    Some(g) => upsert_cache.genre(&mut tx, g).await?,
                     None => None,
                 };
                 if let (Some(cover), Some(aid)) = (&extracted.cover_art, album_id) {
@@ -895,7 +1003,7 @@ pub(crate) async fn scan_folder_inner(
             }
         } else {
             // Brand-new track — insert with all related upserts.
-            let artist_ids = upsert_artist_list(&mut tx, &extracted.artist).await?;
+            let artist_ids = upsert_cache.artist_list(&mut tx, &extracted.artist).await?;
             let artist_id = artist_ids.first().copied();
             let album_id = match &extracted.album {
                 Some(a) => {
@@ -912,7 +1020,7 @@ pub(crate) async fn scan_folder_inner(
                 None => None,
             };
             let genre_id = match &extracted.genre {
-                Some(g) => upsert_genre(&mut tx, g).await?,
+                Some(g) => upsert_cache.genre(&mut tx, g).await?,
                 None => None,
             };
             if let (Some(cover), Some(aid)) = (&extracted.cover_art, album_id) {

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -336,6 +336,53 @@ impl UpsertCache {
         }
         Ok(id)
     }
+}
+
+/// Cached wrapper over [`maybe_link_artist_images`], keyed on
+/// `(artist_id, track parent dir)`.
+///
+/// The sidecar-artist-image walk (`fs::read_dir` of up to 3 ancestor
+/// dirs + a `canonical_name` per entry) is deterministic for a given
+/// `(artist, track-parent)` — every track in the same album folder
+/// walks the identical ancestors and gets the identical result. On a
+/// library with no local artist images that walk finds nothing yet
+/// re-runs for all ~18 tracks of every folder, and it was measured at
+/// ~98 % of the whole scan's DB time (`link_ms_total`). Skipping the
+/// re-walk once `(artist_id, parent)` has been seen collapses it to one
+/// walk per folder per artist.
+///
+/// Behaviour-preserving: the key includes the parent dir, so a
+/// different folder of the same artist still walks (a per-album sidecar
+/// is never missed). The first track of a folder still runs the full
+/// helper, so the `has_artwork` short-circuit + the actual link for
+/// artists that DO have a sidecar are unchanged.
+async fn link_artist_images_cached(
+    conn: &mut sqlx::SqliteConnection,
+    seen: &mut HashSet<(i64, PathBuf)>,
+    artist_raw: Option<&str>,
+    artist_ids: &[i64],
+    track_path: &Path,
+    artwork_dir: &Path,
+) -> AppResult<()> {
+    let parent = track_path.parent();
+    // Skip only when every artist of this track has already been walked
+    // for THIS folder. An empty id list has nothing to resolve.
+    let all_seen = !artist_ids.is_empty()
+        && parent.is_some_and(|p| {
+            artist_ids
+                .iter()
+                .all(|id| seen.contains(&(*id, p.to_path_buf())))
+        });
+    if all_seen {
+        return Ok(());
+    }
+    maybe_link_artist_images(conn, artist_raw, artist_ids, track_path, artwork_dir).await?;
+    if let Some(p) = parent {
+        for id in artist_ids {
+            seen.insert((*id, p.to_path_buf()));
+        }
+    }
+    Ok(())
 }
 
 fn extract_file(
@@ -707,6 +754,10 @@ pub(crate) async fn scan_folder_inner(
     // `UpsertCache`. Lives for the loop's duration so every track on
     // the same album / by the same artist reuses the first resolution.
     let mut upsert_cache = UpsertCache::default();
+    // `(artist_id, parent dir)` pairs already run through the
+    // sidecar-artist-image walk — see `link_artist_images_cached`. The
+    // single biggest scan cost, so this is the one that matters.
+    let mut linked_artist_dirs: HashSet<(i64, PathBuf)> = HashSet::new();
 
     while let Some((path, result)) = extraction_stream.next().await {
         processed += 1;
@@ -850,8 +901,9 @@ pub(crate) async fn scan_folder_inner(
                     .fetch_all(&mut *tx)
                     .await?;
                     let t_link = Instant::now();
-                    maybe_link_artist_images(
+                    link_artist_images_cached(
                         &mut tx,
+                        &mut linked_artist_dirs,
                         Some(raw),
                         &current_ids,
                         track_path,
@@ -922,8 +974,9 @@ pub(crate) async fn scan_folder_inner(
                 }
 
                 let t_link = Instant::now();
-                maybe_link_artist_images(
+                link_artist_images_cached(
                     &mut tx,
+                    &mut linked_artist_dirs,
                     extracted.artist.as_deref(),
                     &artist_ids,
                     Path::new(&extracted.abs_path),
@@ -1052,8 +1105,9 @@ pub(crate) async fn scan_folder_inner(
             }
 
             let t_link = Instant::now();
-            maybe_link_artist_images(
+            link_artist_images_cached(
                 &mut tx,
+                &mut linked_artist_dirs,
                 extracted.artist.as_deref(),
                 &artist_ids,
                 Path::new(&extracted.abs_path),

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -562,39 +562,51 @@ pub(crate) async fn scan_folder_inner(
     let timings = Arc::new(ScanTimings::default());
 
     // Probe map for the insert-vs-update decision in the consumer loop,
-    // pre-loaded ONCE instead of a `SELECT … WHERE library_id = ? AND
-    // file_path = ?` per extracted track (the per-track probe was a
-    // wasted round-trip on every brand-new file — always a miss — and
-    // those dominate a first scan). Built only when there's actually
-    // something to extract: a stat-skip rescan (everything unchanged)
-    // would otherwise pay a full library-wide load for nothing. Keyed
-    // library-wide, NOT folder-scoped like `existing_meta`: a file
-    // already known under another folder of the same library must still
-    // resolve so the loop UPDATEs (and reassigns `folder_id`) instead of
+    // pre-loaded in one pass instead of a `SELECT … WHERE library_id = ?
+    // AND file_path = ?` per extracted track. Scoped to exactly the
+    // `to_extract` paths via an `IN (…)` list — NOT a full library-wide
+    // load: an fs-watcher rescan of a single changed file in a
+    // 4000-track library must not drag in every row. SQLite caps bound
+    // params at 999 and `library_id` takes one slot, so the path list is
+    // chunked well under that. Scoped by `library_id` (not folder), so a
+    // file already known under another folder of the same library still
+    // resolves and the loop UPDATEs (reassigning `folder_id`) instead of
     // hitting the `UNIQUE(library_id, file_path)` constraint. No
     // `is_available` filter — matches the old probe, so a vanished-then-
     // restored track is found and flipped back to available. Snapshot-
     // before-loop is safe: the walk yields distinct paths, so no row
     // inserted earlier in THIS scan is ever probed later.
+    const PROBE_CHUNK: usize = 900;
     let existing_probe: HashMap<String, (i64, i64, String, i64)> = if to_extract.is_empty() {
         HashMap::new()
     } else {
         let t_db = Instant::now();
-        let probe_rows: Vec<(String, i64, i64, String, i64)> = sqlx::query_as(
-            "SELECT file_path, id, file_modified, file_hash, added_at
-               FROM track
-              WHERE library_id = ?",
-        )
-        .bind(library_id)
-        .fetch_all(pool)
-        .await?;
+        let paths: Vec<String> = to_extract
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        let mut probe = HashMap::with_capacity(paths.len());
+        for chunk in paths.chunks(PROBE_CHUNK) {
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+            let sql = format!(
+                "SELECT file_path, id, file_modified, file_hash, added_at
+                   FROM track
+                  WHERE library_id = ? AND file_path IN ({placeholders})"
+            );
+            let mut q =
+                sqlx::query_as::<_, (String, i64, i64, String, i64)>(sqlx::AssertSqlSafe(sql))
+                    .bind(library_id);
+            for p in chunk {
+                q = q.bind(p);
+            }
+            for (path, id, mtime, hash, added_at) in q.fetch_all(pool).await? {
+                probe.insert(path, (id, mtime, hash, added_at));
+            }
+        }
         timings
             .db_us
             .fetch_add(t_db.elapsed().as_micros() as u64, Ordering::Relaxed);
-        probe_rows
-            .into_iter()
-            .map(|(path, id, mtime, hash, added_at)| (path, (id, mtime, hash, added_at)))
-            .collect()
+        probe
     };
 
     // ─── Phase 2: Parallel extract + transactional DB writes ──────

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -557,6 +557,10 @@ pub(crate) async fn scan_folder_inner(
     let stat_ms = t_scan.elapsed().as_millis();
     let to_extract_count = to_extract.len();
 
+    // Created here (before the probe) so the probe SELECT below is
+    // counted in `db_us` like every other DB access.
+    let timings = Arc::new(ScanTimings::default());
+
     // Probe map for the insert-vs-update decision in the consumer loop,
     // pre-loaded ONCE instead of a `SELECT … WHERE library_id = ? AND
     // file_path = ?` per extracted track (the per-track probe was a
@@ -575,6 +579,7 @@ pub(crate) async fn scan_folder_inner(
     let existing_probe: HashMap<String, (i64, i64, String, i64)> = if to_extract.is_empty() {
         HashMap::new()
     } else {
+        let t_db = Instant::now();
         let probe_rows: Vec<(String, i64, i64, String, i64)> = sqlx::query_as(
             "SELECT file_path, id, file_modified, file_hash, added_at
                FROM track
@@ -583,6 +588,9 @@ pub(crate) async fn scan_folder_inner(
         .bind(library_id)
         .fetch_all(pool)
         .await?;
+        timings
+            .db_us
+            .fetch_add(t_db.elapsed().as_micros() as u64, Ordering::Relaxed);
         probe_rows
             .into_iter()
             .map(|(path, id, mtime, hash, added_at)| (path, (id, mtime, hash, added_at)))
@@ -607,7 +615,6 @@ pub(crate) async fn scan_folder_inner(
         .unwrap_or(4);
     const TX_BATCH: usize = 200;
 
-    let timings = Arc::new(ScanTimings::default());
     let extraction_stream = futures::stream::iter(to_extract)
         .map(|path: PathBuf| {
             let artwork_dir = artwork_dir.to_path_buf();

--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -338,53 +338,6 @@ impl UpsertCache {
     }
 }
 
-/// Cached wrapper over [`maybe_link_artist_images`], keyed on
-/// `(artist_id, track parent dir)`.
-///
-/// The sidecar-artist-image walk (`fs::read_dir` of up to 3 ancestor
-/// dirs + a `canonical_name` per entry) is deterministic for a given
-/// `(artist, track-parent)` — every track in the same album folder
-/// walks the identical ancestors and gets the identical result. On a
-/// library with no local artist images that walk finds nothing yet
-/// re-runs for all ~18 tracks of every folder, and it was measured at
-/// ~98 % of the whole scan's DB time (`link_ms_total`). Skipping the
-/// re-walk once `(artist_id, parent)` has been seen collapses it to one
-/// walk per folder per artist.
-///
-/// Behaviour-preserving: the key includes the parent dir, so a
-/// different folder of the same artist still walks (a per-album sidecar
-/// is never missed). The first track of a folder still runs the full
-/// helper, so the `has_artwork` short-circuit + the actual link for
-/// artists that DO have a sidecar are unchanged.
-async fn link_artist_images_cached(
-    conn: &mut sqlx::SqliteConnection,
-    seen: &mut HashSet<(i64, PathBuf)>,
-    artist_raw: Option<&str>,
-    artist_ids: &[i64],
-    track_path: &Path,
-    artwork_dir: &Path,
-) -> AppResult<()> {
-    let parent = track_path.parent();
-    // Skip only when every artist of this track has already been walked
-    // for THIS folder. An empty id list has nothing to resolve.
-    let all_seen = !artist_ids.is_empty()
-        && parent.is_some_and(|p| {
-            artist_ids
-                .iter()
-                .all(|id| seen.contains(&(*id, p.to_path_buf())))
-        });
-    if all_seen {
-        return Ok(());
-    }
-    maybe_link_artist_images(conn, artist_raw, artist_ids, track_path, artwork_dir).await?;
-    if let Some(p) = parent {
-        for id in artist_ids {
-            seen.insert((*id, p.to_path_buf()));
-        }
-    }
-    Ok(())
-}
-
 fn extract_file(
     path: &Path,
     artwork_dir: &Path,
@@ -755,8 +708,8 @@ pub(crate) async fn scan_folder_inner(
     // the same album / by the same artist reuses the first resolution.
     let mut upsert_cache = UpsertCache::default();
     // `(artist_id, parent dir)` pairs already run through the
-    // sidecar-artist-image walk — see `link_artist_images_cached`. The
-    // single biggest scan cost, so this is the one that matters.
+    // sidecar-artist-image walk — threaded into `maybe_link_artist_images`
+    // so it skips a repeat walk per artist (the single biggest scan cost).
     let mut linked_artist_dirs: HashSet<(i64, PathBuf)> = HashSet::new();
 
     while let Some((path, result)) = extraction_stream.next().await {
@@ -901,13 +854,13 @@ pub(crate) async fn scan_folder_inner(
                     .fetch_all(&mut *tx)
                     .await?;
                     let t_link = Instant::now();
-                    link_artist_images_cached(
+                    maybe_link_artist_images(
                         &mut tx,
-                        &mut linked_artist_dirs,
                         Some(raw),
                         &current_ids,
                         track_path,
                         artwork_dir,
+                        &mut linked_artist_dirs,
                     )
                     .await?;
                     timings
@@ -974,13 +927,13 @@ pub(crate) async fn scan_folder_inner(
                 }
 
                 let t_link = Instant::now();
-                link_artist_images_cached(
+                maybe_link_artist_images(
                     &mut tx,
-                    &mut linked_artist_dirs,
                     extracted.artist.as_deref(),
                     &artist_ids,
                     Path::new(&extracted.abs_path),
                     artwork_dir,
+                    &mut linked_artist_dirs,
                 )
                 .await?;
                 timings
@@ -1105,13 +1058,13 @@ pub(crate) async fn scan_folder_inner(
             }
 
             let t_link = Instant::now();
-            link_artist_images_cached(
+            maybe_link_artist_images(
                 &mut tx,
-                &mut linked_artist_dirs,
                 extracted.artist.as_deref(),
                 &artist_ids,
                 Path::new(&extracted.abs_path),
                 artwork_dir,
+                &mut linked_artist_dirs,
             )
             .await?;
             timings

--- a/src-tauri/crates/core/src/scanner/extract.rs
+++ b/src-tauri/crates/core/src/scanner/extract.rs
@@ -364,31 +364,49 @@ pub fn extract_artist_image(
     artist_canonical: &str,
     artwork_dir: &Path,
 ) -> Option<ExtractedCover> {
-    if artist_canonical.is_empty() {
-        return None;
-    }
-
-    let mut current = track_path.parent();
-    for _ in 0..ARTIST_IMAGE_MAX_DEPTH {
-        let Some(dir) = current else { break };
-        if let Some(found) = find_artist_image_in_dir(dir, artist_canonical) {
-            return write_artist_image(&found, artwork_dir);
-        }
-        current = dir.parent();
-    }
-    None
+    // One-shot callers (VA linking, the rescan command) pay a throwaway
+    // cache; the per-scan hot path uses `extract_artist_image_cached`
+    // with a shared one.
+    let mut cache = ArtistImageDirCache::new();
+    extract_artist_image_cached(track_path, artist_canonical, artwork_dir, &mut cache)
 }
 
-pub fn find_artist_image_in_dir(dir: &Path, artist_canonical: &str) -> Option<PathBuf> {
-    let entries = fs::read_dir(dir).ok()?;
-    let mut named_match: Option<PathBuf> = None;
-    let mut stem_match: Option<(usize, PathBuf)> = None;
+/// An image file in a directory, pre-parsed for artist matching. Built
+/// once per directory by [`read_dir_artist_images`] and cached so the
+/// `fs::read_dir` + per-entry work isn't repeated for every artist /
+/// track that walks through the same folder.
+#[derive(Clone)]
+pub struct DirImageCandidate {
+    /// `canonical_name(stem)` — matched against an artist's canonical
+    /// name for the `<Artist>.jpg` convention.
+    canon_stem: String,
+    /// Lowercased stem — matched against [`ARTIST_IMAGE_STEMS`]
+    /// (`artist` / `performer` / `band`).
+    stem_lower: String,
+    path: PathBuf,
+}
 
+/// Per-scan memo of each directory's image candidates. Keyed on the
+/// directory path; the sidecar-artist-image walk reuses it across every
+/// artist and track that shares an ancestor folder — the `read_dir`
+/// (+ a `file_type` per entry + a `canonical_name` per image) is the
+/// dominant first-scan cost, and it's identical for a given directory
+/// regardless of which artist is being resolved.
+pub type ArtistImageDirCache = HashMap<PathBuf, Vec<DirImageCandidate>>;
+
+/// Read a directory's image-file candidates once. Artist-independent.
+/// Uses `entry.file_type()` (populated by `read_dir` on Windows/Linux)
+/// instead of `Path::is_file` so there's no extra `stat` per entry.
+fn read_dir_artist_images(dir: &Path) -> Vec<DirImageCandidate> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
     for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
             continue;
         }
+        let path = entry.path();
         let stem = path
             .file_stem()
             .and_then(|s| s.to_str())
@@ -403,19 +421,68 @@ pub fn find_artist_image_in_dir(dir: &Path, artist_canonical: &str) -> Option<Pa
         if !FOLDER_COVER_EXTENSIONS.contains(&ext.as_str()) {
             continue;
         }
-        if canonical_name(&stem) == artist_canonical {
-            named_match.get_or_insert(path);
+        out.push(DirImageCandidate {
+            canon_stem: canonical_name(&stem),
+            stem_lower: stem,
+            path,
+        });
+    }
+    out
+}
+
+/// Match cached directory candidates against one artist. Mirrors the
+/// old `find_artist_image_in_dir` precedence: an exact `<Artist>.jpg`
+/// (canonical) match wins over a generic `artist`/`performer`/`band`
+/// stem, and among generic stems the earliest in [`ARTIST_IMAGE_STEMS`]
+/// wins.
+fn match_artist_image(candidates: &[DirImageCandidate], artist_canonical: &str) -> Option<PathBuf> {
+    let mut named_match: Option<&PathBuf> = None;
+    let mut stem_match: Option<(usize, &PathBuf)> = None;
+    for c in candidates {
+        if c.canon_stem == artist_canonical {
+            named_match.get_or_insert(&c.path);
             continue;
         }
-        if let Some(rank) = ARTIST_IMAGE_STEMS.iter().position(|s| *s == stem) {
+        if let Some(rank) = ARTIST_IMAGE_STEMS.iter().position(|s| *s == c.stem_lower) {
             match &stem_match {
                 Some((current_rank, _)) if *current_rank <= rank => {}
-                _ => stem_match = Some((rank, path)),
+                _ => stem_match = Some((rank, &c.path)),
             }
         }
     }
+    named_match.or(stem_match.map(|(_, p)| p)).cloned()
+}
 
-    named_match.or(stem_match.map(|(_, p)| p))
+/// Cache-backed variant of [`extract_artist_image`]. Walks the same up
+/// to [`ARTIST_IMAGE_MAX_DEPTH`] ancestor dirs, but each directory's
+/// candidate list is read once via the shared `cache` and reused for
+/// every artist / track that passes through it.
+pub fn extract_artist_image_cached(
+    track_path: &Path,
+    artist_canonical: &str,
+    artwork_dir: &Path,
+    cache: &mut ArtistImageDirCache,
+) -> Option<ExtractedCover> {
+    if artist_canonical.is_empty() {
+        return None;
+    }
+
+    let mut current = track_path.parent();
+    for _ in 0..ARTIST_IMAGE_MAX_DEPTH {
+        let Some(dir) = current else { break };
+        let candidates = cache
+            .entry(dir.to_path_buf())
+            .or_insert_with(|| read_dir_artist_images(dir));
+        if let Some(found) = match_artist_image(candidates, artist_canonical) {
+            return write_artist_image(&found, artwork_dir);
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+pub fn find_artist_image_in_dir(dir: &Path, artist_canonical: &str) -> Option<PathBuf> {
+    match_artist_image(&read_dir_artist_images(dir), artist_canonical)
 }
 
 pub fn write_artist_image(picked: &Path, artwork_dir: &Path) -> Option<ExtractedCover> {

--- a/src-tauri/crates/core/src/scanner/extract.rs
+++ b/src-tauri/crates/core/src/scanner/extract.rs
@@ -403,10 +403,22 @@ fn read_dir_artist_images(dir: &Path) -> Vec<DirImageCandidate> {
     };
     let mut out = Vec::new();
     for entry in entries.flatten() {
-        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+        let path = entry.path();
+        // Fast path: `read_dir`'s file_type avoids a `stat` for regular
+        // files. But it does NOT follow symlinks (a symlinked image
+        // reports `is_symlink()`, not `is_file()`), so fall back to the
+        // link-following `Path::is_file` for those — preserving the
+        // pre-cache behaviour for symlinked sidecars while still paying
+        // the extra syscall only on the rare symlink.
+        let is_file = match entry.file_type() {
+            Ok(t) if t.is_file() => true,
+            Ok(t) if t.is_symlink() => path.is_file(),
+            Ok(_) => false,
+            Err(_) => path.is_file(),
+        };
+        if !is_file {
             continue;
         }
-        let path = entry.path();
         let stem = path
             .file_stem()
             .and_then(|s| s.to_str())

--- a/src-tauri/crates/core/src/scanner/mod.rs
+++ b/src-tauri/crates/core/src/scanner/mod.rs
@@ -31,9 +31,9 @@ pub use extract::{
 #[cfg(feature = "sqlite")]
 pub use upserts::{
     link_local_artist_image, link_va_artist_image, maybe_link_artist_images,
-    merge_implicit_compilations, now_millis,
-    resolve_album_artist, split_artist_name, upsert_album, upsert_artist, upsert_artist_list,
-    upsert_artwork, upsert_genre, VARIOUS_ARTISTS_LABEL,
+    merge_implicit_compilations, now_millis, resolve_album_artist, split_artist_name, upsert_album,
+    upsert_artist, upsert_artist_list, upsert_artwork, upsert_genre, ArtistImageScanCache,
+    VARIOUS_ARTISTS_LABEL,
 };
 
 /// Helper used inside the audio file extractors. Pulled out into the

--- a/src-tauri/crates/core/src/scanner/mod.rs
+++ b/src-tauri/crates/core/src/scanner/mod.rs
@@ -33,7 +33,7 @@ pub use upserts::{
     link_local_artist_image, link_va_artist_image, maybe_link_artist_images,
     merge_implicit_compilations, now_millis, resolve_album_artist, split_artist_name, upsert_album,
     upsert_artist, upsert_artist_list, upsert_artwork, upsert_genre, ArtistImageScanCache,
-    VARIOUS_ARTISTS_LABEL,
+    UpsertCache, VARIOUS_ARTISTS_LABEL,
 };
 
 /// Helper used inside the audio file extractors. Pulled out into the

--- a/src-tauri/crates/core/src/scanner/upserts.rs
+++ b/src-tauri/crates/core/src/scanner/upserts.rs
@@ -8,7 +8,7 @@
 //! breaking the single-writer discipline (see CLAUDE.md "Single writer
 //! to SQLite").
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
@@ -36,6 +36,88 @@ use super::extract::{
 pub struct ArtistImageScanCache {
     seen: HashSet<(i64, PathBuf)>,
     dirs: ArtistImageDirCache,
+}
+
+/// Scan-scoped memo for the `artist` / `genre` lookups that otherwise
+/// fire one `SELECT … WHERE canonical_name = ?` per track. A 900-track
+/// library typically resolves to ~100 distinct artists and ~20 genres,
+/// so without this the scanner's consumer loop pays thousands of
+/// redundant single-writer round-trips.
+///
+/// Keyed on [`canonical_name`] exactly like [`upsert_artist`] /
+/// [`upsert_genre`] so a cache hit returns the same id the SELECT
+/// would. Ids stay valid across the scanner's periodic commits (the
+/// rows they point at are committed, never rolled back — any error
+/// aborts the whole scan and drops the cache with it). `album` is
+/// deliberately NOT memoised: [`upsert_album`] carries sticky
+/// compilation / album-artist backfill logic that must run per track.
+#[derive(Default)]
+pub struct UpsertCache {
+    artists: HashMap<String, i64>,
+    genres: HashMap<String, i64>,
+}
+
+impl UpsertCache {
+    /// Cached [`upsert_artist`]. Mirrors its trim → `canonical_name` →
+    /// empty-guard so the cache key matches the DB lookup key.
+    pub async fn artist(
+        &mut self,
+        conn: &mut sqlx::SqliteConnection,
+        raw_name: &str,
+    ) -> CoreResult<Option<i64>> {
+        let canon = canonical_name(raw_name.trim());
+        if canon.is_empty() {
+            return Ok(None);
+        }
+        if let Some(&id) = self.artists.get(&canon) {
+            return Ok(Some(id));
+        }
+        let id = upsert_artist(conn, raw_name).await?;
+        if let Some(id) = id {
+            self.artists.insert(canon, id);
+        }
+        Ok(id)
+    }
+
+    /// Cached equivalent of [`upsert_artist_list`] — splits the raw
+    /// multi-artist string the same way, then resolves each through
+    /// [`Self::artist`].
+    pub async fn artist_list(
+        &mut self,
+        conn: &mut sqlx::SqliteConnection,
+        raw: &Option<String>,
+    ) -> CoreResult<Vec<i64>> {
+        let Some(raw) = raw else {
+            return Ok(Vec::new());
+        };
+        let mut ids = Vec::new();
+        for name in split_artist_name(raw) {
+            if let Some(id) = self.artist(&mut *conn, &name).await? {
+                ids.push(id);
+            }
+        }
+        Ok(ids)
+    }
+
+    /// Cached [`upsert_genre`].
+    pub async fn genre(
+        &mut self,
+        conn: &mut sqlx::SqliteConnection,
+        raw_name: &str,
+    ) -> CoreResult<Option<i64>> {
+        let canon = canonical_name(raw_name.trim());
+        if canon.is_empty() {
+            return Ok(None);
+        }
+        if let Some(&id) = self.genres.get(&canon) {
+            return Ok(Some(id));
+        }
+        let id = upsert_genre(conn, raw_name).await?;
+        if let Some(id) = id {
+            self.genres.insert(canon, id);
+        }
+        Ok(id)
+    }
 }
 
 /// Sentinel album-artist row used when an album is tagged as a

--- a/src-tauri/crates/core/src/scanner/upserts.rs
+++ b/src-tauri/crates/core/src/scanner/upserts.rs
@@ -8,7 +8,8 @@
 //! breaking the single-writer discipline (see CLAUDE.md "Single writer
 //! to SQLite").
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use sqlx::SqlitePool;
@@ -321,19 +322,44 @@ pub async fn link_local_artist_image(
 /// Skips the "Various Artists" sentinel here because VA is an *album*
 /// artist (it never appears in `track_artist`); its sidecar image is
 /// resolved separately via the album relationship in [`link_va_artist_image`].
+/// `seen` memoises the `(artist_id, track parent dir)` pairs already
+/// run through the sidecar walk **this scan**. The walk is by far the
+/// hottest part of a first scan — `fs::read_dir` of up to 3 ancestor
+/// dirs + a `canonical_name` per image entry, per artist, per track,
+/// nearly all of it wasted on libraries without local artist images
+/// (measured at ~98 % of the scan's DB time). The result for a given
+/// `(artist, track-parent)` is deterministic, so once seen we skip it.
+///
+/// The skip is **per artist**, not per track: a track that adds a new
+/// featured artist to an already-walked album artist only walks for the
+/// newcomer. The parent dir is in the key, so a different folder of the
+/// same artist still walks — no per-album sidecar is missed. Callers
+/// thread one `seen` set across the whole scan; a one-off lookup can
+/// pass a throwaway `&mut HashSet::new()`.
 pub async fn maybe_link_artist_images(
     conn: &mut sqlx::SqliteConnection,
     artist_raw: Option<&str>,
     artist_ids: &[i64],
     track_path: &Path,
     artwork_dir: &Path,
+    seen: &mut HashSet<(i64, PathBuf)>,
 ) -> CoreResult<()> {
     let Some(raw) = artist_raw else {
         return Ok(());
     };
     let names = split_artist_name(raw);
     let va_canon = canonical_name(VARIOUS_ARTISTS_LABEL);
+    let parent = track_path.parent();
     for (name, id) in names.iter().zip(artist_ids.iter()) {
+        // Per-(artist, folder) skip. `insert` returns false when the
+        // pair was already attempted this scan — the walk + the
+        // has-artwork probe below are deterministic for it, so there's
+        // nothing new to find.
+        if let Some(p) = parent {
+            if !seen.insert((*id, p.to_path_buf())) {
+                continue;
+            }
+        }
         let canon = canonical_name(name);
         if canon.is_empty() || canon == va_canon {
             continue;

--- a/src-tauri/crates/core/src/scanner/upserts.rs
+++ b/src-tauri/crates/core/src/scanner/upserts.rs
@@ -16,7 +16,27 @@ use sqlx::SqlitePool;
 
 use crate::error::CoreResult;
 
-use super::extract::{extract_artist_image, ExtractedCover};
+use super::extract::{
+    extract_artist_image, extract_artist_image_cached, ArtistImageDirCache, ExtractedCover,
+};
+
+/// Per-scan cache threaded through [`maybe_link_artist_images`]. Bundles
+/// the two independent memos that make the sidecar-artist-image walk —
+/// otherwise ~98 % of a first scan's DB time — cheap:
+///
+/// - `seen`: `(artist_id, parent dir)` pairs already attempted, so a
+///   repeat artist in the same folder skips the match + has-artwork
+///   probe entirely.
+/// - `dirs`: each directory's image-candidate list, read once via
+///   `read_dir` and reused across every artist that walks through it —
+///   the lever for the common "shared folder, many distinct per-track
+///   artists" layout (OST / compilation rips) where `seen` can't help
+///   because every `(artist, folder)` pair is unique.
+#[derive(Default)]
+pub struct ArtistImageScanCache {
+    seen: HashSet<(i64, PathBuf)>,
+    dirs: ArtistImageDirCache,
+}
 
 /// Sentinel album-artist row used when an album is tagged as a
 /// compilation but has no explicit Album Artist. Resolved to a real
@@ -322,27 +342,26 @@ pub async fn link_local_artist_image(
 /// Skips the "Various Artists" sentinel here because VA is an *album*
 /// artist (it never appears in `track_artist`); its sidecar image is
 /// resolved separately via the album relationship in [`link_va_artist_image`].
-/// `seen` memoises the `(artist_id, track parent dir)` pairs already
-/// run through the sidecar walk **this scan**. The walk is by far the
-/// hottest part of a first scan — `fs::read_dir` of up to 3 ancestor
-/// dirs + a `canonical_name` per image entry, per artist, per track,
-/// nearly all of it wasted on libraries without local artist images
-/// (measured at ~98 % of the scan's DB time). The result for a given
-/// `(artist, track-parent)` is deterministic, so once seen we skip it.
+/// `cache` memoises this scan's sidecar-artist-image work — see
+/// [`ArtistImageScanCache`]. The walk is by far the hottest part of a
+/// first scan (`fs::read_dir` of up to 3 ancestor dirs + a
+/// `canonical_name` per image entry, per artist, per track), nearly all
+/// of it wasted on libraries with no local artist images. The cache
+/// makes both axes cheap: a repeat `(artist, folder)` skips entirely,
+/// and a never-seen `(artist, folder)` still reuses the cached
+/// `read_dir` for any ancestor a sibling track already visited.
 ///
-/// The skip is **per artist**, not per track: a track that adds a new
-/// featured artist to an already-walked album artist only walks for the
-/// newcomer. The parent dir is in the key, so a different folder of the
-/// same artist still walks — no per-album sidecar is missed. Callers
-/// thread one `seen` set across the whole scan; a one-off lookup can
-/// pass a throwaway `&mut HashSet::new()`.
+/// The `seen` skip is **per artist**, not per track, and keyed on the
+/// parent dir, so a different folder of the same artist still resolves —
+/// no per-album sidecar is missed. Callers thread one cache across the
+/// whole scan; a one-off lookup can pass `&mut Default::default()`.
 pub async fn maybe_link_artist_images(
     conn: &mut sqlx::SqliteConnection,
     artist_raw: Option<&str>,
     artist_ids: &[i64],
     track_path: &Path,
     artwork_dir: &Path,
-    seen: &mut HashSet<(i64, PathBuf)>,
+    cache: &mut ArtistImageScanCache,
 ) -> CoreResult<()> {
     let Some(raw) = artist_raw else {
         return Ok(());
@@ -352,11 +371,11 @@ pub async fn maybe_link_artist_images(
     let parent = track_path.parent();
     for (name, id) in names.iter().zip(artist_ids.iter()) {
         // Per-(artist, folder) skip. `insert` returns false when the
-        // pair was already attempted this scan — the walk + the
+        // pair was already attempted this scan — the match + the
         // has-artwork probe below are deterministic for it, so there's
         // nothing new to find.
         if let Some(p) = parent {
-            if !seen.insert((*id, p.to_path_buf())) {
+            if !cache.seen.insert((*id, p.to_path_buf())) {
                 continue;
             }
         }
@@ -374,7 +393,9 @@ pub async fn maybe_link_artist_images(
         if has_artwork.is_some() {
             continue;
         }
-        if let Some(cover) = extract_artist_image(track_path, &canon, artwork_dir) {
+        if let Some(cover) =
+            extract_artist_image_cached(track_path, &canon, artwork_dir, &mut cache.dirs)
+        {
             link_local_artist_image(&mut *conn, *id, &cover).await?;
         }
     }


### PR DESCRIPTION
## Résumé

Premier scan d'une grosse lib **~4× plus rapide** (mesuré en debug sur 902 fichiers AAC : **64 s → 16 s**, 623 MP3 : 33 s → 9 s). Le coupable, trouvé par instrumentation : `maybe_link_artist_images` représentait **~98% du temps de scan**.

## Démarche (data-driven)

Instrumentation d'abord (timers par phase sur la ligne `scan complete`), puis fix ciblé. Le partial-hash de #319 ayant sorti le hash du chemin critique, le reste du `extract_db_ms` était inexpliqué. Split successifs :

| étape | link_ms (AAC 902) | verdict |
|---|---|---|
| baseline (timer `link_us`) | 56 309 ms | **98% du scan** |
| memo `(artiste, dossier)` tout-ou-rien | 41 888 ms | partiel (artistes variés) |
| skip par-artiste | 42 395 ms | nul de plus (paires uniques) |
| **cache `read_dir` par dossier** | **180 ms** | **~312×** ✅ |

## Le fix

`maybe_link_artist_images` walkait jusqu'à 3 dossiers ancêtres par titre (`fs::read_dir` + `canonical_name`/entrée) cherchant un `artist.jpg` — refait pour les ~18 titres de chaque dossier, et même pour les OST/compils (dossier partagé, artistes distincts) où un memo `(artiste,dossier)` ne peut rien skipper.

- **`read_dir_artist_images(dir) → Vec<DirImageCandidate>`** : lecture du dossier **indépendante de l'artiste**, cachée par dossier (`ArtistImageDirCache`). Un dossier ancêtre partagé est lu **une seule fois par scan**, peu importe combien d'artistes le traversent.
- **`ArtistImageScanCache`** bundle ce cache de dossiers + le skip `(artiste, dossier)`, threadé depuis `scan_folder_inner`.
- Bonus : `entry.file_type()` au lieu de `Path::is_file()` → un `stat` en moins par entrée.

**Behaviour-preserving** : `extract_artist_image` / `find_artist_image_in_dir` gardent leur signature (délèguent avec un cache jetable), précédence de match inchangée (`<Artist>` canonique exact > stem générique).

## Aussi inclus (annexes)

- **Instrumentation permanente** : `db_us` / `link_us` sur `ScanTimings` → `db_ms_total` / `link_ms_total` sur la ligne `scan complete` (comme `hash_us`/`tag_us`, utile au support).
- **Mémoïsation upserts artiste/genre** (`UpsertCache`) + **probe insert-vs-update pré-chargé** : gain négligeable en debug (ces SELECT étaient déjà cheap) mais réduisent le nb de statements sérialisés — utile en release / très grosses libs. Album laissé tranquille (sticky compilation).

## Validation

- `cargo check` + `cargo clippy --all-targets` verts (app + core).
- Tests core `extract_artist_image` inchangés (signature préservée) → couverts en CI.
- Mesuré sur lib réelle 902 AAC + 623 MP3.

## Reste (hors scope)

Le coût restant est le **hash I/O disque-bound** (lecture head+tail de chaque fichier) — largement incompressible sans rogner sur la robustesse du hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * Les scans de bibliothèque sont accélérés grâce à un préchargement unique des informations existantes, réduisant les opérations DB par fichier.
  * La résolution et le rattachement des images “sidecar” d’artistes sont améliorés : répertoires relus moins souvent, mémoïsation partagée pendant tout le scan, et conservation plus fidèle de l’ordre et des métadonnées lors des rescans.
* **Mesures & journalisation**
  * Les temps de scan sont désormais mieux ventilés entre la partie DB et la liaison des images, avec des totaux mis à jour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->