### PR TITLE
fix(metadata): reuse fuzzy name match for Deezer artist enrichment

### DIFF
--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -23,6 +23,7 @@ use tauri::{AppHandle, Emitter};
 use waveflow_core::metadata::{
     deezer::DeezerClient,
     lastfm::LastfmClient,
+    name_match::{normalize_name, select_by_name},
     theaudiodb::{make_summary, TheAudioDbClient},
 };
 
@@ -420,9 +421,11 @@ async fn enrich_artist_deezer_inner(
     } else {
         match client.search_artist(&artist_name).await {
             Ok(hits) => {
-                let canonical = artist_name.to_lowercase();
-                hits.into_iter()
-                    .find(|h| h.name.to_lowercase() == canonical)
+                // Share TheAudioDB's fuzzy matcher (#342): Deezer's search
+                // is accent-insensitive too, so an exact-equality filter
+                // dropped the picture/cover for "Celine Dion" ↔ "Céline
+                // Dion" and superset names like "Bob Marley & The Wailers".
+                select_by_name(hits, &normalize_name(&artist_name), |h| Some(h.name.as_str()))
             }
             Err(err) => {
                 tracing::warn!(?err, "Deezer search_artist failed");

--- a/src-tauri/crates/core/src/metadata/mod.rs
+++ b/src-tauri/crates/core/src/metadata/mod.rs
@@ -9,4 +9,5 @@
 pub mod deezer;
 pub mod lastfm;
 pub mod lrclib;
+pub mod name_match;
 pub mod theaudiodb;

--- a/src-tauri/crates/core/src/metadata/name_match.rs
+++ b/src-tauri/crates/core/src/metadata/name_match.rs
@@ -1,0 +1,243 @@
+//! Fuzzy artist-name matching shared across metadata providers.
+//!
+//! Third-party catalogues (TheAudioDB, Deezer, …) return a *ranked* list
+//! for a name query, but the top hit is rarely a byte-identical match: it
+//! may carry a canonical backing-band suffix ("Bob Marley & The Wailers"),
+//! or differ only by case, punctuation or diacritics ("Céline Dion" vs a
+//! library tagged "Celine Dion"). Demanding exact equality silently drops
+//! a perfectly good hit (issue #342), so every provider funnels its
+//! candidate list through [`select_by_name`] instead.
+
+/// Connectors that open a canonical "backing band" / collaboration
+/// extension after normalization (`&` is already folded to "and"). Only a
+/// suffix starting with one of these promotes a prefix into a match.
+const CANONICAL_CONNECTORS: [&str; 5] = ["and", "with", "feat", "featuring", "ft"];
+
+/// Select the entry whose name best matches `searched` (which MUST already
+/// be [`normalize_name`]d). An exact normalized match wins wherever it
+/// sits in the ranked list — so a homonym at index 0 can't shadow the real
+/// entry — and failing that the first canonical-connector prefix match is
+/// taken, preserving the provider's relevance order.
+///
+/// `name_of` extracts the raw (un-normalized) display name from each item;
+/// items without a name are skipped.
+pub fn select_by_name<T>(
+    items: impl IntoIterator<Item = T>,
+    searched: &str,
+    name_of: impl Fn(&T) -> Option<&str>,
+) -> Option<T> {
+    if searched.is_empty() {
+        return None;
+    }
+    let mut prefix_match: Option<T> = None;
+    for item in items {
+        let Some(candidate) = name_of(&item).map(normalize_name) else {
+            continue;
+        };
+        if candidate == searched {
+            return Some(item);
+        }
+        if prefix_match.is_none() && names_prefix_compatible(searched, &candidate) {
+            prefix_match = Some(item);
+        }
+    }
+    prefix_match
+}
+
+/// Normalise an artist name for fuzzy comparison: lowercase, fold common
+/// Latin diacritics, expand `&` to "and", drop punctuation and collapse
+/// whitespace to single spaces. "Boney M." and "Boney M" both become
+/// "boney m"; "Bob Marley & The Wailers" becomes "bob marley and the
+/// wailers"; "Beyoncé" becomes "beyonce". Non-Latin scripts (CJK, …) are
+/// preserved verbatim minus punctuation.
+pub fn normalize_name(name: &str) -> String {
+    let lowered = name.to_lowercase().replace('&', " and ");
+    let mut out = String::with_capacity(lowered.len());
+    let mut pending_space = false;
+    for ch in lowered.chars() {
+        // Drop NFD combining marks (the accent half of a decomposed
+        // character) so "Bjo\u{308}rk" folds to the same "bjork" as its
+        // precomposed NFC form — without this they'd act as a boundary
+        // and split the word. NOT a word boundary, so we `continue`
+        // rather than fall into the punctuation branch below.
+        if is_combining_mark(ch) {
+            continue;
+        }
+        let folded = fold_diacritic(ch);
+        if folded.is_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.push(folded);
+        } else {
+            // Punctuation or whitespace → a single word boundary.
+            pending_space = true;
+        }
+    }
+    out
+}
+
+/// True for Unicode nonspacing combining marks — the accent halves left
+/// standing in an NFD-decomposed string. Covers the standard combining
+/// blocks; dependency-free stand-in for the `Mn` general category so we
+/// don't pull in `unicode-normalization` just to fold accents.
+fn is_combining_mark(ch: char) -> bool {
+    matches!(ch as u32,
+        0x0300..=0x036F | // Combining Diacritical Marks
+        0x1AB0..=0x1AFF | // Combining Diacritical Marks Extended
+        0x1DC0..=0x1DFF | // Combining Diacritical Marks Supplement
+        0x20D0..=0x20FF | // Combining Diacritical Marks for Symbols
+        0xFE20..=0xFE2F,  // Combining Half Marks
+    )
+}
+
+/// Map a lowercase accented Latin char to its base letter; pass anything
+/// else through unchanged. Covers the accents common in Western artist
+/// names without pulling in a Unicode-normalization dependency.
+fn fold_diacritic(ch: char) -> char {
+    match ch {
+        'á' | 'à' | 'â' | 'ä' | 'ã' | 'å' | 'ā' | 'ą' => 'a',
+        'ç' | 'ć' | 'č' => 'c',
+        'é' | 'è' | 'ê' | 'ë' | 'ē' | 'ę' | 'ě' => 'e',
+        'í' | 'ì' | 'î' | 'ï' | 'ī' => 'i',
+        'ñ' | 'ń' => 'n',
+        'ó' | 'ò' | 'ô' | 'ö' | 'õ' | 'ø' | 'ō' => 'o',
+        'ś' | 'š' => 's',
+        'ú' | 'ù' | 'û' | 'ü' | 'ū' => 'u',
+        'ý' | 'ÿ' => 'y',
+        'ź' | 'ż' | 'ž' => 'z',
+        other => other,
+    }
+}
+
+/// True when the two normalized names denote the same artist under a
+/// canonical extension: one is the other followed by a recognized
+/// connector — "bob marley" ↔ "bob marley and the wailers".
+///
+/// A bare word-boundary prefix is deliberately NOT enough. A
+/// parenthetical disambiguator like "nirvana 60s band" (from "Nirvana
+/// (60s band)") is a *different* artist that happens to share a leading
+/// word, so the extension's first token must be an actual connector or we
+/// reject it. Both inputs are single-space-joined with no leading/trailing
+/// space, so the connector always sits right after the shared prefix.
+fn names_prefix_compatible(a: &str, b: &str) -> bool {
+    let (short, long) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    if short.is_empty() {
+        return false;
+    }
+    let Some(rest) = long.strip_prefix(short) else {
+        return false;
+    };
+    // Word-boundary split, then require a known connector as the first
+    // token of the extension.
+    let Some(tail) = rest.strip_prefix(' ') else {
+        return false;
+    };
+    tail.split(' ')
+        .next()
+        .is_some_and(|token| CANONICAL_CONNECTORS.contains(&token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pick<'a>(names: &[&'a str], searched: &str) -> Option<&'a str> {
+        select_by_name(names.iter().copied(), &normalize_name(searched), |n| {
+            Some(*n)
+        })
+    }
+
+    #[test]
+    fn normalize_folds_punctuation_case_and_diacritics() {
+        assert_eq!(normalize_name("Boney M."), "boney m");
+        assert_eq!(normalize_name("Boney M"), "boney m");
+        assert_eq!(
+            normalize_name("Bob Marley & The Wailers"),
+            "bob marley and the wailers"
+        );
+        assert_eq!(normalize_name("Beyoncé"), "beyonce");
+        assert_eq!(normalize_name("Guns N' Roses"), "guns n roses");
+        // Non-Latin script survives (minus punctuation).
+        assert_eq!(normalize_name("宇多田ヒカル"), "宇多田ヒカル");
+    }
+
+    #[test]
+    fn normalize_is_stable_across_nfc_and_nfd_forms() {
+        // "Björk": precomposed ö (NFC) vs o + combining diaeresis (NFD).
+        let bjork_nfc = "Bj\u{00F6}rk";
+        let bjork_nfd = "Bjo\u{0308}rk";
+        assert_eq!(normalize_name(bjork_nfc), "bjork");
+        assert_eq!(normalize_name(bjork_nfd), "bjork");
+        assert_eq!(normalize_name(bjork_nfc), normalize_name(bjork_nfd));
+
+        // "Beyoncé": precomposed é (NFC) vs e + combining acute (NFD).
+        let beyonce_nfc = "Beyonc\u{00E9}";
+        let beyonce_nfd = "Beyonce\u{0301}";
+        assert_eq!(normalize_name(beyonce_nfd), "beyonce");
+        assert_eq!(normalize_name(beyonce_nfc), normalize_name(beyonce_nfd));
+    }
+
+    #[test]
+    fn exact_match_wins_regardless_of_position() {
+        // The relevant entry sits after a homonym; exact match must still win.
+        assert_eq!(
+            pick(&["Nirvana (60s band)", "Nirvana"], "Nirvana"),
+            Some("Nirvana")
+        );
+    }
+
+    #[test]
+    fn accentless_library_name_matches_accented_entry() {
+        // TheAudioDB / Deezer search is accent-insensitive, so "Celine
+        // Dion" (no accent) still returns "Céline Dion"; the client match
+        // must survive the accent difference — jo-el414's report on #342.
+        assert_eq!(pick(&["Céline Dion"], "Celine Dion"), Some("Céline Dion"));
+    }
+
+    #[test]
+    fn punctuation_only_difference_matches() {
+        assert_eq!(pick(&["Boney M"], "Boney M."), Some("Boney M"));
+    }
+
+    #[test]
+    fn superset_name_matches_via_connector() {
+        assert_eq!(
+            pick(&["Bob Marley & The Wailers"], "Bob Marley"),
+            Some("Bob Marley & The Wailers")
+        );
+    }
+
+    #[test]
+    fn prefers_exact_over_prefix() {
+        assert_eq!(
+            pick(&["Bob Marley & The Wailers", "Bob Marley"], "Bob Marley"),
+            Some("Bob Marley")
+        );
+    }
+
+    #[test]
+    fn rejects_unrelated_homonym() {
+        assert_eq!(pick(&["Bob Dylan"], "Bob Marley"), None);
+        assert!(!names_prefix_compatible("bob marley", "bob dylan"));
+    }
+
+    #[test]
+    fn rejects_parenthetical_homonym_when_alone() {
+        // "Nirvana (60s band)" alone must NOT satisfy a "Nirvana" search —
+        // the " 60s band" suffix is a disambiguator, not a connector.
+        assert_eq!(pick(&["Nirvana (60s band)"], "Nirvana"), None);
+        assert!(!names_prefix_compatible(
+            "nirvana",
+            &normalize_name("Nirvana (60s band)")
+        ));
+        // But a real connector suffix still matches.
+        assert!(names_prefix_compatible("nirvana", "nirvana and the deep sea"));
+    }
+
+    #[test]
+    fn empty_search_is_none() {
+        assert_eq!(pick(&["Anything"], ""), None);
+    }
+}

--- a/src-tauri/crates/core/src/metadata/name_match.rs
+++ b/src-tauri/crates/core/src/metadata/name_match.rs
@@ -210,6 +210,18 @@ mod tests {
     }
 
     #[test]
+    fn superset_search_matches_subset_candidate() {
+        // Reverse of `superset_name_matches_via_connector`: the *search*
+        // is the long canonical name and the catalogue only carries the
+        // short one. Exercises the (short, long) swap in
+        // `names_prefix_compatible` from the other side.
+        assert_eq!(
+            pick(&["Bob Marley"], "Bob Marley & The Wailers"),
+            Some("Bob Marley")
+        );
+    }
+
+    #[test]
     fn prefers_exact_over_prefix() {
         assert_eq!(
             pick(&["Bob Marley & The Wailers", "Bob Marley"], "Bob Marley"),

--- a/src-tauri/crates/core/src/metadata/theaudiodb.rs
+++ b/src-tauri/crates/core/src/metadata/theaudiodb.rs
@@ -17,6 +17,8 @@
 
 use serde::Deserialize;
 
+use crate::metadata::name_match::{normalize_name, select_by_name};
+
 const BASE_URL: &str = "https://www.theaudiodb.com/api/v1/json";
 const FREE_API_KEY: &str = "123";
 const USER_AGENT: &str = "WaveFlow/0.1";
@@ -124,8 +126,10 @@ impl TheAudioDbClient {
             .json()
             .await?;
 
-        let Some(artist) =
-            resp.artists.and_then(|artists| pick_artist(artists, &normalize_name(name)))
+        let searched = normalize_name(name);
+        let Some(artist) = resp
+            .artists
+            .and_then(|artists| select_by_name(artists, &searched, |a| a.name.as_deref()))
         else {
             return Ok(None);
         };
@@ -151,140 +155,6 @@ fn non_blank(value: &Option<String>) -> Option<String> {
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string)
-}
-
-/// Pick the artist entry that best matches the normalized search term.
-///
-/// TheAudioDB's `search.php?s=<name>` returns a *relevance-ranked* array,
-/// but the top hit is often a canonical superset ("Bob Marley & The
-/// Wailers" for a library tagged "Bob Marley"). The old code took index 0
-/// and demanded an exact case-insensitive name equality, so any such
-/// superset — or a mere punctuation difference like "Boney M." vs
-/// "Boney M" — silently dropped the bio (issue #342).
-///
-/// Now we scan the whole list: an exact normalized match wins wherever it
-/// sits, and failing that we accept the first word-boundary prefix match
-/// in either direction (subset ↔ superset). Normalization folds case,
-/// common Latin diacritics, `&`/"and", punctuation and whitespace, so
-/// homonym protection is preserved (unrelated names still don't match)
-/// while trivial spelling variance no longer blocks a hit.
-fn pick_artist(artists: Vec<ArtistPayload>, searched: &str) -> Option<ArtistPayload> {
-    if searched.is_empty() {
-        return None;
-    }
-    let mut prefix_match: Option<ArtistPayload> = None;
-    for artist in artists {
-        let Some(candidate) = artist.name.as_deref().map(normalize_name) else {
-            continue;
-        };
-        if candidate == searched {
-            return Some(artist);
-        }
-        if prefix_match.is_none() && names_prefix_compatible(searched, &candidate) {
-            prefix_match = Some(artist);
-        }
-    }
-    prefix_match
-}
-
-/// Normalise an artist name for fuzzy comparison: lowercase, fold common
-/// Latin diacritics, expand `&` to "and", drop punctuation and collapse
-/// whitespace to single spaces. "Boney M." and "Boney M" both become
-/// "boney m"; "Bob Marley & The Wailers" becomes "bob marley and the
-/// wailers"; "Beyoncé" becomes "beyonce". Non-Latin scripts (CJK, …) are
-/// preserved verbatim minus punctuation.
-fn normalize_name(name: &str) -> String {
-    let lowered = name.to_lowercase().replace('&', " and ");
-    let mut out = String::with_capacity(lowered.len());
-    let mut pending_space = false;
-    for ch in lowered.chars() {
-        // Drop NFD combining marks (the accent half of a decomposed
-        // character) so "Bjo\u{308}rk" folds to the same "bjork" as its
-        // precomposed NFC form — without this they'd act as a boundary
-        // and split the word. NOT a word boundary, so we `continue`
-        // rather than fall into the punctuation branch below.
-        if is_combining_mark(ch) {
-            continue;
-        }
-        let folded = fold_diacritic(ch);
-        if folded.is_alphanumeric() {
-            if pending_space && !out.is_empty() {
-                out.push(' ');
-            }
-            pending_space = false;
-            out.push(folded);
-        } else {
-            // Punctuation or whitespace → a single word boundary.
-            pending_space = true;
-        }
-    }
-    out
-}
-
-/// True for Unicode nonspacing combining marks — the accent halves left
-/// standing in an NFD-decomposed string. Covers the standard combining
-/// blocks; dependency-free stand-in for the `Mn` general category so we
-/// don't pull in `unicode-normalization` just to fold accents.
-fn is_combining_mark(ch: char) -> bool {
-    matches!(ch as u32,
-        0x0300..=0x036F | // Combining Diacritical Marks
-        0x1AB0..=0x1AFF | // Combining Diacritical Marks Extended
-        0x1DC0..=0x1DFF | // Combining Diacritical Marks Supplement
-        0x20D0..=0x20FF | // Combining Diacritical Marks for Symbols
-        0xFE20..=0xFE2F,  // Combining Half Marks
-    )
-}
-
-/// Map a lowercase accented Latin char to its base letter; pass anything
-/// else through unchanged. Covers the accents common in Western artist
-/// names without pulling in a Unicode-normalization dependency.
-fn fold_diacritic(ch: char) -> char {
-    match ch {
-        'á' | 'à' | 'â' | 'ä' | 'ã' | 'å' | 'ā' | 'ą' => 'a',
-        'ç' | 'ć' | 'č' => 'c',
-        'é' | 'è' | 'ê' | 'ë' | 'ē' | 'ę' | 'ě' => 'e',
-        'í' | 'ì' | 'î' | 'ï' | 'ī' => 'i',
-        'ñ' | 'ń' => 'n',
-        'ó' | 'ò' | 'ô' | 'ö' | 'õ' | 'ø' | 'ō' => 'o',
-        'ś' | 'š' => 's',
-        'ú' | 'ù' | 'û' | 'ü' | 'ū' => 'u',
-        'ý' | 'ÿ' => 'y',
-        'ź' | 'ż' | 'ž' => 'z',
-        other => other,
-    }
-}
-
-/// Connectors that open a canonical "backing band" / collaboration
-/// extension after normalization (`&` is already folded to "and"). Only a
-/// suffix starting with one of these promotes a prefix into a match.
-const CANONICAL_CONNECTORS: [&str; 5] = ["and", "with", "feat", "featuring", "ft"];
-
-/// True when the two normalized names denote the same artist under a
-/// canonical extension: one is the other followed by a recognized
-/// connector — "bob marley" ↔ "bob marley and the wailers".
-///
-/// A bare word-boundary prefix is deliberately NOT enough. A
-/// parenthetical disambiguator like "nirvana 60s band" (from "Nirvana
-/// (60s band)") is a *different* artist that happens to share a leading
-/// word, so the extension's first token must be an actual connector or we
-/// reject it. Both inputs are single-space-joined with no leading/trailing
-/// space, so the connector always sits right after the shared prefix.
-fn names_prefix_compatible(a: &str, b: &str) -> bool {
-    let (short, long) = if a.len() <= b.len() { (a, b) } else { (b, a) };
-    if short.is_empty() {
-        return false;
-    }
-    let Some(rest) = long.strip_prefix(short) else {
-        return false;
-    };
-    // Word-boundary split, then require a known connector as the first
-    // token of the extension.
-    let Some(tail) = rest.strip_prefix(' ') else {
-        return false;
-    };
-    tail.split(' ')
-        .next()
-        .is_some_and(|token| CANONICAL_CONNECTORS.contains(&token))
 }
 
 /// Normalise line endings and trim. TheAudioDB bios are plain text
@@ -362,129 +232,5 @@ mod tests {
         };
         assert_eq!(payload.bio_for_lang("fr").as_deref(), Some("English bio"));
         assert_eq!(payload.bio_for_lang("de").as_deref(), Some("English bio"));
-    }
-
-    /// Build a payload with only a name + an English bio derived from it,
-    /// so tests can assert *which* entry `pick_artist` selected.
-    fn named(name: &str) -> ArtistPayload {
-        ArtistPayload {
-            name: Some(name.into()),
-            bio_en: Some(format!("bio of {name}")),
-            bio_fr: None,
-            bio_de: None,
-            bio_es: None,
-            bio_it: None,
-            bio_pt: None,
-            bio_nl: None,
-            bio_ru: None,
-            bio_jp: None,
-            bio_cn: None,
-        }
-    }
-
-    #[test]
-    fn normalize_folds_punctuation_case_and_diacritics() {
-        assert_eq!(normalize_name("Boney M."), "boney m");
-        assert_eq!(normalize_name("Boney M"), "boney m");
-        assert_eq!(
-            normalize_name("Bob Marley & The Wailers"),
-            "bob marley and the wailers"
-        );
-        assert_eq!(normalize_name("Beyoncé"), "beyonce");
-        assert_eq!(normalize_name("Guns N' Roses"), "guns n roses");
-        // Non-Latin script survives (minus punctuation).
-        assert_eq!(normalize_name("宇多田ヒカル"), "宇多田ヒカル");
-    }
-
-    #[test]
-    fn normalize_is_stable_across_nfc_and_nfd_forms() {
-        // "Björk": precomposed ö (NFC) vs o + combining diaeresis (NFD).
-        let bjork_nfc = "Bj\u{00F6}rk";
-        let bjork_nfd = "Bjo\u{0308}rk";
-        assert_eq!(normalize_name(bjork_nfc), "bjork");
-        assert_eq!(normalize_name(bjork_nfd), "bjork");
-        assert_eq!(normalize_name(bjork_nfc), normalize_name(bjork_nfd));
-
-        // "Beyoncé": precomposed é (NFC) vs e + combining acute (NFD).
-        let beyonce_nfc = "Beyonc\u{00E9}";
-        let beyonce_nfd = "Beyonce\u{0301}";
-        assert_eq!(normalize_name(beyonce_nfd), "beyonce");
-        assert_eq!(normalize_name(beyonce_nfc), normalize_name(beyonce_nfd));
-    }
-
-    #[test]
-    fn pick_exact_match_wins_regardless_of_position() {
-        // The relevant entry sits after a homonym; exact match must still win.
-        let artists = vec![named("Nirvana (60s band)"), named("Nirvana")];
-        let picked = pick_artist(artists, &normalize_name("Nirvana")).unwrap();
-        assert_eq!(picked.name.as_deref(), Some("Nirvana"));
-    }
-
-    #[test]
-    fn pick_matches_accentless_library_name_to_accented_entry() {
-        // TheAudioDB's search is accent-insensitive, so a library artist
-        // tagged "Celine Dion" (no accent) still gets "Céline Dion" back;
-        // the client match must then survive the accent difference —
-        // exactly jo-el414's report on #342. Both forms normalize to
-        // "celine dion", so it's an exact match, not a fuzzy fallback.
-        let artists = vec![named("Céline Dion")];
-        let picked = pick_artist(artists, &normalize_name("Celine Dion")).unwrap();
-        assert_eq!(picked.name.as_deref(), Some("Céline Dion"));
-    }
-
-    #[test]
-    fn pick_punctuation_only_difference_matches() {
-        // "Boney M." (search) vs "Boney M" (DB) — issue #342.
-        let artists = vec![named("Boney M")];
-        let picked = pick_artist(artists, &normalize_name("Boney M.")).unwrap();
-        assert_eq!(picked.name.as_deref(), Some("Boney M"));
-    }
-
-    #[test]
-    fn pick_superset_name_matches_via_prefix() {
-        // Library tagged "Bob Marley", TheAudioDB canonical is the band — #342.
-        let artists = vec![named("Bob Marley & The Wailers")];
-        let picked = pick_artist(artists, &normalize_name("Bob Marley")).unwrap();
-        assert_eq!(picked.name.as_deref(), Some("Bob Marley & The Wailers"));
-    }
-
-    #[test]
-    fn pick_prefers_exact_over_prefix() {
-        let artists = vec![named("Bob Marley & The Wailers"), named("Bob Marley")];
-        let picked = pick_artist(artists, &normalize_name("Bob Marley")).unwrap();
-        assert_eq!(picked.name.as_deref(), Some("Bob Marley"));
-    }
-
-    #[test]
-    fn pick_rejects_unrelated_homonym() {
-        // "Bob Dylan" must not satisfy a "Bob Marley" search.
-        let artists = vec![named("Bob Dylan")];
-        assert!(pick_artist(artists, &normalize_name("Bob Marley")).is_none());
-        // A shared first word alone is not a word-boundary prefix match.
-        assert!(!names_prefix_compatible("bob marley", "bob dylan"));
-    }
-
-    #[test]
-    fn pick_rejects_parenthetical_homonym_when_alone() {
-        // "Nirvana (60s band)" as the ONLY result must NOT satisfy a
-        // "Nirvana" search — the " 60s band" suffix is a disambiguator,
-        // not a canonical backing-band connector. Isolated from any exact
-        // match so the fallback is what's under test.
-        let artists = vec![named("Nirvana (60s band)")];
-        assert!(pick_artist(artists, &normalize_name("Nirvana")).is_none());
-        assert!(!names_prefix_compatible(
-            "nirvana",
-            &normalize_name("Nirvana (60s band)")
-        ));
-        // But a real connector suffix still matches.
-        assert!(names_prefix_compatible(
-            "nirvana",
-            "nirvana and the deep sea"
-        ));
-    }
-
-    #[test]
-    fn pick_empty_search_is_none() {
-        assert!(pick_artist(vec![named("Anything")], "").is_none());
     }
 }


### PR DESCRIPTION
Fixes #382 — follow-up to #342/#381.

## Problem
`enrich_artist_deezer` selected the Deezer hit with an exact case-insensitive equality:
```rust
let canonical = artist_name.to_lowercase();
hits.into_iter().find(|h| h.name.to_lowercase() == canonical)
```
That's the same too-strict match #342 fixed for TheAudioDB. Deezer's search is accent-insensitive (`Celine Dion` → `Céline Dion`), so the filter dropped the hit and the artist **picture / cover / fan count** stayed un-enriched — same story for `Bob Marley & The Wailers` supersets and `Boney M.` punctuation.

## Change
- New shared module `waveflow_core::metadata::name_match`: `normalize_name` (case + Latin diacritics + NFD combining marks + `&`/and + punctuation) and a generic `select_by_name<T>` (exact-first, then canonical-connector prefix).
- `theaudiodb.rs` now delegates to it — **no behavior change**; its 10 selection/normalization tests move to `name_match` verbatim (re-expressed over `&str` candidates) and still pass.
- `deezer.rs` routes `search_artist` hits through `select_by_name`.

Net: one matcher, two providers, identical semantics. No new dependency.

## Verification
- `cargo test -p waveflow-core --lib metadata::` — 21 passed (10 `name_match` incl. Céline Dion / Bob Marley / Nirvana-disambiguator / NFC-NFD, + theaudiodb bio/summary).
- `cargo check -p waveflow --lib` — clean, no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Améliorations**
  - Amélioration de la sélection des artistes lors des recherches Deezer et TheAudioDB.
  - Meilleure correspondance des noms malgré les variations de casse, de ponctuation et de diacritiques (accents).
  - Prise en charge renforcée des variantes utilisant des connecteurs tels que « and », « with », « feat » ou « featuring ».
  - Réduction des risques d’association à un mauvais homonyme, y compris pour les libellés de disambiguation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->