### PR TITLE
chore(deps): bump rubato from 3.0 to 4.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -294,9 +294,9 @@ checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
 
 [[package]]
 name = "audioadapter"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+checksum = "c75c3943c6c7279bb25a449a8d1727480730ab2efd7b6fd5d6ca51927096e6e4"
 dependencies = [
  "audio-core",
  "num-traits",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-buffers"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+checksum = "ece3390b6eb40379094843a1da5aaccc34bc0d85a8cbf68d09fe092fee6de29e"
 dependencies = [
  "audioadapter",
  "audioadapter-sample",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-sample"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+checksum = "1592f90413568e259413c21a41a3d571feb1774255c209e7966d98f9db708c90"
 dependencies = [
  "audio-core",
  "num-traits",
@@ -4740,9 +4740,9 @@ checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
 name = "rubato"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
+checksum = "f57c655d11e929f05a8663b323ff553f8d9773be05dfdc087795955bedeb8d92"
 dependencies = [
  "audioadapter",
  "audioadapter-buffers",

--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -135,7 +135,7 @@ symphonia = { version = "0.6", default-features = false, features = [
     "all-meta",
 ] }
 cpal = "0.17"
-rubato = "3.0"
+rubato = "4.0"
 rtrb = "0.3"
 crossbeam-channel = "0.5"
 # FFT for the spectrum visualizer. realfft is a thin wrapper over

--- a/src-tauri/crates/app/src/audio/resampler.rs
+++ b/src-tauri/crates/app/src/audio/resampler.rs
@@ -12,7 +12,7 @@
 //! where the user's tracks already match the device rate.
 
 use rubato::audioadapter_buffers::direct::InterleavedSlice;
-use rubato::{Fft, FixedSync, Resampler as _};
+use rubato::{Fft, FixedSync, Resampler as _, WindowFunction};
 
 use crate::error::{AppError, AppResult};
 
@@ -57,12 +57,18 @@ impl Resampler {
             return Ok(Self::Passthrough);
         }
 
-        let inner = Fft::<f32>::new(
+        // rubato 4.0 dropped `sub_chunks` from `Fft::new` (it now
+        // auto-picks ~256-frame sub-chunks); `new_custom` keeps our
+        // deliberate SUB_CHUNKS=2 baseline and pins BlackmanHarris2 —
+        // the exact window `Fft::new` used internally in 3.0 — so the
+        // anti-aliasing response is unchanged across the bump.
+        let inner = Fft::<f32>::new_custom(
             src_rate as usize,
             dst_rate as usize,
             CHUNK_SIZE,
             SUB_CHUNKS,
             channels,
+            WindowFunction::BlackmanHarris2,
             FixedSync::Input,
         )
         .map_err(|e| AppError::Audio(format!("rubato init: {e}")))?;


### PR DESCRIPTION
Bump `rubato` 3.0 → 4.0 (major) in `waveflow` (audio engine).

## Breaking change handled
rubato 4.0 removed the `sub_chunks` parameter from `Fft::new` (it now auto-derives ~256-frame sub-chunks). The resampler ctor now uses `Fft::new_custom(...)` to:
- keep the deliberate `SUB_CHUNKS = 2` baseline documented in `resampler.rs`,
- pin `WindowFunction::BlackmanHarris2` — the exact window `Fft::new` used internally in 3.0 — so the anti-aliasing response is **unchanged** across the bump.

No other rubato API surface changed (`audioadapter_buffers`, `FixedSync::Input`, `process_into_buffer`, `input_frames_next`, `output_frames_max` all identical).

## Why not the Dependabot branch
`dependabot/cargo/src-tauri/rubato-4.0.0` was cut from an older `main` and additionally downgrades `tokio-tungstenite` 0.30 → 0.29. This branch supersedes it with only the rubato change on top of current `main`. The Dependabot PR can be closed.

## Verification
- `cargo check -p waveflow --all-targets` ✅
- `cargo test -p waveflow --lib audio::resampler` ✅ (2/2: passthrough + 48k→44.1k proportional output)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Amélioration de la qualité et de la stabilité du traitement audio.
  * Configuration affinée du resampling audio pour un rendu plus fiable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->