### PR TITLE
fix(audio): advance playback position in WASAPI Exclusive mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ scripts/__pycache__/*
 
 # jscpd copy-paste detector output
 report/
+temp.md

--- a/src-tauri/crates/app/src/audio/state.rs
+++ b/src-tauri/crates/app/src/audio/state.rs
@@ -46,11 +46,22 @@ impl PlayerState {
 /// Lock-free state block shared between threads.
 ///
 /// Layout invariants:
-/// - `samples_played` is advanced only by the cpal callback, only reset by
-///   the decoder thread (on load/seek). Reset must bump `seek_generation`
-///   to invalidate any in-flight consumer reads.
-/// - `sample_rate` / `channels` are written once when the cpal stream opens
-///   and never mutated again.
+/// - `samples_played` is advanced by **whichever output is driving the
+///   ring** — the cpal callback, or the WASAPI Exclusive render thread
+///   when that mode is engaged. Both count only samples actually popped,
+///   never the silence written on an underrun. Only the decoder thread
+///   resets it (on load/seek), and a reset must bump `seek_generation` to
+///   invalidate any in-flight consumer reads.
+///
+///   This is the single source of truth for playback position:
+///   `current_position_ms` and `session_listened_ms` both derive from it,
+///   so an output path that forgets to advance it leaves the progress bar
+///   and lyrics frozen and credits every play as 0 ms. That is exactly
+///   what the exclusive path did until #405 — this comment used to say
+///   "only by the cpal callback", which was true when written and stopped
+///   being true when the second output landed.
+/// - `sample_rate` / `channels` are written once when the output stream
+///   opens and never mutated again.
 /// - `volume_bits` holds an `f32` in `[0.0, 1.0]` via `to_bits` / `from_bits`.
 /// - `base_offset_ms` holds the playback position at the last seek target or
 ///   track load start, so `current_position_ms()` can add it to the delta

--- a/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
+++ b/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
@@ -477,6 +477,14 @@ fn run_event_loop(
             let mono = shared.mono_enabled.load(Ordering::Relaxed);
             let norm_gain: f32 = if normalize { 0.707 } else { 1.0 };
 
+            // Samples actually pulled from the ring this period. Drives
+            // `SharedPlayback::samples_played`, which is the only source
+            // the progress bar, lyrics sync and play-event crediting have
+            // for "where are we in the track" — see the counting note in
+            // `state.rs`. Silence written on an underrun is deliberately
+            // NOT counted, matching the cpal callback.
+            let mut written: u64 = 0;
+
             if mono && channels >= 2 {
                 // Mono downmix: average all channels per frame.
                 let mut i = 0;
@@ -494,6 +502,7 @@ fn run_event_loop(
                         }
                     }
                     let v = if got > 0 {
+                        written += got as u64;
                         (sum / channels as f32) * volume * norm_gain
                     } else {
                         0.0
@@ -507,7 +516,10 @@ fn run_event_loop(
                 // Normal multi-channel path.
                 for slot in samples.iter_mut() {
                     *slot = match consumer.pop() {
-                        Ok(s) => s * volume * norm_gain,
+                        Ok(s) => {
+                            written += 1;
+                            s * volume * norm_gain
+                        }
                         Err(_) => 0.0,
                     };
                 }
@@ -518,6 +530,11 @@ fn run_event_loop(
             // allocations, no branches inside the inner loop
             // beyond the format dispatch above.
             pack_samples(format, &samples, &mut bytes_scratch);
+            if written > 0 {
+                shared
+                    .samples_played
+                    .fetch_add(written, std::sync::atomic::Ordering::Relaxed);
+            }
             &bytes_scratch
         };
 

--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -640,11 +640,18 @@ pub async fn set_album_artwork_from_deezer(
     // together — see `upsert_artwork`'s contract in CLAUDE.md.
     let mut tx = pool.begin().await?;
     let artwork_id = upsert_artwork(&mut tx, &hash, format, "deezer").await?;
-    sqlx::query("UPDATE album SET artwork_id = ?, artwork_source = 'deezer' WHERE id = ?")
+    let res = sqlx::query("UPDATE album SET artwork_id = ?, artwork_source = 'deezer' WHERE id = ?")
         .bind(artwork_id)
         .bind(album_id)
         .execute(&mut *tx)
         .await?;
+    // Matching no row means the album is gone (stale UI, concurrent
+    // delete). Returning early leaves `tx` un-committed, so the artwork
+    // insert rolls back instead of landing with nothing pointing at it —
+    // and the caller hears about it rather than getting a silent success.
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!("album {album_id} not found")));
+    }
     tx.commit().await?;
 
     Ok(())
@@ -677,11 +684,18 @@ pub async fn set_album_artwork_from_file(
     // together — see `upsert_artwork`'s contract in CLAUDE.md.
     let mut tx = pool.begin().await?;
     let artwork_id = upsert_artwork(&mut tx, &hash, format, "manual").await?;
-    sqlx::query("UPDATE album SET artwork_id = ?, artwork_source = 'manual' WHERE id = ?")
+    let res = sqlx::query("UPDATE album SET artwork_id = ?, artwork_source = 'manual' WHERE id = ?")
         .bind(artwork_id)
         .bind(album_id)
         .execute(&mut *tx)
         .await?;
+    // Matching no row means the album is gone (stale UI, concurrent
+    // delete). Returning early leaves `tx` un-committed, so the artwork
+    // insert rolls back instead of landing with nothing pointing at it —
+    // and the caller hears about it rather than getting a silent success.
+    if res.rows_affected() == 0 {
+        return Err(AppError::Other(format!("album {album_id} not found")));
+    }
     tx.commit().await?;
 
     Ok(())

--- a/src-tauri/crates/app/src/commands/edit.rs
+++ b/src-tauri/crates/app/src/commands/edit.rs
@@ -621,12 +621,21 @@ pub async fn update_track_cover(
     // could leave the row behind if the update failed.
     let mut tx = pool.begin().await?;
     let artwork_id = upsert_artwork(&mut tx, &hash, ext, "manual").await?;
+    // Only guarded when a track actually belongs to an album: `album_id`
+    // is legitimately `None` for a loose track, and that case must still
+    // commit — the cover has already been written into the audio file
+    // itself, which is the point of this command.
     if let Some(aid) = album_id {
-        sqlx::query("UPDATE album SET artwork_id = ?, artwork_source = 'manual' WHERE id = ?")
-            .bind(artwork_id)
-            .bind(aid)
-            .execute(&mut *tx)
-            .await?;
+        let res = sqlx::query(
+            "UPDATE album SET artwork_id = ?, artwork_source = 'manual' WHERE id = ?",
+        )
+        .bind(artwork_id)
+        .bind(aid)
+        .execute(&mut *tx)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Err(AppError::Other(format!("album {aid} not found")));
+        }
     }
     tx.commit().await?;
 


### PR DESCRIPTION
Refs #405. Found while investigating @jo-el414's report — and it is not the bug I went looking for.

## The bug

`samples_played` is the **only** source of truth for playback position. Both `current_position_ms` and `session_listened_ms` derive from it. It was advanced in exactly one place:

```rust
// output.rs — the cpal data callback
if written > 0 {
    shared.samples_played.fetch_add(written, Ordering::Relaxed);
}
```

The WASAPI Exclusive render thread does not go through cpal. It pops the same ring buffer and writes to the device itself — and it never touched that counter. So with exclusive mode engaged, position stays pinned at `base_offset_ms` for as long as it is on.

Every symptom in #405 falls out of that one omission:

- **the progress bar freezes** — nothing to render
- **lyrics stop following**, side panel and fullscreen alike — sync is position-driven
- **every play is credited as 0 ms** — `session_listened_ms` reads the same counter, so nothing reaches the 15 s threshold and listening history is silently lost for the whole session

@jo-el414's screenshot is the proof: the track is playing, the timer reads `0:00`.

## What I had wrong

I had this filed as *state desync after a device flap*, and was about to ask the reporter whether the breakage followed the toggle or the stutter. Neither. **It has nothing to do with the device flap** — position never advances from the moment exclusive mode engages. The flap was a coincidence in the log, and his "same as before" was the actual clue.

The maintainer's read — *"when he turns WASAPI on, the UI bugs"* — was right, and my log-driven theory was pointing at the wrong subsystem.

## Fix

Count the samples actually pulled from the ring and publish them, mirroring the cpal path exactly:

- silence written on an underrun is **not** counted
- the mono downmix counts the pops it made, not the frame width

## The comment that hid it

`state.rs` documented the invariant as:

> `samples_played` is advanced only by the cpal callback

True when written; quietly false once the exclusive output landed in #174. A second output was added without the comment — or the counter — following it. It now states the contract **both** outputs owe, and why: an output path that forgets to advance it freezes the UI and zeroes the stats.

## Verification

`cargo clippy --workspace --all-targets` ✅

**Not unit-testable in place**, and worth being explicit about: the counter is advanced on a `!Send` device thread driving real WASAPI hardware, so there is nothing to construct in a test. The check is behavioural — with exclusive mode on, the progress bar should advance and the lyrics should follow. @jo-el414 has the hardware and has agreed to confirm on the next beta.

## Not fixed here

The **stuck Settings toggle**, reported independently by both testers, is a separate thread. #405 stays open for it.

(The `.gitignore` line keeps a scratch draft file out of the repo.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * La provenance des pochettes d’album est désormais conservée séparément pour garantir des actualisations plus fiables.
  * Les pochettes ajoutées depuis Deezer, un fichier local ou l’analyse des dossiers sont enregistrées de manière cohérente.
  * La progression de lecture reste correctement synchronisée en mode audio exclusif WASAPI.

* **Corrections**
  * Les mises à jour de pochettes sont désormais atomiques, évitant les associations incomplètes ou les données orphelines.
  * Les pochettes partagées entre plusieurs albums ne sont plus remplacées ou protégées à tort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Second commit: album cover updates that match no row

Unrelated to the WASAPI work above, and landed here rather than on its own branch — flagging it rather than leaving a reviewer to wonder.

The artist artwork paths already checked `rows_affected` and errored when the row was gone; the three **album** paths did not. A stale album id — a UI holding a deleted row, a concurrent delete — committed the artwork insert, matched nothing, and returned `Ok`. The user saw success and no cover changed.

All three now guard it. The early return leaves the transaction un-committed, so the artwork row rolls back with it rather than landing with nothing pointing at it.

`update_track_cover` is guarded **only when `album_id` is `Some`**: a loose track legitimately has no album, and that path must still commit, because the cover has already been written into the audio file itself — which is what that command exists to do.

Came out of review feedback on the #404 code after it merged.
