### PR TITLE
fix(audio): gate the post-device-error rebuild to a single owner

### DIFF
--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -183,6 +183,72 @@ impl FlapWindow {
     }
 }
 
+/// Quiet period after a rebuild attempt finishes during which a fresh
+/// `DeviceNotAvailable` does NOT arm another rebuild (#365).
+///
+/// On a DAC that resets its audio session every time a client grabs it in
+/// exclusive mode, our own re-open is what produces the next error — so
+/// reacting to it re-arms the loop. Each pass would then open exclusive
+/// while the previous pass's stream was still settling, and the second
+/// open collides with `AUDCLNT_E_DEVICE_IN_USE (0x8889000A)`, whose shared
+/// fallback then fails too, leaving the engine and the Settings toggle
+/// inconsistent (the #355 report).
+///
+/// 2 s is long enough to cover such a self-inflicted reset and short
+/// enough that a genuine unplug still recovers promptly.
+const REBUILD_SETTLE_WINDOW: Duration = Duration::from_secs(2);
+
+/// Single-owner gate for the automatic post-`DeviceNotAvailable` rebuild
+/// (#365).
+///
+/// The `rebuild_in_progress` debounce only covers a rebuild *call that is
+/// currently executing*. It cannot coalesce the real-world pattern, because
+/// the recovery is **deferred**: the cpal error callback schedules the
+/// rebuild 300 ms later, so consecutive errors each queue their own task
+/// and the passes never overlap — one finishes before the next begins, so
+/// every one of them sees a free debounce slot.
+///
+/// This gate closes that hole by tracking the whole arm → delay → run
+/// lifecycle plus a settle window afterwards, so exactly one rebuild runs
+/// per burst of device errors.
+///
+/// Clock is injected so the logic is deterministic under test, same as
+/// [`FlapWindow`].
+#[derive(Default)]
+struct RebuildGate {
+    /// A deferred rebuild has been scheduled and hasn't finished yet.
+    armed: bool,
+    /// When the last rebuild attempt finished, successful or not.
+    last_finished: Option<Instant>,
+}
+
+impl RebuildGate {
+    /// Decide whether a `DeviceNotAvailable` should schedule a rebuild.
+    /// Returns `true` at most once per burst: `false` while one is already
+    /// armed, and `false` inside the settle window after the last one.
+    fn try_arm(&mut self, now: Instant, settle: Duration) -> bool {
+        if self.armed {
+            return false;
+        }
+        if self
+            .last_finished
+            .is_some_and(|t| now.duration_since(t) < settle)
+        {
+            return false;
+        }
+        self.armed = true;
+        true
+    }
+
+    /// Mark the armed rebuild as finished and start the settle window.
+    /// Must run on EVERY exit path of the rebuild, otherwise `armed`
+    /// stays latched and no later device error can ever recover.
+    fn finish(&mut self, now: Instant) {
+        self.armed = false;
+        self.last_finished = Some(now);
+    }
+}
+
 /// Handle stored in Tauri state. Cloning an `Arc<AudioEngine>` is cheap.
 ///
 /// The cpal `Stream` is NOT stored here — it lives on a dedicated output
@@ -226,6 +292,14 @@ pub struct AudioEngine {
     exclusive_suppressed: std::sync::atomic::AtomicBool,
     /// Rolling flap counter feeding [`Self::try_rebuild_after_device_error`].
     exclusive_flaps: Mutex<FlapWindow>,
+    /// Single-owner gate for the deferred post-`DeviceNotAvailable`
+    /// rebuild (#365). `rebuild_in_progress` above only guards a rebuild
+    /// that is *currently executing*; because the recovery is scheduled
+    /// 300 ms after the error, consecutive errors queue separate tasks
+    /// that never overlap, so each one finds the debounce slot free.
+    /// This gate spans the whole arm → delay → run lifecycle plus a
+    /// settle window, so one burst of device errors yields one rebuild.
+    rebuild_gate: Mutex<RebuildGate>,
     /// Last Web Radio session captured at the boundary of
     /// [`Self::send`] (#230). The three output-rebuild paths
     /// ([`Self::set_output_device`], [`Self::set_wasapi_exclusive`],
@@ -340,6 +414,7 @@ impl AudioEngine {
             rebuild_in_progress: std::sync::atomic::AtomicBool::new(false),
             exclusive_suppressed: std::sync::atomic::AtomicBool::new(false),
             exclusive_flaps: Mutex::new(FlapWindow::default()),
+            rebuild_gate: Mutex::new(RebuildGate::default()),
             radio_resume: Mutex::new(None),
         })
     }
