### PR TITLE
fix(similar): drop Deezer's empty-hash placeholder pictures (#406)

### DIFF
--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -490,7 +490,7 @@ async fn enrich_artist_deezer_inner(
         }
     };
 
-    let picture_url = hit.picture_xl.clone().or_else(|| hit.picture_big.clone());
+    let picture_url = hit.best_picture();
 
     // 5. Download artwork into the shared cache (best-effort).
     let picture_hash = match picture_url.as_deref() {
@@ -761,11 +761,16 @@ pub async fn search_artists_deezer(query: String) -> AppResult<Vec<DeezerArtistL
     Ok(hits
         .into_iter()
         .take(20)
-        .map(|h| DeezerArtistLite {
-            deezer_id: h.id,
-            name: h.name,
-            picture_url: h.picture_xl.or(h.picture_big).or(h.picture_medium),
-            nb_fan: h.nb_fan,
+        .map(|h| {
+            // Skip Deezer's empty-hash placeholder (#406) — borrow before
+            // `h.name` moves into the struct.
+            let picture_url = h.best_picture();
+            DeezerArtistLite {
+                deezer_id: h.id,
+                name: h.name,
+                picture_url,
+                nb_fan: h.nb_fan,
+            }
         })
         .collect())
 }
@@ -795,10 +800,7 @@ pub async fn set_artist_artwork_from_deezer(
         .map_err(|err| AppError::Other(format!("deezer get_artist failed: {err}")))?;
 
     let picture_url = hit
-        .picture_xl
-        .clone()
-        .or_else(|| hit.picture_big.clone())
-        .or_else(|| hit.picture_medium.clone())
+        .best_picture()
         .ok_or_else(|| AppError::Other("deezer artist has no picture".into()))?;
 
     let bytes = download_image_bytes(&picture_url).await?;

--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -21,7 +21,7 @@ use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter};
 
 use waveflow_core::metadata::{
-    deezer::DeezerClient,
+    deezer::{is_placeholder_artist_picture, DeezerClient},
     lastfm::LastfmClient,
     name_match::{normalize_name, select_by_name},
     theaudiodb::{make_summary, TheAudioDbClient},
@@ -395,6 +395,19 @@ async fn enrich_artist_deezer_inner(
                 && (active_source != BioSource::TheAudioDb
                     || cached_bio_language.as_deref() == Some(active_lang.as_str()));
             if expires_at > now && bio_fresh {
+                // A row cached before #406 may hold a Deezer placeholder
+                // URL (and a grey-blob hash). Drop both so we surface the
+                // initial-letter avatar instead of the grey box; the row's
+                // own TTL refresh re-fetches through `best_picture`, and a
+                // placeholder means the artist has no real Deezer photo to
+                // heal to anyway.
+                let placeholder =
+                    picture_url.as_deref().is_some_and(is_placeholder_artist_picture);
+                let (picture_url, picture_hash) = if placeholder {
+                    (None, None)
+                } else {
+                    (picture_url, picture_hash)
+                };
                 let picture_path = picture_hash
                     .as_deref()
                     .and_then(|h| metadata_artwork::existing_path(&artwork_dir, h));

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
 use waveflow_core::metadata::{
-    deezer::DeezerClient,
+    deezer::{is_placeholder_artist_picture, DeezerClient},
     lastfm::LastfmClient,
     name_match::{normalize_name, select_by_name},
 };
@@ -366,7 +366,14 @@ async fn enrich_with_deezer_pictures(
             for (name, picture_url, picture_hash) in rows {
                 let canon = canonical_name(&name);
                 if canon_targets.contains(&canon) {
-                    map.insert(canon, (picture_url, picture_hash));
+                    // A row cached before #406 may hold a Deezer placeholder
+                    // URL + grey-blob hash — drop both so it doesn't re-enter
+                    // the map as a grey box (fresh fetches already filter it).
+                    let entry = match picture_url.as_deref() {
+                        Some(u) if is_placeholder_artist_picture(u) => (None, None),
+                        _ => (picture_url, picture_hash),
+                    };
+                    map.insert(canon, entry);
                 }
             }
         }

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -26,7 +26,7 @@ use sqlx::SqlitePool;
 
 use waveflow_core::metadata::{
     deezer::{is_placeholder_artist_picture, DeezerClient},
-    lastfm::LastfmClient,
+    lastfm::{is_lastfm_star_placeholder, LastfmClient},
     name_match::{normalize_name, select_by_name},
 };
 
@@ -216,9 +216,14 @@ pub async fn get_similar_artists(
             // generic star for an artist we already know has no real photo.
             // Only when the artist was never enriched (`meta` is `None`) do
             // we surface the upstream URL as a best-effort remote fallback.
+            // A never-enriched entry (`meta` is `None`) falls back to the
+            // upstream URL — but for a Last.fm-sourced result that is the
+            // generic grey star, so drop it and let the UI show the
+            // initial-letter avatar (#406). A genuine upstream picture
+            // still passes through.
             let picture_url = match meta {
                 Some((url, _)) => url.clone(),
-                None => r.picture_url,
+                None => r.picture_url.filter(|u| !is_lastfm_star_placeholder(u)),
             };
             SimilarArtistDto {
                 name: r.name,

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -434,7 +434,7 @@ async fn enrich_with_deezer_pictures(
 
     for (canon, hit) in fetched {
         let Some(hit) = hit else { continue };
-        let picture_url = hit.picture_xl.clone().or_else(|| hit.picture_big.clone());
+        let picture_url = hit.best_picture();
         let picture_hash = match picture_url.as_deref() {
             Some(url) => metadata_artwork::download_and_cache(url, artwork_dir).await,
             None => None,
@@ -629,14 +629,19 @@ async fn try_deezer(deezer_id: Option<i64>, source_name: &str) -> Option<Vec<Raw
             Some(
                 list.into_iter()
                     .enumerate()
-                    .map(|(i, h)| RawSimilar {
-                        name: h.name,
-                        // Synthesize a decreasing 1.0 → ~0 score from
-                        // the Deezer ranking so the UI can sort
-                        // uniformly with Last.fm output.
-                        match_score: 1.0 - (i as f32) / n,
-                        picture_url: h.picture_big.or(h.picture_medium),
-                        source: "deezer".into(),
+                    .map(|(i, h)| {
+                        // Skip Deezer's empty-hash placeholder (#406) —
+                        // borrow before `h.name` moves into the struct.
+                        let picture_url = h.best_picture();
+                        RawSimilar {
+                            name: h.name,
+                            // Synthesize a decreasing 1.0 → ~0 score from
+                            // the Deezer ranking so the UI can sort
+                            // uniformly with Last.fm output.
+                            match_score: 1.0 - (i as f32) / n,
+                            picture_url,
+                            source: "deezer".into(),
+                        }
                     })
                     .collect(),
             )

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -217,13 +217,14 @@ pub async fn get_similar_artists(
             // Only when the artist was never enriched (`meta` is `None`) do
             // we surface the upstream URL as a best-effort remote fallback.
             // A never-enriched entry (`meta` is `None`) falls back to the
-            // upstream URL — but for a Last.fm-sourced result that is the
-            // generic grey star, so drop it and let the UI show the
-            // initial-letter avatar (#406). A genuine upstream picture
+            // upstream URL — but that can be a "no real photo" sentinel
+            // (Last.fm's grey star, or Deezer's empty-hash silhouette in a
+            // payload cached before #406), so drop those and let the UI
+            // show the initial-letter avatar. A genuine upstream picture
             // still passes through.
             let picture_url = match meta {
                 Some((url, _)) => url.clone(),
-                None => r.picture_url.filter(|u| !is_lastfm_star_placeholder(u)),
+                None => unenriched_fallback_picture(r.picture_url),
             };
             SimilarArtistDto {
                 name: r.name,
@@ -562,6 +563,15 @@ struct RawSimilar {
     source: String,
 }
 
+/// Best-effort remote picture for a similar artist we never enriched
+/// (`meta` was `None`). Both providers embed a "no real photo" sentinel —
+/// Last.fm's md5 star and Deezer's empty-hash silhouette — and a payload
+/// cached before #406 can still carry either, so reject both before
+/// surfacing the URL. A genuine picture passes through unchanged.
+fn unenriched_fallback_picture(url: Option<String>) -> Option<String> {
+    url.filter(|u| !is_lastfm_star_placeholder(u) && !is_placeholder_artist_picture(u))
+}
+
 /// Query the upstream provider(s) and persist the result. Last.fm wins
 /// when an API key is configured AND it returns at least one entry —
 /// otherwise we fall through to Deezer's `/artist/{id}/related`.
@@ -687,5 +697,37 @@ async fn try_deezer(deezer_id: Option<i64>, source_name: &str) -> Option<Vec<Raw
             tracing::warn!(?err, "Deezer get_related_artists failed");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unenriched_fallback_filters_a_cached_deezer_placeholder() {
+        // Regression (#406): an offline/cache payload written before the
+        // fix still carries Deezer's empty-hash silhouette. The None-branch
+        // fallback must drop it, not surface a grey placeholder.
+        let placeholder = Some(
+            "https://e-cdns-images.dzcdn.net/images/artist//500x500-000000-80-0-0.jpg".to_string(),
+        );
+        assert_eq!(unenriched_fallback_picture(placeholder), None);
+    }
+
+    #[test]
+    fn unenriched_fallback_filters_the_lastfm_star() {
+        let star = Some(
+            "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+                .to_string(),
+        );
+        assert_eq!(unenriched_fallback_picture(star), None);
+    }
+
+    #[test]
+    fn unenriched_fallback_keeps_a_real_url() {
+        let real =
+            Some("https://e-cdns-images.dzcdn.net/images/artist/abc123/500x500.jpg".to_string());
+        assert_eq!(unenriched_fallback_picture(real.clone()), real);
     }
 }

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -199,11 +199,17 @@ pub async fn get_similar_artists(
                 .and_then(|(_, hash)| hash.as_deref())
                 .or_else(|| meta.and_then(|(_, hash)| hash.as_deref()))
                 .and_then(|h| metadata_artwork::existing_path(&artwork_dir, h));
-            // Prefer the Deezer URL over Last.fm's placeholder when
-            // both are present. Falls back to whatever the upstream
-            // gave us so a Deezer-fetch failure still surfaces *some*
-            // remote URL (good enough for the in-library badge case).
-            let picture_url = meta.and_then(|(url, _)| url.clone()).or(r.picture_url);
+            // When we have a metadata_artist entry it is authoritative:
+            // its URL (real Deezer picture, or `None` for a genuinely
+            // absent / filtered-placeholder one, #406) wins and must NOT
+            // fall back to `r.picture_url` — that would resurrect Last.fm's
+            // generic star for an artist we already know has no real photo.
+            // Only when the artist was never enriched (`meta` is `None`) do
+            // we surface the upstream URL as a best-effort remote fallback.
+            let picture_url = match meta {
+                Some((url, _)) => url.clone(),
+                None => r.picture_url,
+            };
             SimilarArtistDto {
                 name: r.name,
                 match_score: r.match_score,
@@ -267,12 +273,21 @@ async fn fetch_custom_similar(
         .enumerate()
         .map(
             |(i, (id, name, picture_url, picture_hash, local_hash, local_format))| {
+                // A pre-#406 metadata_artist row may hold a Deezer
+                // placeholder URL (+ grey-blob hash); ignore both so the
+                // local sidecar or the initial-letter avatar wins instead
+                // of a grey box. The local picture is resolved separately
+                // and is unaffected.
+                let (picture_url, cached_hash) = match picture_url {
+                    Some(u) if is_placeholder_artist_picture(&u) => (None, None),
+                    other => (other, picture_hash),
+                };
                 let picture_path = metadata_artwork::resolve_local_or_cached_path(
                     local_artwork_dir,
                     local_hash.as_deref(),
                     local_format.as_deref(),
                     artwork_dir,
-                    picture_hash.as_deref(),
+                    cached_hash.as_deref(),
                 );
                 SimilarArtistDto {
                     name,

--- a/src-tauri/crates/app/src/commands/similar.rs
+++ b/src-tauri/crates/app/src/commands/similar.rs
@@ -162,16 +162,26 @@ pub async fn get_similar_artists(
     let mut local_map: HashMap<String, (i64, Option<String>)> = HashMap::new();
     if !canonicals.is_empty() {
         let sql = format!(
-            "SELECT a.id, a.canonical_name, ma.picture_hash
+            "SELECT a.id, a.canonical_name, ma.picture_url, ma.picture_hash
                FROM artist a
                LEFT JOIN app.metadata_artist ma ON ma.deezer_id = a.deezer_id
               WHERE a.canonical_name IN ({placeholders})"
         );
-        let mut q = sqlx::query_as::<_, (i64, String, Option<String>)>(sqlx::AssertSqlSafe(sql));
+        let mut q = sqlx::query_as::<_, (i64, String, Option<String>, Option<String>)>(
+            sqlx::AssertSqlSafe(sql),
+        );
         for c in &canonicals {
             q = q.bind(c);
         }
-        for (id, canon, hash) in q.fetch_all(&*pool).await? {
+        for (id, canon, url, hash) in q.fetch_all(&*pool).await? {
+            // A placeholder cached before the #406 fix still carries a real
+            // hash pointing at the grey-silhouette blob on disk. Drop it so
+            // `picture_path` doesn't resurface it for library artists — the
+            // metadata_map filter only covers the cross-profile `meta` path.
+            let hash = match url.as_deref() {
+                Some(u) if is_placeholder_artist_picture(u) => None,
+                _ => hash,
+            };
             local_map.insert(canon, (id, hash));
         }
     }

--- a/src-tauri/crates/core/src/metadata/deezer.rs
+++ b/src-tauri/crates/core/src/metadata/deezer.rs
@@ -47,6 +47,35 @@ pub struct DeezerArtistHit {
     pub nb_fan: Option<i64>,
 }
 
+/// Deezer serves a grey-silhouette placeholder when an artist has no real
+/// picture: every size resolves to the same CDN path but with an *empty*
+/// image hash — `…/images/artist//500x500…` (double slash) — or the md5
+/// of the empty string. Caching one of those as a real image is the
+/// "similar artist shows no photo" half of #406, so callers filter them
+/// out at every point a Deezer picture URL is accepted.
+pub fn is_placeholder_artist_picture(url: &str) -> bool {
+    url.contains("/artist//") || url.contains("/artist/d41d8cd98f00b204e9800998ecf8427e/")
+}
+
+impl DeezerArtistHit {
+    /// Highest-quality *real* picture URL, largest first, skipping
+    /// Deezer's empty-hash placeholder (#406). `None` when the artist has
+    /// no genuine image — every size shares the one hash, so a placeholder
+    /// in `picture_xl` means all the others are placeholders too.
+    pub fn best_picture(&self) -> Option<String> {
+        [
+            &self.picture_xl,
+            &self.picture_big,
+            &self.picture_medium,
+            &self.picture_small,
+        ]
+        .into_iter()
+        .flatten()
+        .find(|u| !is_placeholder_artist_picture(u))
+        .cloned()
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct DeezerAlbumHit {
@@ -188,5 +217,68 @@ impl DeezerClient {
             .json()
             .await?;
         Ok(resp.data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(xl: Option<&str>, big: Option<&str>) -> DeezerArtistHit {
+        DeezerArtistHit {
+            id: 1,
+            name: "Test".into(),
+            picture_small: None,
+            picture_medium: None,
+            picture_big: big.map(str::to_string),
+            picture_xl: xl.map(str::to_string),
+            nb_album: None,
+            nb_fan: None,
+        }
+    }
+
+    #[test]
+    fn detects_empty_hash_placeholder() {
+        assert!(is_placeholder_artist_picture(
+            "https://e-cdns-images.dzcdn.net/images/artist//500x500-000000-80-0-0.jpg"
+        ));
+        assert!(is_placeholder_artist_picture(
+            "https://e-cdns-images.dzcdn.net/images/artist/d41d8cd98f00b204e9800998ecf8427e/500x500.jpg"
+        ));
+    }
+
+    #[test]
+    fn accepts_a_real_hash() {
+        assert!(!is_placeholder_artist_picture(
+            "https://e-cdns-images.dzcdn.net/images/artist/f2bc007e9133c946ac3c3907ddc5d2ea/500x500.jpg"
+        ));
+    }
+
+    #[test]
+    fn best_picture_skips_a_placeholder_and_takes_the_next_real_size() {
+        // Real world: all sizes share the hash, so a placeholder xl means
+        // every size is a placeholder → None.
+        let ph = hit(
+            Some("https://e-cdns-images.dzcdn.net/images/artist//1000x1000.jpg"),
+            Some("https://e-cdns-images.dzcdn.net/images/artist//500x500.jpg"),
+        );
+        assert_eq!(ph.best_picture(), None);
+    }
+
+    #[test]
+    fn best_picture_prefers_the_largest_real_size() {
+        let h = hit(
+            Some("https://e-cdns-images.dzcdn.net/images/artist/abc123/1000x1000.jpg"),
+            Some("https://e-cdns-images.dzcdn.net/images/artist/abc123/500x500.jpg"),
+        );
+        assert_eq!(
+            h.best_picture().as_deref(),
+            Some("https://e-cdns-images.dzcdn.net/images/artist/abc123/1000x1000.jpg")
+        );
+    }
+
+    #[test]
+    fn best_picture_is_none_when_no_sizes_present() {
+        assert_eq!(hit(None, None).best_picture(), None);
     }
 }

--- a/src-tauri/crates/core/src/metadata/deezer.rs
+++ b/src-tauri/crates/core/src/metadata/deezer.rs
@@ -256,8 +256,21 @@ mod tests {
 
     #[test]
     fn best_picture_skips_a_placeholder_and_takes_the_next_real_size() {
-        // Real world: all sizes share the hash, so a placeholder xl means
-        // every size is a placeholder → None.
+        // Exercises the `.find()` skip: a placeholder in the largest slot
+        // must not short-circuit — the next real size wins.
+        let h = hit(
+            Some("https://e-cdns-images.dzcdn.net/images/artist//1000x1000.jpg"),
+            Some("https://e-cdns-images.dzcdn.net/images/artist/abc123/500x500.jpg"),
+        );
+        assert_eq!(
+            h.best_picture().as_deref(),
+            Some("https://e-cdns-images.dzcdn.net/images/artist/abc123/500x500.jpg")
+        );
+    }
+
+    #[test]
+    fn best_picture_is_none_when_every_size_is_a_placeholder() {
+        // The real-world shape: all sizes share the one empty hash.
         let ph = hit(
             Some("https://e-cdns-images.dzcdn.net/images/artist//1000x1000.jpg"),
             Some("https://e-cdns-images.dzcdn.net/images/artist//500x500.jpg"),

--- a/src-tauri/crates/core/src/metadata/lastfm.rs
+++ b/src-tauri/crates/core/src/metadata/lastfm.rs
@@ -250,6 +250,16 @@ fn pick_largest_image(images: &[LastfmImage]) -> Option<String> {
     None
 }
 
+/// Last.fm serves one md5-named star asset for every artist without an
+/// uploaded picture (their artist-image API was retired in 2019). The CDN
+/// host has changed over the years but the asset hash is stable, so a
+/// substring match on it is the reliable "no real photo" test. Callers
+/// that fall back to a raw Last.fm URL filter it out so the UI shows its
+/// initial-letter avatar instead of the grey star (#406).
+pub fn is_lastfm_star_placeholder(url: &str) -> bool {
+    url.contains("2a96cbd8b46e442fc41c2b86b821562f")
+}
+
 // ── Signed authentication ───────────────────────────────────────────
 
 /// Errors that can come out of the signed-method surface. Network +
@@ -503,4 +513,26 @@ fn strip_html_tags(input: &str) -> String {
         .join(" ")
         .trim()
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_the_star_placeholder_across_cdn_hosts() {
+        assert!(is_lastfm_star_placeholder(
+            "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+        ));
+        assert!(is_lastfm_star_placeholder(
+            "https://lastfm-img2.akamaized.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+        ));
+    }
+
+    #[test]
+    fn accepts_a_real_lastfm_picture() {
+        assert!(!is_lastfm_star_placeholder(
+            "https://lastfm.freetls.fastly.net/i/u/300x300/abc123def456abc123def456abc12345.png"
+        ));
+    }
 }


### PR DESCRIPTION
Closes the remaining "similar artist shows no photo" half of #406.

## Context

#406 was closed after #412 fixed the main symptom (a *network* failure was being cached empty for 30 days, poisoning the artist's similar list). jo-el414 traced the deeper cause to Deezer's own API changes. The **fuzzy name matcher** and **don't-cache-network-failures** levers are already in.

What was left: a *successful* Deezer answer can still carry a **placeholder image**. Deezer serves a grey silhouette when an artist has no real photo — the CDN path has an **empty image hash** (`/images/artist//500x500…`, double slash) or the md5 of the empty string. We accepted those as real pictures and cached the grey blob into `metadata_artist`, so it stuck across sessions.

## Fix

- `waveflow-core`: `is_placeholder_artist_picture(url)` + `DeezerArtistHit::best_picture()` — largest real size first, skipping the placeholder. Every size shares the one hash, so a placeholder in `picture_xl` means all sizes are placeholders → `None`, and the UI falls back to the initial-letter avatar instead of a grey box.
- Routed **all five** Deezer-picture acceptance points through it: similar-artist enrichment + related-artist fallback (`similar.rs`), and artist enrichment / search / single-artist fetch (`deezer.rs`). Filtering at every write into the shared cache is what stops a placeholder from entering it via any path.

## Reference

The placeholder pattern was confirmed against how **rustmusic** handles the same Deezer quirk (`is_deezer_default_image`). The caching model itself (retry-on-empty vs sticky) was cross-checked against **lokal**'s per-field TTL design — no change needed there, #412 already covers the failure case, and with Deezer's API degraded, aggressively retrying genuine empties would just hammer a broken endpoint.

## Testing

5 unit tests in `waveflow-core` (empty-hash + md5 detection, real-hash acceptance, best_picture skip/prefer/none) — run locally, all pass. `cargo clippy -p waveflow --all-targets` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Corrections**
  * Harmonisation de la sélection et du téléchargement des meilleures images Deezer pour les artistes (pochettes et avatars).
  * Renforcement du filtrage des images Deezer placeholder afin d’éviter l’affichage de “grey boxes”.
  * Mise à jour de la logique de cache pour empêcher la “résurrection” de placeholders avant rafraîchissement, puis reprise correcte après expiration.
  * Correction du traitement des images placeholder Last.fm dans la vue des artistes similaires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->