### PR TITLE
fix(plugins): resolve app version from Tauri runtime, not compile-time macro

### DIFF
--- a/src-tauri/crates/app/src/commands/plugin_store.rs
+++ b/src-tauri/crates/app/src/commands/plugin_store.rs
@@ -182,14 +182,20 @@ fn parse_semver(v: &str) -> (u32, u32, u32) {
     )
 }
 
-fn app_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
+/// Resolved from the Tauri runtime (`tauri.conf.json`'s `version`, patched by
+/// CI to the release tag) rather than `env!("CARGO_PKG_VERSION")` — the CI
+/// version-sync step deliberately leaves `Cargo.toml` untouched (patching it
+/// would desync `Cargo.lock` under a `--locked` build), so the compile-time
+/// macro stays pinned at whatever version was last committed there and would
+/// wrongly gate every beta/RC build behind `min_app_version`.
+fn app_version(app: &tauri::AppHandle) -> String {
+    app.package_info().version.to_string()
 }
 
-fn is_compatible(min_app_version: Option<&str>) -> bool {
+fn is_compatible(app: &tauri::AppHandle, min_app_version: Option<&str>) -> bool {
     match min_app_version {
         None => true,
-        Some(min) => parse_semver(app_version()) >= parse_semver(min),
+        Some(min) => parse_semver(&app_version(app)) >= parse_semver(min),
     }
 }
 
@@ -358,6 +364,7 @@ fn install_from_zip_bytes(
 /// installed locally + this build's version, for the in-app store list.
 #[tauri::command]
 pub async fn list_plugin_marketplace(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
 ) -> AppResult<Vec<MarketplaceEntry>> {
     let registry = fetch_registry().await?;
@@ -371,7 +378,7 @@ pub async fn list_plugin_marketplace(
                 let inst = installed_version(&paths, &e.id);
                 let update_available = matches!(&inst, Some(v) if *v != e.version);
                 MarketplaceEntry {
-                    compatible: is_compatible(e.min_app_version.as_deref()),
+                    compatible: is_compatible(&app, e.min_app_version.as_deref()),
                     update_available,
                     installed: inst.is_some(),
                     installed_version: inst,
@@ -405,6 +412,7 @@ pub async fn list_plugin_marketplace(
 /// both a fresh install and an update; the on-disk swap is idempotent.
 #[tauri::command]
 pub async fn install_plugin_from_registry(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
     plugin_id: String,
 ) -> AppResult<()> {
@@ -431,12 +439,12 @@ pub async fn install_plugin_from_registry(
         .find(|e| e.id == plugin_id)
         .ok_or_else(|| AppError::Other(format!("plugin not in registry: {plugin_id}")))?;
 
-    if !is_compatible(entry.min_app_version.as_deref()) {
+    if !is_compatible(&app, entry.min_app_version.as_deref()) {
         return Err(AppError::Other(format!(
             "{} requires WaveFlow {} or newer (you have {})",
             entry.name,
             entry.min_app_version.as_deref().unwrap_or("?"),
-            app_version()
+            app_version(&app)
         )));
     }
 

--- a/src-tauri/crates/app/src/commands/plugin_store.rs
+++ b/src-tauri/crates/app/src/commands/plugin_store.rs
@@ -192,10 +192,10 @@ fn app_version(app: &tauri::AppHandle) -> String {
     app.package_info().version.to_string()
 }
 
-fn is_compatible(app: &tauri::AppHandle, min_app_version: Option<&str>) -> bool {
+fn is_compatible(app_version: &str, min_app_version: Option<&str>) -> bool {
     match min_app_version {
         None => true,
-        Some(min) => parse_semver(&app_version(app)) >= parse_semver(min),
+        Some(min) => parse_semver(app_version) >= parse_semver(min),
     }
 }
 
@@ -369,6 +369,7 @@ pub async fn list_plugin_marketplace(
 ) -> AppResult<Vec<MarketplaceEntry>> {
     let registry = fetch_registry().await?;
     let paths = state.paths.plugin_paths();
+    let version = app_version(&app);
 
     let entries = tokio::task::spawn_blocking(move || {
         registry
@@ -378,7 +379,7 @@ pub async fn list_plugin_marketplace(
                 let inst = installed_version(&paths, &e.id);
                 let update_available = matches!(&inst, Some(v) if *v != e.version);
                 MarketplaceEntry {
-                    compatible: is_compatible(&app, e.min_app_version.as_deref()),
+                    compatible: is_compatible(&version, e.min_app_version.as_deref()),
                     update_available,
                     installed: inst.is_some(),
                     installed_version: inst,
@@ -439,12 +440,13 @@ pub async fn install_plugin_from_registry(
         .find(|e| e.id == plugin_id)
         .ok_or_else(|| AppError::Other(format!("plugin not in registry: {plugin_id}")))?;
 
-    if !is_compatible(&app, entry.min_app_version.as_deref()) {
+    let version = app_version(&app);
+    if !is_compatible(&version, entry.min_app_version.as_deref()) {
         return Err(AppError::Other(format!(
             "{} requires WaveFlow {} or newer (you have {})",
             entry.name,
             entry.min_app_version.as_deref().unwrap_or("?"),
-            app_version(&app)
+            version
         )));
     }
 


### PR DESCRIPTION
## Summary
- The plugin store's `min_app_version` compat gate (`is_compatible`) read `env!(\"CARGO_PKG_VERSION\")`, a compile-time macro embedding `crates/app/Cargo.toml`'s version.
- CI's release version-sync step (`.github/workflows/release.yml`) only patches `tauri.conf.json` to the tag version — patching `Cargo.toml` too would desync `Cargo.lock` under the `--locked` build.
- Result: every beta/RC build (e.g. `v1.6.2-beta.1`) reported its base stable `Cargo.toml` version (`1.6.0`) to the compat check, so the Apple Motion Artwork plugin (`min_app_version: 1.6.2`) showed **"Update required"** and refused to install even on a fully up-to-date beta install.
- Fix: resolve the version from `AppHandle::package_info().version` at runtime instead — the same source `getVersion()` already reads for the About page (which correctly shows `v1.6.2-beta.1`).

## Test plan
- [x] `cargo check --all-targets` clean
- [x] Install `v1.6.2-beta.1` (or next beta build), confirm Apple Motion Artwork installs from the store without "Update required"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correctifs**
  * Amélioration de la vérification de compatibilité des plugins avec la version réelle de l’application en cours d’exécution (au lieu de la version de build).
  * Affichage de la version actuellement détectée lors du refus d’installation d’un plugin incompatible.
  * Fiabilisation de la liste du marketplace et de l’installation des plugins selon la version active de l’application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->