### PR TITLE
fix(ui): stop main window growing on every launch

### DIFF
--- a/src/hooks/useMainWindowBounds.ts
+++ b/src/hooks/useMainWindowBounds.ts
@@ -12,7 +12,11 @@ import { mainWindowBoundsWritesSuppressed } from "../lib/mainWindowBoundsGuard";
  * `onMoved` and `onResized` events and debounces saves at 300 ms so rapid
  * drag/resize gestures do not hammer SQLite at 60 Hz.
  *
- * Mirrors the mini-player's bounds-persistence logic in MiniPlayer.tsx.
+ * Structurally close to the mini-player's bounds persistence
+ * (MiniPlayer.tsx), but deliberately saves `innerSize` rather than
+ * `outerSize`: the main window carries OS decorations while the mini is
+ * `decorations: false` (inner === outer), so only this window needs the
+ * inner/outer distinction to round-trip through `set_size`. See #379.
  */
 export function useMainWindowBounds(): void {
   useEffect(() => {
@@ -36,7 +40,15 @@ export function useMainWindowBounds(): void {
         try {
           const scale = await win.scaleFactor();
           const pos = await win.outerPosition();
-          const size = await win.outerSize();
+          // Save the INNER (client-area) size, not the outer size. The
+          // Rust restore path uses `window.set_size(LogicalSize)`, which
+          // in Tauri 2 sets the inner size. The main window has OS
+          // decorations (title bar + borders), so persisting `outerSize`
+          // here and restoring it as the inner size grew the window by
+          // one title-bar height (down) + border width (right) on every
+          // launch (issue #379). Position stays on `outerPosition` /
+          // `set_position`, which are already an outer↔outer pair.
+          const size = await win.innerSize();
           // Re-check after awaits: unmount or a later gesture may have
           // invalidated this save while the async calls were in flight.
           if (disposed || generation !== saveGeneration) return;


### PR DESCRIPTION
Fixes #379 (follow-up to #339 / #362).

## Root cause
`useMainWindowBounds` saved `win.outerSize()` (client area **+ OS decorations**), but the Rust restore path (`restore_bounds_and_reveal` in `lib.rs`) applies it with `window.set_size(LogicalSize)`, which in Tauri 2 sets the **inner** size.

On the decorated main window that makes every launch compute:

```
inner := previous outer = previous inner + decoration size
```

so the window crept **down** by one title-bar height and **right** by the border width on each reopen. The mini-player was immune because it's `decorations: false` (inner == outer) — which is exactly why the #362 fix that "mirrored the mini-player logic" didn't catch this.

## Fix
Save `win.innerSize()` so save/restore are a symmetric inner↔inner pair. Position was already correct (`outerPosition` ↔ `set_position` are both outer), so it's untouched.

Self-healing for existing installs: the oversized stored value is applied once on the next launch, then the first resize/move save overwrites it with the true inner size — no migration needed.

## Verification
- `bun run typecheck` ✅
- `bun run lint` ✅
- Logic is confirmed by the report itself: growth-by-title-bar-height is only possible if `outerSize` is saved and `set_size` (inner) restores it.

Note: I couldn't drive the decorated-window behavior end-to-end on Linux CI (decoration metrics are OS-specific), so a quick manual open/close cycle on Windows 11 to confirm the size now holds would be appreciated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Corrections**
  * La taille de la fenêtre enregistrée correspond désormais à sa zone client, assurant une restauration plus précise.
  * Amélioration de la cohérence entre la taille sauvegardée et la taille restaurée par l’application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->