### PR TITLE
fix(audio): probe exclusive formats with the driver-quirk fallbacks

### DIFF
--- a/docs/architecture/audio.md
+++ b/docs/architecture/audio.md
@@ -63,7 +63,14 @@ The endpoint format leads on purpose (#409). The mix format describes the pipe i
 
 **Sample format** — `FORMAT_FALLBACK_CHAIN`, tried in order: `F32` → `S24_3LE` → `S24_4LE` → `S16_LE`. Float32 leads because it costs no conversion at the boundary and most audiophile DACs take it natively; Realtek ALC and many integrated codecs reject it outright but accept PCM, so the two 24-bit PCM representations follow (packed 3-byte, then 24 valid bits in a 4-byte container — the same precision, different wire layout), with `S16_LE` as the universal last resort. Note this is a format sequence, not a monotonic walk down bit depth: `S24_4LE` uses a 32-bit container.
 
-Each rejection logs the full `(rate, channels, format, layout-origin)` at `debug`, and the success logs the same at `info` — a rejection blamed on the bit depth is very often the channel count instead.
+**Representation** — each `(layout, format)` pair is probed through `AudioClient::is_supported_exclusive_with_quirks`, not a bare `is_supported`. Two driver quirks hide behind an `AUDCLNT_E_UNSUPPORTED_FORMAT` that looks like a rate/depth problem but isn't:
+
+- **Channel mask.** `WaveFormat::new(.., None)` guesses one, and a multi-channel endpoint typically accepts exactly one specific mask. The helper re-probes against each recommended `ksmedia.h` mask. *This is the one that bit in practice* (#405): a 7.1-configured endpoint rejected every rate × depth combination purely on the mask.
+- **Structure shape.** `WaveFormat::new` always builds a `WAVEFORMATEXTENSIBLE`; some drivers refuse it while accepting the same PCM layout as a plain `WAVEFORMATEX`. The helper retries that form for mono/stereo only.
+
+Init then uses the shape the probe accepted, falling back to the requested shape when the two differ (wasapi's docs note some drivers validate the simplified form but want the original at init time).
+
+Each rejection logs the full `(rate, channels, format, layout-origin)` at `debug`, the success logs the same at `info`, and a total failure logs **every** attempt in one `warn` line — release builds log at `info`, so without that summary a user report only ever surfaced the last attempt of eight.
 
 Trade-offs:
 

--- a/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
+++ b/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
@@ -468,6 +468,12 @@ fn open_exclusive_session(
 ///
 /// Used only to skip a redundant second init attempt, never to decide
 /// whether a format is acceptable.
+///
+/// Deliberately does **not** compare the subformat GUID (Int vs Float):
+/// both operands always come from the same [`ExclusiveSampleFormat`],
+/// and the quirk probe only ever changes the channel mask or the
+/// `WAVEFORMATEX`/`WAVEFORMATEXTENSIBLE` shape. Don't reuse this as a
+/// general format equality without adding that field.
 fn same_wave_format(a: &WaveFormat, b: &WaveFormat) -> bool {
     a.wave_fmt.Format.cbSize == b.wave_fmt.Format.cbSize
         && a.get_nchannels() == b.get_nchannels()
@@ -518,13 +524,22 @@ fn try_open_with_format(
     // retry is a guaranteed repeat of the same failure.
     match init_stream(device, format, channels, &accepted) {
         Ok(session) => Ok(session),
-        Err(err) if !same_wave_format(&accepted, &requested) => {
+        Err(accepted_err) if !same_wave_format(&accepted, &requested) => {
             tracing::debug!(
                 format = format.label(),
-                %err,
+                err = %accepted_err,
                 "wasapi exclusive: init with the probe-accepted shape failed, retrying as requested"
             );
-            init_stream(device, format, channels, &requested)
+            // Carry both failures. The first one only ever went to
+            // `debug`, which release builds don't emit — the same blind
+            // spot that made this bug take three passes to find. When
+            // both shapes are refused, the caller's summary must say so.
+            init_stream(device, format, channels, &requested).map_err(|requested_err| {
+                AppError::Audio(format!(
+                    "{} refused in both shapes — probe-accepted: {accepted_err}; as requested: {requested_err}",
+                    format.label()
+                ))
+            })
         }
         Err(err) => Err(err),
     }
@@ -916,6 +931,80 @@ mod tests {
     fn degenerate_formats_are_discarded() {
         let candidates = build_layout_candidates(Some((0, 2)), Some((48_000, 0)));
         assert_eq!(layouts(&candidates), vec![(48_000, 2, "stereo")]);
+    }
+
+    // ── same_wave_format ─────────────────────────────────────────────
+    //
+    // This decides whether the init retry runs at all: two shapes that
+    // compare equal skip the second attempt. A field the driver cares
+    // about but this comparison misses would silently swallow the
+    // retry, so each one gets its own case with a single field moved.
+
+    #[test]
+    fn same_wave_format_accepts_identical_formats() {
+        let a = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 2);
+        let b = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 2);
+        assert!(same_wave_format(&a, &b));
+    }
+
+    /// The quirk that actually fixed #405: the probe only accepts the
+    /// format once a different `ksmedia.h` mask is swapped in. If that
+    /// difference were invisible here the retry would be skipped and
+    /// the fix would silently do nothing.
+    #[test]
+    fn same_wave_format_rejects_a_different_channel_mask() {
+        let a = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 8);
+        let mut b = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 8);
+        b.wave_fmt.dwChannelMask ^= 0x1;
+        assert!(!same_wave_format(&a, &b));
+    }
+
+    /// The other quirk: `WAVEFORMATEX` (`cbSize` 0) vs
+    /// `WAVEFORMATEXTENSIBLE` (`cbSize` 22), which the probe swaps for
+    /// mono/stereo. Same numbers, different structure — and drivers
+    /// genuinely accept one and refuse the other.
+    #[test]
+    fn same_wave_format_rejects_a_different_structure_size() {
+        let a = ExclusiveSampleFormat::Pcm16.to_wave_format(44_100, 2);
+        let mut b = ExclusiveSampleFormat::Pcm16.to_wave_format(44_100, 2);
+        b.wave_fmt.Format.cbSize = 0;
+        assert!(!same_wave_format(&a, &b));
+    }
+
+    #[test]
+    fn same_wave_format_rejects_a_different_channel_count() {
+        let a = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 2);
+        let b = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 8);
+        assert!(!same_wave_format(&a, &b));
+    }
+
+    #[test]
+    fn same_wave_format_rejects_a_different_sample_rate() {
+        let a = ExclusiveSampleFormat::Pcm16.to_wave_format(44_100, 2);
+        let b = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 2);
+        assert!(!same_wave_format(&a, &b));
+    }
+
+    #[test]
+    fn same_wave_format_rejects_a_different_bit_depth() {
+        let a = ExclusiveSampleFormat::Pcm16.to_wave_format(48_000, 2);
+        let b = ExclusiveSampleFormat::Pcm24Packed.to_wave_format(48_000, 2);
+        assert!(!same_wave_format(&a, &b));
+    }
+
+    /// `S24_4LE` and `F32` share a 32-bit container and differ only in
+    /// the valid-bit count — the one field a container-size comparison
+    /// alone would miss.
+    #[test]
+    fn same_wave_format_rejects_a_different_valid_bit_count() {
+        let padded = ExclusiveSampleFormat::Pcm24Padded.to_wave_format(48_000, 2);
+        let float = ExclusiveSampleFormat::Float32.to_wave_format(48_000, 2);
+        assert_eq!(
+            padded.get_bitspersample(),
+            float.get_bitspersample(),
+            "precondition: both must use a 32-bit container"
+        );
+        assert!(!same_wave_format(&padded, &float));
     }
 
     #[test]

--- a/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
+++ b/src-tauri/crates/app/src/audio/wasapi_exclusive.rs
@@ -40,7 +40,7 @@ use rtrb::{Consumer, Producer, RingBuffer};
 use tauri::AppHandle;
 use wasapi::{
     AudioClient, AudioRenderClient, Device, DeviceEnumerator, Direction, Handle, SampleType,
-    ShareMode, StreamMode, WaveFormat,
+    StreamMode, WaveFormat,
 };
 
 use super::output::{OutputHandle, RING_CAPACITY};
@@ -392,6 +392,11 @@ fn open_exclusive_session(
     }
 
     let mut last_err: Option<AppError> = None;
+    // Every rejection, kept for the summary below. `debug` alone was
+    // not enough: release logs run at `info`, so a user reporting a
+    // failure only ever showed us the last attempt of eight and the
+    // other seven had to be guessed at.
+    let mut failures: Vec<String> = Vec::new();
     for layout in &layouts {
         for &format in FORMAT_FALLBACK_CHAIN.iter() {
             match try_open_with_format(&device, format, layout.sample_rate, layout.channels) {
@@ -431,6 +436,13 @@ fn open_exclusive_session(
                         %err,
                         "wasapi exclusive candidate rejected; trying next"
                     );
+                    failures.push(format!(
+                        "{}@{}Hz/{}ch[{}]: {err}",
+                        format.label(),
+                        layout.sample_rate,
+                        layout.channels,
+                        layout.origin
+                    ));
                     last_err = Some(err);
                 }
             }
@@ -439,6 +451,8 @@ fn open_exclusive_session(
 
     tracing::warn!(
         candidates = ?layouts,
+        attempts = failures.len(),
+        failures = %failures.join(" | "),
         "wasapi exclusive: no (rate, channels, format) combination was accepted"
     );
 
@@ -447,31 +461,91 @@ fn open_exclusive_session(
     }))
 }
 
