### PR TITLE
feat(context-menu): open the track menu from the keyboard everywhere

### DIFF
--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -34,6 +34,16 @@ Per-view data fetches initialise their `isLoading` state to `true` (not `false`)
 
 - [`NowPlayingPanel`](../../src/components/layout/NowPlayingPanel.tsx) — large artwork, clickable artists, "About the artist" section populated from the Deezer + Last.fm caches, and a "Next in queue" teaser with an "Open queue" link that hands the right slot off to `QueuePanel`. Lightbox on cover click.
 - [`QueuePanel`](../../src/components/layout/QueuePanel.tsx) — current queue with drag reorder, jump-to-track, clear queue. Right-clicking a queue row opens the same track context menu the list views have (Show in Explorer, Properties, play-next / add-to-queue, like, rating…) via [`usePlayerTrackContextMenu`](../../src/hooks/usePlayerTrackContextMenu.tsx) — the player-surface wrapper that supplies the liked-ids lookup + create-playlist modal the base [`useTrackContextMenu`](../../src/hooks/useTrackContextMenu.tsx) needs. Radio/stream rows (negative sentinel id, no local file) are skipped. Payload→`Track` widening is the shared [`queuePayloadToTrack`](../../src/lib/queueTrack.ts). Same menu is reachable by right-clicking the title in [`ImmersiveNowPlaying`](../../src/components/player/ImmersiveNowPlaying.tsx) (library tracks only). Reporter request.
+
+### Opening the track menu from the keyboard
+
+Right-click has no keyboard equivalent unless one is wired by hand, so every surface that shows a track menu answers the same two keys on the focused row — **Menu** (the application key) and **Shift+F10**, its stand-in on keyboards without it. The detection and the anchor live in [`contextMenuKeys.ts`](../../src/lib/contextMenuKeys.ts) and are surfaced as `openFromKeyboard` on [`useTrackContextMenu`](../../src/hooks/useTrackContextMenu.tsx) (forwarded by the player wrapper), rather than reimplemented per view — issue #436 exists precisely because fixing one surface would have produced the inconsistency it set out to remove.
+
+`openFromKeyboard` returns `true` when it opened a menu, so a row's existing `onKeyDown` early-returns instead of re-deriving the condition, and Enter / Space keep playing the track. A keyboard-opened menu anchors just inside the row's bottom-left corner (no pointer to place it at); `ContextMenu` still flips it when it would overflow the viewport.
+
+Once open, [`ContextMenu`](../../src/components/common/ContextMenu.tsx) focuses its first item, moves with Up/Down/Home/End (wrapping), closes on Escape **and Tab** — a menu is not a tab stop, and letting Tab escape behind an open menu is worse than dismissing it — and **restores focus to the element that opened it** on unmount, guarded on `isConnected` for the case where the action just taken removed that row.
+
+Two surfaces needed more than a key handler: history rows had no `tabIndex` at all (unreachable by keyboard, menu or not) and are now focusable with Enter/Space playing the row, and the immersive title takes `tabIndex` + `aria-haspopup="menu"` only while a menu is available — deliberately not `role="button"`, since it opens a menu but remains the heading.
 - [`LyricsPanel`](../../src/components/layout/LyricsPanel.tsx) — synced or static lyrics with auto-scroll.
 - [`NowPlayingChevronTab`](../../src/components/layout/NowPlayingChevronTab.tsx) — right-edge floating tab visible only when no panel is open.
 

--- a/src/components/common/ContextMenu.tsx
+++ b/src/components/common/ContextMenu.tsx
@@ -98,9 +98,80 @@ export function ContextMenu({
     setPos({ top, left, position: "fixed", width });
   }, [point.x, point.y, width]);
 
