### PR TITLE
fix(ui): stop the Home banners' glow orbs bleeding past rounded corners on Safari

### DIFF
--- a/src/components/views/HomeView.tsx
+++ b/src/components/views/HomeView.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from "react";
 import { useTranslation } from "react-i18next";
 import {
   Folder,
@@ -316,13 +322,23 @@ export function HomeView({
     bannerSkinClasses = "p-10";
   }
   const bannerClasses = `relative overflow-hidden rounded-3xl bg-linear-to-br from-emerald-50 to-white shadow-sm border border-emerald-100/50 dark:from-emerald-900/40 dark:to-zinc-800/40 dark:border-zinc-800 dark:shadow-none ${bannerSkinClasses}`;
+  // Safari (issue #414) fails to clip a `filter: blur()` child to its
+  // `overflow-hidden` + `rounded-3xl` parent's corners — the blur's
+  // expanded paint bounds leak past the rounded edge as square glow
+  // patches. `overflow: hidden` alone doesn't trigger Safari's correct
+  // clip path there; a mask does. Applied to every banner below that
+  // has an absolutely-positioned `blur-3xl` decorative orb.
+  const roundedClipMaskStyle: CSSProperties = {
+    WebkitMaskImage: "-webkit-radial-gradient(white, black)",
+    maskImage: "radial-gradient(white, black)",
+  };
 
   return (
     <div className={containerClasses}>
       {isEditorialSkin && <EditorialMasthead />}
       <div className={gridClasses}>
         {/* Welcome Banner */}
-        <div className={bannerClasses}>
+        <div className={bannerClasses} style={roundedClipMaskStyle}>
           <div
             aria-hidden="true"
             className="pointer-events-none absolute -top-24 -left-16 w-80 h-80 rounded-full bg-emerald-300/30 dark:bg-emerald-400/25 blur-3xl"
@@ -466,6 +482,7 @@ export function HomeView({
           style={{
             background:
               "linear-gradient(135deg,#1d0e3a 0%,#3a1052 50%,#7c2d12 100%)",
+            ...roundedClipMaskStyle,
           }}
         >
           <div


### PR DESCRIPTION
## Summary

Addresses #414 — not auto-closing, see Test plan.

Reported on macOS: the welcome greeting card on Home shows square glow patches poking past its rounded corners (screenshot in the issue, confirmed against a fresh screenshot of the same card in this session).

Both Home-view banners (the greeting card and the Wrapped promo card) share the same shape: an `overflow-hidden rounded-3xl` container with an absolutely-positioned `blur-3xl` decorative orb inside. This is a known WebKit rendering bug — `overflow: hidden` + `border-radius` doesn't reliably clip a `filter: blur()` child; the blur's expanded paint bounds escape the rounded edge instead of being cut off by it.

## Fix

A `mask-image` (both `-webkit-` and unprefixed) on the clipping container forces Safari to clip in software instead of relying on the buggy compositor path — the standard, widely-documented workaround for this exact bug class. Shared as one `roundedClipMaskStyle` object between both banners since they're the identical pattern.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Visual confirmation on Safari/macOS — **not done in this session**. This box has no Safari (Linux dev environment); a plain Chromium screenshot of the Vite dev server renders blank since the app needs the Tauri IPC bridge to mount meaningfully, and Chromium wouldn't reproduce a WebKit-specific bug anyway. Needs a macOS user (the reporter or someone else) to confirm on the next beta before closing #414.

Claude-Session: https://claude.ai/code/session_01F9cgAgcbjFFe74k9vTEcjV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations visuelles**
  * Amélioration du rendu des bannières arrondies « Bienvenue » et « Récapitulatif de l’année ».
  * Les éléments décoratifs flous restent désormais correctement contenus dans les contours arrondis des bannières.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->