@@ -466,6 +541,23 @@ impl AudioEngine {
     pub fn try_rebuild_after_device_error(&self) -> AppResult<()> {
         use std::sync::atomic::Ordering;
 
+        // Release the #365 gate on EVERY exit path below (including the
+        // early `return`s and any panic), otherwise `armed` stays latched
+        // and no later device error could ever schedule a recovery again.
+        // Declared first so it drops last, after `force_rebuild_output`
+        // has released the `output` lock — the settle window should start
+        // when the rebuild is really over.
+        struct GateGuard<'a>(&'a Mutex<RebuildGate>);
+        impl Drop for GateGuard<'_> {
+            fn drop(&mut self) {
+                self.0
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .finish(Instant::now());
+            }
+        }
+        let _gate = GateGuard(&self.rebuild_gate);
+
         // Acquire the debounce slot. `swap(true)` returns the
         // previous value, so a `true` here means somebody else is
         // already rebuilding — bail without disturbing them.
@@ -520,6 +612,28 @@ impl AudioEngine {
         // shortcut for "same device" because the device is the
         // same — we just need a fresh stream after the OS reset.
         self.force_rebuild_output(pinned, exclusive)
+    }
+
+    /// Ask permission to schedule a deferred rebuild after a cpal
+    /// `DeviceNotAvailable` (#365). Returns `true` for the caller that
+    /// should own the recovery, `false` for everyone else.
+    ///
+    /// Called from the cpal error callback BEFORE the 300 ms delay, so a
+    /// burst of errors arms exactly one rebuild instead of queueing one
+    /// task per error. A `false` here means either a rebuild is already
+    /// armed / running, or we're inside [`REBUILD_SETTLE_WINDOW`] after
+    /// the last one — on a DAC that resets on every exclusive grab, that
+    /// second case is our own re-open echoing back, and reacting to it is
+    /// exactly what re-arms the cascade.
+    ///
+    /// The matching release lives in `try_rebuild_after_device_error`'s
+    /// RAII guard, so a scheduled-but-failed rebuild still reopens the
+    /// gate.
+    pub fn try_arm_device_rebuild(&self) -> bool {
+        self.rebuild_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .try_arm(Instant::now(), REBUILD_SETTLE_WINDOW)
     }
 
     /// Clear the #322 session-level exclusive suppression and its flap
