### PR TITLE
feat(plugins): disclose ui library.read_artists permission in the store

### DIFF
--- a/src-tauri/crates/app/src/commands/plugin_store.rs
+++ b/src-tauri/crates/app/src/commands/plugin_store.rs
@@ -71,6 +71,12 @@ struct RegistryPermissions {
     storage_read: bool,
     #[serde(default)]
     storage_state: bool,
+    /// `ui`-world redacted artist read (`library.read_artists`). Optional
+    /// so pre-ui registry entries decode unchanged; an older app build
+    /// simply ignores the field (no `deny_unknown_fields`), so publishing
+    /// it can't break any client.
+    #[serde(default)]
+    library_read_artists: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -138,6 +144,10 @@ pub struct MarketplaceEntry {
     pub http: Vec<String>,
     pub storage_read: bool,
     pub storage_state: bool,
+    /// `ui`-world redacted artist read — surfaced before install so the
+    /// user sees the plugin will read their artist list (names + counts
+    /// + opaque ids only, enforced at runtime from the manifest).
+    pub library_read_artists: bool,
     pub tags: Vec<String>,
     pub official: bool,
     /// Present on disk (sideloaded/installed) already.
@@ -411,6 +421,7 @@ pub async fn list_plugin_marketplace(
                     http: e.permissions.http,
                     storage_read: e.permissions.storage_read,
                     storage_state: e.permissions.storage_state,
+                    library_read_artists: e.permissions.library_read_artists,
                     tags: e.tags,
                     official: e.official,
                 }

--- a/src/components/views/settings/PluginStoreCard.tsx
+++ b/src/components/views/settings/PluginStoreCard.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   Check,
   BadgeCheck,
+  Users,
 } from "lucide-react";
 
 import {
@@ -339,7 +340,12 @@ function WorldBadge({ world }: { world: string }) {
  */
 function PermissionsPreview({ entry }: { entry: MarketplaceEntry }) {
   const { t } = useTranslation();
-  if (entry.http.length === 0 && !entry.storageState && !entry.storageRead) {
+  if (
+    entry.http.length === 0 &&
+    !entry.storageState &&
+    !entry.storageRead &&
+    !entry.libraryReadArtists
+  ) {
     return (
       <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5 italic">
         {t("settings.plugins.permissions.none")}
@@ -382,6 +388,12 @@ function PermissionsPreview({ entry }: { entry: MarketplaceEntry }) {
         <div className="flex items-center gap-1 mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
           <FileText size={11} aria-hidden="true" />
           <span>{t("settings.plugins.permissions.storageRead")}</span>
+        </div>
+      )}
+      {entry.libraryReadArtists && (
+        <div className="flex items-center gap-1 mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+          <Users size={11} aria-hidden="true" />
+          <span>{t("settings.plugins.permissions.libraryReadArtists")}</span>
         </div>
       )}
     </div>

--- a/src/lib/tauri/plugins.ts
+++ b/src/lib/tauri/plugins.ts
@@ -212,6 +212,10 @@ export interface MarketplaceEntry {
   http: string[];
   storageRead: boolean;
   storageState: boolean;
+  /** `ui`-world redacted artist read (`library.read_artists`) — names +
+   *  aggregate counts + opaque ids only, no file paths. Surfaced before
+   *  install; enforced at runtime from the installed manifest. */
+  libraryReadArtists: boolean;
   tags: string[];
   /** First-party plugin maintained by the WaveFlow team. */
   official: boolean;


### PR DESCRIPTION
Part of #443. The `waveflow:ui/v1` world added a redacted artist read (`library.read_artists` — names + aggregate counts + opaque ids, no file paths), surfaced for **installed** plugins in `PluginsCard` (Part 1). But the **store card** (`PluginStoreCard`, shown BEFORE install) never disclosed it — so a user could install a ui plugin that reads their artist list without a pre-install permission line for it.

This closes that disclosure gap, ahead of listing the first ui-world plugin (Release Radar) in the registry.

## What changes

- **`commands/plugin_store.rs`** — `RegistryPermissions` gains an optional `library_read_artists` (serde `default`, so pre-ui registry entries decode unchanged; older app builds ignore the field since there's no `deny_unknown_fields`, so publishing it can't break any client). `MarketplaceEntry` echoes it to the frontend.
- **`lib/tauri/plugins.ts`** — `MarketplaceEntry.libraryReadArtists`.
- **`PluginStoreCard`** — a `Users`-icon permission line (mirrors the installed-plugin chip in `PluginsCard`), plus the "no permissions" guard now accounts for it. Reuses the existing `settings.plugins.permissions.libraryReadArtists` key (already in all 17 locales).

The permission itself is still enforced at runtime from the installed `manifest.toml` — this is purely the pre-install disclosure.

## Validation

- `bun run typecheck` — clean
- `bun run lint` — clean
- `cargo check -p waveflow` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de la permission permettant aux plugins de lire les artistes de la bibliothèque.
  * La permission est désormais transmise aux informations des plugins et affichée dans leur aperçu.

* **Améliorations**
  * Les plugins sans permission sont identifiés plus précisément.
  * Une nouvelle icône facilite la compréhension des permissions liées à la bibliothèque musicale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->