### PR TITLE
feat(plugins): support direct download_url in registry entries

### DIFF
--- a/src-tauri/crates/app/src/commands/plugin_store.rs
+++ b/src-tauri/crates/app/src/commands/plugin_store.rs
@@ -107,6 +107,15 @@ struct RegistryEntry {
     blake3: String,
     #[serde(default)]
     asset: Option<String>,
+    /// Optional direct download URL for the release asset. When present it
+    /// OVERRIDES the GitHub `releases/download` URL built from `repo` — this
+    /// lets the app-controlled registry endpoint host a plugin's binary itself
+    /// (e.g. on `waveflow.app`) instead of a public GitHub release, so a
+    /// closed-source plugin can be distributed binary-only with no public repo.
+    /// Trusted like the rest of the entry (the registry is the trust anchor)
+    /// and still blake3-verified after download; required to be `https`.
+    #[serde(default)]
+    download_url: Option<String>,
     permissions: RegistryPermissions,
     #[serde(default)]
     tags: Vec<String>,
@@ -478,15 +487,31 @@ pub async fn install_plugin_from_registry(
         )));
     }
 
-    // The release asset lives in the entry's own repo (releases/download).
-    let asset = entry
-        .asset
-        .clone()
-        .unwrap_or_else(|| format!("{}-v{}.zip", entry.id, entry.version));
-    let url = format!(
-        "https://github.com/{}/releases/download/v{}/{}",
-        entry.repo, entry.version, asset
-    );
+    // A registry-provided `download_url` overrides the GitHub `releases/download`
+    // URL (see the field doc) so the app-controlled endpoint can host the binary
+    // itself. Require https — it can't be a downgrade / loopback target — and the
+    // bytes are still blake3-verified against the registry pin below either way.
+    let url = match &entry.download_url {
+        Some(direct) => {
+            if !direct.starts_with("https://") {
+                return Err(AppError::Other(format!(
+                    "plugin {plugin_id}: registry download_url must be https"
+                )));
+            }
+            direct.clone()
+        }
+        None => {
+            // The release asset lives in the entry's own repo (releases/download).
+            let asset = entry
+                .asset
+                .clone()
+                .unwrap_or_else(|| format!("{}-v{}.zip", entry.id, entry.version));
+            format!(
+                "https://github.com/{}/releases/download/v{}/{}",
+                entry.repo, entry.version, asset
+            )
+        }
+    };
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(60))

--- a/src-tauri/crates/app/src/commands/plugin_store.rs
+++ b/src-tauri/crates/app/src/commands/plugin_store.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tauri::State;
+use waveflow_core::artwork::motion_cache::is_safe_motion_url;
 use waveflow_core::plugin::is_bundled_plugin;
 use waveflow_core::plugin::manifest::{LocalizedString, Manifest};
 use waveflow_core::plugin::PluginPaths;
@@ -489,13 +490,16 @@ pub async fn install_plugin_from_registry(
 
     // A registry-provided `download_url` overrides the GitHub `releases/download`
     // URL (see the field doc) so the app-controlled endpoint can host the binary
-    // itself. Require https — it can't be a downgrade / loopback target — and the
-    // bytes are still blake3-verified against the registry pin below either way.
+    // itself. The bytes are blake3-verified against the registry pin below, but
+    // the URL is a fetch the app makes, so validate it with the shared SSRF
+    // guard: https + reject localhost / loopback / private / link-local hosts
+    // (and userinfo forms pointing at them). Even a compromised entry must not
+    // be able to make the app hit an internal address.
     let url = match &entry.download_url {
         Some(direct) => {
-            if !direct.starts_with("https://") {
+            if !is_safe_motion_url(direct) {
                 return Err(AppError::Other(format!(
-                    "plugin {plugin_id}: registry download_url must be https"
+                    "plugin {plugin_id}: registry download_url is not a safe https URL"
                 )));
             }
             direct.clone()
@@ -513,8 +517,21 @@ pub async fn install_plugin_from_registry(
         }
     };
 
+    // Follow redirects (a GitHub release URL 302s to a CDN) but re-validate
+    // EVERY hop with the same SSRF guard — the initial URL was checked above,
+    // and neither it nor a redirect may point the download at an internal
+    // target. Legit public CDNs pass; a redirect to an internal host is refused.
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.previous().len() > 10 {
+                attempt.error("too many redirects")
+            } else if is_safe_motion_url(attempt.url().as_str()) {
+                attempt.follow()
+            } else {
+                attempt.error("unsafe redirect target")
+            }
+        }))
         .build()
         .map_err(|e| AppError::Other(format!("http client: {e}")))?;
     let mut resp = client


### PR DESCRIPTION
Adds an optional `download_url` to a registry entry. When present, `install_plugin_from_registry` downloads the release asset from **that URL** instead of the GitHub `releases/download` URL built from `repo`.

This decouples the store's install path from GitHub, so the app-controlled registry endpoint (`waveflow.app/api/plugins/registry`) can host a plugin's binary itself — enabling a **closed-source, binary-only** plugin with no public source repo (the first consumer being the Spotify Canvas plugin, whose source stays private).

## What changes

- **`RegistryEntry.download_url: Option<String>`** (serde `default`, so every existing entry decodes unchanged; older/GitHub-listed plugins simply omit it).
- **`install_plugin_from_registry`**: if `download_url` is set, use it (required to be `https` — no downgrade / loopback target); otherwise the existing `github.com/{repo}/releases/download/v{version}/{asset}` URL. The downloaded bytes are still **blake3-verified against the registry pin** either way, so the trust model is unchanged — the registry remains the single source of truth, `download_url` just moves *where* the (still-verified) bytes come from.

No schema change to the public `waveflow-plugins` registry is needed: entries carrying `download_url` are injected by the app-controlled endpoint, not committed to the GitHub registry (they never pass its CI). Older app builds ignore the field and fall back to the GitHub URL.

## Validation

- `cargo check -p waveflow` + `cargo clippy -p waveflow --all-targets` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - L’installation des plugins prend désormais en charge une URL de téléchargement directe lorsqu’elle est fournie.
  - En l’absence d’URL directe sûre, le téléchargement continue d’utiliser automatiquement la source GitHub configurée.

- **Sécurité**
  - Les téléchargements directs sont limités aux adresses HTTPS autorisées.
  - Les redirections sont contrôlées et validées à chaque étape afin de bloquer les destinations non sûres.
  - La vérification d’intégrité BLAKE3 et les contrôles d’installation restent appliqués à tous les plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->