### PR TITLE
fix(metadata): match TheAudioDB artists past exact-name equality

### DIFF
--- a/src-tauri/crates/core/src/metadata/theaudiodb.rs
+++ b/src-tauri/crates/core/src/metadata/theaudiodb.rs
@@ -254,20 +254,37 @@ fn fold_diacritic(ch: char) -> char {
     }
 }
 
-/// True when one normalized name is a word-boundary prefix of the other
-/// (or they're equal). Both inputs are single-space-joined with no
-/// leading/trailing space, so requiring the remainder to start with a
-/// space keeps the match anchored to a whole word — "bob marley" matches
-/// "bob marley and the wailers" but not "bob marleyx".
+/// Connectors that open a canonical "backing band" / collaboration
+/// extension after normalization (`&` is already folded to "and"). Only a
+/// suffix starting with one of these promotes a prefix into a match.
+const CANONICAL_CONNECTORS: [&str; 5] = ["and", "with", "feat", "featuring", "ft"];
+
+/// True when the two normalized names denote the same artist under a
+/// canonical extension: one is the other followed by a recognized
+/// connector — "bob marley" ↔ "bob marley and the wailers".
+///
+/// A bare word-boundary prefix is deliberately NOT enough. A
+/// parenthetical disambiguator like "nirvana 60s band" (from "Nirvana
+/// (60s band)") is a *different* artist that happens to share a leading
+/// word, so the extension's first token must be an actual connector or we
+/// reject it. Both inputs are single-space-joined with no leading/trailing
+/// space, so the connector always sits right after the shared prefix.
 fn names_prefix_compatible(a: &str, b: &str) -> bool {
     let (short, long) = if a.len() <= b.len() { (a, b) } else { (b, a) };
     if short.is_empty() {
         return false;
     }
-    match long.strip_prefix(short) {
-        Some(rest) => rest.is_empty() || rest.starts_with(' '),
-        None => false,
-    }
+    let Some(rest) = long.strip_prefix(short) else {
+        return false;
+    };
+    // Word-boundary split, then require a known connector as the first
+    // token of the extension.
+    let Some(tail) = rest.strip_prefix(' ') else {
+        return false;
+    };
+    tail.split(' ')
+        .next()
+        .is_some_and(|token| CANONICAL_CONNECTORS.contains(&token))
 }
 
 /// Normalise line endings and trim. TheAudioDB bios are plain text
@@ -433,6 +450,25 @@ mod tests {
         assert!(pick_artist(artists, &normalize_name("Bob Marley")).is_none());
         // A shared first word alone is not a word-boundary prefix match.
         assert!(!names_prefix_compatible("bob marley", "bob dylan"));
+    }
+
+    #[test]
+    fn pick_rejects_parenthetical_homonym_when_alone() {
+        // "Nirvana (60s band)" as the ONLY result must NOT satisfy a
+        // "Nirvana" search — the " 60s band" suffix is a disambiguator,
+        // not a canonical backing-band connector. Isolated from any exact
+        // match so the fallback is what's under test.
+        let artists = vec![named("Nirvana (60s band)")];
+        assert!(pick_artist(artists, &normalize_name("Nirvana")).is_none());
+        assert!(!names_prefix_compatible(
+            "nirvana",
+            &normalize_name("Nirvana (60s band)")
+        ));
+        // But a real connector suffix still matches.
+        assert!(names_prefix_compatible(
+            "nirvana",
+            "nirvana and the deep sea"
+        ));
     }
 
     #[test]

