### PR TITLE
feat(player): track context menu on the immersive view + queue panel

### DIFF
--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -33,7 +33,7 @@ Per-view data fetches initialise their `isLoading` state to `true` (not `false`)
 ## Panels
 
 - [`NowPlayingPanel`](../../src/components/layout/NowPlayingPanel.tsx) — large artwork, clickable artists, "About the artist" section populated from the Deezer + Last.fm caches, and a "Next in queue" teaser with an "Open queue" link that hands the right slot off to `QueuePanel`. Lightbox on cover click.
-- [`QueuePanel`](../../src/components/layout/QueuePanel.tsx) — current queue with drag reorder, jump-to-track, clear queue.
+- [`QueuePanel`](../../src/components/layout/QueuePanel.tsx) — current queue with drag reorder, jump-to-track, clear queue. Right-clicking a queue row opens the same track context menu the list views have (Show in Explorer, Properties, play-next / add-to-queue, like, rating…) via [`usePlayerTrackContextMenu`](../../src/hooks/usePlayerTrackContextMenu.tsx) — the player-surface wrapper that supplies the liked-ids lookup + create-playlist modal the base [`useTrackContextMenu`](../../src/hooks/useTrackContextMenu.tsx) needs. Radio/stream rows (negative sentinel id, no local file) are skipped. Payload→`Track` widening is the shared [`queuePayloadToTrack`](../../src/lib/queueTrack.ts). Same menu is reachable by right-clicking the title in [`ImmersiveNowPlaying`](../../src/components/player/ImmersiveNowPlaying.tsx) (library tracks only). Reporter request.
 - [`LyricsPanel`](../../src/components/layout/LyricsPanel.tsx) — synced or static lyrics with auto-scroll.
 - [`NowPlayingChevronTab`](../../src/components/layout/NowPlayingChevronTab.tsx) — right-edge floating tab visible only when no panel is open.
 