+  // Focus management. A menu opened from the keyboard is useless if the
+  // keyboard can't then reach its items, and a menu opened by mouse is
+  // no worse off for being focusable (issue #436).
+  //
+  // The opener is captured on mount and refocused on unmount, so
+  // dismissing the menu returns the caret to the row it came from
+  // rather than dropping focus to <body> — which would send the next
+  // Tab back to the top of the page.
+  const openerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    openerRef.current = document.activeElement as HTMLElement | null;
+    return () => {
+      // `isConnected` guards the case where the opener itself went away
+      // while the menu was open (a row removed by the action just taken).
+      const opener = openerRef.current;
+      if (opener?.isConnected) opener.focus();
+    };
+  }, []);
+
+  const menuItems = useCallback((): HTMLElement[] => {
+    const el = ref.current;
+    if (!el) return [];
+    return Array.from(
+      el.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])'),
+    );
+  }, []);
+
+  // Focus the first item once the menu is positioned. Deferred to an
+  // effect (not the layout pass) so the entry animation has its element
+  // in place; focusing a not-yet-positioned menu makes the browser
+  // scroll the page to -9999px.
+  useEffect(() => {
+    const items = menuItems();
+    items[0]?.focus();
+  }, [menuItems]);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      // Arrow / Home / End move between items and wrap, which is what a
+      // `role="menu"` is expected to do. Tab closes: menus are not tab
+      // stops, and letting Tab escape into the page behind an open menu
+      // is worse than dismissing it.
+      const items = menuItems();
+      if (items.length === 0) return;
+      const current = items.indexOf(document.activeElement as HTMLElement);
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          items[(current + 1 + items.length) % items.length]?.focus();
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          items[(current - 1 + items.length) % items.length]?.focus();
+          break;
+        case "Home":
+          e.preventDefault();
+          items[0]?.focus();
+          break;
+        case "End":
+          e.preventDefault();
+          items[items.length - 1]?.focus();
+          break;
+        case "Tab":
+          e.preventDefault();
+          onClose();
+          break;
+        default:
+          break;
+      }
     };
     const onMouseDown = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
@@ -121,7 +192,7 @@ export function ContextMenu({
       window.removeEventListener("scroll", onClose, true);
       window.removeEventListener("resize", onClose);
     };
-  }, [onClose]);
+  }, [onClose, menuItems]);
 
   return createPortal(
     <motion.div

--- a/src/components/layout/QueuePanel.tsx
+++ b/src/components/layout/QueuePanel.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { createPortal } from "react-dom";
@@ -186,6 +187,18 @@ export function QueuePanel() {
     },
     [trackMenu],
   );
+  // Keyboard counterpart (Menu / Shift+F10) — issue #436. Same radio
+  // guard as the mouse path: a stream row has no local file, so the
+  // track menu has nothing to act on. Returns `true` only when a menu
+  // actually opened, so the row's Enter/Space handling stays intact on
+  // the rows this skips.
+  const handleRowMenuKey = useCallback(
+    (event: ReactKeyboardEvent, item: QueueTrackPayload): boolean => {
+      if (item.id < 0 || !item.file_path) return false;
+      return trackMenu.openFromKeyboard(event, queuePayloadToTrack(item));
+    },
+    [trackMenu],
+  );
 
   return (
     <motion.aside
@@ -262,6 +275,7 @@ export function QueuePanel() {
                   item={nowPlaying}
                   isCurrent
                   onContextMenu={(e) => handleRowContextMenu(e, nowPlaying)}
+                  onMenuKey={(e) => handleRowMenuKey(e, nowPlaying)}
                 />
               </section>
             )}
@@ -276,6 +290,7 @@ export function QueuePanel() {
                   onJump={handleJump}
                   onReorder={handleReorder}
                   onContextMenu={handleRowContextMenu}
+                  onRowMenuKey={handleRowMenuKey}
                 />
               </section>
             )}