@@ -1027,6 +1141,85 @@ mod flap_window_tests {
             assert!(!w.record(t));
             t += EXCLUSIVE_FLAP_WINDOW + Duration::from_secs(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod rebuild_gate_tests {
+    use super::*;
+
+    const SETTLE: Duration = REBUILD_SETTLE_WINDOW;
+
+    #[test]
+    fn arms_the_first_device_error() {
+        let mut g = RebuildGate::default();
+        assert!(g.try_arm(Instant::now(), SETTLE));
+    }
+
+    #[test]
+    fn refuses_a_second_arm_while_one_is_still_armed() {
+        let mut g = RebuildGate::default();
+        let t = Instant::now();
+        assert!(g.try_arm(t, SETTLE));
+        // The deferred rebuild hasn't run yet: every further error in the
+        // burst must be swallowed, however far apart they land.
+        assert!(!g.try_arm(t + Duration::from_millis(10), SETTLE));
+        assert!(!g.try_arm(t + Duration::from_secs(30), SETTLE));
+    }
+
+    #[test]
+    fn refuses_a_rearm_inside_the_settle_window() {
+        let mut g = RebuildGate::default();
+        let t = Instant::now();
+        assert!(g.try_arm(t, SETTLE));
+        g.finish(t + Duration::from_millis(300));
+        // This is the #365 cascade: our own exclusive re-open makes the
+        // DAC reset, and the resulting error must NOT arm another pass.
+        assert!(!g.try_arm(t + Duration::from_millis(340), SETTLE));
+    }
+
+    #[test]
+    fn arms_again_once_the_settle_window_has_passed() {
+        let mut g = RebuildGate::default();
+        let t = Instant::now();
+        assert!(g.try_arm(t, SETTLE));
+        let finished = t + Duration::from_millis(300);
+        g.finish(finished);
+        assert!(!g.try_arm(finished + SETTLE - Duration::from_millis(1), SETTLE));
+        // A genuine later failure (real unplug) still recovers.
+        assert!(g.try_arm(finished + SETTLE, SETTLE));
+    }
+
+    #[test]
+    fn finish_reopens_the_gate_even_when_the_rebuild_failed() {
+        let mut g = RebuildGate::default();
+        let t = Instant::now();
+        assert!(g.try_arm(t, SETTLE));
+        // `finish` runs from the RAII guard on every exit path, including
+        // the error ones — otherwise `armed` would latch forever and the
+        // engine could never recover from a later device loss.
+        g.finish(t);
+        assert!(g.try_arm(t + SETTLE, SETTLE));
+    }
+
+    #[test]
+    fn collapses_a_full_cascade_into_a_single_rebuild() {
+        // Replays the reporter's pattern: an error every ~300 ms, each one
+        // previously queueing its own deferred rebuild.
+        let mut g = RebuildGate::default();
+        let start = Instant::now();
+        let mut armed = 0;
+        for i in 0..10 {
+            let now = start + Duration::from_millis(300 * i);
+            if g.try_arm(now, SETTLE) {
+                armed += 1;
+                // The rebuild lands ~300 ms after it was armed.
+                g.finish(now + Duration::from_millis(300));
+            }
+        }
+        // 10 errors over 2.7 s collapse to the initial rebuild plus one
+        // retry after the settle window — not one per error.
+        assert_eq!(armed, 2);
     }
 }
 

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -618,13 +618,17 @@ impl AudioEngine {
     /// `DeviceNotAvailable` (#365). Returns `true` for the caller that
     /// should own the recovery, `false` for everyone else.
     ///
-    /// Called from the cpal error callback BEFORE the 300 ms delay, so a
-    /// burst of errors arms exactly one rebuild instead of queueing one
-    /// task per error. A `false` here means either a rebuild is already
-    /// armed / running, or we're inside [`REBUILD_SETTLE_WINDOW`] after
-    /// the last one — on a DAC that resets on every exclusive grab, that
-    /// second case is our own re-open echoing back, and reacting to it is
-    /// exactly what re-arms the cascade.
+    /// Called from the deferred recovery task (after its 300 ms backoff),
+    /// not from the cpal error callback itself — the engine may not be
+    /// registered in Tauri state yet at error time. A burst of errors
+    /// therefore queues several tasks, but only the first to wake arms;
+    /// the rest bail here, so the burst still collapses to one rebuild.
+    ///
+    /// A `false` means either a rebuild is already armed / running, or
+    /// we're inside [`REBUILD_SETTLE_WINDOW`] after the last one — on a
+    /// DAC that resets on every exclusive grab, that second case is our
+    /// own re-open echoing back, and reacting to it is exactly what
+    /// re-arms the cascade.
     ///
     /// The matching release lives in `try_rebuild_after_device_error`'s
     /// RAII guard, so a scheduled-but-failed rebuild still reopens the
@@ -1205,16 +1209,19 @@ mod rebuild_gate_tests {
     #[test]
     fn collapses_a_full_cascade_into_a_single_rebuild() {
         // Replays the reporter's pattern: an error every ~300 ms, each one
-        // previously queueing its own deferred rebuild.
+        // queueing its own deferred recovery task. Mirrors the real call
+        // order — a task arms only after its 300 ms backoff, so the gate
+        // is consulted at `error + 300 ms`, not at error time.
         let mut g = RebuildGate::default();
         let start = Instant::now();
         let mut armed = 0;
         for i in 0..10 {
-            let now = start + Duration::from_millis(300 * i);
-            if g.try_arm(now, SETTLE) {
+            let error_at = start + Duration::from_millis(300 * i);
+            let arms_at = error_at + Duration::from_millis(300);
+            if g.try_arm(arms_at, SETTLE) {
                 armed += 1;
-                // The rebuild lands ~300 ms after it was armed.
-                g.finish(now + Duration::from_millis(300));
+                // The rebuild itself takes a few tens of ms.
+                g.finish(arms_at + Duration::from_millis(40));
             }
         }
         // 10 errors over 2.7 s collapse to the initial rebuild plus one

--- a/src-tauri/crates/app/src/audio/output.rs
+++ b/src-tauri/crates/app/src/audio/output.rs
@@ -543,9 +543,20 @@ where
                     );
                     return;
                 }
-                if let Err(err) = engine.try_rebuild_after_device_error() {
-                    tracing::warn!(%err, "auto-rebuild after DeviceNotAvailable failed");
-                }
+                // The rebuild is synchronous and genuinely slow: it joins
+                // the old output thread — which, in WASAPI exclusive mode,
+                // can sit in `wait_for_event` up to its 2 s timeout — and
+                // then opens the device inline (COM init + the #174 format
+                // negotiation ladder). Running that directly on a tokio
+                // worker would park the worker for the whole duration, so
+                // hand it to the blocking pool.
+                let engine = engine.inner().clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Err(err) = engine.try_rebuild_after_device_error() {
+                        tracing::warn!(%err, "auto-rebuild after DeviceNotAvailable failed");
+                    }
+                })
+                .await;
             });
         }
     };