-/// Single attempt with one bit-depth format. Builds a fresh
-/// `IAudioClient`, asks WASAPI to validate the WaveFormat, then
-/// initializes + starts the stream. Pre-fills with silence sized to
-/// the negotiated format so the first device event lands on clean
-/// state.
+/// Do two `WaveFormat`s describe the same stream? Compares every
+/// field that matters to the driver, including the container tag
+/// (`cbSize` distinguishes `WAVEFORMATEX` from `WAVEFORMATEXTENSIBLE`)
+/// and the channel mask.
+///
+/// Used only to skip a redundant second init attempt, never to decide
+/// whether a format is acceptable.
+fn same_wave_format(a: &WaveFormat, b: &WaveFormat) -> bool {
+    a.wave_fmt.Format.cbSize == b.wave_fmt.Format.cbSize
+        && a.get_nchannels() == b.get_nchannels()
+        && a.get_samplespersec() == b.get_samplespersec()
+        && a.get_bitspersample() == b.get_bitspersample()
+        && a.get_validbitspersample() == b.get_validbitspersample()
+        && a.get_dwchannelmask() == b.get_dwchannelmask()
+}
+
+/// Single attempt with one bit-depth format. Probes the format, then
+/// initializes + starts the stream on a fresh `IAudioClient`.
+///
+/// The probe goes through `is_supported_exclusive_with_quirks` rather
+/// than a bare `is_supported` (#405). `WaveFormat::new` always builds a
+/// `WAVEFORMATEXTENSIBLE`, and a good number of drivers reject that
+/// representation outright with `AUDCLNT_E_UNSUPPORTED_FORMAT` while
+/// happily accepting the *same* PCM layout described as a plain
+/// `WAVEFORMATEX` — which is why a device can turn down 16-bit stereo
+/// at its own reported rate, the most universally supported format
+/// there is. The helper also re-probes against each recommended
+/// `ksmedia.h` channel mask, since a multi-channel endpoint typically
+/// accepts exactly one and `WaveFormat::new(.., None)` guesses.
 fn try_open_with_format(
     device: &Device,
     format: ExclusiveSampleFormat,
     sample_rate: usize,
     channels: usize,
 ) -> AppResult<(AudioClient, AudioRenderClient, Handle, u32)> {
-    let mut client = device
+    let requested = format.to_wave_format(sample_rate, channels);
+
+    let probe_client = device
         .get_iaudioclient()
         .map_err(|e| AppError::Audio(format!("get IAudioClient ({}): {e:?}", format.label())))?;
-
-    let wave = format.to_wave_format(sample_rate, channels);
-
-    client
-        .is_supported(&wave, &ShareMode::Exclusive)
+    let accepted = probe_client
+        .is_supported_exclusive_with_quirks(&requested)
         .map_err(|e| {
             AppError::Audio(format!(
                 "is_supported rejected {} in exclusive mode: {e:?}",
                 format.label()
             ))
         })?;
+    drop(probe_client);
+
+    // wasapi's own docs warn that some drivers validate the simplified
+    // representation but want the original one at init time. So try
+    // the shape the probe accepted first, then fall back to the shape
+    // we asked for — but only when they actually differ, otherwise the
+    // retry is a guaranteed repeat of the same failure.
+    match init_stream(device, format, channels, &accepted) {
+        Ok(session) => Ok(session),
+        Err(err) if !same_wave_format(&accepted, &requested) => {
+            tracing::debug!(
+                format = format.label(),
+                %err,
+                "wasapi exclusive: init with the probe-accepted shape failed, retrying as requested"
+            );
+            init_stream(device, format, channels, &requested)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Initialize + start an exclusive stream with one concrete
+/// `WaveFormat`. Pre-fills with silence sized to that format so the
+/// first device event lands on clean state.
+///
+/// Always takes a fresh `IAudioClient`: once initialized (or once an
+/// init has been refused) a client can't be reused, and some drivers
+/// leave a rejected one in an unusable state.
+fn init_stream(
+    device: &Device,
+    format: ExclusiveSampleFormat,
+    channels: usize,
+    wave: &WaveFormat,
+) -> AppResult<(AudioClient, AudioRenderClient, Handle, u32)> {
+    let mut client = device
+        .get_iaudioclient()
+        .map_err(|e| AppError::Audio(format!("get IAudioClient ({}): {e:?}", format.label())))?;
 
     let (default_period, min_period) = client
         .get_device_period()
@@ -480,7 +554,7 @@ fn try_open_with_format(
     let mode = StreamMode::EventsExclusive { period_hns };
 
     client
-        .initialize_client(&wave, &Direction::Render, &mode)
+        .initialize_client(wave, &Direction::Render, &mode)
         .map_err(|e| {
             AppError::Audio(format!(
                 "initialize_client {} exclusive: {e:?}",


### PR DESCRIPTION
Refs #405. Third and final pass on the WASAPI exclusive negotiation — **confirmed working on the reporting hardware.**

## What was actually wrong

The probe asked the driver about exactly one shape: the `WAVEFORMATEXTENSIBLE` that `WaveFormat::new` builds, carrying whatever channel mask `WaveFormat::new(.., None)` guesses. A multi-channel endpoint generally accepts **exactly one specific mask**, so a wrong guess comes back `AUDCLNT_E_UNSUPPORTED_FORMAT` even when the rate, channel count and bit depth are all correct.

#409 is what made this visible. Once the endpoint format was probed first, the log showed the endpoint reporting 8 channels *just like the mix format* — so the channel axis had never been the blocker on that machine — and the stereo fallback #409 added was itself turned down at **16-bit 44.1 kHz**, the most universally supported format there is. No hardware refuses that for real reasons. It had to be something outside the (rate, channels, depth) triple.

## The fix

Probing goes through `is_supported_exclusive_with_quirks`, which re-probes against each recommended `ksmedia.h` mask and, for mono/stereo, also retries the simpler `WAVEFORMATEX` representation some drivers insist on. Init uses the shape the probe accepted, falling back to the requested shape when the two differ — wasapi's own docs note that some drivers validate the simplified form but want the original at init time. `same_wave_format` skips that retry when the shapes are identical, so the common path costs nothing extra. Each attempt still takes a fresh `IAudioClient`.

## Verified

```
INFO wasapi exclusive negotiation succeeded sample_rate=44100 channels=8 format="S16_LE" layout="endpoint"
INFO wasapi exclusive stream opened sample_rate=44100 channels=8 buffer_frames=441
INFO audio output: WASAPI Exclusive Mode engaged
```

Engages with the Windows audio enhancements **both on and off** — the workaround that never worked is now moot. Since `WAVEFORMATEX` is only retried at ≤ 2 channels, an 8-channel success isolates the cause to the mask.

## Also: the diagnostics that cost three passes

A total failure now logs **every** attempt in one `warn` line, not just the last:

```
failures=F32@44100Hz/8ch[endpoint]: … | S24_3LE@44100Hz/8ch[endpoint]: … | …
```

Release builds log at `info`, so the per-attempt `debug` lines were invisible in user reports. Every round of this investigation reasoned from the last failure of eight with no way to tell whether the other seven failed identically — which is precisely why the first two hypotheses (bit depth, then channel count) each looked plausible and were each wrong.

## Testing

`cargo clippy -p waveflow --all-targets` clean; the 7 layout tests from #410 still pass (run standalone — `cargo test -p waveflow --lib` can't start on this box, pre-existing Tauri DLL issue). The negotiation itself is COM-bound and validated on hardware rather than by unit test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations audio**
  - Amélioration de la compatibilité avec les périphériques audio en mode WASAPI exclusif.
  - Négociation plus fiable des formats, canaux et dispositions audio acceptés par le pilote.
  - Nouvelle tentative automatique avec le format demandé lorsque cela est nécessaire.

- **Diagnostic et journalisation**
  - Les échecs de négociation sont désormais regroupés avec le détail de toutes les tentatives.
  - Les journaux indiquent plus clairement le taux, le nombre de canaux, le format et la disposition concernés.

- **Documentation**
  - Documentation enrichie sur la négociation des formats et les particularités des pilotes WASAPI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->