--- a/src-tauri/crates/core/src/metadata/theaudiodb.rs
+++ b/src-tauri/crates/core/src/metadata/theaudiodb.rs
@@ -124,23 +124,11 @@ impl TheAudioDbClient {
             .json()
             .await?;
 
-        let Some(artist) = resp.artists.and_then(|mut a| {
-            if a.is_empty() {
-                None
-            } else {
-                Some(a.swap_remove(0))
-            }
-        }) else {
+        let Some(artist) =
+            resp.artists.and_then(|artists| pick_artist(artists, &normalize_name(name)))
+        else {
             return Ok(None);
         };
-
-        // Guard against homonyms / fuzzy hits: only trust the result when
-        // its name matches what we searched for (case-insensitive) — the
-        // same name-match the Deezer enrichment path applies before
-        // accepting a search hit.
-        if artist.name.as_deref().map(str::to_lowercase) != Some(name.to_lowercase()) {
-            return Ok(None);
-        }
 
         let Some(full) = artist.bio_for_lang(lang).map(clean_text) else {
             return Ok(None);
@@ -163,6 +151,101 @@ fn non_blank(value: &Option<String>) -> Option<String> {
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string)
+}
+
+/// Pick the artist entry that best matches the normalized search term.
+///
+/// TheAudioDB's `search.php?s=<name>` returns a *relevance-ranked* array,
+/// but the top hit is often a canonical superset ("Bob Marley & The
+/// Wailers" for a library tagged "Bob Marley"). The old code took index 0
+/// and demanded an exact case-insensitive name equality, so any such
+/// superset — or a mere punctuation difference like "Boney M." vs
+/// "Boney M" — silently dropped the bio (issue #342).
+///
+/// Now we scan the whole list: an exact normalized match wins wherever it
+/// sits, and failing that we accept the first word-boundary prefix match
+/// in either direction (subset ↔ superset). Normalization folds case,
+/// common Latin diacritics, `&`/"and", punctuation and whitespace, so
+/// homonym protection is preserved (unrelated names still don't match)
+/// while trivial spelling variance no longer blocks a hit.
+fn pick_artist(artists: Vec<ArtistPayload>, searched: &str) -> Option<ArtistPayload> {
+    if searched.is_empty() {
+        return None;
+    }
+    let mut prefix_match: Option<ArtistPayload> = None;
+    for artist in artists {
+        let Some(candidate) = artist.name.as_deref().map(normalize_name) else {
+            continue;
+        };
+        if candidate == searched {
+            return Some(artist);
+        }
+        if prefix_match.is_none() && names_prefix_compatible(searched, &candidate) {
+            prefix_match = Some(artist);
+        }
+    }
+    prefix_match
+}
+
+/// Normalise an artist name for fuzzy comparison: lowercase, fold common
+/// Latin diacritics, expand `&` to "and", drop punctuation and collapse
+/// whitespace to single spaces. "Boney M." and "Boney M" both become
+/// "boney m"; "Bob Marley & The Wailers" becomes "bob marley and the
+/// wailers"; "Beyoncé" becomes "beyonce". Non-Latin scripts (CJK, …) are
+/// preserved verbatim minus punctuation.
+fn normalize_name(name: &str) -> String {
+    let lowered = name.to_lowercase().replace('&', " and ");
+    let mut out = String::with_capacity(lowered.len());
+    let mut pending_space = false;
+    for ch in lowered.chars() {
+        let folded = fold_diacritic(ch);
+        if folded.is_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.push(folded);
+        } else {
+            // Punctuation or whitespace → a single word boundary.
+            pending_space = true;
+        }
+    }
+    out
+}
+
+/// Map a lowercase accented Latin char to its base letter; pass anything
+/// else through unchanged. Covers the accents common in Western artist
+/// names without pulling in a Unicode-normalization dependency.
+fn fold_diacritic(ch: char) -> char {
+    match ch {
+        'á' | 'à' | 'â' | 'ä' | 'ã' | 'å' | 'ā' | 'ą' => 'a',
+        'ç' | 'ć' | 'č' => 'c',
+        'é' | 'è' | 'ê' | 'ë' | 'ē' | 'ę' | 'ě' => 'e',
+        'í' | 'ì' | 'î' | 'ï' | 'ī' => 'i',
+        'ñ' | 'ń' => 'n',
+        'ó' | 'ò' | 'ô' | 'ö' | 'õ' | 'ø' | 'ō' => 'o',
+        'ś' | 'š' => 's',
+        'ú' | 'ù' | 'û' | 'ü' | 'ū' => 'u',
+        'ý' | 'ÿ' => 'y',
+        'ź' | 'ż' | 'ž' => 'z',
+        other => other,
+    }
+}
+
+/// True when one normalized name is a word-boundary prefix of the other
+/// (or they're equal). Both inputs are single-space-joined with no
+/// leading/trailing space, so requiring the remainder to start with a
+/// space keeps the match anchored to a whole word — "bob marley" matches
+/// "bob marley and the wailers" but not "bob marleyx".
+fn names_prefix_compatible(a: &str, b: &str) -> bool {
+    let (short, long) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    if short.is_empty() {
+        return false;
+    }
+    match long.strip_prefix(short) {
+        Some(rest) => rest.is_empty() || rest.starts_with(' '),
+        None => false,
+    }
 }
 
 /// Normalise line endings and trim. TheAudioDB bios are plain text
@@ -240,5 +323,82 @@ mod tests {
         };
         assert_eq!(payload.bio_for_lang("fr").as_deref(), Some("English bio"));
         assert_eq!(payload.bio_for_lang("de").as_deref(), Some("English bio"));
+    }
+
+    /// Build a payload with only a name + an English bio derived from it,
+    /// so tests can assert *which* entry `pick_artist` selected.
+    fn named(name: &str) -> ArtistPayload {
+        ArtistPayload {
+            name: Some(name.into()),
+            bio_en: Some(format!("bio of {name}")),
+            bio_fr: None,
+            bio_de: None,
+            bio_es: None,
+            bio_it: None,
+            bio_pt: None,
+            bio_nl: None,
+            bio_ru: None,
+            bio_jp: None,
+            bio_cn: None,
+        }
+    }
+
+    #[test]
+    fn normalize_folds_punctuation_case_and_diacritics() {
+        assert_eq!(normalize_name("Boney M."), "boney m");
+        assert_eq!(normalize_name("Boney M"), "boney m");
+        assert_eq!(
+            normalize_name("Bob Marley & The Wailers"),
+            "bob marley and the wailers"
+        );
+        assert_eq!(normalize_name("Beyoncé"), "beyonce");
+        assert_eq!(normalize_name("Guns N' Roses"), "guns n roses");
+        // Non-Latin script survives (minus punctuation).
+        assert_eq!(normalize_name("宇多田ヒカル"), "宇多田ヒカル");
+    }
+
+    #[test]
+    fn pick_exact_match_wins_regardless_of_position() {
+        // The relevant entry sits after a homonym; exact match must still win.
+        let artists = vec![named("Nirvana (60s band)"), named("Nirvana")];
+        let picked = pick_artist(artists, &normalize_name("Nirvana")).unwrap();
+        assert_eq!(picked.name.as_deref(), Some("Nirvana"));
+    }
+
+    #[test]
+    fn pick_punctuation_only_difference_matches() {
+        // "Boney M." (search) vs "Boney M" (DB) — issue #342.
+        let artists = vec![named("Boney M")];
+        let picked = pick_artist(artists, &normalize_name("Boney M.")).unwrap();
+        assert_eq!(picked.name.as_deref(), Some("Boney M"));
+    }
+
+    #[test]
+    fn pick_superset_name_matches_via_prefix() {
+        // Library tagged "Bob Marley", TheAudioDB canonical is the band — #342.
+        let artists = vec![named("Bob Marley & The Wailers")];
+        let picked = pick_artist(artists, &normalize_name("Bob Marley")).unwrap();
+        assert_eq!(picked.name.as_deref(), Some("Bob Marley & The Wailers"));
+    }
+
+    #[test]
+    fn pick_prefers_exact_over_prefix() {
+        let artists = vec![named("Bob Marley & The Wailers"), named("Bob Marley")];
+        let picked = pick_artist(artists, &normalize_name("Bob Marley")).unwrap();
+        assert_eq!(picked.name.as_deref(), Some("Bob Marley"));
+    }
+
+    #[test]
+    fn pick_rejects_unrelated_homonym() {
+        // "Bob Dylan" must not satisfy a "Bob Marley" search.
+        let artists = vec![named("Bob Dylan")];
+        assert!(pick_artist(artists, &normalize_name("Bob Marley")).is_none());
+        // A shared first word alone is not a word-boundary prefix match.
+        assert!(!names_prefix_compatible("bob marley", "bob dylan"));
+    }
+
+    #[test]
+    fn pick_empty_search_is_none() {
+        assert!(pick_artist(vec![named("Anything")], "").is_none());
     }
 }

