### PR TITLE
feat(maintenance): safety-backup every profile before reset_app wipes

### DIFF
--- a/src-tauri/crates/app/src/commands/maintenance.rs
+++ b/src-tauri/crates/app/src/commands/maintenance.rs
@@ -12,8 +12,7 @@ use tauri::AppHandle;
 use crate::{
     audio::AudioEngine,
     commands::profile_io::{
-        checkpoint_wal, read_include_metadata_artwork, write_archive, ArchiveManifest,
-        ARCHIVE_VERSION,
+        read_include_metadata_artwork, write_archive, ArchiveManifest, ARCHIVE_VERSION,
     },
     error::{AppError, AppResult},
     state::AppState,
@@ -127,9 +126,9 @@ pub async fn reset_app(
     // profile to a wipe-surviving folder BEFORE tearing anything down, so
     // a user who resets can re-import their playlists + listening history
     // (`play_event`) afterwards. Runs while the active pool is still open
-    // so the WAL checkpoint captures a complete `data.db`. Best-effort —
-    // it must never block the reset (a backup error is not a reason to
-    // trap the user in a broken install).
+    // so the `VACUUM INTO` snapshot sees a consistent, complete `data.db`.
+    // Best-effort — it must never block the reset (a backup error is not a
+    // reason to trap the user in a broken install).
     if let Some(dir) = safety_backup_all_profiles(&state).await {
         tracing::info!(
             dir = %dir.display(),
@@ -204,22 +203,10 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
             }
         };
 
-    // Fold each profile's pending WAL pages into its main file so the
-    // raw `data.db` copy is a complete, consistent snapshot. The active
-    // profile goes through its live pool; inactive profiles have no open
-    // pool, so their WAL is checkpointed per-file below (a closed pool
-    // isn't guaranteed to have TRUNCATE-checkpointed on close, so copying
-    // data.db alone could otherwise miss their newest committed writes).
     let active_id = {
         let guard = state.profile.read().await;
         guard.as_ref().map(|p| p.profile_id)
     };
-    if let Ok(pool) = state.require_profile_pool().await {
-        if let Err(err) = checkpoint_wal(&pool).await {
-            tracing::warn!(?err, "pre-reset safety backup: active WAL checkpoint failed; snapshot may miss the newest writes");
-        }
-    }
-
     let include_meta = read_include_metadata_artwork(&state.app_db)
         .await
         .unwrap_or(true);
@@ -232,10 +219,33 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
         let artwork_dir = state.paths.profile_artwork_dir(profile_id);
         let metadata_artwork_dir = include_meta.then(|| state.paths.metadata_artwork_dir.clone());
 
-        if Some(profile_id) != active_id {
-            if let Err(err) = checkpoint_db_file(&db_path).await {
-                tracing::warn!(?err, profile_id, "pre-reset safety backup: inactive-profile WAL checkpoint failed; its snapshot may miss the newest writes");
+        let final_target = target_dir.join(format!(
+            "pre-reset-{}-{profile_id}-{stamp}.waveflow",
+            sanitize_filename(&profile_name)
+        ));
+        let tmp_target = final_target.with_extension("part");
+        let snapshot_db = final_target.with_extension("dbtmp");
+
+        // 1. Snapshot the db with `VACUUM INTO` instead of raw-copying the
+        //    live `data.db`. `reset_app` stops the audio engine but does
+        //    not freeze the background analyzer / scanner / sync writers,
+        //    and the active pool stays open — so a raw copy could capture
+        //    a torn db if a writer commits or a WAL checkpoint fires mid
+        //    copy. VACUUM INTO reads a single committed point-in-time view
+        //    even under concurrent writes. On failure we skip the profile:
+        //    a corrupt archive is a worse safety net than none.
+        let snapshot_res = if Some(profile_id) == active_id {
+            match state.require_profile_pool().await {
+                Ok(pool) => vacuum_into(&pool, &snapshot_db).await,
+                Err(err) => Err(err),
             }
+        } else {
+            vacuum_into_file(&db_path, &snapshot_db).await
+        };
+        if let Err(err) = snapshot_res {
+            tracing::warn!(?err, profile_id, "pre-reset safety backup: db snapshot failed; skipping this profile");
+            let _ = std::fs::remove_file(&snapshot_db);
+            continue;
         }
 
         let manifest = ArchiveManifest {
@@ -246,23 +256,18 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
             exported_at: Utc::now().to_rfc3339(),
         };
 
-        let final_target = target_dir.join(format!(
-            "pre-reset-{}-{profile_id}-{stamp}.waveflow",
-            sanitize_filename(&profile_name)
-        ));
-        // Write to a temp sibling and rename on success so a failed or
-        // interrupted archive never leaves a truncated `.waveflow` that
-        // looks like a valid backup. Same directory → the rename is an
-        // atomic same-filesystem move.
-        let tmp_target = final_target.with_extension("part");
-
+        // 2. Archive the SNAPSHOT (not the live db) + artwork into a temp
+        //    `.part` sibling, renamed to the final name only on success so
+        //    a failed/interrupted write never leaves a truncated file that
+        //    looks like a valid backup (same dir → atomic rename).
         let write_res = tokio::task::spawn_blocking({
             let tmp_target = tmp_target.clone();
+            let snapshot_db = snapshot_db.clone();
             move || {
                 write_archive(
                     &tmp_target,
                     &profile_dir,
-                    &db_path,
+                    &snapshot_db,
                     &artwork_dir,
                     metadata_artwork_dir.as_deref(),
                     &manifest,
@@ -270,6 +275,10 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
             }
         })
         .await;
+        // The snapshot has been folded into the archive (or the write
+        // failed) — drop it either way.
+        let _ = std::fs::remove_file(&snapshot_db);
+
         match write_res {
             Ok(Ok(())) => match std::fs::rename(&tmp_target, &final_target) {
                 Ok(()) => written += 1,
@@ -292,29 +301,46 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
     (written > 0).then_some(target_dir)
 }
 
-/// Checkpoint an on-disk profile database that has no open pool, folding
-/// its WAL back into the main file so a raw copy of `data.db` is a
-/// complete snapshot. Opens a short-lived connection — safe because an
-/// inactive profile holds no other connection — and TRUNCATE-checkpoints.
-async fn checkpoint_db_file(db_path: &Path) -> AppResult<()> {
+/// Write a transactionally-consistent snapshot of the database behind
+/// `pool` to `snapshot_path` via `VACUUM INTO`. Consistent even while
+/// other pool connections keep writing — the snapshot is a single
+/// committed point in time — so the subsequent raw copy into the archive
+/// can't capture a torn db.
+async fn vacuum_into(pool: &sqlx::SqlitePool, snapshot_path: &Path) -> AppResult<()> {
+    // VACUUM INTO refuses to overwrite an existing file.
+    let _ = std::fs::remove_file(snapshot_path);
+    sqlx::query("VACUUM INTO ?")
+        .bind(snapshot_path.to_string_lossy().as_ref())
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Like [`vacuum_into`] for a profile database with no open pool: opens a
+/// short-lived connection (safe — an inactive profile holds no other
+/// connection) and snapshots it.
+async fn vacuum_into_file(db_path: &Path, snapshot_path: &Path) -> AppResult<()> {
     use sqlx::sqlite::SqliteConnectOptions;
     use sqlx::{ConnectOptions, Connection};
 
     if !db_path.exists() {
-        return Ok(());
+        return Err(AppError::Other(format!(
+            "profile database not found: {}",
+            db_path.display()
+        )));
     }
     let mut conn = SqliteConnectOptions::new()
         .filename(db_path)
         .create_if_missing(false)
         .connect()
         .await?;
-    let checkpoint = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+    let _ = std::fs::remove_file(snapshot_path);
+    let res = sqlx::query("VACUUM INTO ?")
+        .bind(snapshot_path.to_string_lossy().as_ref())
         .execute(&mut conn)
         .await;
-    // Close regardless of the checkpoint result so we never leak the
-    // connection (which would itself leave a WAL behind).
     let _ = conn.close().await;
-    checkpoint?;
+    res?;
     Ok(())
 }
 
@@ -377,4 +403,71 @@ fn regen_in_dir(dir: &Path) -> AppResult<u32> {
         }
     }
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end check that the `VACUUM INTO ?` bound-parameter form
+    /// actually runs, creates the snapshot file, and yields a consistent
+    /// copy of the committed data — the crux of the pre-reset safety
+    /// backup's snapshot path.
+    #[tokio::test]
+    async fn vacuum_into_file_snapshots_committed_rows() {
+        use sqlx::sqlite::SqliteConnectOptions;
+        use sqlx::{ConnectOptions, Connection};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("data.db");
+        let snap_path = dir.path().join("snap.dbtmp");
+
+        {
+            let mut conn = SqliteConnectOptions::new()
+                .filename(&db_path)
+                .create_if_missing(true)
+                .connect()
+                .await
+                .unwrap();
+            sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+                .execute(&mut conn)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO t (v) VALUES ('hello')")
+                .execute(&mut conn)
+                .await
+                .unwrap();
+            conn.close().await.unwrap();
+        }
+
+        vacuum_into_file(&db_path, &snap_path).await.unwrap();
+        assert!(snap_path.exists(), "snapshot file should be created");
+
+        let mut snap = SqliteConnectOptions::new()
+            .filename(&snap_path)
+            .create_if_missing(false)
+            .connect()
+            .await
+            .unwrap();
+        let v: String = sqlx::query_scalar("SELECT v FROM t WHERE id = 1")
+            .fetch_one(&mut snap)
+            .await
+            .unwrap();
+        assert_eq!(v, "hello");
+        snap.close().await.unwrap();
+
+        // VACUUM INTO refuses to overwrite; the helper removes a stale
+        // snapshot first, so a second run must also succeed.
+        vacuum_into_file(&db_path, &snap_path).await.unwrap();
+    }
+
+    /// A missing profile database is a skip (Err), not a silent success —
+    /// the caller drops the profile rather than archiving an empty db.
+    #[tokio::test]
+    async fn vacuum_into_file_missing_db_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.db");
+        let snap = dir.path().join("snap.dbtmp");
+        assert!(vacuum_into_file(&missing, &snap).await.is_err());
+    }
 }

--- a/src-tauri/crates/app/src/commands/maintenance.rs
+++ b/src-tauri/crates/app/src/commands/maintenance.rs
@@ -204,12 +204,19 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
             }
         };
 
-    // Fold the active profile's pending WAL pages back into its main file
-    // so the copied `data.db` is a complete snapshot. Inactive profiles
-    // were already checkpointed when they were deactivated.
+    // Fold each profile's pending WAL pages into its main file so the
+    // raw `data.db` copy is a complete, consistent snapshot. The active
+    // profile goes through its live pool; inactive profiles have no open
+    // pool, so their WAL is checkpointed per-file below (a closed pool
+    // isn't guaranteed to have TRUNCATE-checkpointed on close, so copying
+    // data.db alone could otherwise miss their newest committed writes).
+    let active_id = {
+        let guard = state.profile.read().await;
+        guard.as_ref().map(|p| p.profile_id)
+    };
     if let Ok(pool) = state.require_profile_pool().await {
         if let Err(err) = checkpoint_wal(&pool).await {
-            tracing::warn!(?err, "pre-reset safety backup: WAL checkpoint failed; snapshot may miss the newest writes");
+            tracing::warn!(?err, "pre-reset safety backup: active WAL checkpoint failed; snapshot may miss the newest writes");
         }
     }
 
@@ -225,6 +232,12 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
         let artwork_dir = state.paths.profile_artwork_dir(profile_id);
         let metadata_artwork_dir = include_meta.then(|| state.paths.metadata_artwork_dir.clone());
 
+        if Some(profile_id) != active_id {
+            if let Err(err) = checkpoint_db_file(&db_path).await {
+                tracing::warn!(?err, profile_id, "pre-reset safety backup: inactive-profile WAL checkpoint failed; its snapshot may miss the newest writes");
+            }
+        }
+
         let manifest = ArchiveManifest {
             archive_version: ARCHIVE_VERSION,
             app_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -233,34 +246,76 @@ async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
             exported_at: Utc::now().to_rfc3339(),
         };
 
-        let target = target_dir.join(format!(
+        let final_target = target_dir.join(format!(
             "pre-reset-{}-{profile_id}-{stamp}.waveflow",
             sanitize_filename(&profile_name)
         ));
+        // Write to a temp sibling and rename on success so a failed or
+        // interrupted archive never leaves a truncated `.waveflow` that
+        // looks like a valid backup. Same directory → the rename is an
+        // atomic same-filesystem move.
+        let tmp_target = final_target.with_extension("part");
 
-        let res = tokio::task::spawn_blocking(move || {
-            write_archive(
-                &target,
-                &profile_dir,
-                &db_path,
-                &artwork_dir,
-                metadata_artwork_dir.as_deref(),
-                &manifest,
-            )
+        let write_res = tokio::task::spawn_blocking({
+            let tmp_target = tmp_target.clone();
+            move || {
+                write_archive(
+                    &tmp_target,
+                    &profile_dir,
+                    &db_path,
+                    &artwork_dir,
+                    metadata_artwork_dir.as_deref(),
+                    &manifest,
+                )
+            }
         })
         .await;
-        match res {
-            Ok(Ok(())) => written += 1,
+        match write_res {
+            Ok(Ok(())) => match std::fs::rename(&tmp_target, &final_target) {
+                Ok(()) => written += 1,
+                Err(err) => {
+                    tracing::warn!(?err, profile_id, "pre-reset safety backup: could not finalize archive; discarding partial");
+                    let _ = std::fs::remove_file(&tmp_target);
+                }
+            },
             Ok(Err(err)) => {
-                tracing::warn!(?err, profile_id, "pre-reset safety backup: archive failed for profile")
+                tracing::warn!(?err, profile_id, "pre-reset safety backup: archive failed for profile");
+                let _ = std::fs::remove_file(&tmp_target);
             }
             Err(err) => {
-                tracing::warn!(?err, profile_id, "pre-reset safety backup: task join failed for profile")
+                tracing::warn!(?err, profile_id, "pre-reset safety backup: task join failed for profile");
+                let _ = std::fs::remove_file(&tmp_target);
             }
         }
     }
 
     (written > 0).then_some(target_dir)
+}
+
+/// Checkpoint an on-disk profile database that has no open pool, folding
+/// its WAL back into the main file so a raw copy of `data.db` is a
+/// complete snapshot. Opens a short-lived connection — safe because an
+/// inactive profile holds no other connection — and TRUNCATE-checkpoints.
+async fn checkpoint_db_file(db_path: &Path) -> AppResult<()> {
+    use sqlx::sqlite::SqliteConnectOptions;
+    use sqlx::{ConnectOptions, Connection};
+
+    if !db_path.exists() {
+        return Ok(());
+    }
+    let mut conn = SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(false)
+        .connect()
+        .await?;
+    let checkpoint = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(&mut conn)
+        .await;
+    // Close regardless of the checkpoint result so we never leak the
+    // connection (which would itself leave a WAL behind).
+    let _ = conn.close().await;
+    checkpoint?;
+    Ok(())
 }
 
 /// Strip characters that are hostile in a filename down to `_`, so a

--- a/src-tauri/crates/app/src/commands/maintenance.rs
+++ b/src-tauri/crates/app/src/commands/maintenance.rs
@@ -1,15 +1,20 @@
 //! Maintenance commands. Bulk operations a user can trigger from the
 //! Settings screen (regenerate thumbnails, prune orphan covers, …).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use tauri::AppHandle;
 
 use crate::{
     audio::AudioEngine,
+    commands::profile_io::{
+        checkpoint_wal, read_include_metadata_artwork, write_archive, ArchiveManifest,
+        ARCHIVE_VERSION,
+    },
     error::{AppError, AppResult},
     state::AppState,
 };
@@ -118,6 +123,20 @@ pub async fn reset_app(
         );
     }
 
+    // Guard against irreversible data loss (issue #367): snapshot every
+    // profile to a wipe-surviving folder BEFORE tearing anything down, so
+    // a user who resets can re-import their playlists + listening history
+    // (`play_event`) afterwards. Runs while the active pool is still open
+    // so the WAL checkpoint captures a complete `data.db`. Best-effort —
+    // it must never block the reset (a backup error is not a reason to
+    // trap the user in a broken install).
+    if let Some(dir) = safety_backup_all_profiles(&state).await {
+        tracing::info!(
+            dir = %dir.display(),
+            "reset_app: pre-reset safety backup written; re-importable via the profile importer"
+        );
+    }
+
     let root = state.paths.root.clone();
 
     state.deactivate_profile().await;
@@ -146,6 +165,123 @@ pub async fn reset_app(
     }
 
     app.restart();
+}
+
+/// Write a complete `.waveflow` archive of every profile to a location
+/// that survives the `reset_app` wipe. The configured backup folder
+/// defaults to `<data-root>/backups`, which lives *inside* the directory
+/// the reset removes — so it can never be the safety target. We use the
+/// OS documents dir (`<documents>/WaveFlow Backups`, falling back to the
+/// home dir) instead: outside the wiped root and easy for the user to
+/// find afterwards.
+///
+/// Best-effort throughout — a failure on any single profile is logged and
+/// skipped, and a total failure returns `None` without aborting the
+/// caller. Returns the directory the archives landed in when at least one
+/// was written. Guard for issue #367.
+async fn safety_backup_all_profiles(state: &AppState) -> Option<PathBuf> {
+    let target_dir = dirs::document_dir()
+        .or_else(dirs::home_dir)
+        .map(|base| base.join("WaveFlow Backups"))?;
+    if let Err(err) = std::fs::create_dir_all(&target_dir) {
+        tracing::warn!(
+            ?err,
+            dir = %target_dir.display(),
+            "pre-reset safety backup: could not create target dir; skipping"
+        );
+        return None;
+    }
+
+    let profiles: Vec<(i64, String)> =
+        match sqlx::query_as::<_, (i64, String)>("SELECT id, name FROM profile ORDER BY id")
+            .fetch_all(&state.app_db)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(err) => {
+                tracing::warn!(?err, "pre-reset safety backup: could not list profiles; skipping");
+                return None;
+            }
+        };
+
+    // Fold the active profile's pending WAL pages back into its main file
+    // so the copied `data.db` is a complete snapshot. Inactive profiles
+    // were already checkpointed when they were deactivated.
+    if let Ok(pool) = state.require_profile_pool().await {
+        if let Err(err) = checkpoint_wal(&pool).await {
+            tracing::warn!(?err, "pre-reset safety backup: WAL checkpoint failed; snapshot may miss the newest writes");
+        }
+    }
+
+    let include_meta = read_include_metadata_artwork(&state.app_db)
+        .await
+        .unwrap_or(true);
+    let stamp = Utc::now().format("%Y%m%d-%H%M%S").to_string();
+
+    let mut written = 0usize;
+    for (profile_id, profile_name) in profiles {
+        let profile_dir = state.paths.profile_dir(profile_id);
+        let db_path = state.paths.profile_db(profile_id);
+        let artwork_dir = state.paths.profile_artwork_dir(profile_id);
+        let metadata_artwork_dir = include_meta.then(|| state.paths.metadata_artwork_dir.clone());
+
+        let manifest = ArchiveManifest {
+            archive_version: ARCHIVE_VERSION,
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            profile_name: profile_name.clone(),
+            source_profile_id: profile_id,
+            exported_at: Utc::now().to_rfc3339(),
+        };
+
+        let target = target_dir.join(format!(
+            "pre-reset-{}-{profile_id}-{stamp}.waveflow",
+            sanitize_filename(&profile_name)
+        ));
+
+        let res = tokio::task::spawn_blocking(move || {
+            write_archive(
+                &target,
+                &profile_dir,
+                &db_path,
+                &artwork_dir,
+                metadata_artwork_dir.as_deref(),
+                &manifest,
+            )
+        })
+        .await;
+        match res {
+            Ok(Ok(())) => written += 1,
+            Ok(Err(err)) => {
+                tracing::warn!(?err, profile_id, "pre-reset safety backup: archive failed for profile")
+            }
+            Err(err) => {
+                tracing::warn!(?err, profile_id, "pre-reset safety backup: task join failed for profile")
+            }
+        }
+    }
+
+    (written > 0).then_some(target_dir)
+}
+
+/// Strip characters that are hostile in a filename down to `_`, so a
+/// profile name like `Léa / Work` yields a portable archive name.
+fn sanitize_filename(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || matches!(c, '-' | '_' | ' ') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        "profile".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn regen_in_dir(dir: &Path) -> AppResult<u32> {


### PR DESCRIPTION
Refs #367 (guards-first slice, as agreed).

## Problem
`reset_app` `remove_dir_all`s the whole data root and restarts into onboarding — irreversibly wiping playlists, ratings and the `play_event` **listening history**. The reporter lost their history **5 times** (pushed into resets by the #366 scan bug, now partly fixed in #385) with **no recovery path**. The log in #367 (`stop_and_wait failed during reset`) confirms it was `reset_app`.

The existing auto-backup can't save them here: its default folder is `<data-root>/backups` — **inside** the directory the reset deletes.

## Fix
Before tearing anything down, snapshot **every profile** to a `.waveflow` archive under `<documents>/WaveFlow Backups` (outside the wiped root, easy to find). Re-importable via the existing profile importer after restart.

- Reuses `write_archive` — same complete archive format as manual export / auto-backup (data.db + artwork + optional shared cache per the `backup.include_metadata_artwork` setting).
- WAL-checkpoints the active pool first so `data.db` is a complete snapshot.
- **Best-effort**: a failed profile is logged and skipped; a total failure returns without aborting — a backup error must never trap the user in a half-torn-down install.

## Scope / follow-ups
- The reset confirmation modal (`ResetAppModal`, type-`RESET`) already gates the action — unchanged. A user-facing note ("a safety backup will be saved to Documents") is a natural follow-up but needs copy in all 17 locales, kept out of this PR to avoid half-translated strings.
- `delete_library`'s narrower `play_event` cascade and the durable **stable-natural-key re-attach** (stats surviving a rescan) remain the bigger follow-up we scoped earlier.
- These pre-reset archives aren't auto-pruned (resets are rare); retention could be a follow-up.

## Verification
- `cargo check -p waveflow --lib` — clean, no warnings.
- Not unit-tested: `reset_app` needs a live `AppHandle` + engine + pools + a real data dir, and it ends in `app.restart()`, so there's no harness. Logic is best-effort and non-blocking by construction; a manual reset (observe the archive lands in `~/Documents/WaveFlow Backups` and re-imports) is the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Une sauvegarde de sécurité des profils est désormais tentée automatiquement avant toute réinitialisation de l’application.
  * Les sauvegardes sont exportées au format **.waveflow** dans **Documents**, avec un emplacement de secours si nécessaire.
  * Les sauvegardes par profil sont créées pour garantir un ensemble réimportable autant que possible.

* **Améliorations**
  * Les erreurs de sauvegarde individuelles n’empêchent pas la réinitialisation : le processus se poursuit même en cas de sauvegarde partielle.
  * Les noms des fichiers de sauvegarde sont automatiquement normalisés pour rester compatibles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->