### PR TITLE
feat(reconciliation): add exact track linking

### DIFF
--- a/src-tauri/crates/app/src/commands/remote_auth.rs
+++ b/src-tauri/crates/app/src/commands/remote_auth.rs
@@ -433,7 +433,8 @@ pub async fn remote_create_share(
     description: Option<String>,
     expires_at: Option<i64>,
 ) -> AppResult<String> {
-    let id = crate::remote::write::create_share(&state, &track_ids, description, expires_at).await?;
+    let id =
+        crate::remote::write::create_share(&state, &track_ids, description, expires_at).await?;
     crate::remote::drain::spawn(app);
     Ok(id)
 }
@@ -476,6 +477,65 @@ pub async fn remote_delete_share(
     crate::remote::write::delete_share(&state, &share_id).await?;
     crate::remote::drain::spawn(app);
     Ok(())
+}
+
+/// Scan the local library for conservative M5 reconciliation matches.
+///
+/// Only exact, unique full-file BLAKE3 matches are linked automatically.
+/// Duplicate groups are returned for explicit confirmation.
+#[tauri::command]
+pub async fn remote_reconcile_scan(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<crate::remote::reconciliation::ReconciliationReport> {
+    let pool = state.require_profile_pool().await?;
+    crate::remote::reconciliation::discover(&pool).await
+}
+
+#[tauri::command]
+pub async fn remote_list_reconciliation_links(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<Vec<crate::remote::reconciliation::ReconciliationLink>> {
+    let pool = state.require_profile_pool().await?;
+    crate::remote::reconciliation::links(&pool).await
+}
+
+#[tauri::command]
+pub async fn remote_confirm_reconciliation(
+    state: tauri::State<'_, AppState>,
+    local_track_id: i64,
+    remote_track_id: String,
+) -> AppResult<()> {
+    let pool = state.require_profile_pool().await?;
+    crate::remote::reconciliation::confirm_exact(&pool, local_track_id, &remote_track_id).await
+}
+
+#[tauri::command]
+pub async fn remote_reject_reconciliation(
+    state: tauri::State<'_, AppState>,
+    local_track_id: i64,
+    remote_track_id: String,
+) -> AppResult<()> {
+    let pool = state.require_profile_pool().await?;
+    crate::remote::reconciliation::reject_exact(&pool, local_track_id, &remote_track_id).await
+}
+
+#[tauri::command]
+pub async fn remote_set_reconciliation_preference(
+    state: tauri::State<'_, AppState>,
+    local_track_id: i64,
+    preference: String,
+) -> AppResult<()> {
+    let pool = state.require_profile_pool().await?;
+    crate::remote::reconciliation::set_playback_preference(&pool, local_track_id, &preference).await
+}
+
+#[tauri::command]
+pub async fn remote_remove_reconciliation_link(
+    state: tauri::State<'_, AppState>,
+    local_track_id: i64,
+) -> AppResult<()> {
+    let pool = state.require_profile_pool().await?;
+    crate::remote::reconciliation::remove_link(&pool, local_track_id).await
 }
 
 /// The leased pool of the active profile, or `None` when there is no
@@ -598,8 +658,10 @@ pub struct RemotePlayQueue {
 pub async fn remote_get_play_queue(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<Option<RemotePlayQueue>> {
-    Ok(state.remote_playback.snapshot().map(|(entries, index)| {
-        RemotePlayQueue {
+    Ok(state
+        .remote_playback
+        .snapshot()
+        .map(|(entries, index)| RemotePlayQueue {
             entries: entries
                 .into_iter()
                 .map(|e| RemoteQueueRow {
@@ -612,8 +674,7 @@ pub async fn remote_get_play_queue(
                 })
                 .collect(),
             index,
-        }
-    }))
+        }))
 }
 
 /// Jump the remote play queue to an absolute position and play it. Backs

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -772,6 +772,18 @@ pub fn run() {
             #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_delete_share,
             #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_reconcile_scan,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_list_reconciliation_links,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_confirm_reconciliation,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_reject_reconciliation,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_set_reconciliation_preference,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_remove_reconciliation_link,
+            #[cfg(feature = "sync_v2")]
             commands::lyrics::fetch_remote_lyrics,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,

--- a/src-tauri/crates/app/src/remote/mod.rs
+++ b/src-tauri/crates/app/src/remote/mod.rs
@@ -86,6 +86,7 @@ pub mod playback;
 pub mod probe;
 pub mod projection;
 pub mod read;
+pub mod reconciliation;
 pub mod socket;
 pub mod stream;
 pub mod sync;

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -184,7 +184,8 @@ async fn load_local_candidates(pool: &SqlitePool) -> AppResult<Vec<LocalTrack>> 
            LEFT JOIN album al ON al.id = t.album_id
           WHERE t.is_available = 1
             AND (EXISTS (SELECT 1 FROM remote_track rt
-                          WHERE rt.size = t.file_size AND rt.full_hash IS NOT NULL)
+                          WHERE rt.size = t.file_size AND rt.size >= 0
+                            AND rt.full_hash IS NOT NULL)
                  OR EXISTS (SELECT 1 FROM remote_track_link l
                              WHERE l.local_track_id = t.id))
           ORDER BY t.id",
@@ -628,10 +629,45 @@ pub async fn set_playback_preference(
 }
 
 pub async fn remove_link(pool: &SqlitePool, local_track_id: i64) -> AppResult<()> {
+    let mut tx = pool.begin().await?;
+    // Capture the link's matching evidence before deleting it and record a
+    // rejection for the same pair — otherwise the next `discover` would just
+    // auto-recreate the exact link the user manually removed. Same proof
+    // representation as `reject_exact`, so `reconcile` honours it.
+    if let Some(row) = sqlx::query(
+        "SELECT remote_track_id, method, verified_full_hash
+           FROM remote_track_link WHERE local_track_id = ?",
+    )
+    .bind(local_track_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    {
+        let remote_track_id: String = row.try_get("remote_track_id")?;
+        let method: String = row.try_get("method")?;
+        let verified_full_hash: Option<String> = row.try_get("verified_full_hash")?;
+        // Only an exact-hash link carries a full-hash proof to suppress.
+        if method == "exact_full_hash" {
+            if let Some(proof) = verified_full_hash.filter(|value| valid_full_hash(value)) {
+                sqlx::query(
+                    "INSERT OR IGNORE INTO remote_track_match_rejection
+                        (local_track_id, remote_track_id, proof_kind, proof, rejected_at)
+                     VALUES (?, ?, 'exact_full_hash', ?, ?)",
+                )
+                .bind(local_track_id)
+                .bind(&remote_track_id)
+                .bind(proof.to_ascii_lowercase())
+                .bind(now_ms())
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+    }
+
     sqlx::query("DELETE FROM remote_track_link WHERE local_track_id = ?")
         .bind(local_track_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(())
 }
 

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -1,0 +1,849 @@
+//! Conservative local/server reconciliation (server RFC-004, M5).
+//!
+//! The server publishes a plain full-file BLAKE3 digest. The local
+//! `track.file_hash` is deliberately a different, partial scan digest, so this
+//! module first joins on byte size and only then reads the few possible local
+//! matches in full. A link is automatic only when the exact digest identifies
+//! one local row and one remote row. Every multiplicity stays a candidate for
+//! a human decision.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use chrono::Utc;
+use serde::Serialize;
+use sqlx::{Row, SqlitePool};
+
+use crate::error::{AppError, AppResult};
+
+const STATUS_CONFIRMED: &str = "confirmed";
+const STATUS_STALE: &str = "stale";
+
+#[derive(Debug, Clone)]
+struct LocalTrack {
+    id: i64,
+    title: String,
+    artist: Option<String>,
+    album: Option<String>,
+    file_path: String,
+    size: i64,
+}
+
+#[derive(Debug, Clone)]
+struct HashedLocalTrack {
+    track: LocalTrack,
+    full_hash: String,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteTrack {
+    id: String,
+    title: String,
+    artist: Option<String>,
+    album: Option<String>,
+    size: i64,
+    full_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LocalMatchCandidate {
+    pub track_id: i64,
+    pub title: String,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub file_path: String,
+    pub size: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RemoteMatchCandidate {
+    pub track_id: String,
+    pub title: String,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub size: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MatchCandidateGroup {
+    pub full_hash: String,
+    pub local_tracks: Vec<LocalMatchCandidate>,
+    pub remote_tracks: Vec<RemoteMatchCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReconciliationReport {
+    pub hashed_local_tracks: usize,
+    pub unreadable_local_tracks: usize,
+    pub auto_linked: usize,
+    pub verified_links: usize,
+    pub stale_links: usize,
+    pub rejected_pairs: usize,
+    pub candidates: Vec<MatchCandidateGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReconciliationLink {
+    pub local_track_id: i64,
+    pub remote_track_id: String,
+    pub local_title: String,
+    pub remote_title: Option<String>,
+    pub method: String,
+    pub verified_full_hash: Option<String>,
+    pub status: String,
+    pub playback_preference: String,
+    pub confirmed_at: i64,
+    pub verified_at: i64,
+}
+
+#[derive(Debug, Clone)]
+struct ExistingLink {
+    local_track_id: i64,
+    remote_track_id: String,
+    verified_full_hash: Option<String>,
+}
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+fn valid_full_hash(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Discover exact matches, persist only the unique ones and return every
+/// ambiguous group. Files that cannot be read are reported but never linked.
+pub async fn discover(pool: &SqlitePool) -> AppResult<ReconciliationReport> {
+    let remote_tracks = load_remote_tracks(pool).await?;
+    if remote_tracks.is_empty() {
+        return Ok(ReconciliationReport {
+            hashed_local_tracks: 0,
+            unreadable_local_tracks: 0,
+            auto_linked: 0,
+            verified_links: 0,
+            stale_links: 0,
+            rejected_pairs: 0,
+            candidates: Vec::new(),
+        });
+    }
+
+    let local_tracks = load_local_candidates(pool).await?;
+    let (hashed_local_tracks, unreadable_local_tracks) =
+        tokio::task::spawn_blocking(move || hash_local_tracks(local_tracks))
+            .await
+            .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))?;
+
+    reconcile(
+        pool,
+        hashed_local_tracks,
+        unreadable_local_tracks,
+        remote_tracks,
+    )
+    .await
+}
+
+async fn load_remote_tracks(pool: &SqlitePool) -> AppResult<Vec<RemoteTrack>> {
+    let rows = sqlx::query(
+        "SELECT remote_id, title, artist, album, size, full_hash
+           FROM remote_track
+          WHERE size IS NOT NULL AND size >= 0 AND full_hash IS NOT NULL
+          ORDER BY remote_id",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut tracks = Vec::with_capacity(rows.len());
+    for row in rows {
+        let full_hash: String = row.try_get("full_hash")?;
+        if !valid_full_hash(&full_hash) {
+            continue;
+        }
+        tracks.push(RemoteTrack {
+            id: row.try_get("remote_id")?,
+            title: row.try_get("title")?,
+            artist: row.try_get("artist")?,
+            album: row.try_get("album")?,
+            size: row.try_get("size")?,
+            full_hash: full_hash.to_ascii_lowercase(),
+        });
+    }
+    Ok(tracks)
+}
+
+async fn load_local_candidates(pool: &SqlitePool) -> AppResult<Vec<LocalTrack>> {
+    let rows = sqlx::query(
+        "SELECT t.id, t.title, t.file_path, t.file_size, al.title AS album,
+                (SELECT GROUP_CONCAT(name, ', ') FROM (
+                    SELECT ar.name
+                      FROM track_artist ta
+                      JOIN artist ar ON ar.id = ta.artist_id
+                     WHERE ta.track_id = t.id
+                     ORDER BY ta.position
+                )) AS artist
+           FROM track t
+           LEFT JOIN album al ON al.id = t.album_id
+          WHERE t.is_available = 1
+            AND (EXISTS (SELECT 1 FROM remote_track rt
+                          WHERE rt.size = t.file_size AND rt.full_hash IS NOT NULL)
+                 OR EXISTS (SELECT 1 FROM remote_track_link l
+                             WHERE l.local_track_id = t.id))
+          ORDER BY t.id",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(LocalTrack {
+                id: row.try_get("id")?,
+                title: row.try_get("title")?,
+                artist: row.try_get("artist")?,
+                album: row.try_get("album")?,
+                file_path: row.try_get("file_path")?,
+                size: row.try_get("file_size")?,
+            })
+        })
+        .collect()
+}
+
+fn hash_local_tracks(tracks: Vec<LocalTrack>) -> (Vec<HashedLocalTrack>, usize) {
+    let mut hashed = Vec::with_capacity(tracks.len());
+    let mut unreadable = 0;
+    for track in tracks {
+        match waveflow_core::scanner::hash_file_full(Path::new(&track.file_path)) {
+            Ok(full_hash) => hashed.push(HashedLocalTrack { track, full_hash }),
+            Err(err) => {
+                unreadable += 1;
+                tracing::warn!(
+                    local_track_id = track.id,
+                    error = %err,
+                    "reconciliation full-content hash failed; excluding track"
+                );
+            }
+        }
+    }
+    (hashed, unreadable)
+}
+
+async fn reconcile(
+    pool: &SqlitePool,
+    local_tracks: Vec<HashedLocalTrack>,
+    unreadable_local_tracks: usize,
+    remote_tracks: Vec<RemoteTrack>,
+) -> AppResult<ReconciliationReport> {
+    let hashed_local_count = local_tracks.len();
+    let mut local_by_hash: HashMap<String, Vec<HashedLocalTrack>> = HashMap::new();
+    let mut local_by_id = HashMap::new();
+    for local in local_tracks {
+        local_by_id.insert(local.track.id, local.clone());
+        local_by_hash
+            .entry(local.full_hash.clone())
+            .or_default()
+            .push(local);
+    }
+
+    let mut remote_by_hash: HashMap<String, Vec<RemoteTrack>> = HashMap::new();
+    let mut remote_by_id = HashMap::new();
+    for remote in remote_tracks {
+        remote_by_id.insert(remote.id.clone(), remote.clone());
+        remote_by_hash
+            .entry(remote.full_hash.clone())
+            .or_default()
+            .push(remote);
+    }
+
+    let mut tx = pool.begin().await?;
+    let link_rows = sqlx::query(
+        "SELECT local_track_id, remote_track_id, verified_full_hash
+           FROM remote_track_link",
+    )
+    .fetch_all(&mut *tx)
+    .await?;
+    let mut links = Vec::with_capacity(link_rows.len());
+    for row in link_rows {
+        links.push(ExistingLink {
+            local_track_id: row.try_get("local_track_id")?,
+            remote_track_id: row.try_get("remote_track_id")?,
+            verified_full_hash: row.try_get("verified_full_hash")?,
+        });
+    }
+
+    let rejection_rows = sqlx::query(
+        "SELECT local_track_id, remote_track_id, proof
+           FROM remote_track_match_rejection
+          WHERE proof_kind = 'exact_full_hash'",
+    )
+    .fetch_all(&mut *tx)
+    .await?;
+    let rejections: HashSet<(i64, String, String)> = rejection_rows
+        .into_iter()
+        .map(|row| {
+            Ok((
+                row.try_get("local_track_id")?,
+                row.try_get("remote_track_id")?,
+                row.try_get("proof")?,
+            ))
+        })
+        .collect::<Result<_, sqlx::Error>>()?;
+
+    let now = now_ms();
+    let mut verified_links = 0;
+    let mut stale_links = 0;
+    let mut linked_local: HashMap<i64, String> = HashMap::new();
+    let mut linked_remote: HashMap<String, i64> = HashMap::new();
+
+    for link in &links {
+        linked_local.insert(link.local_track_id, link.remote_track_id.clone());
+        linked_remote.insert(link.remote_track_id.clone(), link.local_track_id);
+
+        let Some(local) = local_by_id.get(&link.local_track_id) else {
+            // An unavailable local file keeps its link; availability is not
+            // evidence that the identity changed.
+            continue;
+        };
+        let Some(remote) = remote_by_id.get(&link.remote_track_id) else {
+            // The remote cache is disposable and may be between refills.
+            continue;
+        };
+        let matches = link.verified_full_hash.as_deref() == Some(local.full_hash.as_str())
+            && local.full_hash == remote.full_hash;
+        let status = if matches {
+            verified_links += 1;
+            STATUS_CONFIRMED
+        } else {
+            stale_links += 1;
+            STATUS_STALE
+        };
+        sqlx::query(
+            "UPDATE remote_track_link SET status = ?, verified_at = ?
+              WHERE local_track_id = ?",
+        )
+        .bind(status)
+        .bind(now)
+        .bind(link.local_track_id)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    let mut auto_linked = 0;
+    for (hash, locals) in &local_by_hash {
+        let Some(remotes) = remote_by_hash.get(hash) else {
+            continue;
+        };
+        if locals.len() != 1 || remotes.len() != 1 {
+            continue;
+        }
+        let local = &locals[0];
+        let remote = &remotes[0];
+        if linked_local.contains_key(&local.track.id)
+            || linked_remote.contains_key(&remote.id)
+            || rejections.contains(&(local.track.id, remote.id.clone(), hash.clone()))
+        {
+            continue;
+        }
+
+        sqlx::query(
+            "INSERT INTO remote_track_link
+                (local_track_id, remote_track_id, method, verified_full_hash,
+                 status, playback_preference, confirmed_at, verified_at)
+             VALUES (?, ?, 'exact_full_hash', ?, 'confirmed', 'local_first', ?, ?)",
+        )
+        .bind(local.track.id)
+        .bind(&remote.id)
+        .bind(hash)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+        linked_local.insert(local.track.id, remote.id.clone());
+        linked_remote.insert(remote.id.clone(), local.track.id);
+        auto_linked += 1;
+    }
+
+    let mut hashes: Vec<String> = local_by_hash
+        .keys()
+        .filter(|hash| remote_by_hash.contains_key(*hash))
+        .cloned()
+        .collect();
+    hashes.sort();
+
+    let mut candidates = Vec::new();
+    let mut rejected_pairs = 0;
+    for hash in hashes {
+        let locals = &local_by_hash[&hash];
+        let remotes = &remote_by_hash[&hash];
+        let mut candidate_locals = Vec::new();
+        let mut candidate_remotes = Vec::new();
+        let mut has_unrejected_pair = false;
+
+        for local in locals {
+            if linked_local.contains_key(&local.track.id) {
+                continue;
+            }
+            candidate_locals.push(local_candidate(local));
+            for remote in remotes {
+                if linked_remote.contains_key(&remote.id) {
+                    continue;
+                }
+                if rejections.contains(&(local.track.id, remote.id.clone(), hash.clone())) {
+                    rejected_pairs += 1;
+                } else {
+                    has_unrejected_pair = true;
+                }
+            }
+        }
+        for remote in remotes {
+            if !linked_remote.contains_key(&remote.id) {
+                candidate_remotes.push(remote_candidate(remote));
+            }
+        }
+
+        if has_unrejected_pair && !candidate_locals.is_empty() && !candidate_remotes.is_empty() {
+            candidates.push(MatchCandidateGroup {
+                full_hash: hash,
+                local_tracks: candidate_locals,
+                remote_tracks: candidate_remotes,
+            });
+        }
+    }
+
+    tx.commit().await?;
+    Ok(ReconciliationReport {
+        hashed_local_tracks: hashed_local_count,
+        unreadable_local_tracks,
+        auto_linked,
+        verified_links,
+        stale_links,
+        rejected_pairs,
+        candidates,
+    })
+}
+
+fn local_candidate(local: &HashedLocalTrack) -> LocalMatchCandidate {
+    LocalMatchCandidate {
+        track_id: local.track.id,
+        title: local.track.title.clone(),
+        artist: local.track.artist.clone(),
+        album: local.track.album.clone(),
+        file_path: local.track.file_path.clone(),
+        size: local.track.size,
+    }
+}
+
+fn remote_candidate(remote: &RemoteTrack) -> RemoteMatchCandidate {
+    RemoteMatchCandidate {
+        track_id: remote.id.clone(),
+        title: remote.title.clone(),
+        artist: remote.artist.clone(),
+        album: remote.album.clone(),
+        size: remote.size,
+    }
+}
+
+/// Confirm one exact pair from an ambiguous group. The local file is re-read
+/// immediately before the transaction so a stale UI cannot confirm old bytes.
+pub async fn confirm_exact(
+    pool: &SqlitePool,
+    local_track_id: i64,
+    remote_track_id: &str,
+) -> AppResult<()> {
+    let row = sqlx::query(
+        "SELECT t.file_path, t.file_size, rt.size AS remote_size, rt.full_hash
+           FROM track t
+           JOIN remote_track rt ON rt.remote_id = ?
+          WHERE t.id = ? AND t.is_available = 1",
+    )
+    .bind(remote_track_id)
+    .bind(local_track_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| AppError::Other("local or remote track is unavailable".into()))?;
+
+    let file_path: String = row.try_get("file_path")?;
+    let local_size: i64 = row.try_get("file_size")?;
+    let remote_size: i64 = row.try_get("remote_size")?;
+    let remote_hash: String = row.try_get("full_hash")?;
+    if local_size != remote_size || !valid_full_hash(&remote_hash) {
+        return Err(AppError::Other(
+            "tracks do not share a valid exact-content candidate".into(),
+        ));
+    }
+
+    let local_hash = tokio::task::spawn_blocking(move || {
+        waveflow_core::scanner::hash_file_full(Path::new(&file_path))
+    })
+    .await
+    .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))??;
+    if !local_hash.eq_ignore_ascii_case(&remote_hash) {
+        return Err(AppError::Other("track contents no longer match".into()));
+    }
+
+    let normalized_hash = remote_hash.to_ascii_lowercase();
+    let now = now_ms();
+    let mut tx = pool.begin().await?;
+    let conflict: Option<(i64, String)> = sqlx::query_as(
+        "SELECT local_track_id, remote_track_id FROM remote_track_link
+          WHERE (local_track_id = ? AND remote_track_id != ?)
+             OR (remote_track_id = ? AND local_track_id != ?)",
+    )
+    .bind(local_track_id)
+    .bind(remote_track_id)
+    .bind(remote_track_id)
+    .bind(local_track_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+    if conflict.is_some() {
+        return Err(AppError::Other(
+            "one of these tracks is already linked elsewhere".into(),
+        ));
+    }
+
+    sqlx::query(
+        "INSERT INTO remote_track_link
+            (local_track_id, remote_track_id, method, verified_full_hash,
+             status, playback_preference, confirmed_at, verified_at)
+         VALUES (?, ?, 'exact_full_hash', ?, 'confirmed', 'local_first', ?, ?)
+         ON CONFLICT(local_track_id) DO UPDATE SET
+             remote_track_id = excluded.remote_track_id,
+             method = excluded.method,
+             verified_full_hash = excluded.verified_full_hash,
+             status = excluded.status,
+             verified_at = excluded.verified_at",
+    )
+    .bind(local_track_id)
+    .bind(remote_track_id)
+    .bind(&normalized_hash)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "DELETE FROM remote_track_match_rejection
+          WHERE local_track_id = ? AND remote_track_id = ?
+            AND proof_kind = 'exact_full_hash' AND proof = ?",
+    )
+    .bind(local_track_id)
+    .bind(remote_track_id)
+    .bind(&normalized_hash)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Hide an exact candidate until its proof changes.
+pub async fn reject_exact(
+    pool: &SqlitePool,
+    local_track_id: i64,
+    remote_track_id: &str,
+) -> AppResult<()> {
+    let row = sqlx::query(
+        "SELECT rt.full_hash,
+                EXISTS(SELECT 1 FROM track t WHERE t.id = ?) AS local_exists,
+                EXISTS(SELECT 1 FROM remote_track_link l
+                        WHERE l.local_track_id = ? OR l.remote_track_id = ?) AS linked
+           FROM remote_track rt WHERE rt.remote_id = ?",
+    )
+    .bind(local_track_id)
+    .bind(local_track_id)
+    .bind(remote_track_id)
+    .bind(remote_track_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| AppError::Other("remote track is unavailable".into()))?;
+    let local_exists = row.try_get::<i64, _>("local_exists")? != 0;
+    let linked = row.try_get::<i64, _>("linked")? != 0;
+    let proof: String = row.try_get("full_hash")?;
+    if !local_exists || !valid_full_hash(&proof) {
+        return Err(AppError::Other("candidate is unavailable".into()));
+    }
+    if linked {
+        return Err(AppError::Other("linked tracks cannot be rejected".into()));
+    }
+
+    sqlx::query(
+        "INSERT OR IGNORE INTO remote_track_match_rejection
+            (local_track_id, remote_track_id, proof_kind, proof, rejected_at)
+         VALUES (?, ?, 'exact_full_hash', ?, ?)",
+    )
+    .bind(local_track_id)
+    .bind(remote_track_id)
+    .bind(proof.to_ascii_lowercase())
+    .bind(now_ms())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn links(pool: &SqlitePool) -> AppResult<Vec<ReconciliationLink>> {
+    let rows = sqlx::query(
+        "SELECT l.local_track_id, l.remote_track_id, t.title AS local_title,
+                rt.title AS remote_title, l.method, l.verified_full_hash,
+                l.status, l.playback_preference, l.confirmed_at, l.verified_at
+           FROM remote_track_link l
+           JOIN track t ON t.id = l.local_track_id
+           LEFT JOIN remote_track rt ON rt.remote_id = l.remote_track_id
+          ORDER BY lower(t.title), l.local_track_id",
+    )
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(ReconciliationLink {
+                local_track_id: row.try_get("local_track_id")?,
+                remote_track_id: row.try_get("remote_track_id")?,
+                local_title: row.try_get("local_title")?,
+                remote_title: row.try_get("remote_title")?,
+                method: row.try_get("method")?,
+                verified_full_hash: row.try_get("verified_full_hash")?,
+                status: row.try_get("status")?,
+                playback_preference: row.try_get("playback_preference")?,
+                confirmed_at: row.try_get("confirmed_at")?,
+                verified_at: row.try_get("verified_at")?,
+            })
+        })
+        .collect()
+}
+
+pub async fn set_playback_preference(
+    pool: &SqlitePool,
+    local_track_id: i64,
+    preference: &str,
+) -> AppResult<()> {
+    if !matches!(preference, "local_first" | "server_first") {
+        return Err(AppError::Other("invalid playback preference".into()));
+    }
+    let result = sqlx::query(
+        "UPDATE remote_track_link SET playback_preference = ?
+          WHERE local_track_id = ?",
+    )
+    .bind(preference)
+    .bind(local_track_id)
+    .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::Other("reconciliation link not found".into()));
+    }
+    Ok(())
+}
+
+pub async fn remove_link(pool: &SqlitePool, local_track_id: i64) -> AppResult<()> {
+    sqlx::query("DELETE FROM remote_track_link WHERE local_track_id = ?")
+        .bind(local_track_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::fs;
+
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::raw_sql(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE album (id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+             CREATE TABLE artist (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+             CREATE TABLE track (
+                 id INTEGER PRIMARY KEY,
+                 album_id INTEGER REFERENCES album(id),
+                 file_path TEXT NOT NULL,
+                 file_size INTEGER NOT NULL,
+                 title TEXT NOT NULL,
+                 is_available INTEGER NOT NULL DEFAULT 1
+             );
+             CREATE TABLE track_artist (
+                 track_id INTEGER NOT NULL REFERENCES track(id) ON DELETE CASCADE,
+                 artist_id INTEGER NOT NULL REFERENCES artist(id),
+                 position INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE remote_track (
+                 remote_id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 artist TEXT,
+                 album TEXT,
+                 size INTEGER,
+                 full_hash TEXT
+             );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::raw_sql(include_str!(
+            "../../../../migrations/profile/20260817100000_remote_track_reconciliation.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    async fn insert_local(pool: &SqlitePool, id: i64, path: &Path, title: &str) {
+        sqlx::query(
+            "INSERT INTO track (id, file_path, file_size, title, is_available)
+             VALUES (?, ?, ?, ?, 1)",
+        )
+        .bind(id)
+        .bind(path.to_string_lossy().as_ref())
+        .bind(fs::metadata(path).unwrap().len() as i64)
+        .bind(title)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_remote(pool: &SqlitePool, id: &str, bytes: &[u8], title: &str) {
+        let hash = blake3::hash(bytes).to_hex().to_string();
+        sqlx::query(
+            "INSERT INTO remote_track (remote_id, title, size, full_hash)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(id)
+        .bind(title)
+        .bind(bytes.len() as i64)
+        .bind(hash)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn unique_exact_content_is_linked_automatically() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local.flac");
+        fs::write(&path, b"identical audio bytes").unwrap();
+        insert_local(&pool, 1, &path, "Local").await;
+        insert_remote(&pool, "remote-1", b"identical audio bytes", "Remote").await;
+
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.auto_linked, 1);
+        assert!(report.candidates.is_empty());
+        let links = links(&pool).await.unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].local_track_id, 1);
+        assert_eq!(links[0].remote_track_id, "remote-1");
+        assert_eq!(links[0].playback_preference, "local_first");
+    }
+
+    #[tokio::test]
+    async fn equal_size_with_different_content_never_links() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local.mp3");
+        fs::write(&path, b"aaaa").unwrap();
+        insert_local(&pool, 1, &path, "Local").await;
+        insert_remote(&pool, "remote-1", b"bbbb", "Remote").await;
+
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.hashed_local_tracks, 1);
+        assert_eq!(report.auto_linked, 0);
+        assert!(report.candidates.is_empty());
+        assert!(links(&pool).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn duplicate_content_requires_confirmation() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.wav");
+        let second = dir.path().join("second.wav");
+        fs::write(&first, b"same").unwrap();
+        fs::write(&second, b"same").unwrap();
+        insert_local(&pool, 1, &first, "First").await;
+        insert_local(&pool, 2, &second, "Second").await;
+        insert_remote(&pool, "remote-1", b"same", "Remote").await;
+
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.auto_linked, 0);
+        assert_eq!(report.candidates.len(), 1);
+        assert_eq!(report.candidates[0].local_tracks.len(), 2);
+
+        confirm_exact(&pool, 2, "remote-1").await.unwrap();
+        let links = links(&pool).await.unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].local_track_id, 2);
+    }
+
+    #[tokio::test]
+    async fn duplicate_remote_copies_never_auto_link() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local.flac");
+        fs::write(&path, b"same").unwrap();
+        insert_local(&pool, 1, &path, "Local").await;
+        insert_remote(&pool, "remote-1", b"same", "First remote").await;
+        insert_remote(&pool, "remote-2", b"same", "Second remote").await;
+
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.auto_linked, 0);
+        assert_eq!(report.candidates.len(), 1);
+        assert_eq!(report.candidates[0].remote_tracks.len(), 2);
+        assert!(links(&pool).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rejection_hides_the_same_proof() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.aac");
+        let second = dir.path().join("second.aac");
+        fs::write(&first, b"same").unwrap();
+        fs::write(&second, b"same").unwrap();
+        insert_local(&pool, 1, &first, "First").await;
+        insert_local(&pool, 2, &second, "Second").await;
+        insert_remote(&pool, "remote-1", b"same", "Remote").await;
+
+        reject_exact(&pool, 1, "remote-1").await.unwrap();
+        reject_exact(&pool, 2, "remote-1").await.unwrap();
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.rejected_pairs, 2);
+        assert!(report.candidates.is_empty());
+        assert!(links(&pool).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn changed_bytes_mark_a_confirmed_link_stale() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local.ogg");
+        fs::write(&path, b"aaaa").unwrap();
+        insert_local(&pool, 1, &path, "Local").await;
+        insert_remote(&pool, "remote-1", b"aaaa", "Remote").await;
+        assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
+
+        fs::write(&path, b"bbbb").unwrap();
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.stale_links, 1);
+        assert_eq!(links(&pool).await.unwrap()[0].status, "stale");
+    }
+
+    #[tokio::test]
+    async fn a_path_move_keeps_and_reverifies_the_link() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("before.flac");
+        let moved = dir.path().join("after.flac");
+        fs::write(&first, b"same bytes").unwrap();
+        insert_local(&pool, 1, &first, "Local").await;
+        insert_remote(&pool, "remote-1", b"same bytes", "Remote").await;
+        assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
+
+        fs::rename(&first, &moved).unwrap();
+        sqlx::query("UPDATE track SET file_path = ? WHERE id = 1")
+            .bind(moved.to_string_lossy().as_ref())
+            .execute(&pool)
+            .await
+            .unwrap();
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.verified_links, 1);
+        assert_eq!(links(&pool).await.unwrap()[0].status, "confirmed");
+    }
+}

--- a/src-tauri/migrations/profile/20260817100000_remote_track_reconciliation.sql
+++ b/src-tauri/migrations/profile/20260817100000_remote_track_reconciliation.sql
@@ -1,0 +1,36 @@
+-- M5: conservative local/server reconciliation.
+--
+-- A link belongs to this profile database. The server cannot persist it:
+-- only the desktop knows the local row id and file path. The remote side has
+-- no foreign key on purpose because `remote_track` is a disposable cache;
+-- dropping or rebuilding that cache must not destroy a confirmed link.
+
+CREATE TABLE remote_track_link (
+    local_track_id       INTEGER PRIMARY KEY
+                                 REFERENCES track(id) ON DELETE CASCADE,
+    remote_track_id      TEXT    NOT NULL UNIQUE,
+    method               TEXT    NOT NULL
+                                 CHECK (method IN ('exact_full_hash', 'confirmed_mbid')),
+    verified_full_hash   TEXT,
+    status               TEXT    NOT NULL
+                                 CHECK (status IN ('confirmed', 'stale')),
+    playback_preference  TEXT    NOT NULL DEFAULT 'local_first'
+                                 CHECK (playback_preference IN ('local_first', 'server_first')),
+    confirmed_at         INTEGER NOT NULL,
+    verified_at          INTEGER NOT NULL,
+    CHECK (method != 'exact_full_hash' OR length(verified_full_hash) = 64)
+);
+
+CREATE INDEX idx_remote_track_link_status ON remote_track_link(status);
+
+-- A rejected pair stays hidden while the proof that produced it is unchanged.
+-- It is separate from `remote_track_link`: a rejected candidate is explicitly
+-- not an identity link and duplicate groups may reject several pairs.
+CREATE TABLE remote_track_match_rejection (
+    local_track_id   INTEGER NOT NULL REFERENCES track(id) ON DELETE CASCADE,
+    remote_track_id  TEXT    NOT NULL,
+    proof_kind       TEXT    NOT NULL CHECK (proof_kind IN ('exact_full_hash', 'mbid')),
+    proof            TEXT    NOT NULL,
+    rejected_at      INTEGER NOT NULL,
+    PRIMARY KEY (local_track_id, remote_track_id, proof_kind, proof)
+);

--- a/src-tauri/migrations/profile/20260817100000_remote_track_reconciliation.sql
+++ b/src-tauri/migrations/profile/20260817100000_remote_track_reconciliation.sql
@@ -18,10 +18,18 @@ CREATE TABLE remote_track_link (
                                  CHECK (playback_preference IN ('local_first', 'server_first')),
     confirmed_at         INTEGER NOT NULL,
     verified_at          INTEGER NOT NULL,
-    CHECK (method != 'exact_full_hash' OR length(verified_full_hash) = 64)
+    -- An exact-hash link must carry its 64-char proof. `length(NULL) = 64`
+    -- evaluates to NULL (not FALSE), so a bare length check would let a NULL
+    -- proof slip through — require non-NULL explicitly.
+    CHECK (method != 'exact_full_hash'
+           OR (verified_full_hash IS NOT NULL AND length(verified_full_hash) = 64))
 );
 
 CREATE INDEX idx_remote_track_link_status ON remote_track_link(status);
+
+-- The reconciliation prefilter joins local files to remote tracks on byte
+-- size (then verifies with a full hash), so index the remote side's size.
+CREATE INDEX idx_remote_track_size ON remote_track(size);
 
 -- A rejected pair stays hidden while the proof that produced it is unchanged.
 -- It is separate from `remote_track_link`: a rejected candidate is explicitly

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -48,6 +48,7 @@ import {
   Puzzle,
 } from "lucide-react";
 import { RemoteServerCard } from "./settings/RemoteServerCard";
+import { ReconciliationCard } from "./settings/ReconciliationCard";
 import { PluginStoreCard } from "./settings/PluginStoreCard";
 import { PluginsCard } from "./settings/PluginsCard";
 import { useTheme } from "../../hooks/useTheme";
@@ -1187,10 +1188,10 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
       const r = await pruneCachedAlbumCovers();
       // Locale-aware one-decimal MB (e.g. "12,5" in fr) rather than the
       // always-`.` `toFixed`.
-      const mb = new Intl.NumberFormat(
-        i18n.resolvedLanguage ?? i18n.language,
-        { minimumFractionDigits: 1, maximumFractionDigits: 1 },
-      ).format(r.bytesFreed / (1024 * 1024));
+      const mb = new Intl.NumberFormat(i18n.resolvedLanguage ?? i18n.language, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }).format(r.bytesFreed / (1024 * 1024));
       setPruneCoversStatus({
         ok: true,
         text: t("settings.pruneAlbumCoversDone", { files: r.filesDeleted, mb }),
@@ -2393,6 +2394,7 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
               the card probes for its own backend and renders nothing
               when `sync_v2` is off, which is every shipped build today. */}
             <RemoteServerCard />
+            <ReconciliationCard />
 
             <div className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
               <div className="flex items-start space-x-4">

--- a/src/components/views/settings/ReconciliationCard.tsx
+++ b/src/components/views/settings/ReconciliationCard.tsx
@@ -206,7 +206,11 @@ export function ReconciliationCard() {
           )}
 
           {error && (
-            <p className="text-xs text-red-600 dark:text-red-400 break-words">
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-xs text-red-600 dark:text-red-400 break-words"
+            >
               {error}
             </p>
           )}
@@ -246,6 +250,20 @@ function CandidateEditor({
     group.remote_tracks[0]?.track_id ?? "",
   );
 
+  // A rescan hands a fresh `group` under the same `full_hash` key, so this
+  // instance (and its selection state) is reused — a stored id can now point
+  // at a track the rescan removed. Derive the effective ids from the current
+  // group, falling back to the first entry, so the selects and the
+  // confirm/reject handlers only ever act on ids still present.
+  const effectiveLocalId = group.local_tracks.some((t) => t.track_id === localId)
+    ? localId
+    : (group.local_tracks[0]?.track_id ?? 0);
+  const effectiveRemoteId = group.remote_tracks.some(
+    (t) => t.track_id === remoteId,
+  )
+    ? remoteId
+    : (group.remote_tracks[0]?.track_id ?? "");
+
   return (
     <div className="rounded-lg border border-amber-200 dark:border-amber-900/60 bg-amber-50/40 dark:bg-amber-950/10 p-3 space-y-2">
       <p className="text-xs font-medium text-amber-800 dark:text-amber-300">
@@ -253,7 +271,7 @@ function CandidateEditor({
       </p>
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-2">
         <select
-          value={localId}
+          value={effectiveLocalId}
           onChange={(event) => setLocalId(Number(event.target.value))}
           disabled={busy !== null}
           aria-label="Local track"
@@ -266,7 +284,7 @@ function CandidateEditor({
           ))}
         </select>
         <select
-          value={remoteId}
+          value={effectiveRemoteId}
           onChange={(event) => setRemoteId(event.target.value)}
           disabled={busy !== null}
           aria-label="Server track"
@@ -283,16 +301,16 @@ function CandidateEditor({
       <div className="flex gap-2">
         <button
           type="button"
-          onClick={() => void onConfirm(localId, remoteId)}
-          disabled={busy !== null || !remoteId}
+          onClick={() => void onConfirm(effectiveLocalId, effectiveRemoteId)}
+          disabled={busy !== null || !effectiveRemoteId}
           className="px-2.5 py-1 text-xs rounded-md bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900 inline-flex items-center gap-1 disabled:opacity-50"
         >
           <Check size={12} aria-hidden="true" /> Confirm pair
         </button>
         <button
           type="button"
-          onClick={() => void onReject(localId, remoteId)}
-          disabled={busy !== null || !remoteId}
+          onClick={() => void onReject(effectiveLocalId, effectiveRemoteId)}
+          disabled={busy !== null || !effectiveRemoteId}
           className="px-2.5 py-1 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 inline-flex items-center gap-1 disabled:opacity-50"
         >
           <X size={12} aria-hidden="true" /> Reject pair

--- a/src/components/views/settings/ReconciliationCard.tsx
+++ b/src/components/views/settings/ReconciliationCard.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useState } from "react";
+import { Check, Link2, Loader2, RefreshCw, Unlink, X } from "lucide-react";
+import {
+  remoteConfirmReconciliation,
+  remoteGetStatus,
+  remoteListReconciliationLinks,
+  remoteReconcileScan,
+  remoteRejectReconciliation,
+  remoteRemoveReconciliationLink,
+  remoteSetReconciliationPreference,
+  type MatchCandidateGroup,
+  type ReconciliationLink,
+  type ReconciliationReport,
+} from "../../../lib/tauri/remoteServer";
+
+/** M5 identity links. Kept beside the connection card because it only makes
+ * sense for a bootstrapped native remote source. */
+export function ReconciliationCard() {
+  const [visible, setVisible] = useState(false);
+  const [links, setLinks] = useState<ReconciliationLink[]>([]);
+  const [report, setReport] = useState<ReconciliationReport | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshLinks = useCallback(async () => {
+    setLinks(await remoteListReconciliationLinks());
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const status = await remoteGetStatus();
+        if (cancelled) return;
+        const nextVisible = status.signed_in && status.bootstrapped;
+        setVisible(nextVisible);
+        if (nextVisible) await refreshLinks();
+      } catch {
+        if (!cancelled) setVisible(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshLinks]);
+
+  const scan = useCallback(async () => {
+    setBusy("scan");
+    setError(null);
+    try {
+      const next = await remoteReconcileScan();
+      setReport(next);
+      await refreshLinks();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(null);
+    }
+  }, [refreshLinks]);
+
+  const runPair = useCallback(
+    async (key: string, action: () => Promise<void>, rescan: boolean) => {
+      setBusy(key);
+      setError(null);
+      try {
+        await action();
+        if (rescan) setReport(await remoteReconcileScan());
+        await refreshLinks();
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refreshLinks],
+  );
+
+  if (!visible) return null;
+
+  return (
+    <div className="py-5 px-4 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
+      <div className="flex items-start space-x-4">
+        <Link2 size={20} className="text-zinc-400 mt-0.5" aria-hidden="true" />
+        <div className="flex-1 min-w-0 space-y-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                Local ↔ server matching
+              </h3>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                Exact full-file matches only. Same-size files are verified with
+                BLAKE3; metadata never creates a link.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void scan()}
+              disabled={busy !== null}
+              className="shrink-0 px-3 py-1.5 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 inline-flex items-center gap-1.5 disabled:opacity-50"
+            >
+              {busy === "scan" ? (
+                <Loader2
+                  size={14}
+                  className="animate-spin"
+                  aria-hidden="true"
+                />
+              ) : (
+                <RefreshCw size={14} aria-hidden="true" />
+              )}
+              Find matches
+            </button>
+          </div>
+
+          {report && <ReportSummary report={report} />}
+
+          {report?.candidates.map((group) => (
+            <CandidateEditor
+              key={group.full_hash}
+              group={group}
+              busy={busy}
+              onConfirm={(localId, remoteId) =>
+                runPair(
+                  `confirm:${localId}:${remoteId}`,
+                  () => remoteConfirmReconciliation(localId, remoteId),
+                  true,
+                )
+              }
+              onReject={(localId, remoteId) =>
+                runPair(
+                  `reject:${localId}:${remoteId}`,
+                  () => remoteRejectReconciliation(localId, remoteId),
+                  true,
+                )
+              }
+            />
+          ))}
+
+          {links.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase">
+                Confirmed links
+              </p>
+              {links.map((link) => (
+                <div
+                  key={link.local_track_id}
+                  className="flex items-center gap-3 rounded-lg border border-zinc-200 dark:border-zinc-700 px-3 py-2"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm text-zinc-800 dark:text-zinc-100 truncate">
+                      {link.local_title}
+                    </p>
+                    <p className="text-xs text-zinc-500 truncate">
+                      {link.remote_title ?? link.remote_track_id}
+                    </p>
+                  </div>
+                  <span
+                    className={`text-[10px] font-medium uppercase ${
+                      link.status === "stale"
+                        ? "text-amber-600 dark:text-amber-400"
+                        : "text-emerald-600 dark:text-emerald-400"
+                    }`}
+                  >
+                    {link.status}
+                  </span>
+                  <select
+                    value={link.playback_preference}
+                    disabled={busy !== null}
+                    onChange={(event) => {
+                      const preference = event.target.value as
+                        "local_first" | "server_first";
+                      void runPair(
+                        `preference:${link.local_track_id}`,
+                        () =>
+                          remoteSetReconciliationPreference(
+                            link.local_track_id,
+                            preference,
+                          ),
+                        false,
+                      );
+                    }}
+                    aria-label={`Playback preference for ${link.local_title}`}
+                    className="px-2 py-1 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+                  >
+                    <option value="local_first">Local first</option>
+                    <option value="server_first">Server first</option>
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void runPair(
+                        `unlink:${link.local_track_id}`,
+                        () =>
+                          remoteRemoveReconciliationLink(link.local_track_id),
+                        false,
+                      )
+                    }
+                    disabled={busy !== null}
+                    aria-label={`Unlink ${link.local_title}`}
+                    className="p-1.5 rounded-md text-zinc-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-50"
+                  >
+                    <Unlink size={14} aria-hidden="true" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {error && (
+            <p className="text-xs text-red-600 dark:text-red-400 break-words">
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReportSummary({ report }: { report: ReconciliationReport }) {
+  return (
+    <p className="text-xs text-zinc-500 dark:text-zinc-400">
+      {report.hashed_local_tracks} local candidates verified ·{" "}
+      {report.auto_linked} linked automatically · {report.candidates.length}{" "}
+      groups need a decision
+      {report.stale_links > 0 ? ` · ${report.stale_links} stale` : ""}
+      {report.unreadable_local_tracks > 0
+        ? ` · ${report.unreadable_local_tracks} unreadable`
+        : ""}
+    </p>
+  );
+}
+
+function CandidateEditor({
+  group,
+  busy,
+  onConfirm,
+  onReject,
+}: {
+  group: MatchCandidateGroup;
+  busy: string | null;
+  onConfirm: (localId: number, remoteId: string) => Promise<void>;
+  onReject: (localId: number, remoteId: string) => Promise<void>;
+}) {
+  const [localId, setLocalId] = useState(group.local_tracks[0]?.track_id ?? 0);
+  const [remoteId, setRemoteId] = useState(
+    group.remote_tracks[0]?.track_id ?? "",
+  );
+
+  return (
+    <div className="rounded-lg border border-amber-200 dark:border-amber-900/60 bg-amber-50/40 dark:bg-amber-950/10 p-3 space-y-2">
+      <p className="text-xs font-medium text-amber-800 dark:text-amber-300">
+        Identical copies need confirmation
+      </p>
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-2">
+        <select
+          value={localId}
+          onChange={(event) => setLocalId(Number(event.target.value))}
+          disabled={busy !== null}
+          aria-label="Local track"
+          className="min-w-0 px-2 py-1.5 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+        >
+          {group.local_tracks.map((track) => (
+            <option key={track.track_id} value={track.track_id}>
+              Local: {track.title} — {track.file_path}
+            </option>
+          ))}
+        </select>
+        <select
+          value={remoteId}
+          onChange={(event) => setRemoteId(event.target.value)}
+          disabled={busy !== null}
+          aria-label="Server track"
+          className="min-w-0 px-2 py-1.5 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+        >
+          {group.remote_tracks.map((track) => (
+            <option key={track.track_id} value={track.track_id}>
+              Server: {track.title}
+              {track.artist ? ` — ${track.artist}` : ""}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => void onConfirm(localId, remoteId)}
+          disabled={busy !== null || !remoteId}
+          className="px-2.5 py-1 text-xs rounded-md bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900 inline-flex items-center gap-1 disabled:opacity-50"
+        >
+          <Check size={12} aria-hidden="true" /> Confirm pair
+        </button>
+        <button
+          type="button"
+          onClick={() => void onReject(localId, remoteId)}
+          disabled={busy !== null || !remoteId}
+          className="px-2.5 py-1 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 inline-flex items-center gap-1 disabled:opacity-50"
+        >
+          <X size={12} aria-hidden="true" /> Reject pair
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tauri/remoteServer.ts
+++ b/src/lib/tauri/remoteServer.ts
@@ -426,7 +426,11 @@ export function remoteReorderPlaylistTrack(
   from: number,
   to: number,
 ): Promise<void> {
-  return invoke<void>("remote_reorder_playlist_track", { playlistId, from, to });
+  return invoke<void>("remote_reorder_playlist_track", {
+    playlistId,
+    from,
+    to,
+  });
 }
 
 /**
@@ -533,4 +537,99 @@ export function remoteUpdateShare(
 
 export function remoteDeleteShare(shareId: string): Promise<void> {
   return invoke<void>("remote_delete_share", { shareId });
+}
+
+export interface LocalMatchCandidate {
+  track_id: number;
+  title: string;
+  artist: string | null;
+  album: string | null;
+  file_path: string;
+  size: number;
+}
+
+export interface RemoteMatchCandidate {
+  track_id: string;
+  title: string;
+  artist: string | null;
+  album: string | null;
+  size: number;
+}
+
+export interface MatchCandidateGroup {
+  full_hash: string;
+  local_tracks: LocalMatchCandidate[];
+  remote_tracks: RemoteMatchCandidate[];
+}
+
+export interface ReconciliationReport {
+  hashed_local_tracks: number;
+  unreadable_local_tracks: number;
+  auto_linked: number;
+  verified_links: number;
+  stale_links: number;
+  rejected_pairs: number;
+  candidates: MatchCandidateGroup[];
+}
+
+export interface ReconciliationLink {
+  local_track_id: number;
+  remote_track_id: string;
+  local_title: string;
+  remote_title: string | null;
+  method: "exact_full_hash" | "confirmed_mbid";
+  verified_full_hash: string | null;
+  status: "confirmed" | "stale";
+  playback_preference: "local_first" | "server_first";
+  confirmed_at: number;
+  verified_at: number;
+}
+
+/**
+ * Find local/server identity links. The backend hashes only local files whose
+ * byte size exists in the remote cache; unique exact matches are persisted,
+ * while duplicate groups come back for explicit confirmation.
+ */
+export function remoteReconcileScan(): Promise<ReconciliationReport> {
+  return invoke<ReconciliationReport>("remote_reconcile_scan");
+}
+
+export function remoteListReconciliationLinks(): Promise<ReconciliationLink[]> {
+  return invoke<ReconciliationLink[]>("remote_list_reconciliation_links");
+}
+
+export function remoteConfirmReconciliation(
+  localTrackId: number,
+  remoteTrackId: string,
+): Promise<void> {
+  return invoke<void>("remote_confirm_reconciliation", {
+    localTrackId,
+    remoteTrackId,
+  });
+}
+
+export function remoteRejectReconciliation(
+  localTrackId: number,
+  remoteTrackId: string,
+): Promise<void> {
+  return invoke<void>("remote_reject_reconciliation", {
+    localTrackId,
+    remoteTrackId,
+  });
+}
+
+export function remoteSetReconciliationPreference(
+  localTrackId: number,
+  preference: "local_first" | "server_first",
+): Promise<void> {
+  return invoke<void>("remote_set_reconciliation_preference", {
+    localTrackId,
+    preference,
+  });
+}
+
+export function remoteRemoveReconciliationLink(
+  localTrackId: number,
+): Promise<void> {
+  return invoke<void>("remote_remove_reconciliation_link", { localTrackId });
 }


### PR DESCRIPTION
## Summary

- persist one-to-one local/server track links per Desktop profile
- prefilter local files by remote byte size, then verify with full-file BLAKE3
- auto-link only unique exact matches; keep duplicate groups for confirmation
- preserve links across path moves and mark changed bytes stale
- add a Settings surface for scanning, confirming/rejecting pairs and managing links

## Contract

Implements the first slice of WaveFlow Server RFC-004. Metadata never establishes identity. MBID matching and local-first audio switching remain separate follow-up slices.

## Migration

Adds `20260817100000_remote_track_reconciliation.sql` with:

- `remote_track_link` (one-to-one, no FK to disposable `remote_track` cache)
- `remote_track_match_rejection` (suppresses a rejected pair until its proof changes)

## Validation

- 7 targeted reconciliation tests passed
- `cargo check --manifest-path src-tauri/Cargo.toml -p waveflow --all-targets`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p waveflow --all-targets -- -D warnings`
- `bun run typecheck`
- targeted ESLint and Prettier checks
- `bun run build`

Windows test note: the Tauri test executable needs a Common Controls v6 manifest to expose `TaskDialogIndirect`; the generated test binary was patched for the local run only. No source or shipped artifact was changed by that workaround.

## Dependency

This PR intentionally targets `feat/sync-v2-remote-source` and should land after or with #502.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout d’un outil de rapprochement entre les pistes locales et distantes.
  - Détection automatique des correspondances uniques et signalement des cas ambigus.
  - Possibilité de confirmer, rejeter, consulter ou supprimer des correspondances.
  - Choix de la source prioritaire pour la lecture : locale ou distante.
  - Nouvelle section de gestion accessible depuis les paramètres lorsqu’une source distante est connectée.
- **Corrections**
  - Meilleure gestion des fichiers modifiés, déplacés, illisibles ou indisponibles lors du rapprochement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->