### PR TITLE
fix(app): drive splash handoff from one reveal task, not a shared flag

### DIFF
--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -498,50 +498,49 @@ pub fn run() {
             // A 15 s safety-net timer force-reveals the main window if
             // `app://ready` never fires — guards against a frontend
             // crash leaving the user stuck on an eternal splash.
-            let handoff_done = Arc::new(AtomicBool::new(false));
-            let handoff_handle = app.handle().clone();
-            let handoff_done_for_event = handoff_done.clone();
+            // Driven by a single reveal task so there is exactly one
+            // owner of the handoff. `app://ready` merely *notifies* it;
+            // the task waits for that signal OR the 15 s deadline
+            // (whichever comes first), then reveals the main window,
+            // retrying until a reveal actually succeeds. The previous
+            // shared-`AtomicBool` coordination let the fallback observe
+            // the flag the event handler had already set and `return`
+            // before the event's own reveal task finished — so if that
+            // task then failed, nobody retried and the user was stuck on
+            // the splash (issue #363). One owner + retry-until-success
+            // removes both the race and the double-reveal window.
+            let ready = Arc::new(tokio::sync::Notify::new());
+            let ready_for_event = ready.clone();
             app.listen("app://ready", move |_event| {
-                if handoff_done_for_event.swap(true, Ordering::SeqCst) {
-                    return;
-                }
-                let app_for_reveal = handoff_handle.clone();
-                let done_flag = handoff_done_for_event.clone();
-                tauri::async_runtime::spawn(async move {
-                    if !restore_bounds_and_reveal(app_for_reveal).await {
-                        done_flag.store(false, Ordering::SeqCst);
-                    }
-                });
+                ready_for_event.notify_one();
             });
 
-            let fallback_handle = app.handle().clone();
-            let fallback_done = handoff_done.clone();
+            let reveal_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
-                // First attempt after 15 s; subsequent retries every
-                // 250 ms up to 10 total attempts. Bounded so a
-                // permanently missing main window doesn't spin forever
-                // (the warn! log surfaces it instead). The retry exists
-                // because `ReadySignal` only emits `app://ready` once
-                // at mount — if we lost the race with that single
-                // event AND the first reveal failed, without a retry
-                // the user would be stuck on the splash.
-                tokio::time::sleep(Duration::from_secs(15)).await;
+                // `notify_one` stores a permit even when it fires before
+                // we reach this await, so an early `app://ready` (racing
+                // the heavy first-launch init) is never lost.
+                tokio::select! {
+                    _ = ready.notified() => {}
+                    _ = tokio::time::sleep(Duration::from_secs(15)) => {
+                        tracing::warn!(
+                            "splash handoff: `app://ready` never fired in 15s, force-revealing main window"
+                        );
+                    }
+                }
+                // Retry until a reveal actually succeeds. Bounded (10 ×
+                // 250 ms) so a permanently missing main window logs an
+                // error instead of spinning forever; each attempt re-runs
+                // the full reveal (show main + close splash).
                 for attempt in 0..10 {
-                    if fallback_done.swap(true, Ordering::SeqCst) {
+                    if restore_bounds_and_reveal(reveal_handle.clone()).await {
                         return;
                     }
-                    tracing::warn!(
-                        attempt,
-                        "splash handoff fallback: `app://ready` never fired in time, force-revealing main window"
-                    );
-                    if restore_bounds_and_reveal(fallback_handle.clone()).await {
-                        return;
-                    }
-                    fallback_done.store(false, Ordering::SeqCst);
+                    tracing::warn!(attempt, "splash handoff: reveal attempt failed, retrying");
                     tokio::time::sleep(Duration::from_millis(250)).await;
                 }
                 tracing::error!(
-                    "splash handoff fallback: exhausted 10 reveal attempts, user is likely stuck on splash"
+                    "splash handoff: exhausted 10 reveal attempts, user is likely stuck on splash"
                 );
             });
 


### PR DESCRIPTION
Fixes #363.

## The race
The splash → main handoff coordinated two producers — the `app://ready` listener and the 15 s fallback timer — through a shared `AtomicBool` (`handoff_done`):

1. `app://ready` fires → listener `swap(true)` (was false) → spawns `restore_bounds_and_reveal`.
2. The 15 s fallback fires **while that task is still in flight** → its own `swap(true)` reads `true` → `return`, permanently exiting the retry loop.
3. The primary reveal then **fails** (`restore_bounds_and_reveal` → false, e.g. a slow SQLite read under `SQLITE_BUSY`) → resets the flag to `false`, but nobody is watching → user stuck on the splash — the exact case the fallback exists to prevent.

Surfaced by CodeRabbit on #362. Astronomically unlikely (needs `app://ready` to have fired *and* its task still running at the 15 s deadline) but a real correctness hole on the boot-critical path.

## The fix
Collapse the two producers into **one reveal task** so there's a single owner:
- `app://ready` merely `notify_one`s a `tokio::sync::Notify`.
- The task `select!`s on that signal vs a 15 s deadline, then reveals with a **bounded retry-until-success** (10 × 250 ms).

Properties this gives us, matching the issue's ask:
- **Retries after a failed restore** (the event path used to do a single no-retry attempt).
- **Only stops after a successful reveal** — no producer can short-circuit another's in-flight attempt.
- **No double-reveal** — only one task ever calls `restore_bounds_and_reveal`.
- **No lost wakeup** — `notify_one` stores a permit, so an early `app://ready` racing the heavy first-launch init still releases the `select!`.

Net −1 line, removes the shared `AtomicBool` + its two clones entirely.

## Verification
- `cargo check -p waveflow --lib` — clean, no warnings.
- Boot-critical concurrency path — **not unit-testable** (needs a live Tauri app). Reasoned through the ordering above; a manual launch (normal path + a forced-slow/failed first reveal) would be the belt-and-braces check the issue itself called for. Same class of change as the v1.1.1 splash fix, which shipped without automated coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correctifs**
  * Amélioration de l’affichage de la fenêtre principale après l’écran de démarrage.
  * Ajout de nouvelles tentatives automatiques en cas d’échec temporaire, afin de garantir l’ouverture correcte de l’application.
  * Réduction des risques de blocage lorsque le signal de chargement est reçu trop tôt ou qu’une première tentative échoue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->