### PR TITLE
fix(stats): local artist images, ragged KPI row, clipped hour labels

### DIFF
--- a/src-tauri/crates/app/src/commands/stats.rs
+++ b/src-tauri/crates/app/src/commands/stats.rs
@@ -234,6 +234,11 @@ struct TopArtistRaw {
     listened_ms: i64,
     picture_url: Option<String>,
     picture_hash: Option<String>,
+    /// Local sidecar image (`artist.jpg` / `<name>.jpg`), via
+    /// `artist.artwork_id`. Independent of the Deezer cache below —
+    /// an artist can have one, both, or neither.
+    artwork_hash: Option<String>,
+    artwork_format: Option<String>,
 }
 
 #[tauri::command]
@@ -243,11 +248,21 @@ pub async fn stats_top_artists(
     limit: i64,
 ) -> AppResult<Vec<TopArtistRow>> {
     let pool = state.require_profile_pool().await?;
-    stats_top_artists_inner(&pool, &state.paths.metadata_artwork_dir, &range, limit).await
+    let profile_id = state.require_profile_id().await?;
+    let artwork_dir = state.paths.profile_artwork_dir(profile_id);
+    stats_top_artists_inner(
+        &pool,
+        &artwork_dir,
+        &state.paths.metadata_artwork_dir,
+        &range,
+        limit,
+    )
+    .await
 }
 
 async fn stats_top_artists_inner(
     pool: &SqlitePool,
+    artwork_dir: &Path,
     metadata_dir: &Path,
     range: &str,
     limit: i64,
@@ -261,10 +276,13 @@ async fn stats_top_artists_inner(
                COUNT(*)                      AS plays,
                COALESCE(SUM(pe.listened_ms), 0) AS listened_ms,
                da.picture_url                AS picture_url,
-               da.picture_hash               AS picture_hash
+               da.picture_hash               AS picture_hash,
+               aw.hash                       AS artwork_hash,
+               aw.format                     AS artwork_format
           FROM play_event pe
           JOIN track_artist ta ON ta.track_id = pe.track_id
           JOIN artist ar       ON ar.id = ta.artist_id
+          LEFT JOIN artwork aw ON aw.id = ar.artwork_id
           LEFT JOIN app.metadata_artist da ON da.deezer_id = ar.deezer_id
          WHERE (?1 IS NULL OR pe.played_at >= ?1)
          GROUP BY ar.id
@@ -280,20 +298,50 @@ async fn stats_top_artists_inner(
     let rows = raw
         .into_iter()
         .map(|r| {
-            let (picture_path_1x, picture_path_2x) = match r.picture_hash.as_deref() {
-                Some(h) => crate::thumbnails::thumbnail_paths_for(metadata_dir, h),
-                None => (None, None),
+            // A user-supplied sidecar image wins over the Deezer cache,
+            // matching how the artist list + artist page resolve it
+            // (`list_artists` / `expand_artist_rows`). Before this join
+            // existed, an artist with only a local image resolved to
+            // nothing here and the row fell back to its initial —
+            // while the very same artist showed a picture elsewhere
+            // in the app (issue #453).
+            let local = r.artwork_hash.as_deref().zip(r.artwork_format.as_deref());
+            let local_full = local
+                .map(|(hash, format)| artwork_dir.join(format!("{hash}.{format}")))
+                .filter(|p| p.exists())
+                .map(|p| p.to_string_lossy().into_owned());
+
+            let (picture_path, picture_path_1x, picture_path_2x) = match (&local_full, local) {
+                (Some(full), Some((hash, _))) => {
+                    let (p1, p2) = crate::thumbnails::thumbnail_paths_for(artwork_dir, hash);
+                    (Some(full.clone()), p1, p2)
+                }
+                _ => {
+                    let (p1, p2) = match r.picture_hash.as_deref() {
+                        Some(h) => crate::thumbnails::thumbnail_paths_for(metadata_dir, h),
+                        None => (None, None),
+                    };
+                    let full = r
+                        .picture_hash
+                        .as_deref()
+                        .and_then(|h| crate::metadata_artwork::existing_path(metadata_dir, h));
+                    (full, p1, p2)
+                }
             };
+
             TopArtistRow {
                 artist_id: r.artist_id,
                 name: r.name,
                 plays: r.plays,
                 listened_ms: r.listened_ms,
-                picture_path: r
-                    .picture_hash
-                    .as_deref()
-                    .and_then(|h| crate::metadata_artwork::existing_path(metadata_dir, h)),
-                picture_url: r.picture_url,
+                picture_path,
+                // Only meaningful as a Deezer remote fallback; a local
+                // image is served from disk, never over the network.
+                picture_url: if local_full.is_some() {
+                    None
+                } else {
+                    r.picture_url
+                },
                 picture_path_1x,
                 picture_path_2x,
             }
@@ -589,7 +637,7 @@ pub async fn export_stats_json(
 
     let overview = stats_overview_inner(&pool, &range).await?;
     let top_tracks = stats_top_tracks_inner(&pool, &artwork_dir, &range, 100).await?;
-    let top_artists = stats_top_artists_inner(&pool, metadata_dir, &range, 100).await?;
+    let top_artists = stats_top_artists_inner(&pool, &artwork_dir, metadata_dir, &range, 100).await?;
     let top_albums = stats_top_albums_inner(&pool, &artwork_dir, &range, 100).await?;
     let top_genres = stats_top_genres_inner(&pool, &range, 100).await?;
     let listening_by_day = stats_listening_by_day_inner(&pool, &range).await?;

--- a/src/components/views/statistics/BarChart.tsx
+++ b/src/components/views/statistics/BarChart.tsx
@@ -97,11 +97,25 @@ export function BarChart({
           );
         })}
       </svg>
+      {/*
+        Labels sit in one cell per bar. At 24 bars in a third-width
+        column (the "by hour" chart on a 1080p screen with the sidebar
+        open) a cell is narrower than "00", so clipping it to the cell
+        chopped the hour in half — issue #453.
+
+        When `thinLabels` thins the row out, the neighbouring cells are
+        empty strings, so a rendered label can safely overflow into
+        them: `overflow-visible` + `whitespace-nowrap` lets it stay
+        centred and complete. With every cell filled (labelStep === 1)
+        that would overlap real text, so clipping stays on there.
+      */}
       <div className="flex mt-2 text-[10px] text-zinc-500 dark:text-zinc-400 tabular-nums">
         {data.map((d, i) => (
           <div
             key={d.key}
-            className="text-center truncate"
+            className={`text-center ${
+              labelStep > 1 ? "overflow-visible whitespace-nowrap" : "truncate"
+            }`}
             style={{ width: `${barWidthPct}%` }}
           >
             {i % labelStep === 0 ? d.label : ""}

--- a/src/components/views/statistics/KpiCard.tsx
+++ b/src/components/views/statistics/KpiCard.tsx
@@ -9,7 +9,12 @@ interface KpiCardProps {
 
 export function KpiCard({ icon, label, value, hint }: KpiCardProps) {
   return (
-    <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/60 p-5 flex flex-col gap-3">
+    // `h-full` so a card with a `hint` (a third line — only "unique
+    // tracks" has one today) doesn't stand taller than its neighbours:
+    // the grid stretches the wrapper, but the card inside would
+    // otherwise keep its content height and leave the row ragged
+    // along the bottom edge (issue #453).
+    <div className="h-full rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/60 p-5 flex flex-col gap-3">
       <div className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
         {icon}
         <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">


### PR DESCRIPTION
Fixes #453 — three UI issues @jo-el414 reported on the Statistics page in 1.7.0.

### 1. Top artists showed an initial for artists that do have a picture

The `stats_top_artists` query resolved images **only** through `app.metadata_artist` — the Deezer cache — joined on `artist.deezer_id`. An artist whose picture comes from a **local sidecar** (`artist.jpg` / `<name>.jpg`, stored as `artist.artwork_id`) simply has no row there, so the card fell back to its initial. The reporter uses local images for all their artists, which is exactly why it hit them so visibly — and why the same artist rendered fine on the artist page, whose query joins `artwork` as well.

Now joins `artwork` too and prefers it over Deezer, matching `list_artists` / `expand_artist_rows` and the documented *"local artist images … prioritised over Deezer"* rule. `picture_url` is dropped when a local file is used, so the row can't fall back to the network for an image it already has on disk.

Same Deezer-only blind spot as #350 — this is its third site.

### 2. "Unique tracks" card taller than the rest of its row

It's the only KPI passing a `hint` (the "N artists" line). The grid stretches the wrapper `div`, but the card inside kept its content height, so the row was ragged along the bottom. `h-full` on the card.

### 3. Hour labels cut in half

Each label is clipped to one bar's width. With 24 bars in a third-width column — 1080p with the sidebar open, precisely the reporter's setup — a cell is narrower than the text "00", so `truncate` chopped the hour. That's also why closing the sidebar "fixed" it.

`thinLabels` already renders only every 3rd label, so the neighbouring cells are empty strings: a rendered label can overflow into them and stay centred and complete. Clipping is kept for the `labelStep === 1` case, where every cell holds real text.

### Verification

`cargo check -p waveflow --all-targets`, `cargo test`, `bun run typecheck`, `bun run lint` — all clean (exit codes read directly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les statistiques des meilleurs artistes privilégient désormais les pochettes locales lorsqu’elles sont disponibles.
  * Les exports de statistiques incluent les pochettes locales associées.
  * Les libellés des graphiques restent lisibles sur les affichages larges, avec moins de troncature lorsque l’espace le permet.
  * Les cartes d’indicateurs statistiques ont désormais une hauteur harmonisée, notamment lorsqu’une indication complémentaire est affichée.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->