--- a/src-tauri/crates/core/src/metadata/theaudiodb.rs
+++ b/src-tauri/crates/core/src/metadata/theaudiodb.rs
@@ -198,6 +198,14 @@ fn normalize_name(name: &str) -> String {
     let mut out = String::with_capacity(lowered.len());
     let mut pending_space = false;
     for ch in lowered.chars() {
+        // Drop NFD combining marks (the accent half of a decomposed
+        // character) so "Bjo\u{308}rk" folds to the same "bjork" as its
+        // precomposed NFC form — without this they'd act as a boundary
+        // and split the word. NOT a word boundary, so we `continue`
+        // rather than fall into the punctuation branch below.
+        if is_combining_mark(ch) {
+            continue;
+        }
         let folded = fold_diacritic(ch);
         if folded.is_alphanumeric() {
             if pending_space && !out.is_empty() {
@@ -211,6 +219,20 @@ fn normalize_name(name: &str) -> String {
         }
     }
     out
+}
+
+/// True for Unicode nonspacing combining marks — the accent halves left
+/// standing in an NFD-decomposed string. Covers the standard combining
+/// blocks; dependency-free stand-in for the `Mn` general category so we
+/// don't pull in `unicode-normalization` just to fold accents.
+fn is_combining_mark(ch: char) -> bool {
+    matches!(ch as u32,
+        0x0300..=0x036F | // Combining Diacritical Marks
+        0x1AB0..=0x1AFF | // Combining Diacritical Marks Extended
+        0x1DC0..=0x1DFF | // Combining Diacritical Marks Supplement
+        0x20D0..=0x20FF | // Combining Diacritical Marks for Symbols
+        0xFE20..=0xFE2F,  // Combining Half Marks
+    )
 }
 
 /// Map a lowercase accented Latin char to its base letter; pass anything
@@ -355,6 +377,22 @@ mod tests {
         assert_eq!(normalize_name("Guns N' Roses"), "guns n roses");
         // Non-Latin script survives (minus punctuation).
         assert_eq!(normalize_name("宇多田ヒカル"), "宇多田ヒカル");
+    }
+
+    #[test]
+    fn normalize_is_stable_across_nfc_and_nfd_forms() {
+        // "Björk": precomposed ö (NFC) vs o + combining diaeresis (NFD).
+        let bjork_nfc = "Bj\u{00F6}rk";
+        let bjork_nfd = "Bjo\u{0308}rk";
+        assert_eq!(normalize_name(bjork_nfc), "bjork");
+        assert_eq!(normalize_name(bjork_nfd), "bjork");
+        assert_eq!(normalize_name(bjork_nfc), normalize_name(bjork_nfd));
+
+        // "Beyoncé": precomposed é (NFC) vs e + combining acute (NFD).
+        let beyonce_nfc = "Beyonc\u{00E9}";
+        let beyonce_nfd = "Beyonce\u{0301}";
+        assert_eq!(normalize_name(beyonce_nfd), "beyonce");
+        assert_eq!(normalize_name(beyonce_nfc), normalize_name(beyonce_nfd));
     }
 
     #[test]

--- a/src-tauri/crates/core/src/metadata/theaudiodb.rs
+++ b/src-tauri/crates/core/src/metadata/theaudiodb.rs
@@ -421,6 +421,18 @@ mod tests {
     }
 
     #[test]
+    fn pick_matches_accentless_library_name_to_accented_entry() {
+        // TheAudioDB's search is accent-insensitive, so a library artist
+        // tagged "Celine Dion" (no accent) still gets "Céline Dion" back;
+        // the client match must then survive the accent difference —
+        // exactly jo-el414's report on #342. Both forms normalize to
+        // "celine dion", so it's an exact match, not a fuzzy fallback.
+        let artists = vec![named("Céline Dion")];
+        let picked = pick_artist(artists, &normalize_name("Celine Dion")).unwrap();
+        assert_eq!(picked.name.as_deref(), Some("Céline Dion"));
+    }
+
+    #[test]
     fn pick_punctuation_only_difference_matches() {
         // "Boney M." (search) vs "Boney M" (DB) — issue #342.
         let artists = vec![named("Boney M")];


### PR DESCRIPTION
Fixes #342.

## Root cause
`TheAudioDbClient::artist_bio` took **only** `search.php`'s top hit (`swap_remove(0)`) and then demanded an **exact** case-insensitive name equality. That silently dropped a perfectly good bio whenever:
- the canonical DB name is a **superset** — e.g. library tagged `Bob Marley`, TheAudioDB canonical `Bob Marley & The Wailers`; or
- the names differ only by **punctuation / diacritics** — `Boney M.` vs `Boney M`, `Beyoncé` vs `Beyonce`.

Both of the reporter's examples (Bob Marley, Boney M.) hit these paths.

## Fix
Scan the whole ranked array via a new `pick_artist`:
1. an **exact normalized** match wins wherever it sits in the list (so a homonym at index 0 no longer shadows the real entry);
2. failing that, the first **word-boundary prefix** match in either direction (subset ↔ superset).

`normalize_name` folds case, common Latin diacritics, `&`↔`and`, punctuation and whitespace. Homonym protection is preserved — `Bob Dylan` still does **not** satisfy a `Bob Marley` search (a shared first word isn't a word-boundary prefix), and unrelated exacts are unaffected.

All pure functions in `waveflow-core`; no dependency added, public API unchanged (caller in `deezer.rs` untouched).

## Verification
`cargo test -p waveflow-core --lib metadata::theaudiodb` — 10/10 green, including:
- `pick_exact_match_wins_regardless_of_position`
- `pick_punctuation_only_difference_matches` (Boney M.)
- `pick_superset_name_matches_via_prefix` (Bob Marley → & The Wailers)
- `pick_prefers_exact_over_prefix`
- `pick_rejects_unrelated_homonym` (Bob Dylan ≠ Bob Marley)
- `normalize_folds_punctuation_case_and_diacritics`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * Amélioration de la sélection des biographies d’artistes depuis TheAudioDB.
  * Normalisation améliorée des noms (casse, ponctuation, espaces, “&” → “and”, réduction des diacritiques) pour mieux repérer le bon artiste.
  * Priorité donnée aux correspondances exactes, sinon détection de compatibilité via préfixe par mots.
* **Corrections**
  * Réduction des cas où la biographie correcte n’était pas choisie et meilleure gestion des homonymes.
  * Retour systématique sans sélection lorsqu’aucun candidat pertinent n’est trouvé.
* **Tests**
  * Ajout de tests unitaires couvrant la normalisation (NFC/NFD, scripts non latins) et la logique de sélection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->