### PR TITLE
fix(deps): pin tao to the upstream Wayland CSD fix commit

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1729,7 +1729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3438,7 +3438,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3537,7 +3537,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4799,7 +4799,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4866,7 +4866,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5329,7 +5329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5906,8 +5906,7 @@ dependencies = [
 [[package]]
 name = "tao"
 version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
+source = "git+https://github.com/tauri-apps/tao?rev=07f3742b1833b64be27b1ef991e38d557d4276c9#07f3742b1833b64be27b1ef991e38d557d4276c9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
@@ -5934,7 +5933,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "raw-window-handle",
- "tao-macros",
+ "tao-macros 0.1.3 (git+https://github.com/tauri-apps/tao?rev=07f3742b1833b64be27b1ef991e38d557d4276c9)",
  "unicode-segmentation",
  "url",
  "windows 0.61.3",
@@ -5948,6 +5947,16 @@ name = "tao-macros"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.3"
+source = "git+https://github.com/tauri-apps/tao?rev=07f3742b1833b64be27b1ef991e38d557d4276c9#07f3742b1833b64be27b1ef991e38d557d4276c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6375,7 +6384,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6925,7 +6934,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6978,7 +6987,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7909,7 +7918,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8506,7 +8515,7 @@ dependencies = [
  "raw-window-handle",
  "sha2 0.10.9",
  "soup3",
- "tao-macros",
+ "tao-macros 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.19",
  "url",
  "webkit2gtk",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,3 +20,14 @@ members = ["crates/core", "crates/app", "crates/plugin-sdk", "crates/spotify", "
 # Patch entries MUST live at the workspace root — Cargo silently ignores
 # `[patch.crates-io]` declared in a workspace member crate.
 glib = { path = "vendor/glib-0.18.5" }
+
+# GNOME/Wayland title bar buttons (minimize/maximize/close) are
+# unresponsive without the CSD fix in tauri-apps/tao#1218 — merged to
+# tao's main branch 2026-06-29 but not yet published as a crates.io
+# release (still 0.35.3 as of this patch, see the covector-planned
+# "next: 0.36.0" that hasn't shipped). Pin straight to the merge commit
+# so the fix ships now instead of waiting on an unscheduled tao release
+# (issue #427). Remove this entry once tao >= 0.36.0 lands on
+# crates.io — `tauri`'s existing "^2.11.4" tauri-runtime-wry range
+# already accepts it, no version bump needed on our side.
+tao = { git = "https://github.com/tauri-apps/tao", rev = "07f3742b1833b64be27b1ef991e38d557d4276c9" }


### PR DESCRIPTION
## Summary
- GNOME/Wayland title bar buttons (minimize/maximize/close) are unresponsive on `tao < 0.36.0` — a known upstream bug (`tauri-apps/tao#1218`).
- The fix merged to tao's `main` branch on 2026-06-29 but hasn't been published as a crates.io release yet (latest published is still 0.35.3).
- Pins `tao`/`tao-macros` to the merge commit via `[patch.crates-io]` (same mechanism already used for the `glib` 0.18.5 backport, see the existing comment in `Cargo.toml`) so the fix ships now instead of waiting on an unscheduled tao release.
- This is a **temporary** pin — documented inline to be removed once tao ≥ 0.36.0 is published on crates.io (`tauri`'s existing `^2.11.4` `tauri-runtime-wry` range already accepts it, no version bump needed on our side at that point).

## Test plan
- [x] `cargo check --workspace --all-targets` — green
- [ ] `cargo test --workspace` — blocked locally by disk space (unrelated to this change); relying on CI
- [ ] Manual: confirm title bar buttons respond on GNOME Wayland once this ships in a build

Closes #427