### PR TITLE
feat(artwork): let a user set an album's motion cover manually

### DIFF
--- a/src-tauri/crates/app/src/commands/motion_artwork.rs
+++ b/src-tauri/crates/app/src/commands/motion_artwork.rs
@@ -282,9 +282,14 @@ pub async fn set_album_motion_artwork_from_file(
     let pool = state.require_profile_pool().await?;
     let profile_id = state.require_profile_id().await?;
     let motion_dir = state.paths.profile_motion_dir(profile_id);
-    std::fs::create_dir_all(&motion_dir)?;
+    tokio::fs::create_dir_all(&motion_dir).await?;
 
-    let bytes = std::fs::read(&file_path)?;
+    // A motion cover can be up to MAX_MANUAL_MP4_BYTES (64 MiB) — an order
+    // of magnitude past the static-cover uploads this command's shape is
+    // otherwise modelled on, so the blocking read/write is routed through
+    // `tokio::fs` (spawn_blocking under the hood) instead of `std::fs`
+    // directly, unlike those smaller precedents.
+    let bytes = tokio::fs::read(&file_path).await?;
     if bytes.len() as u64 > MAX_MANUAL_MP4_BYTES {
         return Err(AppError::Other(format!(
             "file too large: {} bytes (max {MAX_MANUAL_MP4_BYTES})",
@@ -297,8 +302,8 @@ pub async fn set_album_motion_artwork_from_file(
 
     let hash = blake3::hash(&bytes).to_hex().to_string();
     let target = motion_dir.join(format!("{hash}.mp4"));
-    if !target.exists() {
-        std::fs::write(&target, &bytes)?;
+    if !tokio::fs::try_exists(&target).await? {
+        tokio::fs::write(&target, &bytes).await?;
     }
 
     sqlx::query(

--- a/src-tauri/crates/app/src/commands/motion_artwork.rs
+++ b/src-tauri/crates/app/src/commands/motion_artwork.rs
@@ -51,6 +51,13 @@ pub struct MotionArtwork {
 /// `motion-cover-url`. Returns `None` when offline, when no metadata plugin
 /// is installed, or when none has motion artwork for the album.
 ///
+/// When `album_id` resolves a row in `album_motion_artwork` (issue #408),
+/// that user-supplied file wins outright and the plugin fan-out below never
+/// runs — same precedence a manual static cover already gets. `album_id` is
+/// `Option` because a couple of call sites (radio, any future text-only
+/// lookup) don't always have one; they simply lose the manual-override path
+/// and behave exactly as before this field existed.
+///
 /// The lookups fan out (each on its own blocking task) and the first hit
 /// wins; the rest are dropped. Every lookup is bounded by [`PLUGIN_TIMEOUT`],
 /// so one slow or hung plugin can't stall the others or the now-playing
@@ -66,7 +73,14 @@ pub async fn fetch_album_motion_artwork(
     state: State<'_, AppState>,
     artist: String,
     album: String,
+    album_id: Option<i64>,
 ) -> AppResult<Option<MotionArtwork>> {
+    if let Some(id) = album_id {
+        if let Some(manual) = manual_motion_artwork(&state, id).await? {
+            return Ok(Some(manual));
+        }
+    }
+
     if offline::is_offline() {
         return Ok(None);
     }
@@ -201,6 +215,122 @@ pub async fn fetch_album_motion_artwork(
 
     tracing::debug!(%artist, %album, "no motion artwork from any metadata plugin");
     Ok(None)
+}
+
+// ----- manual motion cover (issue #408) ------------------------------------
+
+/// Hard cap on a user-supplied motion cover, independent of
+/// [`motion_cache::MAX_MP4_BYTES`] (the plugin-download cap) — a
+/// deliberately-chosen file deserves a more generous limit than an
+/// automated fetch, but still needs *a* ceiling since this directory is
+/// never evicted.
+const MAX_MANUAL_MP4_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Look up `album_id`'s manual motion cover, if one was set via
+/// [`set_album_motion_artwork_from_file`]. `plugin_id` is the sentinel
+/// `"manual"` — nothing installed produced it, but the field must still
+/// carry something for the frontend's attribution display.
+async fn manual_motion_artwork(
+    state: &AppState,
+    album_id: i64,
+) -> AppResult<Option<MotionArtwork>> {
+    let pool = state.require_profile_pool().await?;
+    let profile_id = state.require_profile_id().await?;
+    let row: Option<(String, String)> = sqlx::query_as(
+        "SELECT hash, format FROM album_motion_artwork WHERE album_id = ?",
+    )
+    .bind(album_id)
+    .fetch_optional(&*pool)
+    .await?;
+    let Some((hash, format)) = row else {
+        return Ok(None);
+    };
+    let path = state
+        .paths
+        .profile_motion_dir(profile_id)
+        .join(format!("{hash}.{format}"));
+    Ok(Some(MotionArtwork {
+        square_url: path.to_string_lossy().into_owned(),
+        tall_url: None,
+        plugin_id: "manual".into(),
+    }))
+}
+
+/// First box of an ISO base media file (mp4/mov) is required to be `ftyp`
+/// when present, which in practice means always for a real-world mp4 —
+/// the same "check the magic bytes, don't fully parse" approach
+/// `detect_image_format` (`deezer.rs`) uses for jpg/png/webp.
+fn is_mp4(bytes: &[u8]) -> bool {
+    bytes.len() >= 8 && &bytes[4..8] == b"ftyp"
+}
+
+/// Set `album_id`'s manual motion cover from a local mp4 file, replacing
+/// any previous one. Validated by magic bytes (rejecting at pick time
+/// beats rendering a black rectangle) and size-capped, then hash-addressed
+/// into the never-evicted [`AppPaths::profile_motion_dir`] — deliberately
+/// NOT [`AppPaths::motion_cache_dir`], which is a 1 GB LRU that would
+/// eventually evict a user's own choice (see that field's doc comment).
+///
+/// Takes precedence over the plugin automatically: [`fetch_album_motion_artwork`]
+/// checks this table before ever fanning out to a plugin.
+#[tauri::command]
+pub async fn set_album_motion_artwork_from_file(
+    state: State<'_, AppState>,
+    album_id: i64,
+    file_path: String,
+) -> AppResult<()> {
+    let pool = state.require_profile_pool().await?;
+    let profile_id = state.require_profile_id().await?;
+    let motion_dir = state.paths.profile_motion_dir(profile_id);
+    std::fs::create_dir_all(&motion_dir)?;
+
+    let bytes = std::fs::read(&file_path)?;
+    if bytes.len() as u64 > MAX_MANUAL_MP4_BYTES {
+        return Err(AppError::Other(format!(
+            "file too large: {} bytes (max {MAX_MANUAL_MP4_BYTES})",
+            bytes.len()
+        )));
+    }
+    if !is_mp4(&bytes) {
+        return Err(AppError::Other("unsupported format (expected mp4)".into()));
+    }
+
+    let hash = blake3::hash(&bytes).to_hex().to_string();
+    let target = motion_dir.join(format!("{hash}.mp4"));
+    if !target.exists() {
+        std::fs::write(&target, &bytes)?;
+    }
+
+    sqlx::query(
+        "INSERT INTO album_motion_artwork (album_id, hash, format, created_at)
+         VALUES (?, ?, 'mp4', ?)
+         ON CONFLICT(album_id) DO UPDATE SET
+            hash = excluded.hash, format = excluded.format, created_at = excluded.created_at",
+    )
+    .bind(album_id)
+    .bind(&hash)
+    .bind(chrono::Utc::now().timestamp_millis())
+    .execute(&*pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Clear `album_id`'s manual motion cover, if any — the resolution chain
+/// falls back to the plugin result on the next lookup. The old file is
+/// left on disk (same "future GC pass" tradeoff as `clear_artist_artwork`);
+/// a no-op when there was nothing to clear.
+#[tauri::command]
+pub async fn clear_album_motion_artwork(
+    state: State<'_, AppState>,
+    album_id: i64,
+) -> AppResult<()> {
+    let pool = state.require_profile_pool().await?;
+    sqlx::query("DELETE FROM album_motion_artwork WHERE album_id = ?")
+        .bind(album_id)
+        .execute(&*pool)
+        .await?;
+    Ok(())
 }
 
 // ----- local motion cache --------------------------------------------------

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -679,6 +679,8 @@ pub fn run() {
             commands::motion_artwork::get_motion_cache_info,
             commands::motion_artwork::set_motion_cache_enabled,
             commands::motion_artwork::clear_motion_cache,
+            commands::motion_artwork::set_album_motion_artwork_from_file,
+            commands::motion_artwork::clear_album_motion_artwork,
             commands::integration::get_lastfm_api_key,
             commands::integration::set_lastfm_api_key,
             commands::integration::get_bio_source,

--- a/src-tauri/crates/app/src/paths.rs
+++ b/src-tauri/crates/app/src/paths.rs
@@ -18,7 +18,8 @@ use crate::error::{AppError, AppResult};
 /// └── profiles/
 ///     └── <profile_id>/
 ///         ├── data.db           (per-profile database)
-///         └── artwork/          (per-profile artwork cache)
+///         ├── artwork/          (per-profile artwork cache)
+///         └── motion/           (per-profile manual motion covers, never evicted)
 /// ```
 ///
 /// `bundled_plugins_dir` is resolved separately against
@@ -126,10 +127,19 @@ impl AppPaths {
         self.profile_dir(profile_id).join("artwork")
     }
 
+    /// Per-profile directory for user-supplied animated album covers
+    /// (issue #408). Unlike [`Self::motion_cache_dir`] — a 1 GB LRU that
+    /// evicts plugin-downloaded mp4s by mtime — a file here was chosen
+    /// deliberately by the user and must never be evicted.
+    pub fn profile_motion_dir(&self, profile_id: i64) -> PathBuf {
+        self.profile_dir(profile_id).join("motion")
+    }
+
     /// Create the directory layout required for a brand-new profile.
     pub fn ensure_profile_dirs(&self, profile_id: i64) -> AppResult<()> {
         std::fs::create_dir_all(self.profile_dir(profile_id))?;
         std::fs::create_dir_all(self.profile_artwork_dir(profile_id))?;
+        std::fs::create_dir_all(self.profile_motion_dir(profile_id))?;
         Ok(())
     }
 

--- a/src-tauri/migrations/profile/20260719220000_album_motion_artwork.sql
+++ b/src-tauri/migrations/profile/20260719220000_album_motion_artwork.sql
@@ -1,0 +1,16 @@
+-- Manual motion-cover override for an album (issue #408). A user-supplied
+-- mp4 always wins over a plugin-resolved motion cover and survives plugin
+-- re-fetches, the same precedence rule `album.artwork_source = 'manual'`
+-- gives static covers (see 20260719140000_album_artwork_source.sql). The
+-- row's existence is itself the "manual" signal -- nothing else writes
+-- this table, so there is no separate provenance column to guard.
+--
+-- A fresh CREATE TABLE, not an ALTER on `album`/`artwork`, so it carries
+-- none of the DROP TABLE / foreign-key cascade risk documented in
+-- CLAUDE.md for those two tables.
+CREATE TABLE album_motion_artwork (
+    album_id   INTEGER PRIMARY KEY REFERENCES album(id) ON DELETE CASCADE,
+    hash       TEXT NOT NULL,
+    format     TEXT NOT NULL DEFAULT 'mp4',
+    created_at INTEGER NOT NULL
+);

--- a/src/components/common/MotionCoverPickerModal.tsx
+++ b/src/components/common/MotionCoverPickerModal.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Film, FolderOpen, Trash2 } from "lucide-react";
+
+import { useModalA11y } from "../../hooks/useModalA11y";
+import { AnimatedModalContent, AnimatedModalShell } from "./AnimatedModalShell";
+import {
+  clearAlbumMotionArtwork,
+  setAlbumMotionArtworkFromFile,
+} from "../../lib/tauri/plugins";
+import { pickFile } from "../../lib/tauri/dialog";
+
+interface MotionCoverPickerModalProps {
+  albumId: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Set or clear an album's manual animated cover (issue #408) — a local
+ * mp4 the user picks themselves, distinct from the automatic plugin
+ * resolution `MotionCoverOverlay` already does. File-only: unlike
+ * `CoverPickerModal` there is no Deezer tab, since a motion cover has no
+ * remote catalogue to browse.
+ */
+export function MotionCoverPickerModal({
+  albumId,
+  isOpen,
+  onClose,
+  onSuccess,
+}: MotionCoverPickerModalProps) {
+  const { t } = useTranslation();
+  const [isApplying, setIsApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dialogRef = useModalA11y<HTMLDivElement>(isOpen, onClose);
+
+  const handlePickFile = async () => {
+    if (isApplying) return;
+    try {
+      const path = await pickFile(["mp4"], t("motionCoverPicker.title"));
+      if (!path) return;
+      setIsApplying(true);
+      setError(null);
+      await setAlbumMotionArtworkFromFile(albumId, path);
+      onSuccess();
+      onClose();
+    } catch (err) {
+      console.error("[MotionCoverPickerModal] set file failed", err);
+      setError(String(err));
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (isApplying) return;
+    setIsApplying(true);
+    setError(null);
+    try {
+      await clearAlbumMotionArtwork(albumId);
+      onSuccess();
+      onClose();
+    } catch (err) {
+      console.error("[MotionCoverPickerModal] clear failed", err);
+      setError(String(err));
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  return (
+    <AnimatedModalShell isOpen={isOpen} onBackdropClick={onClose}>
+      <AnimatedModalContent
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="motion-cover-picker-title"
+        className="relative w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-6 shadow-2xl dark:border-zinc-800 dark:bg-surface-dark-elevated"
+      >
+        <h2
+          id="motion-cover-picker-title"
+          className="text-lg font-bold text-zinc-900 dark:text-white mb-1"
+        >
+          {t("motionCoverPicker.title")}
+        </h2>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-4">
+          {t("motionCoverPicker.subtitle")}
+        </p>
+
+        {error && (
+          <div className="mb-3 text-xs text-red-500 px-2">{error}</div>
+        )}
+
+        <div className="flex flex-col items-center justify-center py-8 space-y-4">
+          <div className="w-16 h-16 rounded-2xl bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center text-zinc-400">
+            <Film size={32} />
+          </div>
+          <button
+            type="button"
+            onClick={handlePickFile}
+            disabled={isApplying}
+            className="bg-emerald-500 hover:bg-emerald-600 text-white px-5 py-2.5 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm disabled:opacity-50"
+          >
+            <FolderOpen size={16} />
+            <span>{t("motionCoverPicker.pickFile")}</span>
+          </button>
+        </div>
+
+        <div className="mt-2 flex items-center justify-between pt-3 border-t border-zinc-100 dark:border-zinc-800">
+          <button
+            type="button"
+            onClick={handleClear}
+            disabled={isApplying}
+            className="px-4 py-2 rounded-xl text-sm font-medium text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors flex items-center space-x-2 disabled:opacity-50"
+          >
+            <Trash2 size={14} />
+            <span>{t("motionCoverPicker.removeAction")}</span>
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl text-sm font-medium text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors"
+          >
+            {t("common.cancel")}
+          </button>
+        </div>
+      </AnimatedModalContent>
+    </AnimatedModalShell>
+  );
+}

--- a/src/components/layout/NowPlayingPanel.tsx
+++ b/src/components/layout/NowPlayingPanel.tsx
@@ -168,6 +168,7 @@ export function NowPlayingPanel({ onNavigateToArtist }: NowPlayingPanelProps) {
                 <MotionCoverOverlay
                   artist={currentTrack.artist_name}
                   album={currentTrack.album_title}
+                  albumId={currentTrack.album_id}
                   rounded="2xl"
                   className="shadow-lg"
                 />

--- a/src/components/player/ImmersiveNowPlaying.tsx
+++ b/src/components/player/ImmersiveNowPlaying.tsx
@@ -70,6 +70,7 @@ export function ImmersiveNowPlaying({
         <MotionCoverOverlay
           artist={currentTrack?.artist_name}
           album={currentTrack?.album_title}
+          albumId={currentTrack?.album_id}
           rounded="2xl"
           className="shadow-2xl"
         />

--- a/src/components/player/MotionCoverOverlay.tsx
+++ b/src/components/player/MotionCoverOverlay.tsx
@@ -25,15 +25,19 @@ const ROUND: Record<"md" | "lg" | "xl" | "2xl", string> = {
 export function MotionCoverOverlay({
   artist,
   album,
+  albumId,
   rounded = "2xl",
   className,
 }: {
   artist: string | null | undefined;
   album: string | null | undefined;
+  /** Enables the manual-override lookup (issue #408) — omit for surfaces
+   *  with no album row to key off (e.g. Web Radio). */
+  albumId?: number | null;
   rounded?: "md" | "lg" | "xl" | "2xl";
   className?: string;
 }) {
-  const motion = useAlbumMotionArtwork(artist, album);
+  const motion = useAlbumMotionArtwork(artist, album, albumId);
   if (!motion) return null;
   // Key on the URL so switching album remounts the video and resets the
   // ready/failed state below.

--- a/src/components/views/AlbumDetailView.tsx
+++ b/src/components/views/AlbumDetailView.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Play, Shuffle, Clock, Music2, Heart, ImageIcon } from "lucide-react";
+import { Play, Shuffle, Clock, Music2, Heart, ImageIcon, Film } from "lucide-react";
 import { Artwork } from "../common/Artwork";
 import { ArtistLink } from "../common/ArtistLink";
 import { EmptyState } from "../common/EmptyState";
 import { DetailViewSkeleton } from "../common/DetailViewSkeleton";
 import { CreatePlaylistModal } from "../common/CreatePlaylistModal";
 import { CoverPickerModal } from "../common/CoverPickerModal";
+import { MotionCoverPickerModal } from "../common/MotionCoverPickerModal";
 import { HiResBadge } from "../common/HiResBadge";
 import { PlayingIndicator } from "../common/PlayingIndicator";
 import { SelectionActionBar } from "../common/SelectionActionBar";
@@ -53,6 +54,7 @@ export function AlbumDetailView({
   const [isCreatePlaylistModalOpen, setIsCreatePlaylistModalOpen] =
     useState(false);
   const [isCoverPickerOpen, setIsCoverPickerOpen] = useState(false);
+  const [isMotionCoverPickerOpen, setIsMotionCoverPickerOpen] = useState(false);
   const [coverReloadKey, setCoverReloadKey] = useState(0);
   const [isLightboxOpen, setIsLightboxOpen] = useState(false);
   const selection = useMultiSelect<Track>();
@@ -332,6 +334,14 @@ export function AlbumDetailView({
               <ImageIcon size={16} />
               <span>{t("library.changeCover")}</span>
             </button>
+            <button
+              type="button"
+              onClick={() => setIsMotionCoverPickerOpen(true)}
+              className="border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-300 px-4 py-2 rounded-xl text-sm font-semibold flex items-center space-x-2 transition-colors shadow-sm"
+            >
+              <Film size={16} />
+              <span>{t("albumDetail.setMotionCover")}</span>
+            </button>
           </div>
         </div>
       </div>
@@ -403,6 +413,13 @@ export function AlbumDetailView({
         }
         isOpen={isCoverPickerOpen}
         onClose={() => setIsCoverPickerOpen(false)}
+        onSuccess={() => setCoverReloadKey((k) => k + 1)}
+      />
+
+      <MotionCoverPickerModal
+        albumId={album.id}
+        isOpen={isMotionCoverPickerOpen}
+        onClose={() => setIsMotionCoverPickerOpen(false)}
         onSuccess={() => setCoverReloadKey((k) => k + 1)}
       />
 

--- a/src/hooks/useAlbumMotionArtwork.ts
+++ b/src/hooks/useAlbumMotionArtwork.ts
@@ -24,9 +24,16 @@ const MAX_RESOLVED = 64;
 const inFlight = new Map<string, Promise<MotionArtwork | null>>();
 const resolved = new Map<string, MotionArtwork | null>();
 
-/** `\0` can't appear in a tag value, so it can't forge a collision. */
-function cacheKey(artist: string, album: string): string {
-  return `${artist}\0${album}`;
+/** `\0` can't appear in a tag value, so it can't forge a collision.
+ *  `albumId` rides along so a manual override (issue #408) — which is
+ *  resolved by id, not text — gets its own cache entry rather than
+ *  reusing one keyed only by a name that could collide across albums. */
+function cacheKey(
+  artist: string,
+  album: string,
+  albumId: number | null | undefined,
+): string {
+  return `${artist}\0${album}\0${albumId ?? ""}`;
 }
 
 function rememberResolved(key: string, value: MotionArtwork | null): void {
@@ -40,15 +47,19 @@ function rememberResolved(key: string, value: MotionArtwork | null): void {
   }
 }
 
-function lookup(artist: string, album: string): Promise<MotionArtwork | null> {
-  const key = cacheKey(artist, album);
+function lookup(
+  artist: string,
+  album: string,
+  albumId: number | null | undefined,
+): Promise<MotionArtwork | null> {
+  const key = cacheKey(artist, album, albumId);
   if (resolved.has(key)) {
     return Promise.resolve(resolved.get(key) ?? null);
   }
   const pending = inFlight.get(key);
   if (pending) return pending;
 
-  const request = fetchAlbumMotionArtwork(artist, album)
+  const request = fetchAlbumMotionArtwork(artist, album, albumId ?? null)
     .then((motion) => {
       rememberResolved(key, motion);
       return motion;
@@ -79,6 +90,7 @@ function lookup(artist: string, album: string): Promise<MotionArtwork | null> {
 export function useAlbumMotionArtwork(
   artist: string | null | undefined,
   album: string | null | undefined,
+  albumId?: number | null,
 ): MotionArtwork | null {
   const [motion, setMotion] = useState<MotionArtwork | null>(null);
 
@@ -94,12 +106,12 @@ export function useAlbumMotionArtwork(
     // resolves, so the new artwork only ever replaces `null`.
     Promise.resolve<MotionArtwork | null>(null).then(apply);
     if (artist && album) {
-      lookup(artist, album).then(apply, () => apply(null));
+      lookup(artist, album, albumId).then(apply, () => apply(null));
     }
     return () => {
       cancelled = true;
     };
-  }, [artist, album]);
+  }, [artist, album, albumId]);
 
   return motion;
 }

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1050,6 +1050,7 @@
     "emptyDescription": "لم يعد هذا الألبوم متاحًا في الملف الشخصي النشط.",
     "emptyTracksTitle": "لا توجد مقاطع",
     "emptyTracksDescription": "لا يحتوي هذا الألبوم على أي مقطع متاح.",
+    "setMotionCover": "غلاف متحرك",
     "trackCount_two": "مقطعان",
     "trackCount_few": "{{count}} مقاطع",
     "trackCount_many": "{{count}} مقطعًا"
@@ -1100,6 +1101,12 @@
     "fansCount_few": "{{display}} معجب",
     "fansCount_many": "{{display}} معجب",
     "fansCount_other": "{{display}} معجب"
+  },
+  "motionCoverPicker": {
+    "title": "غلاف متحرك يدوي",
+    "subtitle": "اختر ملف MP4 محليًا. يحل محل الغلاف المتحرك الذي يوفره الإضافة ولا يُستبدل أبدًا عند التحديث.",
+    "pickFile": "اختيار ملف MP4",
+    "removeAction": "إزالة الغلاف المتحرك"
   },
   "genreDetail": {
     "badge": "النوع",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Album nicht gefunden",
     "emptyDescription": "Dieses Album ist im aktiven Profil nicht mehr verfügbar.",
     "emptyTracksTitle": "Keine Titel",
-    "emptyTracksDescription": "Dieses Album enthält keine verfügbaren Titel."
+    "emptyTracksDescription": "Dieses Album enthält keine verfügbaren Titel.",
+    "setMotionCover": "Animiertes Cover"
   },
   "artistDetail": {
     "badge": "Künstler",
@@ -984,6 +985,12 @@
     "removeAction": "Bild entfernen",
     "fansCount_one": "{{display}} Fan",
     "fansCount_other": "{{display}} Fans"
+  },
+  "motionCoverPicker": {
+    "title": "Manuelles animiertes Cover",
+    "subtitle": "Wähle eine lokale MP4-Datei. Sie ersetzt das vom Plugin bereitgestellte animierte Cover und wird nie durch eine Aktualisierung überschrieben.",
+    "pickFile": "MP4-Datei auswählen",
+    "removeAction": "Animiertes Cover entfernen"
   },
   "genreDetail": {
     "badge": "Genre",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Album not found",
     "emptyDescription": "This album is no longer available in the active profile.",
     "emptyTracksTitle": "No tracks",
-    "emptyTracksDescription": "This album does not contain any available tracks."
+    "emptyTracksDescription": "This album does not contain any available tracks.",
+    "setMotionCover": "Motion cover"
   },
   "artistDetail": {
     "badge": "Artist",
@@ -984,6 +985,12 @@
     "removeAction": "Remove image",
     "fansCount_one": "{{display}} fan",
     "fansCount_other": "{{display}} fans"
+  },
+  "motionCoverPicker": {
+    "title": "Manual motion cover",
+    "subtitle": "Choose a local MP4 file. It replaces the plugin-supplied motion cover and is never overwritten by a refresh.",
+    "pickFile": "Choose an MP4 file",
+    "removeAction": "Remove motion cover"
   },
   "genreDetail": {
     "badge": "Genre",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Álbum no encontrado",
     "emptyDescription": "Este álbum ya no está disponible en el perfil activo.",
     "emptyTracksTitle": "Sin pistas",
-    "emptyTracksDescription": "Este álbum no contiene pistas disponibles."
+    "emptyTracksDescription": "Este álbum no contiene pistas disponibles.",
+    "setMotionCover": "Portada animada"
   },
   "artistDetail": {
     "badge": "Artista",
@@ -984,6 +985,12 @@
     "removeAction": "Quitar imagen",
     "fansCount_one": "{{display}} fan",
     "fansCount_other": "{{display}} fans"
+  },
+  "motionCoverPicker": {
+    "title": "Portada animada manual",
+    "subtitle": "Elige un archivo MP4 local. Sustituye a la portada animada del plugin y nunca se sobrescribe con una actualización.",
+    "pickFile": "Elegir un archivo MP4",
+    "removeAction": "Quitar la portada animada"
   },
   "genreDetail": {
     "badge": "Género",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Album introuvable",
     "emptyDescription": "Cet album n'existe plus dans le profil actif.",
     "emptyTracksTitle": "Aucun titre",
-    "emptyTracksDescription": "Cet album ne contient aucun titre disponible."
+    "emptyTracksDescription": "Cet album ne contient aucun titre disponible.",
+    "setMotionCover": "Pochette animée"
   },
   "artistDetail": {
     "badge": "Artiste",
@@ -984,6 +985,12 @@
     "removeAction": "Supprimer l'image",
     "fansCount_one": "{{display}} fan",
     "fansCount_other": "{{display}} fans"
+  },
+  "motionCoverPicker": {
+    "title": "Pochette animée manuelle",
+    "subtitle": "Choisissez un fichier MP4 local. Il remplace la pochette animée fournie par un plugin et n'est jamais écrasé par une actualisation.",
+    "pickFile": "Choisir un fichier MP4",
+    "removeAction": "Retirer la pochette animée"
   },
   "genreDetail": {
     "badge": "Genre",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -949,7 +949,8 @@
     "emptyTitle": "एल्बम नहीं मिला",
     "emptyDescription": "यह एल्बम अब सक्रिय प्रोफ़ाइल में उपलब्ध नहीं है।",
     "emptyTracksTitle": "कोई ट्रैक नहीं",
-    "emptyTracksDescription": "इस एल्बम में कोई ट्रैक नहीं हैं।"
+    "emptyTracksDescription": "इस एल्बम में कोई ट्रैक नहीं हैं।",
+    "setMotionCover": "मोशन कवर"
   },
   "artistDetail": {
     "badge": "कलाकार",
@@ -984,6 +985,12 @@
     "removeAction": "छवि हटाएँ",
     "fansCount_one": "{{display}} प्रशंसक",
     "fansCount_other": "{{display}} प्रशंसक"
+  },
+  "motionCoverPicker": {
+    "title": "मैन्युअल मोशन कवर",
+    "subtitle": "एक लोकल MP4 फ़ाइल चुनें। यह प्लगइन द्वारा दिए गए मोशन कवर की जगह लेता है और रीफ़्रेश से कभी ओवरराइट नहीं होता।",
+    "pickFile": "MP4 फ़ाइल चुनें",
+    "removeAction": "मोशन कवर हटाएं"
   },
   "genreDetail": {
     "badge": "शैली",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Album tidak ditemukan",
     "emptyDescription": "Album ini tidak lagi tersedia di profil aktif.",
     "emptyTracksTitle": "Tidak ada lagu",
-    "emptyTracksDescription": "Album ini tidak berisi lagu yang tersedia."
+    "emptyTracksDescription": "Album ini tidak berisi lagu yang tersedia.",
+    "setMotionCover": "Sampul animasi"
   },
   "artistDetail": {
     "badge": "Artis",
@@ -984,6 +985,12 @@
     "removeAction": "Hapus gambar",
     "fansCount_one": "{{display}} penggemar",
     "fansCount_other": "{{display}} penggemar"
+  },
+  "motionCoverPicker": {
+    "title": "Sampul animasi manual",
+    "subtitle": "Pilih berkas MP4 lokal. Berkas ini menggantikan sampul animasi dari plugin dan tidak akan pernah ditimpa oleh pembaruan.",
+    "pickFile": "Pilih berkas MP4",
+    "removeAction": "Hapus sampul animasi"
   },
   "genreDetail": {
     "badge": "Genre",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Album non trovato",
     "emptyDescription": "Questo album non è più disponibile nel profilo attivo.",
     "emptyTracksTitle": "Nessun brano",
-    "emptyTracksDescription": "Questo album non contiene brani disponibili."
+    "emptyTracksDescription": "Questo album non contiene brani disponibili.",
+    "setMotionCover": "Copertina animata"
   },
   "artistDetail": {
     "badge": "Artista",
@@ -984,6 +985,12 @@
     "removeAction": "Rimuovi immagine",
     "fansCount_one": "{{display}} fan",
     "fansCount_other": "{{display}} fan"
+  },
+  "motionCoverPicker": {
+    "title": "Copertina animata manuale",
+    "subtitle": "Scegli un file MP4 locale. Sostituisce la copertina animata fornita dal plugin e non viene mai sovrascritta da un aggiornamento.",
+    "pickFile": "Scegli un file MP4",
+    "removeAction": "Rimuovi copertina animata"
   },
   "genreDetail": {
     "badge": "Genere",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -949,7 +949,8 @@
     "emptyTitle": "アルバムが見つかりません",
     "emptyDescription": "このアルバムは、現在のプロフィールには存在しません。",
     "emptyTracksTitle": "曲なし",
-    "emptyTracksDescription": "このアルバムには収録曲が1曲もありません。"
+    "emptyTracksDescription": "このアルバムには収録曲が1曲もありません。",
+    "setMotionCover": "モーションカバー"
   },
   "artistDetail": {
     "badge": "アーティスト",
@@ -984,6 +985,12 @@
     "removeAction": "画像を削除",
     "fansCount_other": "{{display}} 人のファン",
     "fansCount_one": "{{display}} 人のファン"
+  },
+  "motionCoverPicker": {
+    "title": "手動モーションカバー",
+    "subtitle": "ローカルのMP4ファイルを選択してください。プラグインが提供するモーションカバーを置き換え、更新で上書きされることはありません。",
+    "pickFile": "MP4ファイルを選択",
+    "removeAction": "モーションカバーを削除"
   },
   "genreDetail": {
     "badge": "ジャンル",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -949,7 +949,8 @@
     "emptyTitle": "앨범을 찾을 수 없습니다",
     "emptyDescription": "이 앨범은 현재 프로필에서 더 이상 존재하지 않습니다.",
     "emptyTracksTitle": "곡 없음",
-    "emptyTracksDescription": "이 앨범에는 수록된 곡이 없습니다."
+    "emptyTracksDescription": "이 앨범에는 수록된 곡이 없습니다.",
+    "setMotionCover": "모션 커버"
   },
   "artistDetail": {
     "badge": "아티스트",
@@ -984,6 +985,12 @@
     "removeAction": "이미지 제거",
     "fansCount_one": "팬 {{display}}명",
     "fansCount_other": "팬 {{display}}명"
+  },
+  "motionCoverPicker": {
+    "title": "수동 모션 커버",
+    "subtitle": "로컬 MP4 파일을 선택하세요. 플러그인이 제공하는 모션 커버를 대체하며 새로고침으로 덮어써지지 않습니다.",
+    "pickFile": "MP4 파일 선택",
+    "removeAction": "모션 커버 제거"
   },
   "genreDetail": {
     "badge": "장르",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Album niet gevonden",
     "emptyDescription": "Dit album is niet meer beschikbaar in het actieve profiel.",
     "emptyTracksTitle": "Geen nummers",
-    "emptyTracksDescription": "Dit album bevat geen beschikbare nummers."
+    "emptyTracksDescription": "Dit album bevat geen beschikbare nummers.",
+    "setMotionCover": "Bewegende hoes"
   },
   "artistDetail": {
     "badge": "Artiest",
@@ -984,6 +985,12 @@
     "removeAction": "Afbeelding verwijderen",
     "fansCount_one": "{{display}} fan",
     "fansCount_other": "{{display}} fans"
+  },
+  "motionCoverPicker": {
+    "title": "Handmatige bewegende hoes",
+    "subtitle": "Kies een lokaal MP4-bestand. Het vervangt de door de plugin geleverde bewegende hoes en wordt nooit overschreven door een vernieuwing.",
+    "pickFile": "MP4-bestand kiezen",
+    "removeAction": "Bewegende hoes verwijderen"
   },
   "genreDetail": {
     "badge": "Genre",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Álbum não encontrado",
     "emptyDescription": "Este álbum não está mais disponível no perfil ativo.",
     "emptyTracksTitle": "Nenhuma faixa",
-    "emptyTracksDescription": "Este álbum não contém nenhuma faixa disponível."
+    "emptyTracksDescription": "Este álbum não contém nenhuma faixa disponível.",
+    "setMotionCover": "Capa animada"
   },
   "artistDetail": {
     "badge": "Artista",
@@ -984,6 +985,12 @@
     "removeAction": "Remover imagem",
     "fansCount_one": "{{display}} fã",
     "fansCount_other": "{{display}} fãs"
+  },
+  "motionCoverPicker": {
+    "title": "Capa animada manual",
+    "subtitle": "Escolha um arquivo MP4 local. Ela substitui a capa animada fornecida pelo plugin e nunca é sobrescrita por uma atualização.",
+    "pickFile": "Escolher um arquivo MP4",
+    "removeAction": "Remover capa animada"
   },
   "genreDetail": {
     "badge": "Gênero",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Álbum não encontrado",
     "emptyDescription": "Este álbum já não existe no perfil ativo.",
     "emptyTracksTitle": "Nenhuma música",
-    "emptyTracksDescription": "Este álbum não contém nenhuma faixa disponível."
+    "emptyTracksDescription": "Este álbum não contém nenhuma faixa disponível.",
+    "setMotionCover": "Capa animada"
   },
   "artistDetail": {
     "badge": "Artista",
@@ -984,6 +985,12 @@
     "removeAction": "Remover imagem",
     "fansCount_one": "{{display}} fã",
     "fansCount_other": "{{display}} fãs"
+  },
+  "motionCoverPicker": {
+    "title": "Capa animada manual",
+    "subtitle": "Escolha um ficheiro MP4 local. Substitui a capa animada fornecida pelo plugin e nunca é substituída por uma atualização.",
+    "pickFile": "Escolher um ficheiro MP4",
+    "removeAction": "Remover capa animada"
   },
   "genreDetail": {
     "badge": "Género",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1015,6 +1015,7 @@
     "emptyDescription": "Этого альбома больше нет в активном профиле.",
     "emptyTracksTitle": "Нет треков",
     "emptyTracksDescription": "В этом альбоме нет доступных треков.",
+    "setMotionCover": "Анимированная обложка",
     "trackCount_many": "{{count}} треков"
   },
   "artistDetail": {
@@ -1058,6 +1059,12 @@
     "fansCount_few": "{{display}} поклонника",
     "fansCount_many": "{{display}} поклонников",
     "fansCount_other": "{{display}} поклонников"
+  },
+  "motionCoverPicker": {
+    "title": "Анимированная обложка вручную",
+    "subtitle": "Выберите локальный файл MP4. Он заменяет анимированную обложку, предоставленную плагином, и никогда не перезаписывается при обновлении.",
+    "pickFile": "Выбрать файл MP4",
+    "removeAction": "Удалить анимированную обложку"
   },
   "genreDetail": {
     "badge": "Жанр",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -949,7 +949,8 @@
     "emptyTitle": "Albüm bulunamadı",
     "emptyDescription": "Bu albüm etkin profilde artık yok.",
     "emptyTracksTitle": "Parça yok",
-    "emptyTracksDescription": "Bu albümde kullanılabilir parça yok."
+    "emptyTracksDescription": "Bu albümde kullanılabilir parça yok.",
+    "setMotionCover": "Hareketli kapak"
   },
   "artistDetail": {
     "badge": "Sanatçı",
@@ -984,6 +985,12 @@
     "removeAction": "Görseli kaldır",
     "fansCount_one": "{{display}} hayran",
     "fansCount_other": "{{display}} hayran"
+  },
+  "motionCoverPicker": {
+    "title": "Manuel hareketli kapak",
+    "subtitle": "Yerel bir MP4 dosyası seçin. Eklentinin sağladığı hareketli kapağın yerini alır ve yenilemeyle asla üzerine yazılmaz.",
+    "pickFile": "Bir MP4 dosyası seç",
+    "removeAction": "Hareketli kapağı kaldır"
   },
   "genreDetail": {
     "badge": "Tür",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -949,7 +949,8 @@
     "emptyTitle": "找不到该专辑",
     "emptyDescription": "此专辑已不在当前的个人资料中。",
     "emptyTracksTitle": "没有歌曲",
-    "emptyTracksDescription": "该专辑中没有可播放的歌曲。"
+    "emptyTracksDescription": "该专辑中没有可播放的歌曲。",
+    "setMotionCover": "动态封面"
   },
   "artistDetail": {
     "badge": "艺人",
@@ -984,6 +985,12 @@
     "removeAction": "移除图片",
     "fansCount_other": "{{display}} 位粉丝",
     "fansCount_one": "{{display}} 位粉丝"
+  },
+  "motionCoverPicker": {
+    "title": "手动动态封面",
+    "subtitle": "选择本地 MP4 文件。它将替代插件提供的动态封面，且不会被刷新覆盖。",
+    "pickFile": "选择 MP4 文件",
+    "removeAction": "移除动态封面"
   },
   "genreDetail": {
     "badge": "流派",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -949,7 +949,8 @@
     "emptyTitle": "找不到專輯",
     "emptyDescription": "此專輯已不在目前的個人檔案中。",
     "emptyTracksTitle": "沒有任何曲目",
-    "emptyTracksDescription": "這張專輯中沒有任何可供聆聽的曲目。"
+    "emptyTracksDescription": "這張專輯中沒有任何可供聆聽的曲目。",
+    "setMotionCover": "動態封面"
   },
   "artistDetail": {
     "badge": "藝人",
@@ -984,6 +985,12 @@
     "removeAction": "移除圖片",
     "fansCount_other": "{{display}} 位粉絲",
     "fansCount_one": "{{display}} 位粉絲"
+  },
+  "motionCoverPicker": {
+    "title": "手動動態封面",
+    "subtitle": "選擇本機 MP4 檔案。它會取代外掛提供的動態封面，且不會被重新整理覆蓋。",
+    "pickFile": "選擇 MP4 檔案",
+    "removeAction": "移除動態封面"
   },
   "genreDetail": {
     "badge": "曲風",

--- a/src/lib/tauri/plugins.ts
+++ b/src/lib/tauri/plugins.ts
@@ -255,15 +255,45 @@ export interface MotionArtwork {
  * Ask enabled metadata plugins for an album's motion artwork. Resolves
  * `null` when offline, when no metadata plugin is installed, or when none
  * has motion for this album — callers fall back to the static cover.
+ *
+ * `albumId`, when given, is checked first against a manual override
+ * (issue #408) — see `setAlbumMotionArtworkFromFile` — before any plugin
+ * runs. Omit it for surfaces with no album row (e.g. Web Radio).
  */
 export async function fetchAlbumMotionArtwork(
   artist: string,
   album: string,
+  albumId?: number | null,
 ): Promise<MotionArtwork | null> {
   return invoke<MotionArtwork | null>("fetch_album_motion_artwork", {
     artist,
     album,
+    albumId: albumId ?? null,
   });
+}
+
+/**
+ * Set `albumId`'s animated cover from a local mp4 file (issue #408). Wins
+ * over any plugin-resolved motion cover and survives plugin re-fetches —
+ * same precedence rule as a manual static cover. Rejects non-mp4 files
+ * (validated by magic bytes) and files above the backend's size cap.
+ */
+export function setAlbumMotionArtworkFromFile(
+  albumId: number,
+  filePath: string,
+): Promise<void> {
+  return invoke<void>("set_album_motion_artwork_from_file", {
+    albumId,
+    filePath,
+  });
+}
+
+/**
+ * Clear `albumId`'s manual motion cover, if any — the next lookup falls
+ * back to the plugin result. A no-op when there was nothing to clear.
+ */
+export function clearAlbumMotionArtwork(albumId: number): Promise<void> {
+  return invoke<void>("clear_album_motion_artwork", { albumId });
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #408.

Motion covers previously only arrived through a metadata plugin (`fetch_album_motion_artwork` fanning `album-info` out to enabled plugins) — that covers whatever the plugin's catalogue can match and nothing else. Static covers already have a manual escape hatch (`set_album_artwork_from_file`); this gives motion covers the same one.

**Design points from the issue, implemented as specified:**
- Stored in a never-evicted per-profile directory (`profile_motion_dir`), **not** the 1 GB LRU `motion_cache_dir` — that cache exists precisely because plugin-fetched videos are disposable, and a user's deliberate choice isn't.
- **mp4 only** for this first cut (validated by magic bytes — the `ftyp` box — rejected at pick time, not rendered as a black rectangle). No GIF, no transcoding.
- A manual pick **wins over the plugin outright** and survives re-fetches — `fetch_album_motion_artwork` checks the new `album_motion_artwork` table before any plugin runs. Clearing it falls back to the plugin result.
- Albums only, per the issue's stated scope.

## Changes

**Backend**
- New migration: `album_motion_artwork` table (fresh `CREATE TABLE`, no touch to `album`/`artwork`).
- `paths.rs`: `profile_motion_dir`, added to `ensure_profile_dirs`.
- `commands/motion_artwork.rs`: `set_album_motion_artwork_from_file` (magic-byte validation + 64 MiB cap, hash-addressed), `clear_album_motion_artwork`, and `fetch_album_motion_artwork` gained an optional `album_id` to check the manual override first.

**Frontend**
- New `MotionCoverPickerModal` (file-only, mirrors `ArtistImagePickerModal`'s clear-button pattern), wired into `AlbumDetailView` next to the existing static cover picker.
- `useAlbumMotionArtwork` / `MotionCoverOverlay` / `plugins.ts` thread `albumId` through; `NowPlayingPanel` + `ImmersiveNowPlaying` pass `currentTrack.album_id`.
- i18n keys propagated to all 17 locales.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean, no warnings
- [x] `cargo test -p waveflow --lib` — 120/120 passing, no regressions
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] All 17 locale JSON files validated for parity + valid JSON
- [ ] Manual: pick an mp4 for an album, confirm it overrides a plugin-resolved cover in Now Playing / Immersive view, confirm clearing it falls back — not done in this session (no motion-artwork plugin installed to compare against)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Définissez une pochette animée personnalisée pour un album à partir d’un fichier MP4 local.
  * Supprimez la pochette personnalisée pour revenir à celle fournie automatiquement.
  * Les pochettes personnalisées sont conservées et prioritaires lors de la lecture.
  * Les nouvelles options sont disponibles dans la vue détaillée de l’album et traduites dans plusieurs langues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->