### PR TITLE
fix(audio): negotiate WASAPI exclusive against the endpoint format

### DIFF
--- a/docs/architecture/audio.md
+++ b/docs/architecture/audio.md
@@ -44,15 +44,34 @@
 [`audio/wasapi_exclusive.rs`](../../src-tauri/crates/app/src/audio/wasapi_exclusive.rs) is a parallel output backend to the cpal shared-mode default. Engaged via the `audio.wasapi_exclusive` profile setting (toggle in Settings → Audio). When on:
 
 1. `output::spawn_output_with_mode` tries the exclusive backend first via the [`wasapi` crate](https://crates.io/crates/wasapi).
-2. The backend opens the device in **event-driven exclusive mode** at the device's mix-format sample rate (whatever the user picked in the Windows Sound control panel). 32-bit float stereo, anchored on `KSDATAFORMAT_SUBTYPE_IEEE_FLOAT`.
-3. If init fails (device busy with another exclusive app, no float-32 support, COM apartment conflict), the engine logs a warning and falls back transparently to the cpal shared backend so the user keeps hearing audio.
+2. The backend opens the device in **event-driven exclusive mode**, negotiating over two axes (see below).
+3. If every candidate fails (device busy with another exclusive app, no supported format, COM apartment conflict), the engine logs a warning and falls back transparently to the cpal shared backend so the user keeps hearing audio.
+
+### Format negotiation (two axes)
+
+`open_exclusive_session` walks **layout × bit depth** and takes the first pair the driver accepts.
+
+**Layout** — `(sample rate, channel count)`, from `build_layout_candidates`, in order:
+
+| # | Origin     | Source                                                                                           |
+|---|------------|--------------------------------------------------------------------------------------------------|
+| 1 | `endpoint` | `PKEY_AudioEngine_DeviceFormat` — the "Default Format" picked in the Windows Sound control panel |
+| 2 | `mix`      | `IAudioClient::GetMixFormat` — the shared-mode mix format                                        |
+| 3 | `stereo`   | 2 channels at each of the rates above                                                            |
+
+The endpoint format leads on purpose (#409). The mix format describes the pipe into the Windows audio engine **after** its own processing, so with Audio Enhancements, Spatial Sound or a virtual-surround driver active it reports e.g. 8 channels for a plain stereo jack. Negotiating exclusive mode against that asks the hardware for a layout it has never supported: every format is rejected with `AUDCLNT_E_UNSUPPORTED_FORMAT` (`0x88890008`) and the user silently lands back in shared mode. `PKEY_AudioEngine_DeviceFormat` describes the endpoint itself, which is what exclusive mode wants. The two agree on most machines, so candidate 2 is deduped away.
+
+**Bit depth** — `FORMAT_FALLBACK_CHAIN`, high to low: `F32` → `S24_3LE` → `S24_4LE` → `S16_LE`. Most audiophile DACs take Float32 natively; Realtek ALC and many integrated codecs reject it outright but accept PCM.
+
+Each rejection logs the full `(rate, channels, format, layout-origin)` at `debug`, and the success logs the same at `info` — a rejection blamed on the bit depth is very often the channel count instead.
 
 Trade-offs:
 
 - **Bit-perfect to the DAC at the chosen rate.** No Windows mixer between us and the hardware — no automatic resampling, no system-sound mixing, no per-app volume DSP.
 - **One app at a time.** While exclusive is engaged, system sounds (notifications, Discord, browser audio) are silenced. By design.
 - **Mode survives device hot-swaps.** `engine::set_output_device` reuses the same `spawn_output_with_mode` dispatch so picking a new output keeps the chosen mode.
-- **No per-track rate switching yet.** The decoder's rubato resampler still converts every source to the device's mix rate. True bit-perfect at the source rate is a future phase (would require reinitialising the WASAPI client on every rate change).
+- **No per-track rate switching yet.** The decoder's rubato resampler still converts every source to the negotiated rate. True bit-perfect at the source rate is a future phase (would require reinitialising the WASAPI client on every rate change).
+- **The negotiated layout is authoritative downstream.** `open_exclusive_session` stores it into `SharedPlayback.{sample_rate,channels}` before init is reported to the caller, so the decoder thread — spawned only after that — resamples and downmixes to what the device actually accepted, not to what the mix format claimed.
 
 Dependency footprint: the `wasapi` crate + a slim slice of `windows-rs` features (`Win32_Foundation`, `Win32_System_Com`, `Win32_System_Threading`) target-gated to `cfg(target_os = "windows")`. Adds ~5-10 MB to the NSIS / MSI Windows binary; the Linux + macOS bundles are untouched.
 

--- a/docs/architecture/audio.md
+++ b/docs/architecture/audio.md
@@ -61,7 +61,7 @@
 
 The endpoint format leads on purpose (#409). The mix format describes the pipe into the Windows audio engine **after** its own processing, so with Audio Enhancements, Spatial Sound or a virtual-surround driver active it reports e.g. 8 channels for a plain stereo jack. Negotiating exclusive mode against that asks the hardware for a layout it has never supported: every format is rejected with `AUDCLNT_E_UNSUPPORTED_FORMAT` (`0x88890008`) and the user silently lands back in shared mode. `PKEY_AudioEngine_DeviceFormat` describes the endpoint itself, which is what exclusive mode wants. The two agree on most machines, so candidate 2 is deduped away.
 
-**Bit depth** — `FORMAT_FALLBACK_CHAIN`, high to low: `F32` → `S24_3LE` → `S24_4LE` → `S16_LE`. Most audiophile DACs take Float32 natively; Realtek ALC and many integrated codecs reject it outright but accept PCM.
+**Sample format** — `FORMAT_FALLBACK_CHAIN`, tried in order: `F32` → `S24_3LE` → `S24_4LE` → `S16_LE`. Float32 leads because it costs no conversion at the boundary and most audiophile DACs take it natively; Realtek ALC and many integrated codecs reject it outright but accept PCM, so the two 24-bit PCM representations follow (packed 3-byte, then 24 valid bits in a 4-byte container — the same precision, different wire layout), with `S16_LE` as the universal last resort. Note this is a format sequence, not a monotonic walk down bit depth: `S24_4LE` uses a 32-bit container.
 
 Each rejection logs the full `(rate, channels, format, layout-origin)` at `debug`, and the success logs the same at `info` — a rejection blamed on the bit depth is very often the channel count instead.
 

--- a/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
+++ b/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
@@ -17,10 +17,11 @@
 //!   error, we surface it through `player:error` so the user can
 //!   toggle the feature off without restarting.
 //!
-//! Scope: we initialize exclusive at the device's **mix-format
-//! sample rate** (i.e. the default rate Windows reports for the
-//! device, typically the rate the audiophile picked in the Windows
-//! Sound control panel). The decoder's existing rubato resampler
+//! Scope: we initialize exclusive at the device's **endpoint format**
+//! (`PKEY_AudioEngine_DeviceFormat`, i.e. the "Default Format" the
+//! audiophile picked in the Windows Sound control panel), falling
+//! back to the shared-mode mix format and then to plain stereo — see
+//! [`collect_layout_candidates`]. The decoder's existing rubato resampler
 //! still converts every source track to that rate — so this is
 //! "bypass the OS mixer" rather than "honor the source rate
 //! exactly". Per-track sample-rate switching is a future phase.
@@ -221,6 +222,129 @@ const FORMAT_FALLBACK_CHAIN: [ExclusiveSampleFormat; 4] = [
     ExclusiveSampleFormat::Pcm16,
 ];
 
+/// A (sample rate, channel count) pair to try in exclusive mode,
+/// tagged with where it came from so the log says which source
+/// actually got the device open (#409).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LayoutCandidate {
+    sample_rate: usize,
+    channels: usize,
+    origin: &'static str,
+}
+
+/// Build the layout candidates in priority order (#409).
+///
+/// The order matters, and the first entry is the whole point of this
+/// function. `get_mixformat` returns the **shared-mode mix format** —
+/// the shape of the pipe into the Windows audio engine, *after* the
+/// engine has applied whatever it wants. With "Audio Enhancements",
+/// Spatial Sound or a virtual-surround driver in the way, that comes
+/// back as 8 channels even though the endpoint is a plain stereo jack.
+/// Negotiating exclusive mode against it asks the hardware for a
+/// layout it has never supported, so every format in the chain is
+/// rejected with `AUDCLNT_E_UNSUPPORTED_FORMAT` (0x88890008) and the
+/// user silently drops to shared mode.
+///
+/// `get_device_format` reads `PKEY_AudioEngine_DeviceFormat` instead —
+/// the "Default Format" the user picked in the Windows Sound control
+/// panel, which describes the endpoint itself rather than the engine
+/// in front of it. That is the layout exclusive mode actually wants.
+///
+/// The mix format stays as the second candidate (it's correct on the
+/// majority of machines, where the two agree anyway), and a plain
+/// stereo entry closes the list for drivers that report a
+/// multi-channel default no application can open.
+fn collect_layout_candidates(device: &Device) -> Vec<LayoutCandidate> {
+    // A device with no property store, or a driver that doesn't
+    // publish the key, is a soft failure — the mix format still gets
+    // its turn, which is exactly the pre-#409 behaviour.
+    let endpoint = match device.get_device_format() {
+        Ok(fmt) => Some((
+            fmt.get_samplespersec() as usize,
+            fmt.get_nchannels() as usize,
+        )),
+        Err(err) => {
+            tracing::debug!(
+                %err,
+                "wasapi exclusive: endpoint device format unavailable, falling back to mix format"
+            );
+            None
+        }
+    };
+
+    let mix = match device
+        .get_iaudioclient()
+        .and_then(|client| client.get_mixformat())
+    {
+        Ok(fmt) => Some((
+            fmt.get_samplespersec() as usize,
+            fmt.get_nchannels() as usize,
+        )),
+        Err(err) => {
+            tracing::debug!(%err, "wasapi exclusive: mix format unavailable");
+            None
+        }
+    };
+
+    build_layout_candidates(endpoint, mix)
+}
+
+/// Ordering + dedupe half of [`collect_layout_candidates`], split out
+/// so it can be unit-tested without a COM apartment or real hardware.
+///
+/// Both inputs are `(sample_rate, channels)`, and either may be absent
+/// when the corresponding query failed.
+fn build_layout_candidates(
+    endpoint: Option<(usize, usize)>,
+    mix: Option<(usize, usize)>,
+) -> Vec<LayoutCandidate> {
+    // Dedupe on the layout, not the origin: the endpoint format and
+    // the mix format agree on most machines, and probing the same
+    // pair twice would just double the failure log. A zero in either
+    // field means the driver handed back a malformed format — skip it
+    // rather than ask WASAPI for a 0-channel stream.
+    fn push(
+        candidates: &mut Vec<LayoutCandidate>,
+        sample_rate: usize,
+        channels: usize,
+        origin: &'static str,
+    ) {
+        if channels > 0
+            && sample_rate > 0
+            && !candidates
+                .iter()
+                .any(|c| c.sample_rate == sample_rate && c.channels == channels)
+        {
+            candidates.push(LayoutCandidate {
+                sample_rate,
+                channels,
+                origin,
+            });
+        }
+    }
+
+    let mut candidates: Vec<LayoutCandidate> = Vec::new();
+
+    if let Some((rate, channels)) = endpoint {
+        push(&mut candidates, rate, channels, "endpoint");
+    }
+
+    if let Some((rate, channels)) = mix {
+        push(&mut candidates, rate, channels, "mix");
+        // Channel-axis fallback: same rate, plain stereo. Catches the
+        // case where both reported layouts are inflated.
+        push(&mut candidates, rate, 2, "stereo");
+    }
+
+    // Stereo at the endpoint rate too, in case the endpoint and the
+    // engine disagree on the rate as well as the channel count.
+    if let Some((rate, _)) = endpoint {
+        push(&mut candidates, rate, 2, "stereo");
+    }
+
+    candidates
+}
+
 /// Bundle of everything the event loop needs after a successful init.
 /// Kept private so callers can't misuse the wasapi handles outside
 /// the thread that owns the COM apartment.
@@ -236,8 +360,11 @@ struct ExclusiveSession {
     format: ExclusiveSampleFormat,
 }
 
-/// Resolve the device, then walk the format fallback chain
-/// (#174). For each candidate we acquire a fresh `IAudioClient`,
+/// Resolve the device, then walk every (layout × bit depth) candidate
+/// (#174, #409). Layouts come from [`collect_layout_candidates`] —
+/// endpoint format first, then the mix format, then plain stereo —
+/// and each one is probed against the full format chain before moving
+/// on. For each candidate we acquire a fresh `IAudioClient`,
 /// check the format is supported in exclusive mode, and try to
 /// initialize. Many consumer DACs (Realtek ALC, Conexant CX, some
 /// USB codecs) reject `IEEE_FLOAT` outright with
@@ -257,53 +384,63 @@ fn open_exclusive_session(
 ) -> AppResult<ExclusiveSession> {
     let device = pick_device(device_name)?;
 
-    // Mix format gives us the device's native (sample rate,
-    // channel count). It doesn't tell us the supported bit depth
-    // in exclusive mode — that's what the chain below probes.
-    let probe_client = device
-        .get_iaudioclient()
-        .map_err(|e| AppError::Audio(format!("get IAudioClient (probe): {e:?}")))?;
-    let mix_format = probe_client
-        .get_mixformat()
-        .map_err(|e| AppError::Audio(format!("get_mixformat: {e:?}")))?;
-    let sample_rate = mix_format.get_samplespersec() as usize;
-    let channels = mix_format.get_nchannels() as usize;
-    drop(probe_client);
+    let layouts = collect_layout_candidates(&device);
+    if layouts.is_empty() {
+        return Err(AppError::Audio(
+            "wasapi exclusive: device reported no usable sample rate / channel layout".into(),
+        ));
+    }
 
     let mut last_err: Option<AppError> = None;
-    for &format in FORMAT_FALLBACK_CHAIN.iter() {
-        match try_open_with_format(&device, format, sample_rate, channels) {
-            Ok((client, render, event, buffer_frames)) => {
-                tracing::info!(
-                    sample_rate = sample_rate as u32,
-                    channels = channels as u16,
-                    format = format.label(),
-                    "wasapi exclusive negotiation succeeded"
-                );
-                shared
-                    .sample_rate
-                    .store(sample_rate as u32, Ordering::Release);
-                shared.channels.store(channels as u16, Ordering::Release);
-                return Ok(ExclusiveSession {
-                    client,
-                    render,
-                    event,
-                    sample_rate: sample_rate as u32,
-                    channels: channels as u16,
-                    buffer_frames,
-                    format,
-                });
-            }
-            Err(err) => {
-                tracing::debug!(
-                    format = format.label(),
-                    %err,
-                    "wasapi exclusive format rejected; trying next in chain"
-                );
-                last_err = Some(err);
+    for layout in &layouts {
+        for &format in FORMAT_FALLBACK_CHAIN.iter() {
+            match try_open_with_format(&device, format, layout.sample_rate, layout.channels) {
+                Ok((client, render, event, buffer_frames)) => {
+                    tracing::info!(
+                        sample_rate = layout.sample_rate as u32,
+                        channels = layout.channels as u16,
+                        format = format.label(),
+                        layout = layout.origin,
+                        "wasapi exclusive negotiation succeeded"
+                    );
+                    shared
+                        .sample_rate
+                        .store(layout.sample_rate as u32, Ordering::Release);
+                    shared.channels.store(layout.channels as u16, Ordering::Release);
+                    return Ok(ExclusiveSession {
+                        client,
+                        render,
+                        event,
+                        sample_rate: layout.sample_rate as u32,
+                        channels: layout.channels as u16,
+                        buffer_frames,
+                        format,
+                    });
+                }
+                Err(err) => {
+                    // Log the full triple, not just the bit depth: a
+                    // rejection blamed on the format is very often the
+                    // channel count instead, and the pre-#409 log made
+                    // that impossible to tell apart from a diagnostics
+                    // dump.
+                    tracing::debug!(
+                        sample_rate = layout.sample_rate as u32,
+                        channels = layout.channels as u16,
+                        format = format.label(),
+                        layout = layout.origin,
+                        %err,
+                        "wasapi exclusive candidate rejected; trying next"
+                    );
+                    last_err = Some(err);
+                }
             }
         }
     }
+
+    tracing::warn!(
+        candidates = ?layouts,
+        "wasapi exclusive: no (rate, channels, format) combination was accepted"
+    );
 
     Err(last_err.unwrap_or_else(|| {
         AppError::Audio("wasapi exclusive: every format in the fallback chain was rejected".into())
@@ -620,6 +757,92 @@ fn pack_samples(format: ExclusiveSampleFormat, samples: &[f32], bytes: &mut [u8]
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn layouts(candidates: &[LayoutCandidate]) -> Vec<(usize, usize, &'static str)> {
+        candidates
+            .iter()
+            .map(|c| (c.sample_rate, c.channels, c.origin))
+            .collect()
+    }
+
+    /// The #409 report: Windows shows the endpoint as stereo 44.1 kHz,
+    /// but the mix format comes back as 8 channels because the audio
+    /// engine has a virtual-surround effect in front of it. Probing
+    /// the mix format first is what made every format fail.
+    #[test]
+    fn endpoint_layout_is_tried_before_an_inflated_mix_format() {
+        let candidates = build_layout_candidates(Some((44_100, 2)), Some((48_000, 8)));
+        assert_eq!(
+            layouts(&candidates),
+            vec![
+                (44_100, 2, "endpoint"),
+                (48_000, 8, "mix"),
+                (48_000, 2, "stereo"),
+            ],
+            "the endpoint's own format must be candidate #1"
+        );
+    }
+
+    /// The common case: nothing is intercepting the stream, both
+    /// queries agree. One probe, not two identical ones.
+    #[test]
+    fn agreeing_endpoint_and_mix_collapse_to_one_candidate() {
+        let candidates = build_layout_candidates(Some((48_000, 2)), Some((48_000, 2)));
+        assert_eq!(layouts(&candidates), vec![(48_000, 2, "endpoint")]);
+    }
+
+    /// Both sources inflated: the stereo entry is the only way out.
+    #[test]
+    fn stereo_closes_the_list_when_every_reported_layout_is_multichannel() {
+        let candidates = build_layout_candidates(Some((48_000, 6)), Some((48_000, 8)));
+        assert_eq!(
+            layouts(&candidates),
+            vec![
+                (48_000, 6, "endpoint"),
+                (48_000, 8, "mix"),
+                (48_000, 2, "stereo"),
+            ]
+        );
+    }
+
+    /// Endpoint and mix disagree on the rate as well — stereo is
+    /// offered at both rates, endpoint's first.
+    #[test]
+    fn stereo_fallback_covers_both_reported_rates() {
+        let candidates = build_layout_candidates(Some((96_000, 8)), Some((48_000, 8)));
+        assert_eq!(
+            layouts(&candidates),
+            vec![
+                (96_000, 8, "endpoint"),
+                (48_000, 8, "mix"),
+                (48_000, 2, "stereo"),
+                (96_000, 2, "stereo"),
+            ]
+        );
+    }
+
+    /// A driver that doesn't publish `PKEY_AudioEngine_DeviceFormat`
+    /// must still get the pre-#409 behaviour rather than no candidate.
+    #[test]
+    fn missing_endpoint_format_falls_back_to_the_mix_format() {
+        let candidates = build_layout_candidates(None, Some((44_100, 2)));
+        assert_eq!(layouts(&candidates), vec![(44_100, 2, "mix")]);
+    }
+
+    #[test]
+    fn no_usable_format_yields_no_candidates() {
+        assert!(build_layout_candidates(None, None).is_empty());
+    }
+
+    /// A malformed format must not reach WASAPI as a 0-channel or
+    /// 0 Hz stream request. A usable rate carried alongside a bogus
+    /// channel count still earns a stereo probe — that is the whole
+    /// point of the channel-axis fallback.
+    #[test]
+    fn degenerate_formats_are_discarded() {
+        let candidates = build_layout_candidates(Some((0, 2)), Some((48_000, 0)));
+        assert_eq!(layouts(&candidates), vec![(48_000, 2, "stereo")]);
+    }
 
     #[test]
     fn pack_samples_float32_round_trips() {

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -1516,8 +1516,10 @@ pub async fn player_set_output_device(
 
 /// Toggle WASAPI Exclusive Mode (Windows-only audiophile path).
 ///
-/// Re-opens the active output stream in exclusive event-driven mode
-/// at the device's mix-format sample rate. Bypasses the Windows audio
+/// Re-opens the active output stream in exclusive event-driven mode,
+/// negotiating the layout from the endpoint's own format
+/// (`PKEY_AudioEngine_DeviceFormat`) first and only then the
+/// shared-mode mix format (#409). Bypasses the Windows audio
 /// engine so no other app can mix in / DSP / resample our audio.
 /// Falls back silently to cpal shared mode if init fails (device
 /// busy, unsupported format, no exclusive support on the driver) —


### PR DESCRIPTION
Fixes #409.

## The bug

Exclusive-mode negotiation asked the device for the layout reported by `IAudioClient::GetMixFormat`. That is the **shared-mode mix format** — the shape of the pipe into the Windows audio engine, *after* whatever the engine puts in front of the endpoint. With Audio Enhancements, Spatial Sound or a virtual-surround driver active it comes back multi-channel for a physically stereo jack.

On the reporting machine: Windows shows the endpoint as **stereo 44.1 kHz**, cpal reports **8 channels**. Every entry in the format chain was then rejected with `AUDCLNT_E_UNSUPPORTED_FORMAT` (`0x88890008`) — not because the bit depth was wrong, but because no consumer codec opens 8 channels in exclusive mode. The toggle silently fell back to shared mode, so bit-perfect output was simply unreachable.

Disabling the audio enhancements does **not** work around it: the log still showed 8 channels afterwards.

## The fix

Negotiation now walks **layout × bit depth** instead of one layout × bit depth.

Layouts, in order:

1. `endpoint` — `PKEY_AudioEngine_DeviceFormat`, the "Default Format" picked in the Windows Sound control panel. This describes the endpoint itself rather than the engine in front of it, and is what exclusive mode actually wants.
2. `mix` — the previous behaviour, kept as a fallback.
3. `stereo` — 2 channels at each of the rates above, for drivers whose reported default no application can open.

`wasapi` 0.23 already exposes the property read as `Device::get_device_format()`, so no raw Win32 was needed.

Identical pairs are deduped. On the majority of machines the endpoint and mix formats agree, so those users probe **exactly as many times as before** — this is additive, not a behaviour change for the working case.

Rejections now log the full `(rate, channels, format, origin)` tuple. The old line named only the bit depth, which is precisely what made a channel-count mismatch read as a format problem for weeks.

## Notes

- The negotiated layout is stored into `SharedPlayback.{sample_rate,channels}` before init is reported to the caller, and the decoder thread is spawned only afterwards — so it resamples and downmixes to what the device accepted, not to what the mix format claimed. That ordering already held; I documented it rather than changed it.
- Docs: `docs/architecture/audio.md` also still claimed exclusive mode was "32-bit float stereo, anchored on `KSDATAFORMAT_SUBTYPE_IEEE_FLOAT`" — stale since the format chain landed in #174. Corrected in the same pass.

## Testing

The ordering/dedupe logic is split into a pure `build_layout_candidates` so it is testable without a COM apartment or real hardware. 7 unit tests cover the reporter's exact case, the agreeing-formats common case, both-inflated, disagreeing rates, a driver that doesn't publish the key, no usable format, and malformed formats.

**I could not execute them locally**: `cargo test -p waveflow --lib` aborts with `STATUS_ENTRYPOINT_NOT_FOUND` on this Windows box (a pre-existing Tauri DLL issue, not related to this change). To avoid claiming untested code, I extracted the function plus its tests into a standalone binary and ran them there — 7/7 pass. CI runs them for real on the Windows runner.

`cargo clippy -p waveflow --all-targets` is clean.

The end-to-end path needs hardware confirmation from someone whose device exhibits the mismatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Amélioration du mode exclusif WASAPI sous Windows grâce à une négociation plus fiable du format audio.
  * Prise en charge prioritaire du format recommandé par le périphérique, avec plusieurs formats de secours.
  * Conservation de la lecture audio via le mode partagé en cas d’échec du mode exclusif.

* **Documentation**
  * Mise à jour de la documentation sur la sélection des formats, les compromis et le comportement de bascule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->