@@ -290,15 +305,28 @@ function QueueRow({
   item,
   isCurrent = false,
   onContextMenu,
+  onMenuKey,
 }: {
   item: QueueTrackPayload;
   isCurrent?: boolean;
   onContextMenu?: (e: ReactMouseEvent) => void;
+  /** Menu / Shift+F10 on the focused row (issue #436). Returns `true`
+   *  when it opened the menu. */
+  onMenuKey?: (e: ReactKeyboardEvent) => boolean;
 }) {
   return (
+    // Focusable so the context menu is reachable without a mouse. Unlike
+    // the up-next rows there is no Enter/Space action here — this row is
+    // the track already playing, so jumping to it would be a no-op.
     <div
+      tabIndex={onMenuKey ? 0 : undefined}
+      role={onMenuKey ? "button" : undefined}
       onContextMenu={onContextMenu}
-      className={`flex items-center space-x-3 p-2 rounded-lg transition-colors select-none ${
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+        onMenuKey?.(e);
+      }}
+      className={`flex items-center space-x-3 p-2 rounded-lg transition-colors select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
         isCurrent
           ? "bg-emerald-50 dark:bg-emerald-900/20"
           : "hover:bg-zinc-50 dark:hover:bg-zinc-800/60"
@@ -339,6 +367,7 @@ interface SortableUpNextProps {
   onJump: (absoluteIndex: number) => void;
   onReorder: (fromAbsolute: number, toAbsolute: number) => void;
   onContextMenu: (e: ReactMouseEvent, item: QueueTrackPayload) => void;
+  onRowMenuKey: (e: ReactKeyboardEvent, item: QueueTrackPayload) => boolean;
 }
 
 /**
@@ -359,6 +388,7 @@ function SortableUpNext({
   onJump,
   onReorder,
   onContextMenu,
+  onRowMenuKey,
 }: SortableUpNextProps) {
   "use no memo";
   const sensors = useSensors(
@@ -452,6 +482,7 @@ function SortableUpNext({
                   rowHeight={QUEUE_ROW_HEIGHT}
                   onJump={onJump}
                   onContextMenu={onContextMenu}
+                  onRowMenuKey={onRowMenuKey}
                 />
               );
             })}
@@ -526,6 +557,7 @@ const SortableQueueRow = memo(function SortableQueueRow({
   rowHeight,
   onJump,
   onContextMenu,
+  onRowMenuKey,
 }: {
   id: string;
   absoluteIndex: number;
@@ -534,6 +566,7 @@ const SortableQueueRow = memo(function SortableQueueRow({
   rowHeight: number;
   onJump: (absoluteIndex: number) => void;
   onContextMenu: (e: ReactMouseEvent, item: QueueTrackPayload) => void;
+  onRowMenuKey: (e: ReactKeyboardEvent, item: QueueTrackPayload) => boolean;
 }) {
   // `animateLayoutChanges: () => false` disables the CSS transition
   // dnd-kit applies to every neighbour as the drag crosses them — on
@@ -584,6 +617,7 @@ const SortableQueueRow = memo(function SortableQueueRow({
           // the drag-handle button would otherwise bubble up and also
           // jump to the track.
           if (e.target !== e.currentTarget) return;
+          if (onRowMenuKey(e, item)) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onJump(absoluteIndex);

--- a/src/components/layout/QueuePanel.tsx
+++ b/src/components/layout/QueuePanel.tsx
@@ -182,7 +182,7 @@ export function QueuePanel() {
   const handleRowContextMenu = useCallback(
     (event: ReactMouseEvent, item: QueueTrackPayload) => {
       event.preventDefault();
-      if (item.id < 0 || !item.file_path) return;
+      if (!hasTrackMenu(item)) return;
       trackMenu.open(event, queuePayloadToTrack(item));
     },
     [trackMenu],
@@ -194,7 +194,7 @@ export function QueuePanel() {
   // the rows this skips.
   const handleRowMenuKey = useCallback(
     (event: ReactKeyboardEvent, item: QueueTrackPayload): boolean => {
-      if (item.id < 0 || !item.file_path) return false;
+      if (!hasTrackMenu(item)) return false;
       return trackMenu.openFromKeyboard(event, queuePayloadToTrack(item));
     },
     [trackMenu],
@@ -275,7 +275,11 @@ export function QueuePanel() {
                   item={nowPlaying}
                   isCurrent
                   onContextMenu={(e) => handleRowContextMenu(e, nowPlaying)}
-                  onMenuKey={(e) => handleRowMenuKey(e, nowPlaying)}
+                  onMenuKey={
+                    hasTrackMenu(nowPlaying)
+                      ? (e) => handleRowMenuKey(e, nowPlaying)
+                      : undefined
+                  }
                 />
               </section>
             )}
@@ -299,6 +303,15 @@ export function QueuePanel() {
       </div>
     </motion.aside>
   );
+}
+
+/**
+ * Whether a queue row has a track menu at all. Radio / stream rows carry
+ * a negative sentinel id and no local file, so there is nothing for the
+ * menu to act on — and nothing to make the row focusable for.
+ */
+function hasTrackMenu(item: QueueTrackPayload): boolean {
+  return item.id >= 0 && Boolean(item.file_path);
 }
 
 function QueueRow({

--- a/src/components/player/ImmersiveNowPlaying.tsx
+++ b/src/components/player/ImmersiveNowPlaying.tsx
@@ -97,10 +97,26 @@ export function ImmersiveNowPlaying({
             `pb-1` + `leading-tight` on the marquee container give
             descenders (g / y / p) room so the `overflow: hidden` (needed
             for both truncate + the marquee) doesn't clip them. */}
+        {/* The title carries the track menu here — there is no row to
+            right-click in this view. Focusable (and announced via
+            `aria-haspopup`) only when a menu is actually available, so
+            the Menu key / Shift+F10 reach it without a mouse (issue
+            #436). Deliberately NOT `role="button"`: it opens a menu but
+            it is still the heading, and Enter/Space are left alone. */}
         <h1
-          className="text-3xl md:text-4xl font-bold"
+          className="text-3xl md:text-4xl font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 rounded"
+          tabIndex={menuTrack ? 0 : undefined}
+          aria-haspopup={menuTrack ? "menu" : undefined}
           onContextMenu={
             menuTrack ? (e) => trackMenu.open(e, menuTrack) : undefined
+          }
+          onKeyDown={
+            menuTrack
+              ? (e) => {
+                  if (e.target !== e.currentTarget) return;
+                  trackMenu.openFromKeyboard(e, menuTrack);
+                }
+              : undefined
           }
         >
           <MarqueeText text={title} className="leading-tight pb-1" />

--- a/src/components/views/AlbumDetailView.tsx
+++ b/src/components/views/AlbumDetailView.tsx
@@ -385,6 +385,7 @@ export function AlbumDetailView({
           }
           onNavigateToArtist={onNavigateToArtist}
           onContextMenuRow={trackContextMenu.open}
+          onRowMenuKey={trackContextMenu.openFromKeyboard}
           t={t}
           isSelected={selection.isSelected}
           onRowSelect={(track, e) => {
@@ -478,6 +479,9 @@ interface AlbumTrackTableProps {
   onPlayTrack: (index: number) => void;
   onNavigateToArtist: (artistId: number) => void;
   onContextMenuRow: (event: React.MouseEvent, track: Track) => void;
+  /** Keyboard equivalent (Menu / Shift+F10). Returns `true` when it
+   *  opened the menu, so the row's own key handling can stand down. */
+  onRowMenuKey: (event: React.KeyboardEvent, track: Track) => boolean;
   t: (key: string, opts?: Record<string, unknown>) => string;
   isSelected: (id: number) => boolean;
   onRowSelect: (track: Track, e: React.MouseEvent) => void;
@@ -496,6 +500,7 @@ function AlbumTrackTable({
   onPlayTrack,
   onNavigateToArtist,
   onContextMenuRow,
+  onRowMenuKey,
   t,
   isSelected,
   onRowSelect,
@@ -518,6 +523,7 @@ function AlbumTrackTable({
         onKeyDown={(e) => {
           // Only play when the row itself is focused — see LibraryView.
           if (e.target !== e.currentTarget) return;
+          if (onRowMenuKey(e, playableTracks[globalIndex])) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onPlayTrack(globalIndex);

--- a/src/components/views/ArtistDetailView.tsx
+++ b/src/components/views/ArtistDetailView.tsx
@@ -549,6 +549,7 @@ export function ArtistDetailView({
               playTracks(tracks, index, { type: "library", id: null })
             }
             onContextMenuRow={trackContextMenu.open}
+            onRowMenuKey={trackContextMenu.openFromKeyboard}
             t={t}
           />
         </div>
@@ -625,6 +626,7 @@ function ArtistTrackTable({
   onToggleLike,
   onPlayTrack,
   onContextMenuRow,
+  onRowMenuKey,
   t,
 }: {
   tracks: Track[];
@@ -635,6 +637,9 @@ function ArtistTrackTable({
   onToggleLike: (trackId: number) => void;
   onPlayTrack: (index: number) => void;
   onContextMenuRow: (event: React.MouseEvent, track: Track) => void;
+  /** Keyboard equivalent (Menu / Shift+F10). Returns `true` when it
+   *  opened the menu, so the row's own key handling can stand down. */
+  onRowMenuKey: (event: React.KeyboardEvent, track: Track) => boolean;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
   const gridCols = "grid-cols-[3rem_2.75rem_1fr_1fr_5rem_2rem]";
@@ -675,6 +680,7 @@ function ArtistTrackTable({
               onKeyDown={(e) => {
                 // Only play when the row itself is focused — see LibraryView.
                 if (e.target !== e.currentTarget) return;
+                if (onRowMenuKey(e, tracks[index])) return;
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   onPlayTrack(index);

--- a/src/components/views/GenreDetailView.tsx
+++ b/src/components/views/GenreDetailView.tsx
@@ -223,6 +223,7 @@ export function GenreDetailView({
           onNavigateToAlbum={onNavigateToAlbum}
           onNavigateToArtist={onNavigateToArtist}
           onContextMenuRow={trackContextMenu.open}
+          onRowMenuKey={trackContextMenu.openFromKeyboard}
           t={t}
         />
       ) : (
@@ -277,6 +278,7 @@ function GenreTrackTable({
   onNavigateToAlbum,
   onNavigateToArtist,
   onContextMenuRow,
+  onRowMenuKey,
   t,
 }: {
   tracks: Track[];
@@ -289,6 +291,9 @@ function GenreTrackTable({
   onNavigateToAlbum: (albumId: number) => void;
   onNavigateToArtist: (artistId: number) => void;
   onContextMenuRow: (event: React.MouseEvent, track: Track) => void;
+  /** Keyboard equivalent (Menu / Shift+F10). Returns `true` when it
+   *  opened the menu, so the row's own key handling can stand down. */
+  onRowMenuKey: (event: React.KeyboardEvent, track: Track) => boolean;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
   const gridCols = "grid-cols-[3rem_2.75rem_1.5fr_1fr_1fr_5rem_2rem]";
@@ -330,6 +335,7 @@ function GenreTrackTable({
               onKeyDown={(e) => {
                 // Only play when the row itself is focused — see LibraryView.
                 if (e.target !== e.currentTarget) return;
+                if (onRowMenuKey(e, tracks[index])) return;
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   onPlayTrack(index);

--- a/src/components/views/HistoryView.tsx
+++ b/src/components/views/HistoryView.tsx
@@ -469,12 +469,18 @@ function DayGroup({
           return (
             <li
               key={row.event_id}
-              // Focusable like every other track row (issue #436): the
-              // context menu has to be reachable without a mouse, and a
-              // row nobody can focus can't receive the Menu key. Enter /
-              // Space play, matching the double-click already wired.
+              // Focusable so the context menu is reachable without a
+              // mouse (issue #436) — a row nobody can focus can't
+              // receive the Menu key.
+              //
+              // Deliberately NOT `role="button"`: this row contains an
+              // ArtistLink, and a screen reader can't reliably expose an
+              // interactive link inside a button. `aria-haspopup` is the
+              // honest description instead — it announces the menu
+              // without claiming the row is something it isn't. Enter /
+              // Space still play, mirroring the double-click.
               tabIndex={0}
-              role="button"
+              aria-haspopup="menu"
               onContextMenu={(e) => onContextMenu(e, row)}
               onDoubleClick={() => onPlay(row)}
               onKeyDown={(e) => {

--- a/src/components/views/HistoryView.tsx
+++ b/src/components/views/HistoryView.tsx
@@ -328,6 +328,9 @@ export function HistoryView({
                 onContextMenu={(e, row) =>
                   trackContextMenu.open(e, rowToTrack(row))
                 }
+                onRowMenuKey={(e, row) =>
+                  trackContextMenu.openFromKeyboard(e, rowToTrack(row))
+                }
                 onPlay={(row) =>
                   // Single-track play — uses the row's track_id and a
                   // synthetic queue of just this track. Source type is
@@ -428,6 +431,9 @@ interface DayGroupProps {
   locale: string;
   currentTrackId: number | null;
   onContextMenu: (e: React.MouseEvent, row: PlayHistoryRow) => void;
+  /** Keyboard equivalent (Menu / Shift+F10). Returns `true` when it
+   *  opened the menu, so the row's own key handling can stand down. */
+  onRowMenuKey: (e: React.KeyboardEvent, row: PlayHistoryRow) => boolean;
   onPlay: (row: PlayHistoryRow) => void;
   onNavigateToArtist: (artistId: number) => void;
 }
@@ -437,6 +443,7 @@ function DayGroup({
   locale,
   currentTrackId,
   onContextMenu,
+  onRowMenuKey,
   onPlay,
   onNavigateToArtist,
 }: DayGroupProps) {
@@ -462,9 +469,29 @@ function DayGroup({
           return (
             <li
               key={row.event_id}
+              // Focusable like every other track row (issue #436): the
+              // context menu has to be reachable without a mouse, and a
+              // row nobody can focus can't receive the Menu key. Enter /
+              // Space play, matching the double-click already wired.
+              tabIndex={0}
+              role="button"
               onContextMenu={(e) => onContextMenu(e, row)}
               onDoubleClick={() => onPlay(row)}
-              className={`grid grid-cols-[3rem_1fr_1fr_5rem_4rem] gap-4 px-3 py-2 items-center rounded-lg transition-colors cursor-default ${
+              onKeyDown={(e) => {
+                // Only act when the row itself is focused — nested
+                // links (artist / album) handle their own keys.
+                if (e.target !== e.currentTarget) return;
+                if (onRowMenuKey(e, row)) return;
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onPlay(row);
+                }
+              }}
+              onKeyUp={(e) => {
+                if (e.target !== e.currentTarget) return;
+                if (e.key === " ") e.preventDefault();
+              }}
+              className={`grid grid-cols-[3rem_1fr_1fr_5rem_4rem] gap-4 px-3 py-2 items-center rounded-lg transition-colors cursor-default focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
                 isCurrent
                   ? "bg-emerald-50 dark:bg-emerald-900/20"
                   : "hover:bg-zinc-50 dark:hover:bg-zinc-800/60"

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -767,6 +767,7 @@ export function LibraryView({
                 onNavigateToAlbum={onNavigateToAlbum}
                 onNavigateToArtist={onNavigateToArtist}
                 onContextMenuRow={trackContextMenu.open}
+                onRowMenuKey={trackContextMenu.openFromKeyboard}
                 isSelected={selection.isSelected}
                 onRowSelect={(track, e) => {
                   // Modifier-driven selection always wins so multi-select
@@ -1204,6 +1205,9 @@ interface TrackTableProps {
   onNavigateToAlbum: (albumId: number) => void;
   onNavigateToArtist: (artistId: number) => void;
   onContextMenuRow: (event: React.MouseEvent, track: Track) => void;
+  /** Keyboard equivalent (Menu / Shift+F10). Returns `true` when it
+   *  opened the menu, so the row's own key handling can stand down. */
+  onRowMenuKey: (event: React.KeyboardEvent, track: Track) => boolean;
   isSelected: (id: number) => boolean;
   onRowSelect: (track: Track, e: React.MouseEvent) => void;
 }
@@ -1225,6 +1229,7 @@ function TrackTable({
   onNavigateToAlbum,
   onNavigateToArtist,
   onContextMenuRow,
+  onRowMenuKey,
   isSelected,
   onRowSelect,
 }: TrackTableProps) {
@@ -1349,6 +1354,7 @@ function TrackTable({
                 // double-fires playback alongside the button's own
                 // action.
                 if (e.target !== e.currentTarget) return;
+                if (onRowMenuKey(e, track)) return;
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   onPlayTrack(index);

--- a/src/components/views/LikedView.tsx
+++ b/src/components/views/LikedView.tsx
@@ -167,6 +167,7 @@ export function LikedView({
                     // fired from nested buttons / links would otherwise
                     // bubble here and double-fire playback.
                     if (e.target !== e.currentTarget) return;
+                    if (trackContextMenu.openFromKeyboard(e, track)) return;
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();
                       playTracks(tracks, index, { type: "liked", id: null });

--- a/src/components/views/PlaylistView.tsx
+++ b/src/components/views/PlaylistView.tsx
@@ -379,6 +379,7 @@ export function PlaylistView({
     selectedTrackIds: [...selection.selectedIds],
   });
   const onContextMenuRow = trackContextMenu.open;
+  const onRowMenuKey = trackContextMenu.openFromKeyboard;
 
   // Fetch playlist + its tracks whenever the focused id changes. Also
   // re-runs when the playlist list itself updates (e.g. after rename via
@@ -727,6 +728,7 @@ export function PlaylistView({
           likeLabel={likeLabel}
           unlikeLabel={unlikeLabel}
           onContextMenuRow={onContextMenuRow}
+          onRowMenuKey={onRowMenuKey}
           onReorder={handleReorder}
           isSelected={selection.isSelected}
           onRowSelect={handleRowSelect}
@@ -829,6 +831,9 @@ interface PlaylistTrackTableProps {
   likeLabel: string;
   unlikeLabel: string;
   onContextMenuRow: (event: React.MouseEvent, track: Track) => void;
+  /** Keyboard equivalent (Menu / Shift+F10). Returns `true` when it
+   *  opened the menu, so the row's own key handling can stand down. */
+  onRowMenuKey: (event: React.KeyboardEvent, track: Track) => boolean;
   onReorder: (fromIndex: number, toIndex: number) => void;
   isSelected: (id: number) => boolean;
   onRowSelect: (track: Track, e: React.MouseEvent) => void;
@@ -858,6 +863,7 @@ function PlaylistTrackTable({
   likeLabel,
   unlikeLabel,
   onContextMenuRow,
+  onRowMenuKey,
   onReorder,
   isSelected,
   onRowSelect,
@@ -996,6 +1002,7 @@ function PlaylistTrackTable({
                   unknownLabel={unknownLabel}
                   onPlayTrack={onPlayTrack}
                   onContextMenuRow={onContextMenuRow}
+                  onRowMenuKey={onRowMenuKey}
                   onToggleLike={onToggleLike}
                   onNavigateToAlbum={onNavigateToAlbum}
                   onNavigateToArtist={onNavigateToArtist}
@@ -1073,6 +1080,9 @@ interface SortablePlaylistRowProps {
   unknownLabel: string;
   onPlayTrack: (index: number) => void;
   onContextMenuRow: (event: React.MouseEvent, track: Track) => void;
+  /** Keyboard equivalent (Menu / Shift+F10). Returns `true` when it
+   *  opened the menu, so the row's own key handling can stand down. */
+  onRowMenuKey: (event: React.KeyboardEvent, track: Track) => boolean;
   onToggleLike: (trackId: number) => void;
   onNavigateToAlbum: (albumId: number) => void;
   onNavigateToArtist: (artistId: number) => void;
@@ -1099,6 +1109,7 @@ const SortablePlaylistRow = memo(function SortablePlaylistRow({
   unknownLabel,
   onPlayTrack,
   onContextMenuRow,
+  onRowMenuKey,
   onToggleLike,
   onNavigateToAlbum,
   onNavigateToArtist,
@@ -1155,6 +1166,7 @@ const SortablePlaylistRow = memo(function SortablePlaylistRow({
       onKeyDown={(e) => {
         // Only play when the row itself is focused — see LibraryView.
         if (e.target !== e.currentTarget) return;
+        if (onRowMenuKey(e, track)) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onPlayTrack(index);

--- a/src/hooks/usePlayerTrackContextMenu.tsx
+++ b/src/hooks/usePlayerTrackContextMenu.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { CreatePlaylistModal } from "../components/common/CreatePlaylistModal";
@@ -88,6 +89,15 @@ export function usePlayerTrackContextMenu() {
     [menu],
   );
 
+  // Same keyboard contract as the library surfaces — see
+  // `useTrackContextMenu.openFromKeyboard`. Forwarded rather than
+  // reimplemented so the player surfaces can't drift from the rest.
+  const openFromKeyboard = useCallback(
+    (event: ReactKeyboardEvent, track: Track) =>
+      menu.openFromKeyboard(event, track),
+    [menu],
+  );
+
   const render = useCallback(
     () => (
       <>
@@ -116,5 +126,5 @@ export function usePlayerTrackContextMenu() {
     [menu, isCreatePlaylistOpen, createPlaylist],
   );
 
-  return { open, render };
+  return { open, openFromKeyboard, render };
 }

--- a/src/hooks/useTrackContextMenu.tsx
+++ b/src/hooks/useTrackContextMenu.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import {
@@ -10,6 +11,7 @@ import {
 import { TrackPropertiesModal } from "../components/common/TrackPropertiesModal";
 import { BatchTagEditModal } from "../components/common/BatchTagEditModal";
 import type { Track } from "../lib/tauri/track";
+import { isContextMenuKey, menuAnchorForElement } from "../lib/contextMenuKeys";
 import { setTrackRating, toggleLikeTrack } from "../lib/tauri/track";
 import {
   playerAddToQueue,
@@ -91,6 +93,39 @@ export function useTrackContextMenu({
       track,
     });
   }, []);
+
+  /**
+   * Keyboard counterpart of {@link open}: answers the Menu key and
+   * Shift+F10 on a focused row, anchoring the menu to that row since
+   * there is no pointer to place it at.
+   *
+   * Returns `true` when it handled the event, so a caller's existing
+   * `onKeyDown` can early-return instead of re-deriving the condition:
+   *
+   * ```tsx
+   * onKeyDown={(e) => {
+   *   if (openFromKeyboard(e, track)) return;
+   *   // …existing Enter/Space activation
+   * }}
+   * ```
+   *
+   * The `e.target !== e.currentTarget` guard stays the caller's job —
+   * each surface already applies it so a keystroke inside a row's own
+   * action button doesn't act on the row.
+   */
+  const openFromKeyboard = useCallback(
+    (event: ReactKeyboardEvent, track: Track): boolean => {
+      if (!isContextMenuKey(event)) return false;
+      event.preventDefault();
+      event.stopPropagation();
+      setState({
+        point: menuAnchorForElement(event.currentTarget as HTMLElement),
+        track,
+      });
+      return true;
+    },
+    [],
+  );
 
   const close = useCallback(() => setState(null), []);
 
@@ -226,5 +261,5 @@ export function useTrackContextMenu({
     closeBatchEdit,
   ]);
 
-  return { open, close, render };
+  return { open, openFromKeyboard, close, render };
 }

--- a/src/lib/contextMenuKeys.ts
+++ b/src/lib/contextMenuKeys.ts
@@ -1,0 +1,41 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+import type { ContextMenuPoint } from "../components/common/ContextMenu";
+
+/**
+ * Shared keyboard contract for opening a context menu.
+ *
+ * Right-click has no keyboard equivalent unless one is wired by hand, so
+ * every surface that shows a track context menu answers the same two
+ * keys — the ones every desktop environment already trains people on:
+ *
+ * - **Menu** (the "application" key, `event.key === "ContextMenu"`)
+ * - **Shift+F10**, its universal stand-in on keyboards without that key
+ *   (laptops, most Mac layouts, TKL boards)
+ *
+ * Kept in one module rather than repeated per view: issue #436 exists
+ * because fixing this on a single surface would have produced exactly
+ * the inconsistency it set out to remove.
+ */
+export function isContextMenuKey(event: ReactKeyboardEvent): boolean {
+  return event.key === "ContextMenu" || (event.shiftKey && event.key === "F10");
+}
+
+/**
+ * Where to anchor a keyboard-opened menu.
+ *
+ * A mouse-opened menu lands at the pointer; a keyboard one has no
+ * pointer, so it anchors to the focused row the way the OS does — just
+ * inside its bottom-left corner, so the menu reads as belonging to that
+ * row and never covers the row it acts on.
+ *
+ * Coordinates are viewport-relative because `ContextMenu` is
+ * `position: fixed`, and it does its own flipping when the menu would
+ * overflow the viewport, so a row near the bottom edge still works.
+ */
+export function menuAnchorForElement(element: HTMLElement): ContextMenuPoint {
+  const rect = element.getBoundingClientRect();
+  // Inset a few pixels so the menu overlaps the row's edge rather than
+  // floating detached from it.
+  return { x: rect.left + 8, y: rect.bottom - 4 };
+}


### PR DESCRIPTION
Closes #436.

The track context menu was **right-click only**, so everything it holds — Properties, Play next, Add to playlist, Show in Explorer, rating, Remove from playlist — was unreachable without a mouse.

## Approach

The two keys desktop environments already train people on, on the focused row:

- **Menu** (the application key)
- **Shift+F10**, its stand-in on keyboards without it (laptops, most Mac layouts, TKL boards)

Detection and anchoring live in one module ([`contextMenuKeys.ts`](../../src/lib/contextMenuKeys.ts)) and reach the views as `openFromKeyboard` on the shared hook. That indirection is the point of the issue: *"une correction limitée à une seule vue créerait une expérience incohérente"* — so nothing is reimplemented per surface.

`openFromKeyboard` returns whether it opened a menu, so each row's existing `onKeyDown` early-returns instead of re-deriving the condition:

```tsx
onKeyDown={(e) => {
  if (e.target !== e.currentTarget) return;   // already there
  if (onRowMenuKey(e, track)) return;         // added
  if (e.key === "Enter" || e.key === " ") { … }
}}
```

Enter / Space keep playing the track, and right-click is untouched — both explicit acceptance criteria.

**All nine surfaces** that expose the menu are wired: Library, Album, Artist, Genre and Playlist list views, Liked, History, the Queue panel (now-playing *and* up-next rows), and the immersive title.

## Opening it was only half the problem

The menu itself wasn't keyboard-operable: no initial focus, no arrow navigation, and focus dropped to `<body>` on close. `ContextMenu` now focuses its first item, moves with Up/Down/Home/End (wrapping), closes on Escape **and Tab** — a menu is not a tab stop, and letting Tab escape behind an open menu is worse than dismissing it — and restores focus to the opener on unmount, guarded on `isConnected` for when the action just taken removed that row.

## Two surfaces needed more than a key handler

- **History rows had no `tabIndex` at all** — not reachable by keyboard, menu or not. They are focusable now, with Enter/Space playing the row to match the double-click already wired.
- **The immersive title** takes `tabIndex` + `aria-haspopup="menu"` only while a menu is available, and deliberately **not** `role="button"`: it opens a menu but it is still the heading, and Enter/Space are left alone there.

## Verification

`bun run typecheck`, `bun run lint`, prettier — clean (exit codes read directly). I also cross-checked the surfaces: every file that opens the menu on `onContextMenu` now has a keyboard path, so none was missed.

**Not verified with an actual keyboard** — the app doesn't run outside the Tauri shell here, so focus order, menu placement and the restore-on-close are reasoned from the DOM, not observed. This is the change in this series that most deserves a hands-on pass: tab to a track row, press Menu (or Shift+F10), arrow through the items, Escape, and check focus lands back on the row.

Worth trying on a row near the bottom of the window too — the anchor is the row's bottom-left corner and `ContextMenu` flips it when it would overflow, which is exactly the path a keyboard user hits on the last row of a list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ouverture des menus contextuels des pistes au clavier avec les touches **Menu** et **Maj+F10**.
  * Navigation dans les menus avec les flèches, **Origine** et **Fin**, puis fermeture avec **Tab**.
  * Restauration automatique du focus après la fermeture du menu.
  * Priorité donnée à l’ouverture du menu avant la lecture lors de l’utilisation d’**Entrée** ou de la **barre d’espace**.
  * Accessibilité améliorée des rangées d’historique et des titres de pistes, avec indicateurs de focus visibles.

* **Documentation**
  * Documentation ajoutée sur les raccourcis clavier, la navigation, l’ancrage et la gestion du focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->