### PR TITLE
fix(scan): resurface a byte-identical re-added track on rescan

### DIFF
--- a/src-tauri/crates/app/src/commands/scan.rs
+++ b/src-tauri/crates/app/src/commands/scan.rs
@@ -719,11 +719,19 @@ pub(crate) async fn scan_folder_inner(
                     }
                 }
 
+                // `is_available = 1` resurfaces a track whose file had
+                // vanished (marked `is_available = 0` by a prior scan)
+                // and has now reappeared BYTE-IDENTICAL. This skip branch
+                // is the only path that handles an unchanged re-add — the
+                // full-rewrite `else` branch also sets it, but a same
+                // mtime+hash file never reaches there — so without this
+                // the row stays hidden forever (issue #366, symptom B).
                 sqlx::query(
                     "UPDATE track
-                        SET bit_depth   = COALESCE(bit_depth, ?),
-                            codec       = COALESCE(codec, ?),
-                            musical_key = COALESCE(musical_key, ?)
+                        SET bit_depth    = COALESCE(bit_depth, ?),
+                            codec        = COALESCE(codec, ?),
+                            musical_key  = COALESCE(musical_key, ?),
+                            is_available = 1
                       WHERE id = ?",
                 )
                 .bind(extracted.bit_depth)


### PR DESCRIPTION
Refs #366 (symptom B — the "more serious one").

## Root cause
When a file vanishes it's marked `is_available = 0` (scanner's `removed` path). On a later rescan the probe finds the row — it has **no `is_available` filter** (`WHERE library_id = ? AND file_path IN (...)`), by design, so a vanished-then-restored track is meant to be flipped back to available.

But if the re-added file is **byte-identical** (same mtime + hash), it lands in the *skip* branch, which only backfilled cover / codec / multi-artist and **never set `is_available = 1`**. The full-rewrite `else` branch does set it — but a same mtime+hash file never reaches there. So the track stayed `is_available = 0` (invisible) forever, and the only user workaround was wiping the whole library — which then triggers the stats loss in #367.

Repro:
1. Scan a folder → tracks visible.
2. Delete the files on disk, rescan → tracks marked unavailable (`removed=N`).
3. Put the identical files back, rescan → **tracks do not reappear** (before this fix).

## Fix
Add `is_available = 1` to the skip branch's existing `UPDATE track` (one clause, no new query). Now step 3 resurfaces the track.

No sync emit is needed: an `is_available` flip doesn't round-trip — the `0` was never emitted as a delete (documented convention), so the server row still exists and simply becomes visible again locally.

## Scope
Symptom **A** in the same issue (metadata/artwork-only edits skipped because the `(mtime, size)` fast path doesn't see them) is a separate decision about the fast-path contract — deferred, issue stays open for it.

## Verification
- `cargo check -p waveflow --lib` — clean.
- Not unit-tested: the reconciliation lives in `scan_folder_inner`, which needs a live Tauri `emit` context + real files + a profile pool, so there's no harness for it. High confidence from the symmetry argument — the sibling `else` branch already sets `is_available = 1` for the changed-file case; this closes the identical-file gap. Manual repro above is the belt-and-braces check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Corrections de bugs**
  * Les pistes redevenues disponibles après un scan sont désormais correctement réactivées.
  * Les fichiers identiques déjà analysés ne restent plus masqués lorsqu’ils réapparaissent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->