### PR TITLE
fix(audio): resync the WASAPI exclusive toggle after an automatic rebuild

### DIFF
--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use crossbeam_channel::{unbounded, Sender};
 use rtrb::Producer;
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::unbounded_channel;
 
 use crate::error::{AppError, AppResult};
@@ -734,6 +734,11 @@ impl AudioEngine {
             guard.as_ref().map(|h| h.wasapi_exclusive).unwrap_or(false),
             std::sync::atomic::Ordering::Release,
         );
+        // Settings' exclusive-mode toggle only re-reads its state on
+        // mount and after a manual click (issue #405) — this is the
+        // one signal that tells it a rebuild just happened behind its
+        // back, whether that landed in exclusive or fell back to shared.
+        let _ = self.app.emit("player:audio-mode-changed", ());
 
         // Resume best-effort. Same async pattern as
         // `set_output_device` and `set_wasapi_exclusive` — pull the
@@ -890,6 +895,9 @@ impl AudioEngine {
             guard.as_ref().map(|h| h.wasapi_exclusive).unwrap_or(false),
             std::sync::atomic::Ordering::Release,
         );
+        // See force_rebuild_output's comment (issue #405) — a device
+        // switch can also flip the actually-engaged exclusive mode.
+        let _ = self.app.emit("player:audio-mode-changed", ());
 
         // Step 6 — resume the previous track if we were playing one.
         // Radio (negative sentinel id) re-dispatches the cached
@@ -1006,6 +1014,11 @@ impl AudioEngine {
         *guard = Some(handle);
         self.wasapi_exclusive_active
             .store(active_mode, std::sync::atomic::Ordering::Release);
+        // Redundant with the caller's own re-read after a manual toggle
+        // (ExclusiveModeCard.tsx), but kept for consistency with the
+        // other two write sites (issue #405) in case this is ever
+        // called from somewhere that doesn't already refresh itself.
+        let _ = self.app.emit("player:audio-mode-changed", ());
 
         // Radio sessions re-dispatch `LoadUrlAndPlay` directly so
         // the WASAPI flip doesn't drop the user off the stream.

--- a/src/components/views/settings/ExclusiveModeCard.tsx
+++ b/src/components/views/settings/ExclusiveModeCard.tsx
@@ -57,20 +57,32 @@ export function ExclusiveModeCard() {
   useEffect(() => {
     if (!isWindows) return;
     let unlisten: UnlistenFn | null = null;
+    // `listen()` is async, so the effect can unmount before it resolves.
+    // Without this flag the cleanup below runs while `unlisten` is still
+    // null, does nothing, and the handle assigned afterward is never
+    // released — a live listener leaks for the rest of the app's life
+    // every time this card mounts and unmounts (opening/closing Settings).
+    let cancelled = false;
     (async () => {
       try {
-        unlisten = await listen("player:audio-mode-changed", () => {
+        const stop = await listen("player:audio-mode-changed", () => {
           playerGetWasapiExclusive()
             .then(setEnabled)
             .catch((err) => {
               console.error("[ExclusiveModeCard] refresh after rebuild failed", err);
             });
         });
+        if (cancelled) {
+          stop();
+        } else {
+          unlisten = stop;
+        }
       } catch (err) {
         console.error("[ExclusiveModeCard] listen failed", err);
       }
     })();
     return () => {
+      cancelled = true;
       if (unlisten) unlisten();
     };
   }, [isWindows]);

--- a/src/components/views/settings/ExclusiveModeCard.tsx
+++ b/src/components/views/settings/ExclusiveModeCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Lock } from "lucide-react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 import {
   playerGetWasapiExclusive,
@@ -43,6 +44,35 @@ export function ExclusiveModeCard() {
         console.error("[ExclusiveModeCard] get failed", err);
         setEnabled(false);
       });
+  }, [isWindows]);
+
+  // The engine can rebuild the output stream on its own — a device
+  // flap (issue #405), a device switch from the output-device picker —
+  // without the user ever touching this toggle. Without this listener
+  // `enabled` only ever reflected the mount-time read or the last
+  // manual click, so it could show "on" while a fallback had silently
+  // dropped the engine to shared mode. `player:audio-mode-changed`
+  // carries no payload; a re-fetch here mirrors the one `toggle()`
+  // already does after a manual click.
+  useEffect(() => {
+    if (!isWindows) return;
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      try {
+        unlisten = await listen("player:audio-mode-changed", () => {
+          playerGetWasapiExclusive()
+            .then(setEnabled)
+            .catch((err) => {
+              console.error("[ExclusiveModeCard] refresh after rebuild failed", err);
+            });
+        });
+      } catch (err) {
+        console.error("[ExclusiveModeCard] listen failed", err);
+      }
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
   }, [isWindows]);
 
   if (!isWindows) return null;


### PR DESCRIPTION
## Summary

Addresses part of #405 — not auto-closing, see Test plan. Thanks @jo-el414 for the 1.6.5-beta.1 log + screenshot that pinned this down.

His log confirmed the position/lyrics/seek-bar fix (#407) holds and the `RebuildGate` (#393) works as designed — both the immediate and the 300ms-gated rebuild succeeded in exclusive mode, no `AUDCLNT_E_DEVICE_IN_USE`. But the Settings toggle still showed stuck ON afterward, alongside a raw `build_output_stream` error banner.

Root cause, traced through the code: `ExclusiveModeCard.tsx` only ever called `playerGetWasapiExclusive()` on mount and immediately after a manual click. Nothing re-checked it after the engine rebuilt the output stream on its own — a device flap, or a device-picker switch. In the reporter's log the toggle happened to still read correctly because the rebuild landed back in exclusive mode; but nothing would have caught it silently falling back to shared, which is the scarier version of the same bug.

## Fix

`engine.rs` now emits `player:audio-mode-changed` from all three sites that write `wasapi_exclusive_active`: the automatic device-error rebuild, the output-device switch, and the manual toggle path itself (redundant there, kept for consistency). `ExclusiveModeCard` listens and re-fetches — same shape as `PlayerContext`'s existing `sample_rate`/`channels` refresh on `player:track-changed`.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p waveflow --lib` — 120/120 passing
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: reproduce a device flap on the reporter's hardware, confirm the toggle now updates on its own instead of needing a restart to trust — not done in this session (Windows/WASAPI-only, no matching hardware here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * Le réglage du mode audio exclusif WASAPI se met à jour automatiquement sur Windows lorsque le moteur audio change de mode.
  * L’interface reflète plus fidèlement l’état WASAPI réel après une reconfiguration du flux, notamment lors d’un basculement de périphérique ou d’un rebuild forcé.
  * La synchronisation est assurée y compris pour les changements effectués en dehors de l’interaction avec le bouton.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->