### PR TITLE
fix(lyrics): let static lyrics scroll clear of the bottom in the immersive view

### DIFF
--- a/src/components/player/ImmersiveLyricsColumn.tsx
+++ b/src/components/player/ImmersiveLyricsColumn.tsx
@@ -249,7 +249,7 @@ export function ImmersiveLyricsColumn({
               })}
             </ul>
           ) : (
-            <p className="text-2xl leading-relaxed text-white/90 whitespace-pre-line py-16 text-center">
+            <p className="text-2xl leading-relaxed text-white/90 whitespace-pre-line pt-16 pb-[40vh] text-center">
               {staticText ?? payload.content}
             </p>
           )}


### PR DESCRIPTION
## Problème
Dans la vue immersive, les paroles **non synchronisées** (static) ne peuvent pas être lues jusqu'au bout : les dernières lignes restaient collées au bord bas de la fenêtre et paraissaient coupées.

## Cause
La branche static de `ImmersiveLyricsColumn` n'avait que `py-16` (64 px) de marge, alors que la branche synced dispose de `py-[40vh]` — d'où la place pour remonter la ligne active. Sans cette marge basse, la dernière ligne du texte statique ne peut pas remonter au-dessus du bord.

## Fix
`py-16` → `pt-16 pb-[40vh]` sur le bloc static. La dernière ligne remonte désormais confortablement. Le correctif couvre les deux surfaces qui partagent cette colonne : le plein écran classique **et** le panneau latéral du mode dual.

## Validation
- `bun run typecheck` ✅
- `bun run lint` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations d’interface**
  * Amélioration de l’espacement vertical des paroles non synchronisées pour une lecture plus confortable.
  * Conservation de l’affichage centré et des retours à la ligne.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->