### PR TITLE
fix(ui): wrap long bio tokens and infer radio region from timezone

### DIFF
--- a/src/components/views/ArtistDetailView.tsx
+++ b/src/components/views/ArtistDetailView.tsx
@@ -367,7 +367,7 @@ export function ArtistDetailView({
             {t("artistDetail.bio.title")}
           </h2>
           <div className="rounded-2xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-800/40">
-            <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300 whitespace-pre-line">
+            <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-300 whitespace-pre-line break-words hyphens-auto">
               {bioExpanded ? (bioFull ?? bioShort) : bioShort}
             </p>
             {bioFull && bioFull.length > bioShort.length && (

--- a/src/components/views/WebRadioView.tsx
+++ b/src/components/views/WebRadioView.tsx
@@ -51,11 +51,107 @@ function countryLabel(uiLang: string, code: string): string {
   return code;
 }
 
-/** Best-effort ISO 3166-1 alpha-2 region from the browser locale
- *  ("fr-FR" → "FR"), or null when the locale carries no region (e.g.
- *  a bare "en"). Used as the initial fallback; overridden by the
+/** IANA time-zone → ISO 3166-1 alpha-2 country. Reflects the user's
+ *  physical location far better than the OS UI language (an en-US
+ *  Windows install outside the US is extremely common). Not exhaustive
+ *  — falls through to the locale region when a zone isn't mapped. */
+const TIMEZONE_TO_REGION: Record<string, string> = {
+  // Europe
+  "Europe/Paris": "FR",
+  "Europe/London": "GB",
+  "Europe/Dublin": "IE",
+  "Europe/Madrid": "ES",
+  "Europe/Lisbon": "PT",
+  "Europe/Berlin": "DE",
+  "Europe/Zurich": "CH",
+  "Europe/Vienna": "AT",
+  "Europe/Rome": "IT",
+  "Europe/Amsterdam": "NL",
+  "Europe/Brussels": "BE",
+  "Europe/Luxembourg": "LU",
+  "Europe/Copenhagen": "DK",
+  "Europe/Oslo": "NO",
+  "Europe/Stockholm": "SE",
+  "Europe/Helsinki": "FI",
+  "Europe/Warsaw": "PL",
+  "Europe/Prague": "CZ",
+  "Europe/Bratislava": "SK",
+  "Europe/Budapest": "HU",
+  "Europe/Bucharest": "RO",
+  "Europe/Sofia": "BG",
+  "Europe/Athens": "GR",
+  "Europe/Zagreb": "HR",
+  "Europe/Belgrade": "RS",
+  "Europe/Ljubljana": "SI",
+  "Europe/Kyiv": "UA",
+  "Europe/Kiev": "UA",
+  "Europe/Moscow": "RU",
+  "Europe/Istanbul": "TR",
+  // Americas
+  "America/New_York": "US",
+  "America/Chicago": "US",
+  "America/Denver": "US",
+  "America/Phoenix": "US",
+  "America/Los_Angeles": "US",
+  "America/Anchorage": "US",
+  "Pacific/Honolulu": "US",
+  "America/Toronto": "CA",
+  "America/Vancouver": "CA",
+  "America/Edmonton": "CA",
+  "America/Winnipeg": "CA",
+  "America/Halifax": "CA",
+  "America/Mexico_City": "MX",
+  "America/Sao_Paulo": "BR",
+  "America/Argentina/Buenos_Aires": "AR",
+  "America/Santiago": "CL",
+  "America/Bogota": "CO",
+  "America/Lima": "PE",
+  // Asia / Middle East
+  "Asia/Tokyo": "JP",
+  "Asia/Seoul": "KR",
+  "Asia/Shanghai": "CN",
+  "Asia/Hong_Kong": "HK",
+  "Asia/Taipei": "TW",
+  "Asia/Singapore": "SG",
+  "Asia/Bangkok": "TH",
+  "Asia/Jakarta": "ID",
+  "Asia/Kuala_Lumpur": "MY",
+  "Asia/Manila": "PH",
+  "Asia/Kolkata": "IN",
+  "Asia/Calcutta": "IN",
+  "Asia/Dubai": "AE",
+  "Asia/Riyadh": "SA",
+  "Asia/Jerusalem": "IL",
+  "Asia/Tel_Aviv": "IL",
+  "Asia/Tehran": "IR",
+  // Oceania / Africa
+  "Australia/Sydney": "AU",
+  "Australia/Melbourne": "AU",
+  "Australia/Brisbane": "AU",
+  "Australia/Perth": "AU",
+  "Pacific/Auckland": "NZ",
+  "Africa/Johannesburg": "ZA",
+  "Africa/Cairo": "EG",
+  "Africa/Lagos": "NG",
+  "Africa/Casablanca": "MA",
+  "Africa/Tunis": "TN",
+  "Africa/Algiers": "DZ",
+};
+
+/** Best-effort ISO 3166-1 alpha-2 region for the "Local stations"
+ *  default. Prefers the IANA time zone (reflects physical location)
+ *  and falls back to the browser locale region ("fr-FR" → "FR") when
+ *  the zone isn't mapped. Returns null when neither yields a region
+ *  (e.g. a bare "en"). Used as the initial default; overridden by the
  *  user's pinned preference loaded from the backend on mount. */
 function detectLocalRegion(): string | null {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const fromTz = tz ? TIMEZONE_TO_REGION[tz] : undefined;
+    if (fromTz) return fromTz;
+  } catch {
+    // fall through to locale
+  }
   try {
     const region = new Intl.Locale(navigator.language).region;
     return region && /^[A-Za-z]{2}$/.test(region) ? region.toUpperCase() : null;


### PR DESCRIPTION
Corrige deux petits bugs frontend rapportés par des bêta-testeurs.

## #368 — Bio artiste : texte sans espace déborde de la carte
Un token sans espace (`aaaa…`) débordait horizontalement et sortait de l'écran. Ajout de `break-words` (`overflow-wrap: break-word`) + `hyphens-auto` sur le `<p>` de la bio dans `ArtistDetailView.tsx` pour qu'il s'enroule dans la carte.

Closes #368

## #364 — Web Radio : "Stations locales" par défaut sur les USA en `en-US`
Le défaut était dérivé de `navigator.language`, donc un Windows en anglais (US) installé **hors** des États-Unis affichait toujours *United States*. `detectLocalRegion` privilégie désormais le fuseau horaire IANA (`Intl.DateTimeFormat().resolvedOptions().timeZone` → ISO-3166 via une petite table), avec repli sur la région de la locale. Aucun réseau, respecte la posture offline-first. La préférence persistée par profil (#362) reste inchangée.

Closes #364

## Vérifications
- \`bun run typecheck\` ✅
- \`bun run lint\` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Amélioration de la lisibilité des biographies grâce à une meilleure césure automatique du texte.
  * Sélection initiale des stations locales plus précise selon le fuseau horaire détecté, avec une solution de repli basée sur la langue du navigateur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->