--- a/src-tauri/crates/app/src/audio/output.rs
+++ b/src-tauri/crates/app/src/audio/output.rs
@@ -514,38 +514,39 @@ where
 
         if matches!(err, cpal::StreamError::DeviceNotAvailable) {
             let app_clone = err_app.clone();
-            // #365: arm the recovery BEFORE the delay, not inside it.
-            // Scheduling unconditionally queued one task per error, and
-            // since each task runs 300 ms later they never overlap — so
-            // the engine's in-flight debounce always found a free slot and
-            // every error got its own rebuild. On a DAC that resets on
-            // each exclusive grab, our own re-open triggers the next
-            // error, so the passes chase each other until one opens
-            // exclusive while the previous stream is still settling and
-            // collides with AUDCLNT_E_DEVICE_IN_USE. The gate lets exactly
-            // one rebuild through per burst.
-            let armed = app_clone
-                .try_state::<std::sync::Arc<super::AudioEngine>>()
-                .is_some_and(|engine| engine.try_arm_device_rebuild());
-            if armed {
-                tauri::async_runtime::spawn(async move {
-                    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-                    if let Some(engine) = app_clone.try_state::<std::sync::Arc<super::AudioEngine>>()
-                    {
-                        if let Err(err) = engine.try_rebuild_after_device_error() {
-                            tracing::warn!(
-                                %err,
-                                "auto-rebuild after DeviceNotAvailable failed"
-                            );
-                        }
-                    }
-                });
-            } else {
-                tracing::debug!(
-                    "device rebuild already armed or within the settle window; \
-                     ignoring this DeviceNotAvailable"
-                );
-            }
+            // Everything below runs off this callback, on the tokio task:
+            // the engine lookup, the #365 gate, the rebuild and its logs.
+            // The engine is resolved AFTER the delay on purpose — an error
+            // can fire while `AudioEngine::new` is still running, i.e.
+            // before the engine has been registered in Tauri's managed
+            // state, and looking it up eagerly here would silently drop
+            // the recovery for that window.
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                let Some(engine) = app_clone.try_state::<std::sync::Arc<super::AudioEngine>>()
+                else {
+                    return;
+                };
+                // #365: one rebuild per burst of device errors. A DAC that
+                // resets on every exclusive grab makes our own re-open
+                // trigger the next error, so without a gate the passes
+                // chase each other until one opens exclusive while the
+                // previous stream is still settling and collides with
+                // AUDCLNT_E_DEVICE_IN_USE. Gating here (rather than before
+                // the sleep) still collapses the burst: whichever task
+                // wakes first arms, and the others hit either `armed` or
+                // the settle window.
+                if !engine.try_arm_device_rebuild() {
+                    tracing::debug!(
+                        "device rebuild already armed or within the settle window; \
+                         ignoring this DeviceNotAvailable"
+                    );
+                    return;
+                }
+                if let Err(err) = engine.try_rebuild_after_device_error() {
+                    tracing::warn!(%err, "auto-rebuild after DeviceNotAvailable failed");
+                }
+            });
         }
     };
 

--- a/src-tauri/crates/app/src/audio/output.rs
+++ b/src-tauri/crates/app/src/audio/output.rs
@@ -514,17 +514,38 @@ where
 
         if matches!(err, cpal::StreamError::DeviceNotAvailable) {
             let app_clone = err_app.clone();
-            tauri::async_runtime::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-                if let Some(engine) = app_clone.try_state::<std::sync::Arc<super::AudioEngine>>() {
-                    if let Err(err) = engine.try_rebuild_after_device_error() {
-                        tracing::warn!(
-                            %err,
-                            "auto-rebuild after DeviceNotAvailable failed"
-                        );
+            // #365: arm the recovery BEFORE the delay, not inside it.
+            // Scheduling unconditionally queued one task per error, and
+            // since each task runs 300 ms later they never overlap — so
+            // the engine's in-flight debounce always found a free slot and
+            // every error got its own rebuild. On a DAC that resets on
+            // each exclusive grab, our own re-open triggers the next
+            // error, so the passes chase each other until one opens
+            // exclusive while the previous stream is still settling and
+            // collides with AUDCLNT_E_DEVICE_IN_USE. The gate lets exactly
+            // one rebuild through per burst.
+            let armed = app_clone
+                .try_state::<std::sync::Arc<super::AudioEngine>>()
+                .is_some_and(|engine| engine.try_arm_device_rebuild());
+            if armed {
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                    if let Some(engine) = app_clone.try_state::<std::sync::Arc<super::AudioEngine>>()
+                    {
+                        if let Err(err) = engine.try_rebuild_after_device_error() {
+                            tracing::warn!(
+                                %err,
+                                "auto-rebuild after DeviceNotAvailable failed"
+                            );
+                        }
                     }
-                }
-            });
+                });
+            } else {
+                tracing::debug!(
+                    "device rebuild already armed or within the settle window; \
+                     ignoring this DeviceNotAvailable"
+                );
+            }
         }
     };
 