--- a/src/components/layout/QueuePanel.tsx
+++ b/src/components/layout/QueuePanel.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -25,6 +33,8 @@ import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { usePlayer } from "../../hooks/usePlayer";
+import { usePlayerTrackContextMenu } from "../../hooks/usePlayerTrackContextMenu";
+import { queuePayloadToTrack } from "../../lib/queueTrack";
 import { Artwork } from "../common/Artwork";
 import {
   playerGetQueue,
@@ -163,6 +173,20 @@ export function QueuePanel() {
 
   const isActive = playbackState === "playing" || playbackState === "paused";
 
+  // Right-click a queue row for the same track menu the list views have
+  // (Show in Explorer, Properties, queue ops…) — mail reporter request.
+  // Radio / stream rows (negative sentinel id, no local file) are skipped
+  // but still swallow the native menu so the gesture reads consistently.
+  const trackMenu = usePlayerTrackContextMenu();
+  const handleRowContextMenu = useCallback(
+    (event: ReactMouseEvent, item: QueueTrackPayload) => {
+      event.preventDefault();
+      if (item.id < 0 || !item.file_path) return;
+      trackMenu.open(event, queuePayloadToTrack(item));
+    },
+    [trackMenu],
+  );
+
   return (
     <motion.aside
       key="queue"
@@ -173,6 +197,7 @@ export function QueuePanel() {
       className="h-full shrink-0 overflow-hidden border-l bg-surface-light border-zinc-200 text-zinc-800 dark:bg-surface-dark dark:border-zinc-800 dark:text-zinc-100"
     >
       <div className="p-6 flex flex-col h-full w-80">
+        {trackMenu.render()}
         <div className="flex items-center justify-between mb-6">
           <div>
             <h2 className="text-xl font-bold">{t("queue.title")}</h2>
@@ -233,7 +258,11 @@ export function QueuePanel() {
                 <div className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase mb-2 px-1">
                   {t("queue.nowPlaying")}
                 </div>
-                <QueueRow item={nowPlaying} isCurrent />
+                <QueueRow
+                  item={nowPlaying}
+                  isCurrent
+                  onContextMenu={(e) => handleRowContextMenu(e, nowPlaying)}
+                />
               </section>
             )}
             {upNext.length > 0 && (
@@ -246,6 +275,7 @@ export function QueuePanel() {
                   startIndex={currentIndex + 1}
                   onJump={handleJump}
                   onReorder={handleReorder}
+                  onContextMenu={handleRowContextMenu}
                 />
               </section>
             )}
@@ -259,12 +289,15 @@ export function QueuePanel() {
 function QueueRow({
   item,
   isCurrent = false,
+  onContextMenu,
 }: {
   item: QueueTrackPayload;
   isCurrent?: boolean;
+  onContextMenu?: (e: ReactMouseEvent) => void;
 }) {
   return (
     <div
+      onContextMenu={onContextMenu}
       className={`flex items-center space-x-3 p-2 rounded-lg transition-colors select-none ${
         isCurrent
           ? "bg-emerald-50 dark:bg-emerald-900/20"
@@ -305,6 +338,7 @@ interface SortableUpNextProps {
   startIndex: number;
   onJump: (absoluteIndex: number) => void;
   onReorder: (fromAbsolute: number, toAbsolute: number) => void;
+  onContextMenu: (e: ReactMouseEvent, item: QueueTrackPayload) => void;
 }
 
 /**
@@ -324,6 +358,7 @@ function SortableUpNext({
   startIndex,
   onJump,
   onReorder,
+  onContextMenu,
 }: SortableUpNextProps) {
   "use no memo";
   const sensors = useSensors(
@@ -416,6 +451,7 @@ function SortableUpNext({
                   top={virtualRow.start}
                   rowHeight={QUEUE_ROW_HEIGHT}
                   onJump={onJump}
+                  onContextMenu={onContextMenu}
                 />
               );
             })}
@@ -489,6 +525,7 @@ const SortableQueueRow = memo(function SortableQueueRow({
   top,
   rowHeight,
   onJump,
+  onContextMenu,
 }: {
   id: string;
   absoluteIndex: number;
@@ -496,6 +533,7 @@ const SortableQueueRow = memo(function SortableQueueRow({
   top: number;
   rowHeight: number;
   onJump: (absoluteIndex: number) => void;
+  onContextMenu: (e: ReactMouseEvent, item: QueueTrackPayload) => void;
 }) {
   // `animateLayoutChanges: () => false` disables the CSS transition
   // dnd-kit applies to every neighbour as the drag crosses them — on
@@ -538,6 +576,7 @@ const SortableQueueRow = memo(function SortableQueueRow({
           tabIndex + role + onKeyDown wiring. */}
       <div
         onDoubleClick={() => onJump(absoluteIndex)}
+        onContextMenu={(e) => onContextMenu(e, item)}
         tabIndex={0}
         role="button"
         onKeyDown={(e) => {

--- a/src/components/player/ImmersiveNowPlaying.tsx
+++ b/src/components/player/ImmersiveNowPlaying.tsx
@@ -10,6 +10,7 @@ import { VolumeControl } from "./VolumeControl";
 import { SpectrumVisualizer } from "./SpectrumVisualizer";
 import { usePlayer } from "../../hooks/usePlayer";
 import { useWebRadioFavorites } from "../../hooks/useWebRadioFavorites";
+import { usePlayerTrackContextMenu } from "../../hooks/usePlayerTrackContextMenu";
 import { isRadioTrack } from "../../lib/playerSources";
 
 interface ImmersiveNowPlayingProps {
@@ -38,7 +39,16 @@ export function ImmersiveNowPlaying({
   onToggleLike,
 }: ImmersiveNowPlayingProps) {
   const { t } = useTranslation();
-  const { currentTrack, currentRadioStation } = usePlayer();
+  const { currentTrack, currentRadioStation, activeProvider } = usePlayer();
+  // Right-click the title to reach the same track menu the list views have
+  // (Show in Explorer, Properties, queue ops…) — mail reporter request.
+  // Only for a real library track: radio (negative sentinel id) and
+  // Spotify playback have no local file / library row to act on.
+  const trackMenu = usePlayerTrackContextMenu();
+  const menuTrack =
+    currentTrack && activeProvider !== "spotify" && !isRadioTrack(currentTrack)
+      ? currentTrack
+      : null;
   // Live radio: favorite the STATION (★) instead of liking a track (♥) —
   // a radio session has a negative sentinel id with no library row to
   // like. Mirrors the PlayerBar / mini-player treatment.
@@ -56,6 +66,7 @@ export function ImmersiveNowPlaying({
     // controls stranded at the bottom". The cover is sized so the full
     // stack still fits a 1080p viewport at 125 % DPI (see #54).
     <div className="h-full flex flex-col items-center justify-center text-white px-8 py-10 gap-7 min-h-0">
+      {trackMenu.render()}
       <div className="relative w-full max-w-[min(42vh,24rem)] aspect-square shrink-0">
         <Artwork
           path={currentTrack?.artwork_path ?? null}
@@ -82,7 +93,12 @@ export function ImmersiveNowPlaying({
             `pb-1` + `leading-tight` on the marquee container give
             descenders (g / y / p) room so the `overflow: hidden` (needed
             for both truncate + the marquee) doesn't clip them. */}
-        <h1 className="text-3xl md:text-4xl font-bold">
+        <h1
+          className="text-3xl md:text-4xl font-bold"
+          onContextMenu={
+            menuTrack ? (e) => trackMenu.open(e, menuTrack) : undefined
+          }
+        >
           <MarqueeText text={title} className="leading-tight pb-1" />
         </h1>
         <div className="mt-2 text-lg text-white/80 flex items-center justify-center gap-3 flex-wrap">

--- a/src/components/player/ImmersiveNowPlaying.tsx
+++ b/src/components/player/ImmersiveNowPlaying.tsx
@@ -42,11 +42,15 @@ export function ImmersiveNowPlaying({
   const { currentTrack, currentRadioStation, activeProvider } = usePlayer();
   // Right-click the title to reach the same track menu the list views have
   // (Show in Explorer, Properties, queue ops…) — mail reporter request.
-  // Only for a real library track: radio (negative sentinel id) and
-  // Spotify playback have no local file / library row to act on.
+  // Only for a real library track: radio (negative sentinel id), Spotify
+  // playback, and any streamed track with no local file have nothing the
+  // file-oriented actions can act on, so require a real `file_path`.
   const trackMenu = usePlayerTrackContextMenu();
   const menuTrack =
-    currentTrack && activeProvider !== "spotify" && !isRadioTrack(currentTrack)
+    currentTrack &&
+    activeProvider !== "spotify" &&
+    !isRadioTrack(currentTrack) &&
+    !!currentTrack.file_path
       ? currentTrack
       : null;
   // Live radio: favorite the STATION (★) instead of liking a track (♥) —

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -14,6 +14,7 @@ import {
 import { useProfile } from "../hooks/useProfile";
 import { useSpotify } from "../hooks/useSpotify";
 import type { Track } from "../lib/tauri/track";
+import { queuePayloadToTrack } from "../lib/queueTrack";
 import type { SpotifyTrackLite } from "../lib/tauri/spotify";
 import {
   playerCycleRepeat,
@@ -43,42 +44,6 @@ import {
 import type { PluginFavorite } from "../lib/tauri/plugins";
 import { enrichArtistDeezer } from "../lib/tauri/detail";
 import { isRadioTrack } from "../lib/playerSources";
-
-/**
- * Minimal conversion from the thin `QueueTrackPayload` returned by
- * `player_get_state` to the full `Track` shape the rest of the UI
- * consumes. Fields we don't carry (bitrate, sample rate, file size,
- * year, …) are nulled out — they're not needed for the PlayerBar.
- */
-function queuePayloadToTrack(payload: QueueTrackPayload): Track {
-  return {
-    id: payload.id,
-    library_id: 0,
-    title: payload.title,
-    album_id: null,
-    album_title: payload.album_title,
-    artist_id: payload.artist_id,
-    artist_name: payload.artist_name,
-    artist_ids: payload.artist_ids,
-    duration_ms: payload.duration_ms,
-    track_number: null,
-    disc_number: null,
-    year: null,
-    bitrate: payload.bitrate,
-    sample_rate: payload.sample_rate,
-    channels: payload.channels,
-    bit_depth: payload.bit_depth,
-    codec: payload.codec,
-    musical_key: null,
-    file_path: payload.file_path,
-    file_size: payload.file_size,
-    added_at: 0,
-    artwork_path: payload.artwork_path,
-    artwork_path_1x: payload.artwork_path_1x,
-    artwork_path_2x: payload.artwork_path_2x,
-    rating: null,
-  };
-}
 
 /**
  * Build the stable station identity (favorite shape, id `url:<stream>`)

--- a/src/hooks/usePlayerTrackContextMenu.tsx
+++ b/src/hooks/usePlayerTrackContextMenu.tsx
@@ -1,12 +1,14 @@
 import {
   useCallback,
   useEffect,
+  useRef,
   useState,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { CreatePlaylistModal } from "../components/common/CreatePlaylistModal";
 import { useTrackContextMenu } from "./useTrackContextMenu";
 import { usePlaylist } from "./usePlaylist";
+import { useProfile } from "./useProfile";
 import { listLikedTrackIds, type Track } from "../lib/tauri/track";
 
 /**
@@ -18,20 +20,39 @@ import { listLikedTrackIds, type Track } from "../lib/tauri/track";
  * the rest of the menu from the immersive view and the queue (mail
  * reporter request).
  *
- * Liked ids are fetched once on mount and kept in sync through the base
- * hook's `onLikedChanged`; navigation + remove-from-playlist are omitted
- * because these surfaces have no in-view destination for them.
+ * Liked ids are (re)fetched per active profile and kept in sync through
+ * the base hook's `onLikedChanged`; navigation + remove-from-playlist are
+ * omitted because these surfaces have no in-view destination for them.
+ * The rating action is omitted too: the queue payload these surfaces
+ * widen into a `Track` carries no rating, so the submenu would misreport
+ * an already-rated track as unrated.
  */
 export function usePlayerTrackContextMenu() {
   const { createPlaylist } = usePlaylist();
+  const { activeProfile } = useProfile();
   const [likedIds, setLikedIds] = useState<Set<number>>(new Set());
   const [isCreatePlaylistOpen, setIsCreatePlaylistOpen] = useState(false);
+  // Toggles the user made through `onLikedChanged` while the per-profile
+  // fetch was still in flight. Re-applied on top of the fetched base so a
+  // late response can't revert a like/unlike the user just performed.
+  const likedDeltasRef = useRef<Map<number, boolean>>(new Map());
 
   useEffect(() => {
     let cancelled = false;
+    // Fresh profile → the pending deltas belonged to the old one.
+    likedDeltasRef.current = new Map();
+    // `listLikedTrackIds` is scoped to the active profile pool, so a
+    // profile switch must reload; the cancel guard drops a stale
+    // profile's response.
     listLikedTrackIds()
       .then((ids) => {
-        if (!cancelled) setLikedIds(new Set(ids));
+        if (cancelled) return;
+        const merged = new Set(ids);
+        for (const [id, nowLiked] of likedDeltasRef.current) {
+          if (nowLiked) merged.add(id);
+          else merged.delete(id);
+        }
+        setLikedIds(merged);
       })
       .catch((err) =>
         console.error("[usePlayerTrackContextMenu] liked fetch failed", err),
@@ -39,11 +60,12 @@ export function usePlayerTrackContextMenu() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [activeProfile?.id]);
 
   const menu = useTrackContextMenu({
     likedIds,
     onLikedChanged: (trackId, nowLiked) => {
+      likedDeltasRef.current.set(trackId, nowLiked);
       setLikedIds((prev) => {
         const next = new Set(prev);
         if (nowLiked) next.add(trackId);
@@ -52,6 +74,7 @@ export function usePlayerTrackContextMenu() {
       });
     },
     onCreatePlaylist: () => setIsCreatePlaylistOpen(true),
+    enableRating: false,
   });
 
   const open = useCallback(

--- a/src/hooks/usePlayerTrackContextMenu.tsx
+++ b/src/hooks/usePlayerTrackContextMenu.tsx
@@ -1,0 +1,91 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { CreatePlaylistModal } from "../components/common/CreatePlaylistModal";
+import { useTrackContextMenu } from "./useTrackContextMenu";
+import { usePlaylist } from "./usePlaylist";
+import { listLikedTrackIds, type Track } from "../lib/tauri/track";
+
+/**
+ * Track context menu for the player surfaces (ImmersiveView, QueuePanel)
+ * that don't own a track list of their own. Bundles the liked-id lookup
+ * and the "create playlist" modal the base [`useTrackContextMenu`] needs,
+ * so a caller only wires `onContextMenu={(e) => open(e, track)}` on the
+ * row and `{render()}` near its root — reaching "Show in Explorer" and
+ * the rest of the menu from the immersive view and the queue (mail
+ * reporter request).
+ *
+ * Liked ids are fetched once on mount and kept in sync through the base
+ * hook's `onLikedChanged`; navigation + remove-from-playlist are omitted
+ * because these surfaces have no in-view destination for them.
+ */
+export function usePlayerTrackContextMenu() {
+  const { createPlaylist } = usePlaylist();
+  const [likedIds, setLikedIds] = useState<Set<number>>(new Set());
+  const [isCreatePlaylistOpen, setIsCreatePlaylistOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    listLikedTrackIds()
+      .then((ids) => {
+        if (!cancelled) setLikedIds(new Set(ids));
+      })
+      .catch((err) =>
+        console.error("[usePlayerTrackContextMenu] liked fetch failed", err),
+      );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const menu = useTrackContextMenu({
+    likedIds,
+    onLikedChanged: (trackId, nowLiked) => {
+      setLikedIds((prev) => {
+        const next = new Set(prev);
+        if (nowLiked) next.add(trackId);
+        else next.delete(trackId);
+        return next;
+      });
+    },
+    onCreatePlaylist: () => setIsCreatePlaylistOpen(true),
+  });
+
+  const open = useCallback(
+    (event: ReactMouseEvent, track: Track) => menu.open(event, track),
+    [menu],
+  );
+
+  const render = useCallback(
+    () => (
+      <>
+        {menu.render()}
+        <CreatePlaylistModal
+          isOpen={isCreatePlaylistOpen}
+          onClose={() => setIsCreatePlaylistOpen(false)}
+          onCreate={async (data) => {
+            try {
+              await createPlaylist({
+                name: data.name,
+                description: data.description || null,
+                color_id: data.colorId,
+                icon_id: data.iconId,
+              });
+            } catch (err) {
+              console.error(
+                "[usePlayerTrackContextMenu] create playlist failed",
+                err,
+              );
+            }
+          }}
+        />
+      </>
+    ),
+    [menu, isCreatePlaylistOpen, createPlaylist],
+  );
+
+  return { open, render };
+}

--- a/src/hooks/usePlayerTrackContextMenu.tsx
+++ b/src/hooks/usePlayerTrackContextMenu.tsx
@@ -41,6 +41,12 @@ export function usePlayerTrackContextMenu() {
     let cancelled = false;
     // Fresh profile → the pending deltas belonged to the old one.
     likedDeltasRef.current = new Map();
+    // Drop the previous profile's liked set so its likes can't bleed into
+    // this profile's menu during the load window below. A default-unliked
+    // display self-corrects: the like action always toggles against real
+    // DB state via `toggleLikeTrack`.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLikedIds(new Set());
     // `listLikedTrackIds` is scoped to the active profile pool, so a
     // profile switch must reload; the cancel guard drops a stale
     // profile's response.

--- a/src/hooks/useTrackContextMenu.tsx
+++ b/src/hooks/useTrackContextMenu.tsx
@@ -39,6 +39,12 @@ interface UseTrackContextMenuArgs {
    * a "Edit tags for N tracks…" item appears that opens the batch
    * editor. Omit on views without multi-select. */
   selectedTrackIds?: number[];
+  /** Whether the rating submenu is shown. Defaults to `true`. Set
+   * `false` on surfaces whose `Track` doesn't carry a real `rating`
+   * (e.g. the queue-payload-derived tracks in the player surfaces),
+   * where the submenu would misreport an already-rated track as
+   * unrated. */
+  enableRating?: boolean;
 }
 
 /**
@@ -60,6 +66,7 @@ export function useTrackContextMenu({
   currentPlaylistId,
   onRemoveFromPlaylist,
   selectedTrackIds,
+  enableRating = true,
 }: UseTrackContextMenuArgs) {
   const { playlists, addTracksToPlaylist } = usePlaylist();
   const [state, setState] = useState<{
@@ -176,7 +183,7 @@ export function useTrackContextMenu({
             onAddToPlaylist={handleAddToPlaylist}
             onCreatePlaylist={onCreatePlaylist}
             onToggleLike={handleToggleLike}
-            onSetRating={handleSetRating}
+            onSetRating={enableRating ? handleSetRating : undefined}
             onRemoveFromPlaylist={onRemoveFromPlaylist}
             onNavigateToAlbum={onNavigateToAlbum}
             onNavigateToArtist={onNavigateToArtist}
@@ -206,6 +213,7 @@ export function useTrackContextMenu({
     onCreatePlaylist,
     handleToggleLike,
     handleSetRating,
+    enableRating,
     onRemoveFromPlaylist,
     onNavigateToAlbum,
     onNavigateToArtist,

--- a/src/lib/queueTrack.ts
+++ b/src/lib/queueTrack.ts
@@ -1,0 +1,41 @@
+import type { Track } from "./tauri/track";
+import type { QueueTrackPayload } from "./tauri/player";
+
+/**
+ * Widen a lock-free `QueueTrackPayload` (the slim shape the engine ships
+ * for queue rows + the current-track event) into a full `Track`. Fields
+ * the queue payload doesn't carry — `album_id`, `rating`, `track_number`,
+ * `library_id`, `added_at`, … — default to `null`/`0`; the consumers that
+ * matter (the PlayerContext current-track state and the player-surface
+ * track context menu) only read the fields present here, and the menu
+ * simply omits the actions that need the missing ones (e.g. go-to-album).
+ */
+export function queuePayloadToTrack(payload: QueueTrackPayload): Track {
+  return {
+    id: payload.id,
+    library_id: 0,
+    title: payload.title,
+    album_id: null,
+    album_title: payload.album_title,
+    artist_id: payload.artist_id,
+    artist_name: payload.artist_name,
+    artist_ids: payload.artist_ids,
+    duration_ms: payload.duration_ms,
+    track_number: null,
+    disc_number: null,
+    year: null,
+    bitrate: payload.bitrate,
+    sample_rate: payload.sample_rate,
+    channels: payload.channels,
+    bit_depth: payload.bit_depth,
+    codec: payload.codec,
+    musical_key: null,
+    file_path: payload.file_path,
+    file_size: payload.file_size,
+    added_at: 0,
+    artwork_path: payload.artwork_path,
+    artwork_path_1x: payload.artwork_path_1x,
+    artwork_path_2x: payload.artwork_path_2x,
+    rating: null,
+  };
+}


### PR DESCRIPTION
Requested by a mail reporter: reach **Show in Explorer** (and the rest of the track menu — Properties, play-next / add-to-queue, like, rating, add-to-playlist…) from the **immersive now-playing view** and the **sidebar playback queue**, where right-clicking a song previously did nothing. The list views already have this menu; these two player surfaces didn't.

## Change

New [`usePlayerTrackContextMenu`](src/hooks/usePlayerTrackContextMenu.tsx) — a thin wrapper over the base [`useTrackContextMenu`](src/hooks/useTrackContextMenu.tsx) that supplies the two things the list-less player surfaces don't own: the liked-ids lookup (fetched once, kept in sync via the base hook's `onLikedChanged`) and the create-playlist modal. Exposes just `{ open, render }`.

- **[`ImmersiveNowPlaying`](src/components/player/ImmersiveNowPlaying.tsx)** — right-click the title opens the menu for the current track. Guarded to library tracks: radio (negative sentinel id) and Spotify playback have no local file / library row to act on.
- **[`QueuePanel`](src/components/layout/QueuePanel.tsx)** — right-click a queue row opens it, with a handler threaded down to the now-playing + up-next rows. Radio/stream rows are skipped but still swallow the native browser menu so the gesture stays consistent.

Extracted `queuePayloadToTrack` into [`src/lib/queueTrack.ts`](src/lib/queueTrack.ts) (out of `PlayerContext`, which also clears a `react-refresh/only-export-components` warning) so both the player context and the queue rows widen the slim `QueueTrackPayload` into a `Track` the same way. The menu simply omits actions that need fields the payload lacks (e.g. go-to-album, since `album_id` isn't carried).

Navigation + remove-from-playlist are intentionally omitted on these surfaces — no in-view destination.

## Validation

- `bun run typecheck` ✅
- `bun run lint` ✅

Frontend-only; no backend/schema change; no new i18n (reuses `trackActions.*`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un menu contextuel sur les morceaux de la file d’attente via clic droit.
  * Le menu permet désormais aussi de créer une playlist.
  * Ajout du même menu contextuel au titre de la vue de lecture immersive.
* **Améliorations**
  * Les informations du menu sont alimentées correctement à partir des données de la file d’attente.
  * Le menu est désactivé pour les morceaux radio et ceux non disponibles localement.
* **Correctifs**
  * Empêche qu’une action de favori soit écrasée par une mise à jour tardive du état.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->