### PR TITLE
fix(dlna): rebuild the worker's resources on a profile switch

### DIFF
--- a/src-tauri/crates/app/src/commands/dlna.rs
+++ b/src-tauri/crates/app/src/commands/dlna.rs
@@ -41,10 +41,10 @@ pub async fn dlna_get_status(state: tauri::State<'_, AppState>) -> AppResult<Dln
 /// Snapshot the per-profile pool + artwork dirs into a `DlnaResources`
 /// the worker thread can hold across requests.
 ///
-/// Only called from the boot path and from `dlna_set_config` — notably
-/// **not** from `switch_profile`, so a running server keeps serving the
-/// profile it was started with until it is stopped and restarted. That
-/// gap predates the lease work and is tracked in issue #399.
+/// Called from the boot path, from `dlna_set_config`, and from
+/// `switch_profile` when the worker is already running (issue #399) —
+/// a running server otherwise keeps serving the profile it was started
+/// with, and its pool goes stale the moment the old profile is closed.
 pub async fn build_resources(state: &AppState) -> AppResult<DlnaResources> {
     // Deliberately unleashed: the worker holds this pool for the life of
     // the server, not for the span of a command, so a lease would stall

--- a/src-tauri/crates/app/src/commands/profile.rs
+++ b/src-tauri/crates/app/src/commands/profile.rs
@@ -163,6 +163,30 @@ pub async fn switch_profile(
 
     state.activate_profile(profile_id).await?;
 
+    // Refresh the DLNA worker for the new profile if it's currently
+    // serving — otherwise it keeps exposing the previous profile's
+    // library over the LAN, and its pool becomes closed out from
+    // under it moments later when `activate_profile` above drops the
+    // old one (issue #399). `status().running` reflects the worker's
+    // actual state rather than the persisted `dlna.enabled` flag, so
+    // this can't accidentally start a server the user turned off.
+    // `DlnaServer::start` restarts the whole worker (new listener,
+    // new SSDP announce) — there's no lighter "just swap the pool"
+    // path, see `dlna::mod`'s `WorkerState::start`.
+    if state.dlna.status().await.running {
+        match crate::commands::dlna::build_resources(&state).await {
+            Ok(resources) => {
+                let cfg = crate::dlna::config::load(&state.app_db)
+                    .await
+                    .unwrap_or_default();
+                state.dlna.start(cfg, resources);
+            }
+            Err(err) => {
+                tracing::warn!(%err, "DLNA resource refresh after profile switch failed");
+            }
+        }
+    }
+
     // Re-arm watchers from the new profile's library_folder rows.
     if let Ok(pool) = state.require_profile_pool().await {
         if let Err(err) = watcher.restore_from_db(&pool).await {

--- a/src-tauri/crates/app/src/commands/profile.rs
+++ b/src-tauri/crates/app/src/commands/profile.rs
@@ -182,6 +182,13 @@ pub async fn switch_profile(
                 state.dlna.start(cfg, resources);
             }
             Err(err) => {
+                // The worker is still holding the OLD profile's
+                // `DlnaResources`, whose pool `activate_profile` above
+                // already closed — left running, it would silently
+                // fail every `/stream` and `/art` request instead of
+                // picking up the new profile. Stop it rather than
+                // leave a broken server behind.
+                state.dlna.stop();
                 tracing::warn!(%err, "DLNA resource refresh after profile switch failed");
             }
         }


### PR DESCRIPTION
## Summary

Fixes #399.

`DlnaResources` (the worker's pool + artwork dirs) was only ever rebuilt from the boot path and `dlna_set_config`. `switch_profile` never touched it, so a running DLNA server:

1. kept exposing the **previous** profile's library to the LAN after a switch — a privacy-adjacent surprise, since switching profiles is often exactly how a user changes what's exposed;
2. then had its pool closed out from under it once `activate_profile` dropped the old profile, so every subsequent `/stream/<id>` and `/art/<hash>` request failed against a closed pool.

`switch_profile` now rebuilds `DlnaResources` from the newly-activated profile and pushes them through `DlnaServer::start` — but only when `state.dlna.status().await.running` is true, so a switch can't accidentally start a server the user has turned off. There's no lighter "just swap the pool" path on the worker (`WorkerState::start` already tears down and rebinds on every `Start`), so this restarts the listener + SSDP announce, same as a manual reconfigure.

## Test plan

- [x] `cargo check -p waveflow --all-targets` — clean, no warnings
- [ ] Manual: enable DLNA, switch profiles, confirm a controller (or `curl` against `/ContentDirectory/control`) sees the new profile's library and `/stream/<id>` no longer 500s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Le service DLNA actualise désormais automatiquement ses ressources lors d’un changement de profil, lorsqu’il est déjà actif.
  * Le changement de profil continue de fonctionner même si la génération des ressources DLNA échoue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->