### PR TITLE
fix(audio): recover from WASAPI exclusive device-reset flap storm (#322)

### DIFF
--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -166,6 +166,26 @@ struct FlapWindow {
     window_start: Option<Instant>,
 }
 
+impl FlapWindow {
+    /// Record one flap at `now` and report whether it trips the storm
+    /// threshold ([`EXCLUSIVE_FLAP_THRESHOLD`] flaps within
+    /// [`EXCLUSIVE_FLAP_WINDOW`]). A flap outside the current window
+    /// restarts the count at 1. Clock is injected so the logic is
+    /// deterministic under test.
+    fn record(&mut self, now: Instant) -> bool {
+        let within_window = self
+            .window_start
+            .is_some_and(|start| now.duration_since(start) <= EXCLUSIVE_FLAP_WINDOW);
+        if within_window {
+            self.count += 1;
+        } else {
+            self.window_start = Some(now);
+            self.count = 1;
+        }
+        self.count >= EXCLUSIVE_FLAP_THRESHOLD
+    }
+}
+
 /// Handle stored in Tauri state. Cloning an `Arc<AudioEngine>` is cheap.
 ///
 /// The cpal `Stream` is NOT stored here — it lives on a dedicated output
@@ -481,25 +501,15 @@ impl AudioEngine {
         let mut exclusive =
             pref_exclusive && !self.exclusive_suppressed.load(Ordering::Relaxed);
         if exclusive {
-            let mut flaps = self
+            let tripped = self
                 .exclusive_flaps
                 .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let now = Instant::now();
-            let within_window = flaps
-                .window_start
-                .is_some_and(|start| now.duration_since(start) <= EXCLUSIVE_FLAP_WINDOW);
-            if within_window {
-                flaps.count += 1;
-            } else {
-                flaps.window_start = Some(now);
-                flaps.count = 1;
-            }
-            if flaps.count >= EXCLUSIVE_FLAP_THRESHOLD {
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .record(Instant::now());
+            if tripped {
                 self.exclusive_suppressed.store(true, Ordering::Relaxed);
                 exclusive = false;
                 tracing::warn!(
-                    flaps = flaps.count,
                     "WASAPI exclusive disabled for this session after repeated device \
                      flaps; staying on shared mode. Re-enable it in Settings to retry."
                 );
@@ -991,6 +1001,47 @@ fn apply_radio_resume_update(
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod flap_window_tests {
+    use super::*;
+
+    // Threshold is 3 within a 12 s window — see the consts under test.
+
+    #[test]
+    fn trips_on_the_threshold_flap_within_window() {
+        let mut w = FlapWindow::default();
+        let t = Instant::now();
+        assert!(!w.record(t)); // 1
+        assert!(!w.record(t + Duration::from_secs(2))); // 2
+        assert!(w.record(t + Duration::from_secs(4))); // 3 → trip
+    }
+
+    #[test]
+    fn resets_when_a_flap_lands_outside_the_window() {
+        let mut w = FlapWindow::default();
+        let t = Instant::now();
+        assert!(!w.record(t)); // 1
+        assert!(!w.record(t + Duration::from_secs(1))); // 2
+        // Past the window → counter restarts, so this does NOT trip.
+        let after = t + EXCLUSIVE_FLAP_WINDOW + Duration::from_secs(1);
+        assert!(!w.record(after)); // 1 (fresh window)
+        assert!(!w.record(after + Duration::from_secs(1))); // 2
+        assert!(w.record(after + Duration::from_secs(2))); // 3 → trip
+    }
+
+    #[test]
+    fn never_trips_for_spaced_out_flaps() {
+        let mut w = FlapWindow::default();
+        let mut t = Instant::now();
+        // Each flap sits just past the previous window, so the count keeps
+        // restarting at 1 and never reaches the threshold.
+        for _ in 0..6 {
+            assert!(!w.record(t));
+            t += EXCLUSIVE_FLAP_WINDOW + Duration::from_secs(1);
+        }
     }
 }
 

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crossbeam_channel::{unbounded, Sender};
 use rtrb::Producer;
@@ -149,6 +149,23 @@ impl std::fmt::Debug for AudioCmd {
     }
 }
 
+/// A WASAPI-exclusive "flap storm" (#322) is this many `DeviceNotAvailable`
+/// rebuilds within [`EXCLUSIVE_FLAP_WINDOW`]. Some onboard codecs (Realtek)
+/// reset the device right after an exclusive grab, so every re-engage
+/// re-triggers the reset and the engine thrashes forever.
+const EXCLUSIVE_FLAP_THRESHOLD: u32 = 3;
+/// Time window over which [`EXCLUSIVE_FLAP_THRESHOLD`] flaps trip the
+/// session-level exclusive suppression.
+const EXCLUSIVE_FLAP_WINDOW: Duration = Duration::from_secs(12);
+
+/// Rolling counter of exclusive-mode device flaps, behind
+/// [`AudioEngine::try_rebuild_after_device_error`].
+#[derive(Default)]
+struct FlapWindow {
+    count: u32,
+    window_start: Option<Instant>,
+}
+
 /// Handle stored in Tauri state. Cloning an `Arc<AudioEngine>` is cheap.
 ///
 /// The cpal `Stream` is NOT stored here — it lives on a dedicated output
@@ -182,6 +199,16 @@ pub struct AudioEngine {
     /// flap would otherwise queue two concurrent rebuilds that
     /// each interrupt the same track.
     rebuild_in_progress: std::sync::atomic::AtomicBool,
+    /// Session-only kill switch for WASAPI Exclusive after a flap storm
+    /// (#322). Once tripped, every rebuild / hot-swap stays on cpal
+    /// shared regardless of the `wasapi_exclusive` preference, so a
+    /// device that resets on every exclusive grab (Realtek onboard)
+    /// stops thrashing and playback survives. Reset when the user
+    /// re-toggles exclusive or picks a device. Does NOT touch the
+    /// persisted preference — a fresh launch tries exclusive again.
+    exclusive_suppressed: std::sync::atomic::AtomicBool,
+    /// Rolling flap counter feeding [`Self::try_rebuild_after_device_error`].
+    exclusive_flaps: Mutex<FlapWindow>,
     /// Last Web Radio session captured at the boundary of
     /// [`Self::send`] (#230). The three output-rebuild paths
     /// ([`Self::set_output_device`], [`Self::set_wasapi_exclusive`],
@@ -294,6 +321,8 @@ impl AudioEngine {
             wasapi_exclusive: std::sync::atomic::AtomicBool::new(wasapi_exclusive),
             wasapi_exclusive_active: std::sync::atomic::AtomicBool::new(wasapi_exclusive_active),
             rebuild_in_progress: std::sync::atomic::AtomicBool::new(false),
+            exclusive_suppressed: std::sync::atomic::AtomicBool::new(false),
+            exclusive_flaps: Mutex::new(FlapWindow::default()),
             radio_resume: Mutex::new(None),
         })
     }
@@ -442,7 +471,40 @@ impl AudioEngine {
         let _guard = ResetGuard(&self.rebuild_in_progress);
 
         let pinned = self.current_output_device();
-        let exclusive = self.wasapi_exclusive.load(Ordering::Relaxed);
+        let pref_exclusive = self.wasapi_exclusive.load(Ordering::Relaxed);
+
+        // #322: an exclusive-mode flap storm. A device that resets on every
+        // exclusive grab fires DeviceNotAvailable ~300 ms after each
+        // re-engage, so re-opening exclusive here just re-arms the loop.
+        // Count flaps and, past the threshold, give up on exclusive for the
+        // rest of the session so the device settles on shared mode.
+        let mut exclusive =
+            pref_exclusive && !self.exclusive_suppressed.load(Ordering::Relaxed);
+        if exclusive {
+            let mut flaps = self
+                .exclusive_flaps
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let now = Instant::now();
+            let within_window = flaps
+                .window_start
+                .is_some_and(|start| now.duration_since(start) <= EXCLUSIVE_FLAP_WINDOW);
+            if within_window {
+                flaps.count += 1;
+            } else {
+                flaps.window_start = Some(now);
+                flaps.count = 1;
+            }
+            if flaps.count >= EXCLUSIVE_FLAP_THRESHOLD {
+                self.exclusive_suppressed.store(true, Ordering::Relaxed);
+                exclusive = false;
+                tracing::warn!(
+                    flaps = flaps.count,
+                    "WASAPI exclusive disabled for this session after repeated device \
+                     flaps; staying on shared mode. Re-enable it in Settings to retry."
+                );
+            }
+        }
 
         tracing::info!(
             device = pinned.as_deref().unwrap_or("<os-default>"),
@@ -454,6 +516,18 @@ impl AudioEngine {
         // shortcut for "same device" because the device is the
         // same — we just need a fresh stream after the OS reset.
         self.force_rebuild_output(pinned, exclusive)
+    }
+
+    /// Clear the #322 session-level exclusive suppression and its flap
+    /// counter. Called when the user explicitly re-toggles WASAPI exclusive
+    /// or switches output device — both are a fresh chance for exclusive to
+    /// work, so a prior flap storm shouldn't keep it pinned to shared.
+    fn reset_exclusive_suppression(&self) {
+        self.exclusive_suppressed
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        if let Ok(mut flaps) = self.exclusive_flaps.lock() {
+            *flaps = FlapWindow::default();
+        }
     }
 
     /// Internal helper: rebuild the output stream against the given
@@ -481,6 +555,29 @@ impl AudioEngine {
             .load(std::sync::atomic::Ordering::Acquire);
         let position_ms = self.shared.current_position_ms();
 
+        // #322: a WASAPI *exclusive* client locks the device entirely — no
+        // other client, exclusive OR shared, can open it until that client
+        // is released. So when the OLD stream is exclusive, spawning the new
+        // one first fails: a new exclusive open hits AUDCLNT_E_DEVICE_IN_USE
+        // (0x8889000A), and even the shared fallback hits "device no longer
+        // available" (both lines seen in the #322 report). Release the old
+        // exclusive stream FIRST, whatever mode we're rebuilding into. This
+        // path only runs after a DeviceNotAvailable error, so the old stream
+        // is already dead — there's no working state to roll back to. When
+        // the old stream is shared we keep the spawn-first order so a failed
+        // spawn can still roll back.
+        let pre_release = guard.as_ref().is_some_and(|h| h.wasapi_exclusive);
+        if pre_release {
+            if was_playing {
+                self.cmd_tx
+                    .send(AudioCmd::Stop)
+                    .map_err(|e| AppError::Audio(format!("audio command channel closed: {e}")))?;
+            }
+            if let Some(old) = guard.take() {
+                old.stop();
+            }
+        }
+
         let (producer, handle) =
             spawn_output_with_mode(self.shared.clone(), self.app.clone(), device_name, exclusive)?;
 
@@ -492,11 +589,12 @@ impl AudioEngine {
         // leak the thread until process exit. Same pattern as
         // `set_output_device`'s error rollback.
         let send_result = (|| {
-            if was_playing {
+            if was_playing && !pre_release {
                 self.cmd_tx
                     .send(AudioCmd::Stop)
                     .map_err(|e| AppError::Audio(format!("audio command channel closed: {e}")))?;
             }
+            // No-op when `pre_release` already took the old handle above.
             if let Some(old) = guard.take() {
                 old.stop();
             }
@@ -605,6 +703,10 @@ impl AudioEngine {
         if current == requested {
             return Ok(());
         }
+
+        // A different device may support exclusive fine — clear any #322
+        // flap-storm suppression tied to the previous device.
+        self.reset_exclusive_suppression();
 
         // Snapshot what's playing so we can resume on the new device.
         let was_playing = matches!(
@@ -740,6 +842,10 @@ impl AudioEngine {
         if previous == enabled {
             return Ok(());
         }
+        // An explicit user toggle clears any #322 flap-storm suppression so
+        // re-enabling exclusive actually retries it (and disabling resets
+        // the counter for next time).
+        self.reset_exclusive_suppression();
         // Reuse `set_output_device` with the active device name — the
         // current/requested equality check inside it would short-circuit
         // a same-device call, so go straight to the rebuild path by


### PR DESCRIPTION
## What & why

Fixes the WASAPI Exclusive freeze in #322. New reporter logs pinned the root cause.

**Root cause** — some onboard codecs (Realtek HD Audio here) reset the device right after an exclusive grab, firing cpal `DeviceNotAvailable` ~300 ms later. The same-device auto-rebuild (#175) then re-opened exclusive while the **old exclusive client still owned the device**, so:

- the re-init failed with `AUDCLNT_E_DEVICE_IN_USE` (`0x8889000A`), and
- even the shared fallback failed with *"device no longer available"*.

Re-engaging exclusive re-armed the reset → infinite loop. Symptom: playback stalls, and turning the toggle off takes many clicks.

```
wasapi exclusive stream opened … format="S24_4LE"   ← engages
rebuilding cpal output after DeviceNotAvailable exclusive=true
wasapi exclusive init failed … HRESULT(0x8889000A)  ← DEVICE_IN_USE (old client still held it)
WASAPI Exclusive init failed, falling back to shared mode
auto-rebuild after DeviceNotAvailable failed … build_output_stream: The requested device is no longer available
```

## The fix (`audio/engine.rs`)

1. **Release-before-reopen** — in `force_rebuild_output`, when the *old* stream is exclusive, stop it **before** spawning the new one. A WASAPI exclusive client locks the device against *every* other client (exclusive or shared), so the old handle must go first. Fixes both error lines above. Only runs after a device error (old stream already dead); shared-old keeps the spawn-first order so a failed spawn can still roll back.
2. **Flap-storm suppression** — count exclusive `DeviceNotAvailable` rebuilds; past **3 within 12 s**, disable exclusive for the rest of the session and settle on shared so the device stops thrashing. Session-only: the persisted preference is untouched (a fresh launch retries exclusive), and an explicit device switch or exclusive re-toggle clears it.

Context: `rustmusic` (our audio reference) sidesteps this whole class by never using WASAPI exclusive — pure cpal shared. So there was nothing to borrow; the fix is ours. Their design does validate fix #2 (falling back to shared is what every other player effectively does).

## ⚠️ Needs hardware testing before merge

I **cannot reproduce WASAPI exclusive locally**, so this is reasoned from the logs + code, not verified end-to-end. `cargo check` + `clippy` are clean, but please don't merge until the reporter (or someone with a device that flaps on exclusive) confirms a test build:

- turn WASAPI Exclusive **on**, press play → audio should either play in exclusive, or fall back to shared and **keep playing** (no stall);
- if it can't hold exclusive, after a few seconds it should log `WASAPI exclusive disabled for this session after repeated device flaps` and stay on shared;
- toggling exclusive **off** should be immediate (no multi-click).

## Docs

No user-facing behaviour/setting change (the existing "transparent fallback to cpal shared" still holds), so docs are untouched. Will add a one-liner to `docs/features/playback.md` at merge if we want to note the flap-suppression.

Closes #322 (pending reporter confirmation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une protection contre les basculements répétés du mode audio exclusif lors des reconnections du périphérique (WASAPI exclusif).

* **Correctifs**
  * Réduction des erreurs « périphérique déjà utilisé » pendant le hot-swap du périphérique.
  * Si le mode exclusif échoue trop souvent sur la session, l’application bascule temporairement en mode partagé pour préserver la lecture.
  * Réinitialisation plus fiable de la suppression du mode exclusif lors d’un changement de périphérique ou d’un réglage utilisateur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->