### PR TITLE
fix(lyrics): stop caching a provider outage as a permanent miss

### DIFF
--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -367,18 +367,35 @@ fn shared_external_client() -> AppResult<&'static SyncedLyricsClient> {
     }
 }
 
+/// Outcome of one external provider query (#391).
+///
+/// `Miss` and `Unavailable` are kept apart **here**, at the source, rather
+/// than reconstructed by callers: only this function knows whether any
+/// request was actually issued. A caller that tried to infer it afterwards
+/// — say by re-reading the offline flag — would be guessing against state
+/// that can change between the call and the check, and a wrong guess
+/// caches a permanent "no lyrics".
+enum SearchOutcome {
+    Found(ExternalLyricsResult),
+    /// Providers were queried and none had lyrics. A real negative.
+    Miss,
+    /// Nothing was queried at all — offline mode, or the provider list was
+    /// empty once the Musixmatch opt-in filter ran. Never a negative.
+    Unavailable,
+}
+
 async fn external_lyrics_search(
     meta: &TrackMeta,
     providers: Vec<Provider>,
     mode: SearchMode,
     enhanced: bool,
     lang: Option<&str>,
-) -> AppResult<Option<ExternalLyricsResult>> {
+) -> AppResult<SearchOutcome> {
     // Defense in depth: every outbound HTTP path must honour offline mode
-    // regardless of caller. Returning Ok(None) short-circuits before any
-    // request is issued (see the process-wide offline contract).
+    // regardless of caller. Short-circuit before any request is issued
+    // (see the process-wide offline contract).
     if crate::offline::is_offline() {
-        return Ok(None);
+        return Ok(SearchOutcome::Unavailable);
     }
     // Apply the Musixmatch opt-in here — at a single chokepoint — so
     // call sites don't have to know whether Musixmatch is in their
@@ -386,7 +403,7 @@ async fn external_lyrics_search(
     // to query": short-circuit instead of building a no-op client.
     let providers = filter_providers(providers);
     if providers.is_empty() {
-        return Ok(None);
+        return Ok(SearchOutcome::Unavailable);
     }
     // The syncedlyrics client treats `lang = Some(_)` as a hard
     // filter for Musixmatch-only — passing it to a fallback chain
@@ -401,9 +418,9 @@ async fn external_lyrics_search(
     };
     let query = external_query(&meta.title, meta.artist_name.as_deref());
     let client = shared_external_client()?;
-    // A transient provider error surfaces as Err here (not Ok(None)) so
-    // callers don't cache an empty "miss" on a network blip.
-    client
+    // A transient provider error surfaces as Err here (never as a miss) so
+    // callers don't cache an empty row on a network blip.
+    let found = client
         .search(SearchOptions {
             query,
             mode,
@@ -414,7 +431,12 @@ async fn external_lyrics_search(
             netease_cookie: std::env::var("SYNCEDLYRICS_NETEASE_COOKIE").ok(),
         })
         .await
-        .map_err(|err| AppError::Other(format!("external lyrics search failed: {err}")))
+        .map_err(|err| AppError::Other(format!("external lyrics search failed: {err}")))?;
+    // We got here only by actually querying, so `None` is a real negative.
+    Ok(match found {
+        Some(result) => SearchOutcome::Found(result),
+        None => SearchOutcome::Miss,
+    })
 }
 
 /// `profile_setting` key for the user-picked Musixmatch translation
@@ -505,20 +527,13 @@ async fn try_external_fallback(
     )
     .await
     {
-        Ok(Some(result)) => Ok(FallbackOutcome::Found(
+        Ok(SearchOutcome::Found(result)) => Ok(FallbackOutcome::Found(
             cache_external_lyrics(pool, track_id, &meta.file_hash, result).await?,
         )),
-        Ok(None) => {
-            // `external_lyrics_search` also short-circuits to `Ok(None)`
-            // when offline mode is on. `fetch_lyrics` checks offline before
-            // reaching this tier, but the flag can flip mid-waterfall — and
-            // "couldn't ask" must never be recorded as "nobody has it".
-            if crate::offline::is_offline() {
-                Ok(FallbackOutcome::Unavailable)
-            } else {
-                Ok(FallbackOutcome::Miss)
-            }
-        }
+        // Propagated straight through: only the search itself knows whether
+        // a request was issued, so nothing here re-derives it.
+        Ok(SearchOutcome::Miss) => Ok(FallbackOutcome::Miss),
+        Ok(SearchOutcome::Unavailable) => Ok(FallbackOutcome::Unavailable),
         Err(err) => {
             tracing::debug!(?err, "external fallback chain failed; not caching a miss");
             Ok(FallbackOutcome::Unavailable)
@@ -1141,11 +1156,15 @@ pub async fn fetch_lyrics(
         )
         .await
         {
-            Ok(Some(result)) if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) => {
+            Ok(SearchOutcome::Found(result))
+                if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) =>
+            {
                 return cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
                     .await
                     .map(Some);
             }
+            // Anything else (line-level hit, miss, or Musixmatch not opted
+            // in) just falls through to LRCLIB — nothing is cached here.
             Ok(_) => {}
             Err(err) => tracing::debug!(?err, "Musixmatch enhanced lookup failed"),
         }
@@ -1353,10 +1372,17 @@ pub async fn refetch_lyrics(
     )
     .await
     {
-        Ok(Some(result)) => cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
-            .await
-            .map(Some),
-        Ok(None) => {
+        Ok(SearchOutcome::Found(result)) => {
+            cache_external_lyrics(&pool, track_id, &meta.file_hash, result)
+                .await
+                .map(Some)
+        }
+        // The provider was never queried (offline, or the user pinned
+        // Musixmatch without the opt-in). Caching a miss attributed to it
+        // would blame a provider that never answered, so persist nothing
+        // and let the next attempt through.
+        Ok(SearchOutcome::Unavailable) => Ok(None),
+        Ok(SearchOutcome::Miss) => {
             // Pinned provider returned nothing. Cache an empty miss
             // attributed to it so the badge reflects what the user
             // just tried — they can pick a different provider and
@@ -1619,7 +1645,9 @@ async fn run_prefetch(
         )
         .await
         {
-            Ok(Some(result)) if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) => {
+            Ok(SearchOutcome::Found(result))
+                if matches!(result.format, ExternalLyricsFormat::EnhancedLrc) =>
+            {
                 if let Err(e) = cache_external_lyrics(&pool, track_id, &file_hash, result).await {
                     tracing::warn!(track_id, ?e, "persist Musixmatch enhanced lyrics failed");
                     failed += 1;
@@ -1712,7 +1740,7 @@ async fn run_prefetch(
                         )
                         .await
                         {
-                            Ok(Some(result)) => {
+                            Ok(SearchOutcome::Found(result)) => {
                                 if let Err(e) =
                                     cache_external_lyrics(&pool, track_id, &file_hash, result).await
                                 {
@@ -1722,7 +1750,7 @@ async fn run_prefetch(
                                     hits += 1;
                                 }
                             }
-                            Ok(None) => {
+                            Ok(SearchOutcome::Miss) => {
                                 let _ = upsert_lyrics(
                                     &pool,
                                     &file_hash,
@@ -1733,6 +1761,11 @@ async fn run_prefetch(
                                 )
                                 .await;
                                 misses += 1;
+                            }
+                            // Nothing was queried — don't record a negative
+                            // for a track we never actually asked about.
+                            Ok(SearchOutcome::Unavailable) => {
+                                failed += 1;
                             }
                             Err(err) => {
                                 tracing::warn!(track_id, ?err, "external lyrics prefetch failed");
@@ -1754,7 +1787,7 @@ async fn run_prefetch(
                 )
                 .await
                 {
-                    Ok(Some(result)) => {
+                    Ok(SearchOutcome::Found(result)) => {
                         if let Err(e) =
                             cache_external_lyrics(&pool, track_id, &file_hash, result).await
                         {
@@ -1764,7 +1797,7 @@ async fn run_prefetch(
                             hits += 1;
                         }
                     }
-                    Ok(None) => {
+                    Ok(SearchOutcome::Miss) => {
                         // No provider had lyrics. Cache as empty so re-runs
                         // of the prefetch and re-opens of the lyrics panel
                         // skip this track. User can force a re-search
@@ -1779,6 +1812,11 @@ async fn run_prefetch(
                         )
                         .await;
                         misses += 1;
+                    }
+                    // Nothing was queried — don't record a negative for a
+                    // track we never actually asked about.
+                    Ok(SearchOutcome::Unavailable) => {
+                        failed += 1;
                     }
                     Err(err) => {
                         tracing::warn!(track_id, ?err, "external lyrics prefetch failed");
@@ -2391,7 +2429,7 @@ pub async fn fetch_radio_lyrics(
         };
 
     match result {
-        Some(r) => {
+        SearchOutcome::Found(r) => {
             let format = external_format_to_app(r.format);
             let provider = r.provider.as_str();
             upsert_radio_lyrics(
@@ -2414,12 +2452,15 @@ pub async fn fetch_radio_lyrics(
                 sidecar_write_skipped: None,
             }))
         }
-        None => {
+        SearchOutcome::Miss => {
             // Cache the miss (empty content) so a recurring song on the
             // station's rotation doesn't re-hit the network every time.
             upsert_radio_lyrics(&pool, &key, artist, title, "", &LyricsFormat::Plain, None).await?;
             Ok(None)
         }
+        // Nothing was queried, so there is no verdict to remember — leave
+        // the cache untouched and let the next spin of this song retry.
+        SearchOutcome::Unavailable => Ok(None),
     }
 }
 

--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -15,6 +15,12 @@
 //! once a row exists — the user can manually overwrite by importing a
 //! `.lrc` file via [`import_lrc_file`].
 //!
+//! Because of that cache-first rule, **only a confirmed negative may be
+//! cached** (#391). A provider outage is `Unavailable`, not a miss: it
+//! persists nothing, so the next panel open retries. Caching it would
+//! freeze a one-off network blip into a permanent "no lyrics" that only a
+//! manual refetch could clear.
+//!
 //! **Prefer-LRCLIB toggle** (`profile_setting['lyrics.prefer_lrclib']`,
 //! issue #378): when on, [`fetch_lyrics`] flips tiers 2–3 (embedded +
 //! sidecar) to run *after* the online providers — LRCLIB / Musixmatch /
@@ -457,19 +463,37 @@ async fn cache_external_lyrics(
     })
 }
 
-/// Walk the post-LRCLIB fallback chain (NetEase / Megalobiz / Genius)
-/// and persist the first hit. Returns `Some(payload)` on a hit (already
-/// cached), or `None` when every provider misses — or one errors and the
-/// rest miss. A provider `Err` is non-fatal here (LRCLIB has already
-/// given a verdict, this chain is best-effort enrichment): it's logged
-/// and treated like a miss, so the caller decides what to do with `None`
-/// (cache an empty miss, or fall back to another tier under
-/// `lyrics.prefer_lrclib`).
+/// What the post-LRCLIB fallback chain concluded (#391).
+///
+/// The distinction that matters is `Miss` vs `Unavailable`. Collapsing
+/// both into "no lyrics" is what let a one-off provider outage be written
+/// as an empty row — and because the waterfall is cache-first and never
+/// re-fetches once a row exists, that transient blip marked the track as
+/// permanently lyric-less until the user hit Refetch by hand.
+enum FallbackOutcome {
+    /// A provider had lyrics — already cached.
+    Found(LyricsPayload),
+    /// Every provider answered and none had lyrics. A real negative, safe
+    /// to remember so the panel stops re-hitting the network on each open.
+    Miss,
+    /// The chain could not be consulted at all. NOT a negative — nothing
+    /// may be cached, so the next attempt retries.
+    Unavailable,
+}
+
+/// Walk the post-LRCLIB fallback chain (NetEase / Megalobiz / Genius) and
+/// persist the first hit.
+///
+/// A provider `Err` stays non-fatal for the waterfall — LRCLIB has already
+/// given its verdict and this chain is best-effort enrichment, so we don't
+/// fail the whole lookup. But it now surfaces as [`FallbackOutcome::Unavailable`]
+/// rather than masquerading as a miss, so the caller knows not to persist
+/// anything.
 async fn try_external_fallback(
     pool: &sqlx::SqlitePool,
     track_id: i64,
     meta: &TrackMeta,
-) -> AppResult<Option<LyricsPayload>> {
+) -> AppResult<FallbackOutcome> {
     match external_lyrics_search(
         meta,
         external_fallback_providers(),
@@ -481,13 +505,23 @@ async fn try_external_fallback(
     )
     .await
     {
-        Ok(Some(result)) => Ok(Some(
+        Ok(Some(result)) => Ok(FallbackOutcome::Found(
             cache_external_lyrics(pool, track_id, &meta.file_hash, result).await?,
         )),
-        Ok(None) => Ok(None),
+        Ok(None) => {
+            // `external_lyrics_search` also short-circuits to `Ok(None)`
+            // when offline mode is on. `fetch_lyrics` checks offline before
+            // reaching this tier, but the flag can flip mid-waterfall — and
+            // "couldn't ask" must never be recorded as "nobody has it".
+            if crate::offline::is_offline() {
+                Ok(FallbackOutcome::Unavailable)
+            } else {
+                Ok(FallbackOutcome::Miss)
+            }
+        }
         Err(err) => {
-            tracing::debug!(?err, "external fallback chain failed");
-            Ok(None)
+            tracing::debug!(?err, "external fallback chain failed; not caching a miss");
+            Ok(FallbackOutcome::Unavailable)
         }
     }
 }
@@ -526,25 +560,41 @@ async fn cache_lyrics_miss(
 /// Resolve a track once LRCLIB has given no usable lyrics (404 or an
 /// empty row). Tries the external provider chain first; then, under
 /// `lyrics.prefer_lrclib` (where the local tiers haven't run yet), the
-/// embedded + sidecar tiers; and finally caches an empty miss. Always
-/// returns a `LyricsPayload`. With `prefer_lrclib = false` this is the
-/// original "external chain, else miss" behaviour — the two `fetch_lyrics`
-/// LRCLIB call sites share it so they can't drift on the contract.
+/// embedded + sidecar tiers.
+///
+/// Returns `None` when the chain was [`FallbackOutcome::Unavailable`] and
+/// no local tier covered for it: nothing is cached in that case, so the
+/// next panel open retries instead of being served a miss that was really
+/// just a network blip (#391). A confirmed [`FallbackOutcome::Miss`] still
+/// caches the empty row, preserving the "don't re-hit the network on every
+/// open" property. The two `fetch_lyrics` LRCLIB call sites share this so
+/// they can't drift on the contract.
 async fn resolve_after_lrclib_miss(
     pool: &sqlx::SqlitePool,
     track_id: i64,
     meta: &TrackMeta,
     prefer_lrclib: bool,
-) -> AppResult<LyricsPayload> {
-    if let Some(payload) = try_external_fallback(pool, track_id, meta).await? {
-        return Ok(payload);
+) -> AppResult<Option<LyricsPayload>> {
+    let outcome = try_external_fallback(pool, track_id, meta).await?;
+    if let FallbackOutcome::Found(payload) = outcome {
+        return Ok(Some(payload));
     }
+
+    // Under prefer-LRCLIB the local tiers were deferred, so they still owe
+    // us an answer — whether the chain missed or was unreachable.
     if prefer_lrclib {
         if let Some(payload) = try_local_lyrics(pool, track_id, meta).await? {
-            return Ok(payload);
+            return Ok(Some(payload));
         }
     }
-    cache_lyrics_miss(pool, track_id, meta).await
+
+    match outcome {
+        FallbackOutcome::Miss => cache_lyrics_miss(pool, track_id, meta).await.map(Some),
+        // Transient: persist nothing so the next attempt can retry.
+        FallbackOutcome::Unavailable => Ok(None),
+        // Handled above.
+        FallbackOutcome::Found(_) => unreachable!("Found returns early"),
+    }
 }
 
 /// `profile_setting` key: prefer the online providers (LRCLIB / Musixmatch
@@ -1140,9 +1190,7 @@ pub async fn fetch_lyrics(
             // LRCLIB's metadata endpoint, so they only run after the exact
             // lookup fails. See `resolve_after_lrclib_miss` for the
             // error-handling contract (provider Err is non-fatal here).
-            return resolve_after_lrclib_miss(&pool, track_id, &meta, prefer_lrclib)
-                .await
-                .map(Some);
+            return resolve_after_lrclib_miss(&pool, track_id, &meta, prefer_lrclib).await;
         }
         Err(err) => {
             // Surface transient network failures (timeout, DNS, refused
@@ -1201,9 +1249,7 @@ pub async fn fetch_lyrics(
             // Same as the 404 branch above: LRCLIB returned an entry
             // but it was empty, so fall through to the fallback chain
             // (and the deferred local tiers under prefer-LRCLIB).
-            return resolve_after_lrclib_miss(&pool, track_id, &meta, prefer_lrclib)
-                .await
-                .map(Some);
+            return resolve_after_lrclib_miss(&pool, track_id, &meta, prefer_lrclib).await;
         }
     };
 


### PR DESCRIPTION
Closes #391.

## The bug

The post-LRCLIB fallback chain (NetEase / Megalobiz / Genius) collapsed a **provider error** into the same `Ok(None)` it used for a **real negative**, and the caller then wrote an empty `lyrics` row.

Because the waterfall is cache-first and never re-fetches once a row exists, a single network blip marked the track as **permanently lyric-less** — only a manual "Refetch" could clear it.

## The fix

```rust
enum FallbackOutcome { Found(LyricsPayload), Miss, Unavailable }
```

- **Found** → cached, returned (unchanged).
- **Miss** → every provider answered and none had lyrics. Still caches the empty row, so the "don't re-hit the network on every panel open" property is preserved.
- **Unavailable** → the chain couldn't be consulted. **Persists nothing** and returns no lyrics for this attempt, so the next open retries.

Offline folds into `Unavailable` as well: `external_lyrics_search` also short-circuits to `Ok(None)` when offline mode is on. `fetch_lyrics` checks offline before reaching this tier, but the flag can flip mid-waterfall — and *"couldn't ask"* must never be recorded as *"nobody has it"*.

Under `lyrics.prefer_lrclib` (#378) the deferred local tiers still get their turn whether the chain missed **or** was unreachable, so the toggle can't lose lyrics the file already carries.

## `run_prefetch` deliberately unchanged

The issue flagged the bulk loop as carrying its own inline copy of the fallback handling and suspected it needed the same treatment. Checked — it already gets this right:

```rust
Ok(Some(result)) => { … hits += 1; }
Ok(None)         => { upsert empty row; misses += 1; }
Err(err)         => { tracing::warn!(…); failed += 1; }   // ← no caching
```

Both of its fallback sites count an error as `failed` **without** persisting anything, and `prefetch_library_lyrics` refuses to run at all in offline mode. So the bug was specific to the on-demand path.

## Checks
- `cargo check -p waveflow --all-targets` ✅
- `cargo clippy -p waveflow --all-targets` ✅ (no warnings)

> No unit test: exercising this needs a live profile pool plus a way to make a provider fail, and the app-crate test binary doesn't run locally on Windows (`STATUS_ENTRYPOINT_NOT_FOUND`). The change is a pure control-flow split with no new I/O, and both call sites go through the one shared helper.
