### PR TITLE
fix: 3 quick beta feedback fixes (#350, #343, #341)

### DIFF
--- a/src-tauri/crates/app/src/commands/artist_overrides.rs
+++ b/src-tauri/crates/app/src/commands/artist_overrides.rs
@@ -44,9 +44,10 @@ pub async fn get_artist_overrides(
     state: tauri::State<'_, AppState>,
     artist_id: i64,
 ) -> AppResult<ArtistOverrides> {
-    let pool = state.require_profile_pool().await?;
+    // Atomic (pool, profile_id) so a concurrent switch_profile can't pair
+    // one profile's pool with another's artwork dir.
+    let (pool, profile_id) = state.require_profile_snapshot().await?;
     let artwork_dir = &state.paths.metadata_artwork_dir;
-    let profile_id = state.require_profile_id().await?;
     let local_artwork_dir = state.paths.profile_artwork_dir(profile_id);
 
     let custom_bio: Option<String> =
@@ -60,6 +61,7 @@ pub async fn get_artist_overrides(
     // #350): prefer the artist's own local `artwork` sidecar before the
     // shared Deezer cache, so a curated chip for an artist with only a
     // local `artist.jpg` and no Deezer enrichment doesn't render blank.
+    #[allow(clippy::type_complexity)]
     let rows: Vec<(
         i64,
         String,
@@ -86,20 +88,13 @@ pub async fn get_artist_overrides(
         .into_iter()
         .map(
             |(id, name, picture_url, picture_hash, local_hash, local_format)| {
-                let local_picture_path = match (local_hash.as_deref(), local_format.as_deref()) {
-                    (Some(hash), Some(format)) => Some(
-                        local_artwork_dir
-                            .join(format!("{hash}.{format}"))
-                            .to_string_lossy()
-                            .into_owned(),
-                    ),
-                    _ => None,
-                };
-                let picture_path = local_picture_path.or_else(|| {
-                    picture_hash
-                        .as_deref()
-                        .and_then(|h| metadata_artwork::existing_path(artwork_dir, h))
-                });
+                let picture_path = metadata_artwork::resolve_local_or_cached_path(
+                    &local_artwork_dir,
+                    local_hash.as_deref(),
+                    local_format.as_deref(),
+                    artwork_dir,
+                    picture_hash.as_deref(),
+                );
                 ArtistOverrideSimilar {
                     artist_id: id,
                     name,

--- a/src-tauri/crates/app/src/commands/artist_overrides.rs
+++ b/src-tauri/crates/app/src/commands/artist_overrides.rs
@@ -46,6 +46,8 @@ pub async fn get_artist_overrides(
 ) -> AppResult<ArtistOverrides> {
     let pool = state.require_profile_pool().await?;
     let artwork_dir = &state.paths.metadata_artwork_dir;
+    let profile_id = state.require_profile_id().await?;
+    let local_artwork_dir = state.paths.profile_artwork_dir(profile_id);
 
     let custom_bio: Option<String> =
         sqlx::query_scalar("SELECT custom_bio FROM artist WHERE id = ?")
@@ -54,12 +56,24 @@ pub async fn get_artist_overrides(
             .await?
             .flatten();
 
-    let rows: Vec<(i64, String, Option<String>, Option<String>)> = sqlx::query_as(
+    // Picture resolution mirrors `browse::get_artist_detail` (issue
+    // #350): prefer the artist's own local `artwork` sidecar before the
+    // shared Deezer cache, so a curated chip for an artist with only a
+    // local `artist.jpg` and no Deezer enrichment doesn't render blank.
+    let rows: Vec<(
+        i64,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )> = sqlx::query_as(
         r#"
-        SELECT a.id, a.name, ma.picture_url, ma.picture_hash
+        SELECT a.id, a.name, ma.picture_url, ma.picture_hash, aw.hash, aw.format
           FROM artist_similar_custom sc
           JOIN artist a ON a.id = sc.similar_artist_id
           LEFT JOIN app.metadata_artist ma ON ma.deezer_id = a.deezer_id
+          LEFT JOIN artwork aw ON aw.id = a.artwork_id
          WHERE sc.artist_id = ?
          ORDER BY sc.position
         "#,
@@ -71,13 +85,27 @@ pub async fn get_artist_overrides(
     let similar = rows
         .into_iter()
         .map(
-            |(id, name, picture_url, picture_hash)| ArtistOverrideSimilar {
-                artist_id: id,
-                name,
-                picture_path: picture_hash
-                    .as_deref()
-                    .and_then(|h| metadata_artwork::existing_path(artwork_dir, h)),
-                picture_url,
+            |(id, name, picture_url, picture_hash, local_hash, local_format)| {
+                let local_picture_path = match (local_hash.as_deref(), local_format.as_deref()) {
+                    (Some(hash), Some(format)) => Some(
+                        local_artwork_dir
+                            .join(format!("{hash}.{format}"))
+                            .to_string_lossy()
+                            .into_owned(),
+                    ),
+                    _ => None,
+                };
+                let picture_path = local_picture_path.or_else(|| {
+                    picture_hash
+                        .as_deref()
+                        .and_then(|h| metadata_artwork::existing_path(artwork_dir, h))
+                });
+                ArtistOverrideSimilar {
+                    artist_id: id,
+                    name,
+                    picture_path,
+                    picture_url,
+                }
             },
         )
         .collect();

--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -21,7 +21,8 @@ use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter};
 
 use waveflow_core::metadata::{
-    deezer::DeezerClient, lastfm::LastfmClient, theaudiodb::TheAudioDbClient,
+    deezer::DeezerClient, lastfm::LastfmClient,
+    theaudiodb::{make_summary, TheAudioDbClient},
 };
 
 use crate::{
@@ -300,8 +301,11 @@ pub async fn enrich_artist_deezer(
     // another's artist.
     let mut enrichment = enrich_artist_deezer_inner(state, pool, artist_id).await?;
     if let Some(bio) = custom_bio {
-        enrichment.bio_full = Some(bio.clone());
-        enrichment.bio_short = Some(bio);
+        // Synthesize a truncated lead-in the same way the online sources
+        // do (issue #343) — without it bio_short == bio_full verbatim and
+        // the frontend's length-based "Read more" toggle never appears.
+        enrichment.bio_short = Some(make_summary(&bio));
+        enrichment.bio_full = Some(bio);
     }
     Ok(enrichment)
 }

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -66,9 +66,10 @@ pub async fn get_similar_artists(
     state: tauri::State<'_, AppState>,
     artist_id: i64,
 ) -> AppResult<Vec<SimilarArtistDto>> {
-    let pool = state.require_profile_pool().await?;
+    // Atomic (pool, profile_id) so a concurrent switch_profile can't pair
+    // one profile's pool with another's artwork dir.
+    let (pool, profile_id) = state.require_profile_snapshot().await?;
     let artwork_dir = state.paths.metadata_artwork_dir.clone();
-    let profile_id = state.require_profile_id().await?;
     let local_artwork_dir = state.paths.profile_artwork_dir(profile_id);
 
     // 0. Per-profile curated override (issue #323) wins over every
@@ -226,6 +227,7 @@ async fn fetch_custom_similar(
     local_artwork_dir: &std::path::Path,
     artist_id: i64,
 ) -> AppResult<Vec<SimilarArtistDto>> {
+    #[allow(clippy::type_complexity)]
     let rows: Vec<(
         i64,
         String,
@@ -258,20 +260,13 @@ async fn fetch_custom_similar(
         .enumerate()
         .map(
             |(i, (id, name, picture_url, picture_hash, local_hash, local_format))| {
-                let local_picture_path = match (local_hash.as_deref(), local_format.as_deref()) {
-                    (Some(hash), Some(format)) => Some(
-                        local_artwork_dir
-                            .join(format!("{hash}.{format}"))
-                            .to_string_lossy()
-                            .into_owned(),
-                    ),
-                    _ => None,
-                };
-                let picture_path = local_picture_path.or_else(|| {
-                    picture_hash
-                        .as_deref()
-                        .and_then(|h| metadata_artwork::existing_path(artwork_dir, h))
-                });
+                let picture_path = metadata_artwork::resolve_local_or_cached_path(
+                    local_artwork_dir,
+                    local_hash.as_deref(),
+                    local_format.as_deref(),
+                    artwork_dir,
+                    picture_hash.as_deref(),
+                );
                 SimilarArtistDto {
                     name,
                     // Synthesize a decreasing score from the curated order so

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -68,12 +68,15 @@ pub async fn get_similar_artists(
 ) -> AppResult<Vec<SimilarArtistDto>> {
     let pool = state.require_profile_pool().await?;
     let artwork_dir = state.paths.metadata_artwork_dir.clone();
+    let profile_id = state.require_profile_id().await?;
+    let local_artwork_dir = state.paths.profile_artwork_dir(profile_id);
 
     // 0. Per-profile curated override (issue #323) wins over every
     //    online source and works offline. When the user has pinned a
     //    similar list it's library-scoped by construction, so we return
     //    it verbatim — no cache, no network.
-    let custom = fetch_custom_similar(&pool, &artwork_dir, artist_id).await?;
+    let custom =
+        fetch_custom_similar(&pool, &artwork_dir, &local_artwork_dir, artist_id).await?;
     if !custom.is_empty() {
         return Ok(custom);
     }
@@ -210,19 +213,33 @@ pub async fn get_similar_artists(
 /// resolved into display DTOs. Returns an empty vec when no override is
 /// set — the caller then falls through to the online cascade. Every
 /// entry is in the library by construction, so `library_artist_id` is
-/// always populated and `picture_path` comes straight from the shared
-/// Deezer cache (works offline).
+/// always populated. Picture resolution mirrors
+/// [`super::browse::get_artist_detail`]'s cascade (issue #350): prefer
+/// the artist's own local `artwork` sidecar (e.g. `artist.jpg`) before
+/// falling back to the shared Deezer cache — a curated artist with only
+/// a local picture and no Deezer enrichment used to render the
+/// initial-letter placeholder because this path only ever checked
+/// `metadata_artist`.
 async fn fetch_custom_similar(
     pool: &SqlitePool,
     artwork_dir: &std::path::Path,
+    local_artwork_dir: &std::path::Path,
     artist_id: i64,
 ) -> AppResult<Vec<SimilarArtistDto>> {
-    let rows: Vec<(i64, String, Option<String>, Option<String>)> = sqlx::query_as(
+    let rows: Vec<(
+        i64,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )> = sqlx::query_as(
         r#"
-        SELECT a.id, a.name, ma.picture_url, ma.picture_hash
+        SELECT a.id, a.name, ma.picture_url, ma.picture_hash, aw.hash, aw.format
           FROM artist_similar_custom sc
           JOIN artist a ON a.id = sc.similar_artist_id
           LEFT JOIN app.metadata_artist ma ON ma.deezer_id = a.deezer_id
+          LEFT JOIN artwork aw ON aw.id = a.artwork_id
          WHERE sc.artist_id = ?
          ORDER BY sc.position
         "#,
@@ -240,17 +257,31 @@ async fn fetch_custom_similar(
         .take(RESULT_LIMIT)
         .enumerate()
         .map(
-            |(i, (id, name, picture_url, picture_hash))| SimilarArtistDto {
-                name,
-                // Synthesize a decreasing score from the curated order so
-                // the UI sorts these the same way it sorts online results.
-                match_score: 1.0 - (i as f32) / n,
-                picture_path: picture_hash
-                    .as_deref()
-                    .and_then(|h| metadata_artwork::existing_path(artwork_dir, h)),
-                picture_url,
-                library_artist_id: Some(id),
-                source: "custom".into(),
+            |(i, (id, name, picture_url, picture_hash, local_hash, local_format))| {
+                let local_picture_path = match (local_hash.as_deref(), local_format.as_deref()) {
+                    (Some(hash), Some(format)) => Some(
+                        local_artwork_dir
+                            .join(format!("{hash}.{format}"))
+                            .to_string_lossy()
+                            .into_owned(),
+                    ),
+                    _ => None,
+                };
+                let picture_path = local_picture_path.or_else(|| {
+                    picture_hash
+                        .as_deref()
+                        .and_then(|h| metadata_artwork::existing_path(artwork_dir, h))
+                });
+                SimilarArtistDto {
+                    name,
+                    // Synthesize a decreasing score from the curated order so
+                    // the UI sorts these the same way it sorts online results.
+                    match_score: 1.0 - (i as f32) / n,
+                    picture_path,
+                    picture_url,
+                    library_artist_id: Some(id),
+                    source: "custom".into(),
+                }
             },
         )
         .collect();

--- a/src-tauri/crates/core/src/artwork/metadata.rs
+++ b/src-tauri/crates/core/src/artwork/metadata.rs
@@ -38,6 +38,32 @@ pub fn existing_path(dir: &Path, hash: &str) -> Option<String> {
     }
 }
 
+/// Resolve an artist/album picture path preferring a local profile-artwork
+/// sidecar (`<local_dir>/<local_hash>.<local_format>`, e.g. `artist.jpg`
+/// imported into the profile) over the shared Deezer metadata cache
+/// ([`existing_path`]). Each candidate is returned only when the file
+/// actually exists on disk, so a stale DB reference to a wiped file falls
+/// through to the next source instead of yielding a broken path (#350).
+///
+/// The local sidecar carries its own `format` column (jpg/png/webp) so we
+/// take it explicitly; the metadata cache is always `.jpg`, so `cache_hash`
+/// goes through [`existing_path`] which knows the extension.
+pub fn resolve_local_or_cached_path(
+    local_dir: &Path,
+    local_hash: Option<&str>,
+    local_format: Option<&str>,
+    cache_dir: &Path,
+    cache_hash: Option<&str>,
+) -> Option<String> {
+    if let (Some(hash), Some(format)) = (local_hash, local_format) {
+        let p = local_dir.join(format!("{hash}.{format}"));
+        if p.exists() {
+            return Some(p.to_string_lossy().into_owned());
+        }
+    }
+    cache_hash.and_then(|h| existing_path(cache_dir, h))
+}
+
 /// Download `url`, blake3-hash the bytes and write the file to
 /// `<dir>/<hash>.jpg` if missing. Returns the hex hash on success.
 ///

--- a/src-tauri/crates/core/src/artwork/metadata.rs
+++ b/src-tauri/crates/core/src/artwork/metadata.rs
@@ -111,3 +111,92 @@ pub async fn download_and_cache(url: &str, dir: &Path) -> Option<String> {
     crate::artwork::thumbnails::spawn_thumbnail_job(out, dir.to_path_buf(), hash.clone());
     Some(hash)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn touch(dir: &Path, name: &str) {
+        fs::write(dir.join(name), b"x").unwrap();
+    }
+
+    #[test]
+    fn prefers_existing_local_over_cache() {
+        let local = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        touch(local.path(), "abc.png");
+        touch(cache.path(), "def.jpg"); // cache also present
+
+        let got = resolve_local_or_cached_path(
+            local.path(),
+            Some("abc"),
+            Some("png"),
+            cache.path(),
+            Some("def"),
+        )
+        .unwrap();
+        assert_eq!(got, local.path().join("abc.png").to_string_lossy());
+    }
+
+    #[test]
+    fn falls_back_to_cache_when_local_file_missing() {
+        let local = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        // Local hash/format point at a file that was wiped; only the cache exists.
+        touch(cache.path(), "def.jpg");
+
+        let got = resolve_local_or_cached_path(
+            local.path(),
+            Some("abc"),
+            Some("png"),
+            cache.path(),
+            Some("def"),
+        )
+        .unwrap();
+        assert_eq!(got, cache.path().join("def.jpg").to_string_lossy());
+    }
+
+    #[test]
+    fn incomplete_local_skips_to_cache() {
+        let local = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        touch(cache.path(), "def.jpg");
+
+        // hash without format → local candidate is not even attempted.
+        let got = resolve_local_or_cached_path(
+            local.path(),
+            Some("abc"),
+            None,
+            cache.path(),
+            Some("def"),
+        );
+        assert_eq!(got.unwrap(), cache.path().join("def.jpg").to_string_lossy());
+    }
+
+    #[test]
+    fn none_when_nothing_resolves() {
+        let local = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+
+        // Local file missing, no cache hash at all.
+        assert!(resolve_local_or_cached_path(
+            local.path(),
+            Some("abc"),
+            Some("png"),
+            cache.path(),
+            None,
+        )
+        .is_none());
+
+        // Cache hash given but the file doesn't exist on disk either.
+        assert!(resolve_local_or_cached_path(
+            local.path(),
+            None,
+            None,
+            cache.path(),
+            Some("ghost"),
+        )
+        .is_none());
+    }
+}

--- a/src-tauri/crates/core/src/metadata/theaudiodb.rs
+++ b/src-tauri/crates/core/src/metadata/theaudiodb.rs
@@ -177,7 +177,13 @@ const SUMMARY_MAX: usize = 280;
 /// Derive a short lead-in from the full bio: stop at the first blank
 /// line (paragraph break) when that's already short enough, otherwise
 /// truncate at a word boundary near `SUMMARY_MAX` and append an ellipsis.
-fn make_summary(full: &str) -> String {
+///
+/// `pub` so `commands::deezer::enrich_artist_deezer` (issue #343) can
+/// reuse it to synthesize a `bio_short` for a manually-edited
+/// `custom_bio` override — without it, the override set `bio_short ==
+/// bio_full` verbatim and the frontend's "Read more" toggle (which
+/// triggers on `bio_full.length > bio_short.length`) never appeared.
+pub fn make_summary(full: &str) -> String {
     let first_para = full.split("\n\n").next().unwrap_or(full).trim();
     let collapsed = first_para.split_whitespace().collect::<Vec<_>>().join(" ");
     if collapsed.chars().count() <= SUMMARY_MAX {

--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -902,8 +902,11 @@ export function LyricsEditorModal({
           </div>
         )}
 
-        {/* Footer */}
-        <div className="flex items-center justify-between gap-4 px-6 py-4 border-t border-zinc-200 dark:border-zinc-800">
+        {/* Footer — flex-wrap so on a narrow modal (viewport < max-w-3xl)
+            the destination pills and the action group stack onto two
+            rows instead of overflowing horizontally and pushing the Save
+            button off-screen (issue #341). */}
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 px-6 py-4 border-t border-zinc-200 dark:border-zinc-800">
           {/* Destination segmented control. Replaces the previous
               "Écrire dans le fichier" checkbox (issue #201): the
               third option (Sidecar) writes a sibling .lrc / .txt
@@ -945,7 +948,7 @@ export function LyricsEditorModal({
               without it, a long "Exported to <path>" message pushed the
               destination pills into wrapping their labels and squeezed
               the Save button out of view (issue #341). */}
-          <div className="flex items-center gap-2 min-w-0 justify-end">
+          <div className="flex flex-1 items-center gap-2 min-w-0 justify-end">
             {warning && (
               <span className="text-xs text-amber-600 dark:text-amber-400 truncate min-w-0">
                 {warning}

--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -948,7 +948,7 @@ export function LyricsEditorModal({
               without it, a long "Exported to <path>" message pushed the
               destination pills into wrapping their labels and squeezed
               the Save button out of view (issue #341). */}
-          <div className="flex flex-1 items-center gap-2 min-w-0 justify-end">
+          <div className="flex basis-full md:flex-1 items-center gap-2 min-w-0 justify-end">
             {warning && (
               <span className="text-xs text-amber-600 dark:text-amber-400 truncate min-w-0">
                 {warning}

--- a/src/components/common/LyricsEditorModal.tsx
+++ b/src/components/common/LyricsEditorModal.tsx
@@ -914,7 +914,7 @@ export function LyricsEditorModal({
           <div
             role="radiogroup"
             aria-label={t("lyricsEditor.destinationLabel")}
-            className="flex items-center rounded-full bg-zinc-100 dark:bg-zinc-800 p-0.5 text-xs"
+            className="flex items-center shrink-0 whitespace-nowrap rounded-full bg-zinc-100 dark:bg-zinc-800 p-0.5 text-xs"
           >
             {(["tag", "sidecar", "db_only"] as const).map((value) => {
               const checked = destination === value;
@@ -940,47 +940,54 @@ export function LyricsEditorModal({
               );
             })}
           </div>
-          <div className="flex items-center gap-2">
+          {/* min-w-0 lets the warning/error text truncate to whatever
+              space is left instead of forcing the row to overflow —
+              without it, a long "Exported to <path>" message pushed the
+              destination pills into wrapping their labels and squeezed
+              the Save button out of view (issue #341). */}
+          <div className="flex items-center gap-2 min-w-0 justify-end">
             {warning && (
-              <span className="text-xs text-amber-600 dark:text-amber-400 truncate max-w-xs">
+              <span className="text-xs text-amber-600 dark:text-amber-400 truncate min-w-0">
                 {warning}
               </span>
             )}
             {error && (
-              <span className="text-xs text-red-500 truncate max-w-xs">
+              <span className="text-xs text-red-500 truncate min-w-0">
                 {error}
               </span>
             )}
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 rounded-full text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
-            >
-              {t("common.cancel")}
-            </button>
-            <button
-              type="button"
-              onClick={handleExportToFile}
-              disabled={isSaving}
-              className="px-4 py-2 rounded-full text-sm border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors disabled:opacity-50 flex items-center gap-2"
-              title={t("lyricsEditor.exportToFileHint") ?? undefined}
-            >
-              <FileDown size={14} />
-              {t("lyricsEditor.exportToFile")}
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={isSaving || trackId == null}
-              className="px-5 py-2 rounded-full bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center gap-2"
-            >
-              {isSaving ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <Save size={14} />
-              )}
-              {t("common.save")}
-            </button>
+            <div className="flex items-center gap-2 shrink-0">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 rounded-full text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+              >
+                {t("common.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleExportToFile}
+                disabled={isSaving}
+                className="px-4 py-2 rounded-full text-sm border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors disabled:opacity-50 flex items-center gap-2 whitespace-nowrap"
+                title={t("lyricsEditor.exportToFileHint") ?? undefined}
+              >
+                <FileDown size={14} />
+                {t("lyricsEditor.exportToFile")}
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={isSaving || trackId == null}
+                className="px-5 py-2 rounded-full bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center gap-2 whitespace-nowrap"
+              >
+                {isSaving ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Save size={14} />
+                )}
+                {t("common.save")}
+              </button>
+            </div>
           </div>
         </div>
       </AnimatedModalContent>


### PR DESCRIPTION
## Summary
Batch of 3 low-risk fixes from beta tester feedback, ahead of the next beta cut:

- **#350** — Curated similar artists (offline overrides, #323) rendered the initial-letter placeholder instead of a local `artist.jpg` sidecar because `fetch_custom_similar` / `get_artist_overrides` only ever checked the Deezer `metadata_artist` cache. Now mirrors `get_artist_detail`'s existing local-then-Deezer cascade.
- **#343** — A manually-edited artist bio (offline override) set `bio_short == bio_full` verbatim, so the "Read more" toggle never appeared (it triggers on `bio_full.length > bio_short.length`). Now reuses TheAudioDB's `make_summary` truncation to synthesize a proper short lead-in.
- **#341** — The lyrics editor footer's destination pills + Cancel/Export/Save buttons had no `min-w-0`/`shrink-0` boundaries, so a long "Exported to `<path>`" confirmation message forced the row to overflow — pill labels wrapped onto two lines and the Save button got squeezed out of view. Fixed the flex layout so the message truncates instead.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Manual verification in a running build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * Les visuels des artistes “similaires” privilégient désormais les illustrations locales (notamment les assets de profil) avant de retomber sur le cache partagé.
  * Les bios courtes personnalisées (Deezer) sont désormais automatiquement résumées, tout en conservant la biographie complète.
* **Corrections d’interface**
  * L’éditeur de paroles évite mieux le débordement horizontal et le décalage des boutons sur petits écrans, même avec des messages longs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->