### PR DESCRIPTION
Refs #365, parent #355.

## The mechanism (this corrects #365's own analysis)

#365 assumed the two rebuild passes were **concurrent**. The timestamps say otherwise: the error at `.341` plus the 300 ms delay lands exactly on the `.653` pass — so the earlier pass at `.377` is the deferred rebuild of a *previous* error, not a racing trigger.

What actually happens is a **self-sustaining cascade**:

1. `DeviceNotAvailable` fires → a rebuild is scheduled 300 ms later.
2. The rebuild re-opens WASAPI exclusive.
3. This DAC resets its audio session on *every* exclusive grab → a fresh `DeviceNotAvailable`.
4. That error schedules **another** rebuild → back to step 2.

The `rebuild_in_progress` debounce could never catch this, because the recovery is **deferred**: each error queues its own task, and those tasks never overlap — one finishes before the next begins, so every single one finds a free debounce slot. Eventually a pass opens exclusive while the previous stream is still settling and collides with `AUDCLNT_E_DEVICE_IN_USE (0x8889000A)`; its shared fallback then fails too (`device no longer available`), leaving the engine and the Settings toggle inconsistent — which is exactly the "only closing and reopening WaveFlow resets the button" symptom in #355.

The `#322` flap-storm suppression doesn't fire either, and correctly so: the reporter's events are **hours** apart, so 3 flaps never land inside the 12 s window. This isn't a storm, it's a one-off device reset that amplifies itself.

## The fix

A `RebuildGate` that owns the whole **arm → delay → run** lifecycle instead of just the in-flight call:

- **Arming moves into the error callback**, before the 300 ms delay. A burst of errors arms exactly one rebuild rather than queueing one task per error.
- **A 2 s settle window** after each attempt. This is the part that actually breaks the cascade: on this hardware our own re-open is what provokes the next error, so reacting to it is what re-arms the loop. A genuine later failure (real unplug) still recovers once the window elapses.
- **Released via an RAII guard on every exit path** of `try_rebuild_after_device_error` — including the early returns and the error paths — so a failed rebuild can't latch the gate shut and block all future recovery.

Clock-injected and unit-tested, same shape as the existing `FlapWindow`.

### On the S16_LE / S24_4LE detail

#365 lists the format regression as point 3. It's a **symptom, not a separate bug**: the #174 negotiation ladder degrades precisely because the device is still held by the previous stream. It should resolve once the collision is gone — worth confirming in the reporter's next log rather than "fixing" separately.

## Verification

- `cargo check -p waveflow --all-targets` ✅
- `cargo clippy -p waveflow --all-targets` ✅ (no warnings)
- 7 unit tests on the gate, including a replay of the reporter's ~300 ms error cadence: **10 errors collapse to 2 rebuilds instead of 10**.

> **Two honest caveats.**
>
> 1. The app-crate test binary **cannot run on this machine** — it aborts with `STATUS_ENTRYPOINT_NOT_FOUND` (a known local Tauri DLL issue, environmental). The tests compile under `--all-targets` and I verified the identical state machine in a standalone binary outside the Tauri crate (7/7 passing), but **CI is the real run**.
> 2. **I could not reproduce the trigger.** It needs hardware that resets its session on every exclusive grab. The reasoning is traced to the reporter's log line by line, but this should go out as a **beta build for @jo-el414 to confirm** before we call #355 closed.
>
> What to look for in his next log: a single `rebuilding cpal output after DeviceNotAvailable` per event, no `0x8889000A`, and the negotiation staying on `S24_4LE`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correctifs**
  * Réduit les reconstructions audio en cascade lors d’une perte temporaire du périphérique audio.
  * Introduit une fenêtre de stabilisation pour regrouper les tentatives et empêcher les rebuilds rapprochés.
  * Permet un rebuild différé uniquement lorsqu’il n’y en a pas déjà un en cours et après expiration du délai de stabilisation.
  * Améliore la gestion et le suivi des erreurs lors de la récupération audio (journaux plus adaptés).
  * Ajoute des tests unitaires pour valider le comportement du mécanisme de coalescence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->