### PR TITLE
fix(ui): stop truncated headings from clipping their descenders

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -404,6 +404,38 @@
   z-index: 2;
 }
 
+/* Truncated headings must not lose their descenders.
+ *
+ * `truncate` is only ever applied to clip a long title HORIZONTALLY and
+ * add the ellipsis — but it expands to `overflow: hidden`, which clips
+ * BOTH axes. The vertical clipping is collateral damage: Tailwind pairs
+ * `text-4xl` with a line-height of just 1.11x the font size, while most
+ * fonts need ~1.2x for their full ascent + descent, so the tails of
+ * g / j / p / q / y get shaved by a pixel or two.
+ *
+ * CSS offers no way to say "clip x, leave y alone" — the moment one axis
+ * is `hidden`, the other can no longer be `visible`. `overflow-clip-margin`
+ * is the way out: it widens the clip region WITHOUT reserving space, so
+ * the descender is allowed to paint outside the box and no layout shifts.
+ * Padding would work too, but it compensates for a symptom by pushing
+ * everything below the heading down.
+ *
+ * Progressive enhancement: an engine without `overflow-clip-margin` (older
+ * WebKitGTK) simply falls back to a plain clip — i.e. exactly today's
+ * behaviour, never worse. `text-overflow: ellipsis` keeps working, since it
+ * applies to any `overflow` other than `visible`.
+ *
+ * `:where()` keeps specificity at 0 so a component can still override.
+ * Scoped to headings on purpose: the clipping is only perceptible at large
+ * sizes, and blanket-applying it to every `.truncate` would touch hundreds
+ * of small labels for no visible gain. Non-heading titles that are big
+ * enough to show it (a `text-xl` card title, say) should opt in with the
+ * same two declarations. */
+:where(h1, h2, h3).truncate {
+  overflow: clip;
+  overflow-clip-margin: 0.125rem;
+}
+
 /* Global focus-visible fallback for keyboard users.
  *
  * Many components rely on Tailwind's `focus-visible:ring-*` per-button,


### PR DESCRIPTION
Titles on the artist, genre, track-properties and Spotify views were shaving a pixel or two off `g` / `j` / `p` / `q` / `y`.

## Why

`truncate` is only ever applied to clip a long title **horizontally** and add the ellipsis — but it expands to `overflow: hidden`, which clips **both axes**. Tailwind pairs `text-4xl` with a line-height of just `1.11×` the font size, while most fonts need `~1.2×` for their full ascent + descent, so the tails got cut.

The vertical clipping was collateral damage nobody asked for. CSS gives no way to say *"clip x, leave y alone"* — the moment one axis is `hidden`, the other can no longer be `visible`.

The codebase had already hit this once: [`ImmersiveNowPlaying`](src/components/player/ImmersiveNowPlaying.tsx) carries a comment explaining that `leading-tight pb-1` is there to give descenders room under `overflow: hidden`.

## The fix

```css
:where(h1, h2, h3).truncate {
  overflow: clip;
  overflow-clip-margin: 0.125rem;
}
```

`overflow-clip-margin` widens the clip region **without reserving space**, so the descender is allowed to paint outside the box and nothing shifts. Padding would work too, but it compensates for a symptom by pushing every element below the heading down.

- **Progressive enhancement.** An engine without `overflow-clip-margin` (older WebKitGTK) falls back to a plain clip — exactly today's behaviour, never worse.
- **Ellipsis still works.** `text-overflow` applies to any `overflow` other than `visible`.
- **`:where()`** keeps specificity at 0, so a component can still override it.
- **Verified in the production bundle**: the rule survives Lightning CSS as `:where(h1,h2,h3).truncate{overflow-clip-margin:.125rem;overflow:clip}`.

## Scope

Deliberately limited to headings. The clipping is only perceptible at large sizes; blanket-applying it to every `.truncate` would touch hundreds of small labels for no visible gain. Non-heading titles large enough to show it (a `text-xl` card title, say) can opt in with the same two declarations — noted in the comment.

Four call sites benefit today: `ArtistDetailView`, `GenreDetailView`, `TrackPropertiesModal`, `SpotifyView`.

## Checks
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run build` ✅

> **Needs a visual pass.** I can't render the UI here — worth opening an artist page whose name has a descender (the report came from *Tibeauthetraveler* / *Superfly*) and confirming the tail is intact, ideally on Linux too since that's where the fallback path would kick in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Corrections de bugs**
  * Amélioration de l’affichage des titres tronqués avec des points de suspension.
  * Évite que les parties descendantes des lettres soient coupées verticalement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->