### PR TITLE
ci: sync app version to the release tag before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,23 @@ jobs:
         with:
           ref: ${{ env.TAG_NAME }}
 
+      - name: Sync app version to the release tag
+        shell: bash
+        env:
+          VERSION: ${{ env.VERSION }}
+        # `cut-beta` tags main's HEAD without bumping the manifests, so a beta
+        # build would otherwise report the base stable version (e.g. 1.6.0)
+        # while the published manifest says 1.6.1-beta.1 — the updater would
+        # then re-offer the beta on every check because the installed build
+        # never reaches the manifest version. Patch the app version in
+        # tauri.conf.json (what `package_info().version` / the updater read)
+        # to the tag version. Idempotent for stable releases (release-please
+        # already set it). ONLY tauri.conf.json — bumping Cargo.toml here
+        # would desync Cargo.lock and break the `--locked` build. Node is
+        # pre-installed on every GitHub runner, so no setup is needed yet.
+        run: |
+          node -e "const fs=require('fs'),p='src-tauri/crates/app/tauri.conf.json',c=JSON.parse(fs.readFileSync(p,'utf8'));c.version=process.env.VERSION;fs.writeFileSync(p,JSON.stringify(c,null,2)+'\n');console.log('Patched app version -> '+c.version);"
+
       - name: Install Linux system dependencies
         if: matrix.platform == 'linux'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,10 @@ jobs:
         # would desync Cargo.lock and break the `--locked` build. Node is
         # pre-installed on every GitHub runner, so no setup is needed yet.
         run: |
+          if [ -z "$VERSION" ]; then
+            echo "::error::VERSION is empty — refusing to patch tauri.conf.json"
+            exit 1
+          fi
           node -e "const fs=require('fs'),p='src-tauri/crates/app/tauri.conf.json',c=JSON.parse(fs.readFileSync(p,'utf8'));c.version=process.env.VERSION;fs.writeFileSync(p,JSON.stringify(c,null,2)+'\n');console.log('Patched app version -> '+c.version);"
 
       - name: Install Linux system dependencies


### PR DESCRIPTION
## What & why

`cut-beta` tags `main`'s HEAD without bumping the version manifests, so a beta build compiles with the **base stable version** in `tauri.conf.json` (e.g. `1.6.0`) while the published `latest-beta.json` says `1.6.1-beta.1`. The Rust-driven updater compares the running app version (`package_info().version`, baked from `tauri.conf.json`) against the manifest, so the installed beta would **re-offer itself on every check** — it never reaches the manifest version. This is the first beta ever cut, so it was never exercised.

## Fix

One step in `release.yml`, right after checkout: patch `tauri.conf.json` `version` to the tag version (`$VERSION`) before the build, so the built app self-reports the tag version and matches its own manifest.

- **Idempotent for stable releases** — release-please already sets that version, so the patch is a no-op write there.
- **Only `tauri.conf.json`** — this is what `package_info().version` / the updater read. Deliberately NOT touching `Cargo.toml`: that would desync `Cargo.lock` and break the `--locked` build.
- Node is pre-installed on every GitHub runner, so the step needs no setup and runs on linux/windows/macos.

Validated: YAML parses (js-yaml), and the node one-liner correctly rewrites the version on a temp copy → `1.6.1-beta.1`.

## Stable channel is unaffected

Confirmed independently while reviewing this: a pre-release tag marks the GitHub release `--prerelease`, publishes only `latest-beta.json` to the fixed `beta-channel` release (never `latest.json`), and skips the AUR/Winget/COPR/apt dispatch. The stable updater endpoint `releases/latest/download/latest.json` resolves to the newest **non**-prerelease (still v1.6.0). This PR doesn't change any of that.

## Merge order

Merge this **before** cutting the first beta — `cut-beta` dispatches `release.yml` from `main`, so the version-sync step has to be on `main` for the beta build to pick it up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La version de l’application est désormais alignée automatiquement sur le tag de release.
  * Le numéro de version affiché et utilisé pour la mise à jour correspond mieux aux versions publiées, y compris les préversions.
* **Correctifs**
  * Réduction des écarts entre la version visible dans l’application et celle du package publié.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->