### PR TITLE
fix(remote): address deferred CodeRabbit findings from #502

### DIFF
--- a/src-tauri/crates/app/src/audio/analytics.rs
+++ b/src-tauri/crates/app/src/audio/analytics.rs
@@ -100,6 +100,21 @@ async fn handle_message(
     app: &AppHandle,
 ) -> Result<(), String> {
     let state = app.state::<AppState>();
+
+    // A remote-queue track has no library row: it writes no play_event and
+    // needs no profile pool. Handle it before acquiring the pool so a
+    // missing or momentarily-unavailable profile can't strand remote
+    // auto-advance (a plain radio stream ending here is a no-op).
+    if let AnalyticsMsg::RemoteTrackEnded { .. } = msg {
+        #[cfg(feature = "sync_v2")]
+        if state.remote_playback.is_active() {
+            if let Err(err) = crate::remote::playback::advance(app, Direction::Next).await {
+                tracing::warn!(%err, "remote auto-advance failed");
+            }
+        }
+        return Ok(());
+    }
+
     let pool = state
         .require_profile_pool()
         .await
@@ -189,20 +204,9 @@ async fn handle_message(
             )
             .await;
         }
-        AnalyticsMsg::RemoteTrackEnded { track_id } => {
-            // No play_event — a remote-queue track has no library row.
-            // Advance the remote queue if one is active; otherwise this
-            // was a plain radio stream ending, so do nothing.
-            let _ = track_id;
-            #[cfg(feature = "sync_v2")]
-            if state.remote_playback.is_active() {
-                if let Err(err) =
-                    crate::remote::playback::advance(app, Direction::Next).await
-                {
-                    tracing::warn!(%err, "remote auto-advance failed");
-                }
-            }
-        }
+        // Handled before the pool acquisition above (no play_event, no
+        // pool needed).
+        AnalyticsMsg::RemoteTrackEnded { .. } => {}
         AnalyticsMsg::PrefetchNext => {
             // Look up what would be played next without bumping the
             // cursor (the cursor is bumped only when the crossfade

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -444,17 +444,17 @@ fn decoder_loop(
                 // the cache via `transition_state`.
                 // A remote-queue track and a radio station both arrive via
                 // `LoadUrlAndPlay` with a negative id; the live remote-session
-                // flag is the only thing that tells them apart. Read it once
-                // (a plain `std::sync::Mutex`, no await) — it drives the emit
-                // below AND whether the source is opened seekable.
-                let is_remote = {
+                // flag is the only thing that tells them apart. Read the
+                // active flag, duration and artwork hash in ONE lock (a plain
+                // `std::sync::Mutex`, no await) so they stay consistent — three
+                // separate reads could straddle a `clear()` and emit
+                // `is_remote = true` with a `None` duration/artwork. It drives
+                // the emit below AND whether the source is opened seekable.
+                let remote_meta = {
                     let state = app.state::<crate::state::AppState>();
-                    state.remote_playback.is_active()
+                    state.remote_playback.current_stream_meta()
                 };
-                let remote_duration = app
-                    .state::<crate::state::AppState>()
-                    .remote_playback
-                    .current_duration_ms();
+                let is_remote = remote_meta.is_remote;
 
                 emit_radio_metadata(
                     &app,
@@ -473,13 +473,10 @@ fn decoder_loop(
                         is_remote,
                         // A remote-queue entry carries its length; radio
                         // does not. Drives a bounded seekbar on the bar.
-                        duration_ms: remote_duration,
+                        duration_ms: remote_meta.duration_ms,
                         // Cover hash for a remote track — the frontend turns
                         // it into a data URL for the PlayerBar.
-                        artwork_hash: app
-                            .state::<crate::state::AppState>()
-                            .remote_playback
-                            .current_artwork_hash(),
+                        artwork_hash: remote_meta.artwork_hash,
                     },
                 );
 

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -359,14 +359,28 @@ fn split_artist_title(raw: &str) -> (String, Option<String>) {
 /// rather than trusting it.
 fn parse_content_range_start(value: &str) -> Option<u64> {
     let rest = value.trim().strip_prefix("bytes ")?;
-    let range = rest.split('/').next()?; // "<start>-<end>"
-    // A 206 always carries BOTH bounds — an open-ended "<start>-" is only
-    // valid in a *request* Range, so a missing end means a malformed
-    // response. Require both, and reject a start that runs past the end.
+    // Exactly "<range>/<total>": one slash, total required (a 206 always
+    // sends it). A missing or extra slash is malformed.
+    let (range, total) = rest.split_once('/')?;
+    if total.contains('/') {
+        return None;
+    }
+    // Total is a byte count, or "*" when the full length is unknown.
+    let total = match total.trim() {
+        "*" => None,
+        other => Some(other.parse::<u64>().ok()?),
+    };
+    // A 206 carries BOTH bounds — an open-ended "<start>-" is only valid in
+    // a *request* Range. Require both, reject a start past the end, and
+    // reject a range that reaches or passes the total (end is inclusive, so
+    // the last valid byte is total-1).
     let (start, end) = range.split_once('-')?;
     let start = start.trim().parse::<u64>().ok()?;
     let end = end.trim().parse::<u64>().ok()?;
     if start > end {
+        return None;
+    }
+    if total.is_some_and(|total| end >= total) {
         return None;
     }
     Some(start)
@@ -692,6 +706,14 @@ mod tests {
         assert_eq!(parse_content_range_start("bytes 512-/2048"), None);
         // Start past end.
         assert_eq!(parse_content_range_start("bytes 100-50/200"), None);
+        // Range reaches/passes the total (end is inclusive).
+        assert_eq!(parse_content_range_start("bytes 0-100/100"), None);
+        // Missing total entirely (no slash).
+        assert_eq!(parse_content_range_start("bytes 0-99"), None);
+        // Extra slash / trailing suffix.
+        assert_eq!(parse_content_range_start("bytes 0-99/100/200"), None);
+        // Non-numeric total.
+        assert_eq!(parse_content_range_start("bytes 0-99/abc"), None);
         // Unsatisfied range → no start byte.
         assert_eq!(parse_content_range_start("bytes */1024"), None);
         // Wrong unit.

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -360,8 +360,16 @@ fn split_artist_title(raw: &str) -> (String, Option<String>) {
 fn parse_content_range_start(value: &str) -> Option<u64> {
     let rest = value.trim().strip_prefix("bytes ")?;
     let range = rest.split('/').next()?; // "<start>-<end>"
-    let start = range.split('-').next()?; // "<start>"
-    start.trim().parse::<u64>().ok()
+    // A 206 always carries BOTH bounds — an open-ended "<start>-" is only
+    // valid in a *request* Range, so a missing end means a malformed
+    // response. Require both, and reject a start that runs past the end.
+    let (start, end) = range.split_once('-')?;
+    let start = start.trim().parse::<u64>().ok()?;
+    let end = end.trim().parse::<u64>().ok()?;
+    if start > end {
+        return None;
+    }
+    Some(start)
 }
 
 impl Read for HttpMediaSource {
@@ -674,12 +682,16 @@ mod tests {
             Some(200)
         );
         assert_eq!(parse_content_range_start("bytes 0-99/100"), Some(0));
-        // An open-ended satisfied range still carries the start.
-        assert_eq!(parse_content_range_start("bytes 512-/2048"), Some(512));
+        // Unknown total ("*") is fine as long as both bounds are present.
+        assert_eq!(parse_content_range_start("bytes 512-1023/*"), Some(512));
     }
 
     #[test]
     fn parse_content_range_start_rejects_unusable_shapes() {
+        // Missing end bound — only valid in a request Range, not a 206.
+        assert_eq!(parse_content_range_start("bytes 512-/2048"), None);
+        // Start past end.
+        assert_eq!(parse_content_range_start("bytes 100-50/200"), None);
         // Unsatisfied range → no start byte.
         assert_eq!(parse_content_range_start("bytes */1024"), None);
         // Wrong unit.

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -358,7 +358,12 @@ fn split_artist_title(raw: &str) -> (String, Option<String>) {
 /// garbage — so the caller treats an unverifiable range as a failure
 /// rather than trusting it.
 fn parse_content_range_start(value: &str) -> Option<u64> {
-    let rest = value.trim().strip_prefix("bytes ")?;
+    // The range unit is case-insensitive per HTTP — accept "bytes",
+    // "Bytes", "BYTES" — then a single space before the range.
+    let (unit, rest) = value.trim().split_once(' ')?;
+    if !unit.eq_ignore_ascii_case("bytes") {
+        return None;
+    }
     // Exactly "<range>/<total>": one slash, total required (a 206 always
     // sends it). A missing or extra slash is malformed.
     let (range, total) = rest.split_once('/')?;
@@ -698,6 +703,9 @@ mod tests {
         assert_eq!(parse_content_range_start("bytes 0-99/100"), Some(0));
         // Unknown total ("*") is fine as long as both bounds are present.
         assert_eq!(parse_content_range_start("bytes 512-1023/*"), Some(512));
+        // The range unit is case-insensitive.
+        assert_eq!(parse_content_range_start("Bytes 200-1023/1024"), Some(200));
+        assert_eq!(parse_content_range_start("BYTES 0-99/100"), Some(0));
     }
 
     #[test]

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -81,11 +81,16 @@ pub fn redact_url(raw: &str) -> String {
 /// a spinner for a misconfigured station.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-// No request-level read timeout — reqwest::blocking's `timeout()` is a
+// No request-level `timeout()` anywhere — reqwest::blocking's is a
 // deadline for the *entire* call, which would kill a long-running radio
-// stream after 30 s. Stalls are rare in practice; if they happen the
-// user hits Stop and the decoder thread unwinds through the next
-// `try_recv`.
+// stream, and a seekable body is a *long file* whose remainder streams
+// through one ranged GET, so a total timeout would cap its playback just
+// the same. A per-read (inter-read) timeout would be the right tool for a
+// stalled seek-reopen, but reqwest::blocking's `ClientBuilder` doesn't
+// expose one (only the async builder does). Rather than pull in a
+// watchdog-thread wrapper, we accept the same failure mode as radio: a
+// stalled read blocks the decoder thread until the user hits Stop, which
+// unwinds it through the next `try_recv`.
 
 /// User-Agent advertised to radio servers. radio-browser entries vary
 /// in how strictly they filter — some Icecast configs reject empty UAs
@@ -347,6 +352,18 @@ fn split_artist_title(raw: &str) -> (String, Option<String>) {
     }
 }
 
+/// Parse the start byte out of a `Content-Range: bytes <start>-<end>/<total>`
+/// header value. Returns `None` for any shape we don't recognize — an
+/// unsatisfied-range `bytes */<total>`, a unit other than `bytes`, or
+/// garbage — so the caller treats an unverifiable range as a failure
+/// rather than trusting it.
+fn parse_content_range_start(value: &str) -> Option<u64> {
+    let rest = value.trim().strip_prefix("bytes ")?;
+    let range = rest.split('/').next()?; // "<start>-<end>"
+    let start = range.split('-').next()?; // "<start>"
+    start.trim().parse::<u64>().ok()
+}
+
 impl Read for HttpMediaSource {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // `Mutex::lock` only fails on poisoning; we never panic inside
@@ -487,6 +504,28 @@ impl Seek for HttpMediaSource {
                 response.status().as_u16()
             )));
         }
+        // A 206 must actually start at the byte we asked for. A server that
+        // answers 206 from a different offset — or with a malformed or
+        // absent Content-Range — would desync `pos` and corrupt the decode
+        // just as a bare 200 would, so verify the range's start byte.
+        match response
+            .headers()
+            .get(reqwest::header::CONTENT_RANGE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_content_range_start)
+        {
+            Some(start) if start == target => {}
+            Some(start) => {
+                return Err(io::Error::other(format!(
+                    "range start mismatch: asked for byte {target}, got {start}"
+                )));
+            }
+            None => {
+                return Err(io::Error::other(
+                    "206 response without a usable Content-Range header",
+                ));
+            }
+        }
 
         let mut guard = self
             .inner
@@ -626,6 +665,28 @@ mod tests {
             split_artist_title("Artist - "),
             ("Artist - ".to_string(), None)
         );
+    }
+
+    #[test]
+    fn parse_content_range_start_reads_the_offset() {
+        assert_eq!(
+            parse_content_range_start("bytes 200-1023/1024"),
+            Some(200)
+        );
+        assert_eq!(parse_content_range_start("bytes 0-99/100"), Some(0));
+        // An open-ended satisfied range still carries the start.
+        assert_eq!(parse_content_range_start("bytes 512-/2048"), Some(512));
+    }
+
+    #[test]
+    fn parse_content_range_start_rejects_unusable_shapes() {
+        // Unsatisfied range → no start byte.
+        assert_eq!(parse_content_range_start("bytes */1024"), None);
+        // Wrong unit.
+        assert_eq!(parse_content_range_start("items 0-9/10"), None);
+        // Garbage.
+        assert_eq!(parse_content_range_start("nonsense"), None);
+        assert_eq!(parse_content_range_start(""), None);
     }
 
     #[test]

--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -356,15 +356,25 @@ pub async fn enrich_artist_by_name(
     // id before — otherwise the None path skips the id-keyed cache check
     // and re-hits the network on every remote track change / view open. A
     // miss just falls through to a fresh fetch, which caches for next time.
-    let cached_deezer_id: Option<i64> = sqlx::query_scalar(
-        "SELECT deezer_id FROM app.metadata_artist
-          WHERE name = ? ORDER BY fetched_at DESC LIMIT 1",
+    //
+    // Match the name the *same* way a fresh Deezer search would
+    // (`select_by_name` over `normalize_name`d candidates), not by
+    // byte-exact SQL equality: the cache stores the raw Deezer display
+    // name, so a server-supplied "Beyonce" must still hit a cached
+    // "Beyoncé" row instead of re-fetching. Rows are walked most-recent
+    // first so recency still breaks ties, mirroring the old
+    // `ORDER BY fetched_at DESC LIMIT 1`.
+    let searched = normalize_name(&name);
+    let candidates: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT deezer_id, name FROM app.metadata_artist
+          WHERE deezer_id IS NOT NULL AND name IS NOT NULL
+          ORDER BY fetched_at DESC",
     )
-    .bind(&name)
-    .fetch_optional(&*pool)
+    .fetch_all(&*pool)
     .await
-    .ok()
-    .flatten();
+    .unwrap_or_default();
+    let cached_deezer_id: Option<i64> =
+        select_by_name(candidates, &searched, |(_, n)| Some(n.as_str())).map(|(id, _)| id);
     enrich_artist_named(state, (*pool).clone(), name, cached_deezer_id).await
 }
 

--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -352,29 +352,32 @@ pub async fn enrich_artist_by_name(
         return Ok(DeezerArtistEnrichment::empty());
     }
     let pool = state.require_profile_pool().await?;
-    // Reuse the shared cache when this name has been resolved to a Deezer
-    // id before — otherwise the None path skips the id-keyed cache check
-    // and re-hits the network on every remote track change / view open. A
-    // miss just falls through to a fresh fetch, which caches for next time.
+    // Reuse a previously-resolved Deezer id for this name so the None path
+    // doesn't re-hit the network on every remote track change / view open.
     //
-    // Match the name the *same* way a fresh Deezer search would
-    // (`select_by_name` over `normalize_name`d candidates), not by
-    // byte-exact SQL equality: the cache stores the raw Deezer display
-    // name, so a server-supplied "Beyonce" must still hit a cached
-    // "Beyoncé" row instead of re-fetching. Rows are walked most-recent
-    // first so recency still breaks ties, mirroring the old
-    // `ORDER BY fetched_at DESC LIMIT 1`.
-    let searched = normalize_name(&name);
-    let candidates: Vec<(i64, String)> = sqlx::query_as(
-        "SELECT deezer_id, name FROM app.metadata_artist
-          WHERE deezer_id IS NOT NULL AND name IS NOT NULL
-          ORDER BY fetched_at DESC",
+    // A bounded, case-insensitive exact match evaluated inside SQLite —
+    // rather than loading the whole cache into Rust to fuzzy-match every
+    // row — catches the common same-name/different-case hit. A diacritic-
+    // only variant ("Beyonce" vs a cached "Beyoncé") misses here and falls
+    // through to a fresh fetch, which does the accent-insensitive match
+    // against Deezer's own results and then caches it for next time.
+    let cached_deezer_id: Option<i64> = match sqlx::query_scalar::<_, i64>(
+        "SELECT deezer_id FROM app.metadata_artist
+          WHERE deezer_id IS NOT NULL AND name = ? COLLATE NOCASE
+          ORDER BY fetched_at DESC LIMIT 1",
     )
-    .fetch_all(&*pool)
+    .bind(&name)
+    .fetch_optional(&*pool)
     .await
-    .unwrap_or_default();
-    let cached_deezer_id: Option<i64> =
-        select_by_name(candidates, &searched, |(_, n)| Some(n.as_str())).map(|(id, _)| id);
+    {
+        Ok(id) => id,
+        Err(err) => {
+            // A lookup failure is not fatal — fall through to a fresh fetch
+            // — but it is distinct from a clean cache miss, so log it.
+            tracing::debug!(%err, artist = %name, "cached deezer id lookup failed");
+            None
+        }
+    };
     enrich_artist_named(state, (*pool).clone(), name, cached_deezer_id).await
 }
 

--- a/src-tauri/crates/app/src/commands/remote_auth.rs
+++ b/src-tauri/crates/app/src/commands/remote_auth.rs
@@ -158,9 +158,10 @@ pub async fn remote_sync_now(state: tauri::State<'_, AppState>) -> AppResult<Rem
 pub async fn remote_get_overview(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<crate::remote::read::RemoteOverview> {
-    let Some(mut conn) = optional_conn(&state).await? else {
+    let Some(pool) = optional_pool(&state).await? else {
         return Ok(Default::default());
     };
+    let mut conn = pool.acquire().await?;
     crate::remote::read::overview(&mut conn).await
 }
 
@@ -169,9 +170,10 @@ pub async fn remote_get_overview(
 pub async fn remote_list_playlists(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<Vec<crate::remote::read::RemotePlaylistSummary>> {
-    let Some(mut conn) = optional_conn(&state).await? else {
+    let Some(pool) = optional_pool(&state).await? else {
         return Ok(Vec::new());
     };
+    let mut conn = pool.acquire().await?;
     crate::remote::read::playlists(&mut conn).await
 }
 
@@ -183,9 +185,10 @@ pub async fn remote_list_playlist_tracks(
     state: tauri::State<'_, AppState>,
     playlist_id: String,
 ) -> AppResult<Vec<crate::remote::read::RemoteTrack>> {
-    let Some(mut conn) = optional_conn(&state).await? else {
+    let Some(pool) = optional_pool(&state).await? else {
         return Ok(Vec::new());
     };
+    let mut conn = pool.acquire().await?;
     crate::remote::read::playlist_tracks(&mut conn, &playlist_id).await
 }
 
@@ -194,9 +197,10 @@ pub async fn remote_list_playlist_tracks(
 pub async fn remote_list_queue(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<Vec<crate::remote::read::RemoteTrack>> {
-    let Some(mut conn) = optional_conn(&state).await? else {
+    let Some(pool) = optional_pool(&state).await? else {
         return Ok(Vec::new());
     };
+    let mut conn = pool.acquire().await?;
     crate::remote::read::queue_tracks(&mut conn).await
 }
 
@@ -474,16 +478,19 @@ pub async fn remote_delete_share(
     Ok(())
 }
 
-/// A connection to the active profile, or `None` when there is no
+/// The leased pool of the active profile, or `None` when there is no
 /// active profile.
 ///
 /// No profile is an ordinary state for these reads — onboarding queries
 /// them before one exists — so it answers empty rather than failing.
-async fn optional_conn(
-    state: &AppState,
-) -> AppResult<Option<sqlx::pool::PoolConnection<sqlx::Sqlite>>> {
+///
+/// Returns the *lease*, not a bare connection: the caller acquires its
+/// connection from the returned pool and keeps the lease bound for the
+/// whole read, so a profile switch can't close the pool under a live
+/// connection (CLAUDE.md "profile-scoped pool").
+async fn optional_pool(state: &AppState) -> AppResult<Option<crate::state::ProfilePool>> {
     match state.require_profile_pool().await {
-        Ok(pool) => Ok(Some(pool.acquire().await?)),
+        Ok(pool) => Ok(Some(pool)),
         Err(AppError::NoActiveProfile) => Ok(None),
         Err(err) => Err(err),
     }

--- a/src-tauri/crates/app/src/remote/auth.rs
+++ b/src-tauri/crates/app/src/remote/auth.rs
@@ -42,12 +42,12 @@
 //! URI once, from the port we actually got, makes that true by
 //! construction rather than by discipline.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use tiny_http::Server;
+use tiny_http::{Response, Server};
 
 use crate::{
     commands::loopback::html_response,
@@ -224,50 +224,72 @@ fn hostname() -> Option<String> {
 }
 
 /// Block until the browser hits the callback, and hand back the code.
+///
+/// The loopback port can receive requests that are not the callback — a
+/// browser favicon probe, a prefetch, an OS port check. Those are answered
+/// `404` and ignored rather than mistaken for a state-mismatched callback,
+/// which would abort a sign-in that had not actually failed. All the
+/// waiting shares one deadline, so those stray requests cannot extend the
+/// window indefinitely.
 fn wait_for_code(server: Server, expected_state: &str) -> AppResult<String> {
-    let request = server
-        .recv_timeout(CALLBACK_TIMEOUT)
-        .map_err(|err| AppError::Other(format!("sign-in callback failed: {err}")))?
-        .ok_or_else(|| AppError::Other("sign-in timed out — try again".into()))?;
+    let deadline = Instant::now() + CALLBACK_TIMEOUT;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| AppError::Other("sign-in timed out — try again".into()))?;
+        let request = server
+            .recv_timeout(remaining)
+            .map_err(|err| AppError::Other(format!("sign-in callback failed: {err}")))?
+            .ok_or_else(|| AppError::Other("sign-in timed out — try again".into()))?;
 
-    let url = request.url().to_string();
-    let query = url.split_once('?').map(|(_, q)| q).unwrap_or("");
-    let parsed = serde_urlencoded::from_str::<CallbackQuery>(query)
-        .map_err(|err| AppError::Other(format!("could not read the callback: {err}")))?;
+        let url = request.url().to_string();
+        let (path, query) = match url.split_once('?') {
+            Some((path, query)) => (path, query),
+            None => (url.as_str(), ""),
+        };
 
-    match (parsed.code, parsed.error, parsed.state.as_deref()) {
-        // `error` absent is part of the success condition on purpose:
-        // accepting a code that arrived alongside an error claim would
-        // mask a protocol change instead of failing on it.
-        (Some(code), None, state) if state == Some(expected_state) => {
-            let _ = request.respond(html_response(
-                "<!doctype html><title>WaveFlow</title>\
-                 <p>Signed in. You can close this tab and return to WaveFlow.</p>",
-            ));
-            Ok(code)
+        if path != CALLBACK_PATH {
+            let _ = request.respond(Response::empty(404));
+            continue;
         }
-        (_, Some(error), _) => {
-            let _ = request.respond(html_response(
-                "<!doctype html><title>WaveFlow</title>\
-                 <p>Sign-in was cancelled.</p>",
-            ));
-            // The consent screen's Deny button sends exactly this.
-            if error == "access_denied" {
-                Err(AppError::Other("sign-in was declined".into()))
-            } else {
-                Err(AppError::Other(format!("sign-in failed: {error}")))
+
+        let parsed = serde_urlencoded::from_str::<CallbackQuery>(query)
+            .map_err(|err| AppError::Other(format!("could not read the callback: {err}")))?;
+
+        return match (parsed.code, parsed.error, parsed.state.as_deref()) {
+            // `error` absent is part of the success condition on purpose:
+            // accepting a code that arrived alongside an error claim would
+            // mask a protocol change instead of failing on it.
+            (Some(code), None, state) if state == Some(expected_state) => {
+                let _ = request.respond(html_response(
+                    "<!doctype html><title>WaveFlow</title>\
+                     <p>Signed in. You can close this tab and return to WaveFlow.</p>",
+                ));
+                Ok(code)
             }
-        }
-        _ => {
-            let _ = request.respond(html_response(
-                "<!doctype html><title>WaveFlow</title>\
-                 <p>Sign-in failed: the reply did not match this request. \
-                 Start again from WaveFlow.</p>",
-            ));
-            Err(AppError::Other(
-                "sign-in reply did not match this request (state mismatch)".into(),
-            ))
-        }
+            (_, Some(error), _) => {
+                let _ = request.respond(html_response(
+                    "<!doctype html><title>WaveFlow</title>\
+                     <p>Sign-in was cancelled.</p>",
+                ));
+                // The consent screen's Deny button sends exactly this.
+                if error == "access_denied" {
+                    Err(AppError::Other("sign-in was declined".into()))
+                } else {
+                    Err(AppError::Other(format!("sign-in failed: {error}")))
+                }
+            }
+            _ => {
+                let _ = request.respond(html_response(
+                    "<!doctype html><title>WaveFlow</title>\
+                     <p>Sign-in failed: the reply did not match this request. \
+                     Start again from WaveFlow.</p>",
+                ));
+                Err(AppError::Other(
+                    "sign-in reply did not match this request (state mismatch)".into(),
+                ))
+            }
+        };
     }
 }
 

--- a/src-tauri/crates/app/src/remote/auth.rs
+++ b/src-tauri/crates/app/src/remote/auth.rs
@@ -253,8 +253,24 @@ fn wait_for_code(server: Server, expected_state: &str) -> AppResult<String> {
             continue;
         }
 
-        let parsed = serde_urlencoded::from_str::<CallbackQuery>(query)
-            .map_err(|err| AppError::Other(format!("could not read the callback: {err}")))?;
+        let parsed = match serde_urlencoded::from_str::<CallbackQuery>(query) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                // A query we cannot read is not our callback — keep waiting
+                // rather than aborting the sign-in on a stray request.
+                let _ = request.respond(Response::empty(404));
+                continue;
+            }
+        };
+
+        // Nothing actionable — no authorization code and no error. A bare
+        // hit to the callback path (a prefetch, a manual visit) is not a
+        // completed sign-in, so ignore it and keep waiting; a real callback
+        // still carries one of the two.
+        if parsed.code.is_none() && parsed.error.is_none() {
+            let _ = request.respond(Response::empty(404));
+            continue;
+        }
 
         return match (parsed.code, parsed.error, parsed.state.as_deref()) {
             // `error` absent is part of the success condition on purpose:

--- a/src-tauri/crates/app/src/remote/binding.rs
+++ b/src-tauri/crates/app/src/remote/binding.rs
@@ -296,12 +296,16 @@ mod tests {
             .connect(":memory:")
             .await
             .unwrap();
-        sqlx::raw_sql(include_str!(
-            "../../../../migrations/profile/20260810120000_remote_source_projection.sql"
-        ))
-        .execute(&pool)
-        .await
-        .unwrap();
+        for migration in [
+            include_str!(
+                "../../../../migrations/profile/20260810120000_remote_source_projection.sql"
+            ),
+            include_str!("../../../../migrations/profile/20260810140000_remote_track_cache.sql"),
+            include_str!("../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"),
+            include_str!("../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"),
+        ] {
+            sqlx::raw_sql(migration).execute(&pool).await.unwrap();
+        }
         pool
     }
 
@@ -323,6 +327,78 @@ mod tests {
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
         assert_eq!(read(&mut conn).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn switching_accounts_leaves_no_inherited_metadata() {
+        // Binding a second account after clearing must not let any of the
+        // first account's projection or queued writes survive — a cursor
+        // and queued mutations name *that* account's resources, and cached
+        // titles/artwork keyed by remote_id would resolve to the wrong
+        // library.
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        // Account 1, with some of everything projected.
+        write(&mut conn, &waveflow_binding(42)).await.unwrap();
+        sqlx::query("INSERT INTO remote_playlist (remote_id, name) VALUES ('p1', 'Acc1 mix')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO remote_playlist_track VALUES ('p1', 0, 't1')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO remote_favorite (entity_type, entity_id, starred_at) \
+             VALUES ('track', 't1', 0)",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO remote_track (remote_id, title) VALUES ('t1', 'Acc1 song')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO remote_mutation (operation_id, kind, payload, created_at) \
+             VALUES ('op-1', 'set_favorite', '{}', 0)",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        // Switch: clear, then bind account 2.
+        clear_account_state(&mut conn).await.unwrap();
+        let mut account_two = waveflow_binding(0);
+        if let RemoteIdentity::Waveflow {
+            account_id,
+            device_id,
+            ..
+        } = &mut account_two.identity
+        {
+            *account_id = "acc-2".into();
+            *device_id = "dev-2".into();
+        }
+        write(&mut conn, &account_two).await.unwrap();
+
+        // Nothing from account 1 survives, in any table. (Literal SQL per
+        // table — sqlx 0.9 rejects a `format!`d query string.)
+        async fn count(conn: &mut SqliteConnection, sql: &'static str) -> i64 {
+            sqlx::query_scalar(sql).fetch_one(&mut *conn).await.unwrap()
+        }
+        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_playlist").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_playlist_track").await,
+            0
+        );
+        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_favorite").await, 0);
+        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_track").await, 0);
+        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_mutation").await, 0);
+
+        // And the binding is now account 2.
+        let bound = read(&mut conn).await.unwrap().unwrap();
+        assert_eq!(bound.identity, account_two.identity);
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/remote/catalogue.rs
+++ b/src-tauri/crates/app/src/remote/catalogue.rs
@@ -120,7 +120,11 @@ pub async fn search(state: &AppState, query: &str, limit: i64) -> AppResult<Vec<
     if crate::offline::is_offline() {
         return Err(AppError::Other("offline mode is enabled".into()));
     }
-    let client = RemoteClient::try_build(state)
+    // Pin the client and the cache pool to one profile for the whole call,
+    // so a switch mid-request can't read one profile's session and cache
+    // into another's tables.
+    let profile_id = state.require_profile_id().await?;
+    let client = RemoteClient::try_build_for(state, profile_id)
         .await?
         .ok_or_else(|| AppError::Other("not signed in to a remote server".into()))?;
 
@@ -137,7 +141,7 @@ pub async fn search(state: &AppState, query: &str, limit: i64) -> AppResult<Vec<
         // a re-auth rather than shrug.
         .map_err(|err| AppError::Other(format!("search failed: {err}")))?;
 
-    let pool = state.require_profile_pool().await?;
+    let pool = state.require_profile_pool_for(Some(profile_id)).await?;
     let mut tracks = Vec::with_capacity(resp.songs.len());
     // Cache every hit in one transaction: the rows exist only to label the
     // picker, and committing each individually multiplies the fsyncs for no
@@ -158,7 +162,9 @@ pub async fn get_album(state: &AppState, album_id: &str) -> AppResult<RemoteAlbu
     if crate::offline::is_offline() {
         return Err(AppError::Other("offline mode is enabled".into()));
     }
-    let client = RemoteClient::try_build(state)
+    // Pin the client and the cache pool to one profile (see `search`).
+    let profile_id = state.require_profile_id().await?;
+    let client = RemoteClient::try_build_for(state, profile_id)
         .await?
         .ok_or_else(|| AppError::Other("not signed in to a remote server".into()))?;
 
@@ -169,7 +175,7 @@ pub async fn get_album(state: &AppState, album_id: &str) -> AppResult<RemoteAlbu
         // distinguishable from a missing album.
         .map_err(|err| AppError::Other(format!("album fetch failed: {err}")))?;
 
-    let pool = state.require_profile_pool().await?;
+    let pool = state.require_profile_pool_for(Some(profile_id)).await?;
     let mut tracks = Vec::with_capacity(resp.songs.len());
     // Cache the album's songs and read back the favorites in one
     // transaction, so the tracks are cached-and-labelled atomically.

--- a/src-tauri/crates/app/src/remote/catalogue.rs
+++ b/src-tauri/crates/app/src/remote/catalogue.rs
@@ -131,15 +131,23 @@ pub async fn search(state: &AppState, query: &str, limit: i64) -> AppResult<Vec<
                 .query(&[("q", query), ("limit", &limit.to_string())]),
         )
         .await
-        .map_err(|err| AppError::Other(format!("search: {}", err.message)))?;
+        // Surface the whole failure (status + code + message), not just the
+        // message: a 401 here means the session lapsed, which the caller
+        // must be able to tell apart from a plain "search failed" to prompt
+        // a re-auth rather than shrug.
+        .map_err(|err| AppError::Other(format!("search failed: {err}")))?;
 
     let pool = state.require_profile_pool().await?;
-    let mut conn = pool.acquire().await?;
     let mut tracks = Vec::with_capacity(resp.songs.len());
+    // Cache every hit in one transaction: the rows exist only to label the
+    // picker, and committing each individually multiplies the fsyncs for no
+    // benefit.
+    let mut tx = pool.begin().await?;
     for song in &resp.songs {
-        crate::remote::projection::cache_song(&mut conn, song).await?;
+        crate::remote::projection::cache_song(&mut tx, song).await?;
         tracks.push(song_to_track(song));
     }
+    tx.commit().await?;
     Ok(tracks)
 }
 
@@ -157,13 +165,17 @@ pub async fn get_album(state: &AppState, album_id: &str) -> AppResult<RemoteAlbu
     let resp: AlbumDetailResponse = client
         .send_json(client.get(&format!("/api/v2/albums/{album_id}")))
         .await
-        .map_err(|err| AppError::Other(format!("album: {}", err.message)))?;
+        // Preserve the status (see `search`) so a lapsed session is
+        // distinguishable from a missing album.
+        .map_err(|err| AppError::Other(format!("album fetch failed: {err}")))?;
 
     let pool = state.require_profile_pool().await?;
-    let mut conn = pool.acquire().await?;
     let mut tracks = Vec::with_capacity(resp.songs.len());
+    // Cache the album's songs and read back the favorites in one
+    // transaction, so the tracks are cached-and-labelled atomically.
+    let mut tx = pool.begin().await?;
     for song in &resp.songs {
-        crate::remote::projection::cache_song(&mut conn, song).await?;
+        crate::remote::projection::cache_song(&mut tx, song).await?;
         tracks.push(song_to_track(song));
     }
 
@@ -171,10 +183,11 @@ pub async fn get_album(state: &AppState, album_id: &str) -> AppResult<RemoteAlbu
     // the server's view, which can lag a pending local like/unlike.
     let starred: std::collections::HashSet<String> =
         sqlx::query_scalar("SELECT entity_id FROM remote_favorite WHERE entity_type = 'track'")
-            .fetch_all(&mut *conn)
+            .fetch_all(&mut *tx)
             .await?
             .into_iter()
             .collect();
+    tx.commit().await?;
     for track in &mut tracks {
         track.starred = starred.contains(&track.id);
     }
@@ -204,7 +217,9 @@ pub async fn get_artist(state: &AppState, artist_id: &str) -> AppResult<RemoteAr
     let resp: ArtistDetailResponse = client
         .send_json(client.get(&format!("/api/v2/artists/{artist_id}")))
         .await
-        .map_err(|err| AppError::Other(format!("artist: {}", err.message)))?;
+        // Preserve the status (see `search`) so a lapsed session is
+        // distinguishable from a missing artist.
+        .map_err(|err| AppError::Other(format!("artist fetch failed: {err}")))?;
 
     Ok(RemoteArtist {
         id: resp.id,

--- a/src-tauri/crates/app/src/remote/client.rs
+++ b/src-tauri/crates/app/src/remote/client.rs
@@ -28,7 +28,7 @@
 //! result instead of spending our now-stale token. Without that second
 //! read the gate would only serialize the damage, not prevent it.
 
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -223,7 +223,11 @@ struct RefreshCtx<'a> {
 pub struct RemoteClient<'a> {
     base_url: String,
     device_id: Option<String>,
-    access_token: String,
+    /// Shared so a `401` refresh can publish the rotated token in place:
+    /// a client is reused across a whole drain batch, and without this
+    /// every entry after a mid-batch rotation would 401 once on the stale
+    /// token before the gate re-read recovered it.
+    access_token: Arc<RwLock<String>>,
     http: reqwest::Client,
     /// Present when built from a live profile: lets [`Self::send`] refresh
     /// and replay a single `401` in-band. Absent for the test constructor.
@@ -242,7 +246,18 @@ impl<'a> RemoteClient<'a> {
         // it. A switch landing mid-way must fail this call rather than
         // read one profile's binding and write another profile's tokens.
         let profile_id = state.require_profile_id().await?;
+        Self::try_build_for(state, profile_id).await
+    }
 
+    /// Like [`Self::try_build`], but pinned to a profile id the caller
+    /// captured earlier. Lets the caller bind the client and its own pool
+    /// acquisition to the *same* profile across an operation, so a switch
+    /// landing mid-way fails cleanly instead of reading one profile's
+    /// tokens and writing another's data.
+    pub async fn try_build_for(
+        state: &'a AppState,
+        profile_id: i64,
+    ) -> AppResult<Option<Self>> {
         let (binding, pair) = {
             let pool = state.require_profile_pool_for(Some(profile_id)).await?;
             let mut conn = pool.acquire().await?;
@@ -284,13 +299,23 @@ impl<'a> RemoteClient<'a> {
         Ok(Self {
             base_url: binding.server_url.trim_end_matches('/').to_string(),
             device_id: binding.identity.device_id().map(str::to_owned),
-            access_token: pair.access_token.clone(),
+            access_token: Arc::new(RwLock::new(pair.access_token.clone())),
             http: reqwest::Client::builder()
                 .timeout(REQUEST_TIMEOUT)
                 .build()
                 .map_err(|err| AppError::Other(format!("http client init: {err}")))?,
             refresh_ctx: None,
         })
+    }
+
+    /// The current access token, cloned out of the shared cell. Read fresh
+    /// on every request so a `401` refresh (which writes the rotated token
+    /// back into the cell) is picked up by later calls on the same client.
+    fn token(&self) -> String {
+        self.access_token
+            .read()
+            .expect("access token lock poisoned")
+            .clone()
     }
 
     /// A read request. No idempotency headers — a GET has nothing to
@@ -308,7 +333,7 @@ impl<'a> RemoteClient<'a> {
     pub fn request(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {
         self.http
             .request(method, self.url(path))
-            .bearer_auth(&self.access_token)
+            .bearer_auth(self.token())
     }
 
     /// A mutation, stamped so the server can recognize a replay.
@@ -327,7 +352,7 @@ impl<'a> RemoteClient<'a> {
         let mut builder = self
             .http
             .request(method, self.url(path))
-            .bearer_auth(&self.access_token)
+            .bearer_auth(self.token())
             .header(OPERATION_ID_HEADER, operation_id);
         if let Some(device_id) = &self.device_id {
             builder = builder.header(DEVICE_ID_HEADER, device_id);
@@ -347,8 +372,11 @@ impl<'a> RemoteClient<'a> {
         &self.base_url
     }
 
-    pub fn access_token(&self) -> &str {
-        &self.access_token
+    /// The current access token, cloned out of the shared cell. Owned
+    /// rather than borrowed so a caller (the socket upgrade) isn't tied to
+    /// the lock guard's lifetime.
+    pub fn access_token(&self) -> String {
+        self.token()
     }
 
     /// Send a request and decode its JSON body.
@@ -421,6 +449,11 @@ impl<'a> RemoteClient<'a> {
             Ok(pair) => pair,
             Err(_) => return Self::interpret(response).await,
         };
+        // Publish the rotated token so later requests on this same client
+        // (a drain reuses one across the batch) don't 401 on the stale one.
+        if let Ok(mut guard) = self.access_token.write() {
+            guard.clone_from(&fresh.access_token);
+        }
         let Ok(bearer) =
             reqwest::header::HeaderValue::from_str(&format!("Bearer {}", fresh.access_token))
         else {

--- a/src-tauri/crates/app/src/remote/client.rs
+++ b/src-tauri/crates/app/src/remote/client.rs
@@ -192,26 +192,41 @@ pub struct AuthUserResponse {
     pub username: String,
 }
 
+/// What a client needs to refresh its own token and replay a request
+/// once when the server answers `401`. Held only by a client built from a
+/// live [`AppState`] (via [`RemoteClient::try_build`]); a
+/// [`RemoteClient::from_parts`] client — the test constructor — has none
+/// and simply surfaces the `401`.
+struct RefreshCtx<'a> {
+    state: &'a AppState,
+    profile_id: i64,
+    binding: RemoteBinding,
+    pair: TokenPair,
+}
+
 /// A client bound to one profile's server and credentials.
 ///
 /// Built per operation rather than held long-term: the credential it
 /// carries is a snapshot, and a client kept across a refresh would go on
 /// presenting a token that has been rotated away.
-pub struct RemoteClient {
+pub struct RemoteClient<'a> {
     base_url: String,
     device_id: Option<String>,
     access_token: String,
     http: reqwest::Client,
+    /// Present when built from a live profile: lets [`Self::send`] refresh
+    /// and replay a single `401` in-band. Absent for the test constructor.
+    refresh_ctx: Option<RefreshCtx<'a>>,
 }
 
-impl RemoteClient {
+impl<'a> RemoteClient<'a> {
     /// Build against the active profile's binding and tokens, or
     /// `Ok(None)` when the profile is not bound to a native server.
     ///
     /// Returns `None` — not an error — for an unbound profile, a
     /// signed-out one, or a Subsonic binding: local-only is the normal
     /// case, and a server without a journal has no business here.
-    pub async fn try_build(state: &AppState) -> AppResult<Option<Self>> {
+    pub async fn try_build(state: &'a AppState) -> AppResult<Option<Self>> {
         // Capture the profile up front and pin every later acquisition to
         // it. A switch landing mid-way must fail this call rather than
         // read one profile's binding and write another profile's tokens.
@@ -244,7 +259,14 @@ impl RemoteClient {
             pair
         };
 
-        Ok(Some(Self::from_parts(&binding, &pair)?))
+        let mut client = Self::from_parts(&binding, &pair)?;
+        client.refresh_ctx = Some(RefreshCtx {
+            state,
+            profile_id,
+            binding,
+            pair,
+        });
+        Ok(Some(client))
     }
 
     fn from_parts(binding: &RemoteBinding, pair: &TokenPair) -> AppResult<Self> {
@@ -256,6 +278,7 @@ impl RemoteClient {
                 .timeout(REQUEST_TIMEOUT)
                 .build()
                 .map_err(|err| AppError::Other(format!("http client init: {err}")))?,
+            refresh_ctx: None,
         })
     }
 
@@ -357,15 +380,64 @@ impl RemoteClient {
             });
         }
 
-        let response = builder.send().await.map_err(RemoteFailure::transport)?;
+        let request = builder.build().map_err(RemoteFailure::transport)?;
+        // Keep a clone to replay after a refresh if the token is refused.
+        // `try_clone` returns `None` only for a streaming body, which none
+        // of our requests use.
+        let replay = request.try_clone();
+        let response = self
+            .http
+            .execute(request)
+            .await
+            .map_err(RemoteFailure::transport)?;
+
+        if response.status().as_u16() != 401 {
+            return Self::interpret(response).await;
+        }
+
+        // A 401 means the access token was refused. `try_build`'s
+        // pre-emptive refresh covers the common lapse; this handles the
+        // narrow race where the token expired (or was rotated) between that
+        // check and the server reading it. Refresh once — single-flighted
+        // process-wide — and replay with the fresh token. Anything that
+        // stops us (no refresh context, an uncloneable request, a failed
+        // refresh) falls through to surfacing the original 401 as
+        // `Unauthorized`, and the queue retries later.
+        let (Some(ctx), Some(mut replay)) = (self.refresh_ctx.as_ref(), replay) else {
+            return Self::interpret(response).await;
+        };
+        let fresh = match refresh(ctx.state, ctx.profile_id, &ctx.binding, &ctx.pair).await {
+            Ok(pair) => pair,
+            Err(_) => return Self::interpret(response).await,
+        };
+        let Ok(bearer) =
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", fresh.access_token))
+        else {
+            return Self::interpret(response).await;
+        };
+        replay
+            .headers_mut()
+            .insert(reqwest::header::AUTHORIZATION, bearer);
+        let retried = self
+            .http
+            .execute(replay)
+            .await
+            .map_err(RemoteFailure::transport)?;
+        Self::interpret(retried).await
+    }
+
+    /// Turn a completed response into `Ok(response)` or a classified
+    /// [`RemoteFailure`], reading the structured error body while it is
+    /// still available. The code is kept as a field, not formatted away:
+    /// callers branch on it, and a substring match on a message would be a
+    /// fragile way to make a destructive decision.
+    async fn interpret(
+        response: reqwest::Response,
+    ) -> Result<reqwest::Response, RemoteFailure> {
         let status = response.status().as_u16();
         match classify_status(status) {
             None => Ok(response),
             Some(kind) => {
-                // Read the structured body while we still can. The code
-                // is kept as a field, not formatted away: callers have to
-                // branch on it, and a substring match on a message would
-                // be a fragile way to make a destructive decision.
                 let (code, message) = match response.json::<ErrorBody>().await {
                     Ok(body) => (Some(body.code), body.message),
                     Err(_) => (None, "no error body".to_string()),
@@ -398,10 +470,22 @@ pub async fn refresh(
         let pool = state.require_profile_pool_for(Some(profile_id)).await?;
         let mut conn = pool.acquire().await?;
 
-        // Somebody may have refreshed while we waited for the gate.
-        if let Some(current) = tokens::read(&mut conn).await? {
-            if current.refresh_token != known.refresh_token {
+        // Somebody may have acted while we waited for the gate. If the
+        // stored pair changed, another task already refreshed — adopt its
+        // result rather than spend our now-stale token. If it is gone
+        // entirely, a concurrent sign-out or forget cleared it, and
+        // refreshing now would silently resurrect the credentials the user
+        // just dropped — so stop and let the caller treat this as
+        // signed-out.
+        match tokens::read(&mut conn).await? {
+            Some(current) if current.refresh_token != known.refresh_token => {
                 return Ok(current);
+            }
+            Some(_) => {}
+            None => {
+                return Err(AppError::Other(
+                    "signed out while a token refresh was queued".into(),
+                ));
             }
         }
         // Lease released before the request — see `try_build`.
@@ -458,8 +542,13 @@ pub async fn refresh(
                  could not be stored and that profile will need to sign in again"
             );
         })?;
-    let mut conn = pool.acquire().await?;
-    tokens::write(&mut conn, &pair).await?;
+
+    // The rotated pair and any device-id correction commit together. A
+    // half-write — new tokens stored but the re-issued device left behind —
+    // would let every subsequent mutation stamp the wrong device and 401,
+    // so the two writes share one transaction.
+    let mut tx = pool.begin().await?;
+    tokens::write(&mut tx, &pair).await?;
 
     // The server echoes the device back rather than minting a new one,
     // so this normally matches what we already hold. Adopting it anyway
@@ -478,9 +567,10 @@ pub async fn refresh(
                 },
                 ..binding.clone()
             };
-            binding::write(&mut conn, &updated).await?;
+            binding::write(&mut tx, &updated).await?;
         }
     }
+    tx.commit().await?;
 
     Ok(pair)
 }

--- a/src-tauri/crates/app/src/remote/client.rs
+++ b/src-tauri/crates/app/src/remote/client.rs
@@ -95,6 +95,12 @@ pub const CODE_CURSOR_EXPIRED: &str = "cursor_expired";
 
 /// Error code for a request that collides with existing state — an
 /// operation id replayed with a different payload, most of all.
+///
+/// Kept as the documented counterpart to [`CODE_CURSOR_EXPIRED`] — the two
+/// share `409` and demand opposite reactions — and exercised by the tests
+/// that pin that distinction, though the drain classifies a conflict as
+/// permanent by status alone rather than reading this.
+#[allow(dead_code)]
 pub const CODE_CONFLICT: &str = "conflict";
 
 /// Classify an HTTP status.
@@ -164,6 +170,11 @@ impl RemoteFailure {
 
     /// The request collides with existing state. Permanent, and the fix
     /// is a new operation id — never a retry of this one.
+    ///
+    /// The symmetric counterpart to [`Self::is_cursor_expired`]; only the
+    /// tests read it today (the drain acts on the permanent status), but it
+    /// keeps the 409 duality legible in one place.
+    #[allow(dead_code)]
     pub fn is_conflict(&self) -> bool {
         self.code.as_deref() == Some(CODE_CONFLICT)
     }

--- a/src-tauri/crates/app/src/remote/drain.rs
+++ b/src-tauri/crates/app/src/remote/drain.rs
@@ -88,9 +88,13 @@ pub async fn drain(state: &AppState) -> AppResult<DrainReport> {
         return Ok(report);
     };
     let profile_id = state.require_profile_id().await?;
+    // Resolve the leased pool once and keep the handle bound for the whole
+    // pass — re-resolving per entry both churns the lease and risks a
+    // profile swap landing mid-drain, applying one profile's queue against
+    // another's data.
+    let pool = state.require_profile_pool_for(Some(profile_id)).await?;
 
     let queued = {
-        let pool = state.require_profile_pool_for(Some(profile_id)).await?;
         let mut conn = pool.acquire().await?;
         mutation::pending(&mut conn, BATCH).await?
     };
@@ -98,7 +102,6 @@ pub async fn drain(state: &AppState) -> AppResult<DrainReport> {
     for entry in queued {
         match send(&client, &entry).await {
             Ok(created) => {
-                let pool = state.require_profile_pool_for(Some(profile_id)).await?;
                 let mut tx = pool.begin().await?;
                 // The identifier and the entry's removal commit
                 // together. Resolving without removing would re-send a
@@ -125,7 +128,6 @@ pub async fn drain(state: &AppState) -> AppResult<DrainReport> {
                 report.sent += 1;
             }
             Err(failure) => {
-                let pool = state.require_profile_pool_for(Some(profile_id)).await?;
                 let mut conn = pool.acquire().await?;
                 match failure.kind {
                     FailureKind::Permanent => {
@@ -157,7 +159,7 @@ pub async fn drain(state: &AppState) -> AppResult<DrainReport> {
 /// that is the one case where the server's reply carries something the
 /// caller must keep.
 async fn send(
-    client: &RemoteClient,
+    client: &RemoteClient<'_>,
     entry: &QueuedMutation,
 ) -> Result<Option<Created>, RemoteFailure> {
     let op = &entry.operation_id;

--- a/src-tauri/crates/app/src/remote/drain.rs
+++ b/src-tauri/crates/app/src/remote/drain.rs
@@ -84,10 +84,13 @@ pub async fn drain(state: &AppState) -> AppResult<DrainReport> {
     if offline::is_offline() {
         return Ok(report);
     }
-    let Some(client) = RemoteClient::try_build(state).await? else {
+    // Capture the profile once and pin BOTH the client and the pool to it,
+    // so the whole pass reads tokens and writes the queue for the same
+    // profile even if a switch lands mid-drain.
+    let profile_id = state.require_profile_id().await?;
+    let Some(client) = RemoteClient::try_build_for(state, profile_id).await? else {
         return Ok(report);
     };
-    let profile_id = state.require_profile_id().await?;
     // Resolve the leased pool once and keep the handle bound for the whole
     // pass — re-resolving per entry both churns the lease and risks a
     // profile swap landing mid-drain, applying one profile's queue against

--- a/src-tauri/crates/app/src/remote/dto.rs
+++ b/src-tauri/crates/app/src/remote/dto.rs
@@ -200,7 +200,10 @@ pub struct SyncChange {
     pub action: String,
     #[serde(default)]
     pub payload: serde_json::Value,
+    // Part of the wire shape, kept so the DTO mirrors the server's change
+    // record; the apply path doesn't branch on the originating device.
     #[serde(default)]
+    #[allow(dead_code)]
     pub origin_device_id: Option<String>,
     #[serde(default)]
     pub changed_at: i64,

--- a/src-tauri/crates/app/src/remote/mod.rs
+++ b/src-tauri/crates/app/src/remote/mod.rs
@@ -74,14 +74,6 @@
 //! on top. Only WaveFlow offers it, which is why nothing in this module
 //! may assume it is present without having observed it.
 
-// This slice lands the foundation; its consumers — the PKCE handshake,
-// the snapshot bootstrap, the outbound drain — land in the ones that
-// follow. Until then most of the surface below has no caller and
-// `dead_code` would flag nearly all of it, drowning the warnings that
-// mean something. Same treatment, and the same reason, as
-// `sync/mode.rs`. Drop this once the drain consumes the client.
-#![allow(dead_code)]
-
 pub mod auth;
 pub mod binding;
 pub mod catalogue;

--- a/src-tauri/crates/app/src/remote/mutation.rs
+++ b/src-tauri/crates/app/src/remote/mutation.rs
@@ -246,19 +246,31 @@ pub async fn pending(conn: &mut SqliteConnection, limit: i64) -> AppResult<Vec<Q
 
     let mut queued = Vec::with_capacity(rows.len());
     for row in rows {
+        let id: i64 = row.try_get("id")?;
         let payload: String = row.try_get("payload")?;
-        // A payload this build cannot parse is a row written by a newer
-        // one. Skipping it keeps the queue moving; failing the whole
-        // drain would stall every later entry over one unknown shape.
         match serde_json::from_str::<Mutation>(&payload) {
             Ok(mutation) => queued.push(QueuedMutation {
-                id: row.try_get("id")?,
+                id,
                 operation_id: row.try_get("operation_id")?,
                 mutation,
                 attempt_count: row.try_get("attempt_count")?,
             }),
             Err(error) => {
-                tracing::warn!(%error, "skipping a queued mutation this build cannot read");
+                // A payload this build cannot parse can never be sent by
+                // it — most likely a row written by a newer build. It must
+                // not be skipped: the drain relies on FIFO order, so
+                // letting a later entry overtake it could send an edit
+                // before the creation it depends on. Mark it permanently
+                // failed (surfacing it in diagnostics and excluding it from
+                // the next pass) and stop here, so nothing behind it slips
+                // past within this batch. The next pass resumes past it.
+                tracing::warn!(
+                    %error,
+                    mutation_id = id,
+                    "a queued mutation cannot be read by this build; marking it failed and stopping the pass"
+                );
+                mark_failed(conn, id, &format!("unreadable payload: {error}")).await?;
+                break;
             }
         }
     }
@@ -331,25 +343,50 @@ pub async fn resolve_placeholder(
     placeholder: &str,
     remote_id: &str,
 ) -> AppResult<()> {
-    sqlx::query(
-        "INSERT INTO remote_playlist
-            (remote_id, name, comment, is_public, created_at, updated_at)
-         SELECT ?, name, comment, is_public, created_at, updated_at
-           FROM remote_playlist WHERE remote_id = ?",
-    )
-    .bind(remote_id)
-    .bind(placeholder)
-    .execute(&mut *conn)
-    .await?;
-    sqlx::query("UPDATE remote_playlist_track SET playlist_remote_id = ? WHERE playlist_remote_id = ?")
+    // Idempotent: a `/changes` echo of our own creation can project the
+    // real playlist under `remote_id` before the drain resolves the
+    // placeholder. If it did, copying the placeholder over it collides on
+    // the primary key and re-pointing its tracks collides on
+    // `(playlist_remote_id, position)`. In that case the projection is
+    // authoritative — just drop the placeholder side.
+    let already_projected: i64 =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM remote_playlist WHERE remote_id = ?)")
+            .bind(remote_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+    if already_projected != 0 {
+        sqlx::query("DELETE FROM remote_playlist_track WHERE playlist_remote_id = ?")
+            .bind(placeholder)
+            .execute(&mut *conn)
+            .await?;
+        sqlx::query("DELETE FROM remote_playlist WHERE remote_id = ?")
+            .bind(placeholder)
+            .execute(&mut *conn)
+            .await?;
+    } else {
+        sqlx::query(
+            "INSERT INTO remote_playlist
+                (remote_id, name, comment, is_public, created_at, updated_at)
+             SELECT ?, name, comment, is_public, created_at, updated_at
+               FROM remote_playlist WHERE remote_id = ?",
+        )
         .bind(remote_id)
         .bind(placeholder)
         .execute(&mut *conn)
         .await?;
-    sqlx::query("DELETE FROM remote_playlist WHERE remote_id = ?")
+        sqlx::query(
+            "UPDATE remote_playlist_track SET playlist_remote_id = ? WHERE playlist_remote_id = ?",
+        )
+        .bind(remote_id)
         .bind(placeholder)
         .execute(&mut *conn)
         .await?;
+        sqlx::query("DELETE FROM remote_playlist WHERE remote_id = ?")
+            .bind(placeholder)
+            .execute(&mut *conn)
+            .await?;
+    }
 
     rewrite_queued_references(conn, placeholder, remote_id).await
 }
@@ -367,28 +404,54 @@ pub async fn resolve_share_placeholder(
     remote_id: &str,
     url: Option<&str>,
 ) -> AppResult<()> {
-    // Copied, re-pointed, dropped — for the same foreign-key reason as
-    // the playlist above.
-    sqlx::query(
-        "INSERT INTO remote_share
-            (remote_id, description, expires_at, visit_count, url, created_at, updated_at)
-         SELECT ?, description, expires_at, visit_count, COALESCE(?, url), created_at, updated_at
-           FROM remote_share WHERE remote_id = ?",
-    )
-    .bind(remote_id)
-    .bind(url)
-    .bind(placeholder)
-    .execute(&mut *conn)
-    .await?;
-    sqlx::query("UPDATE remote_share_track SET share_remote_id = ? WHERE share_remote_id = ?")
+    // Idempotent, like `resolve_placeholder`: a `/changes` echo may have
+    // projected the real share already. If it did, still capture the URL —
+    // the journal never carries it, so the creation response is the only
+    // chance — then drop the placeholder side.
+    let already_projected: i64 =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM remote_share WHERE remote_id = ?)")
+            .bind(remote_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+    if already_projected != 0 {
+        sqlx::query("UPDATE remote_share SET url = COALESCE(?, url) WHERE remote_id = ?")
+            .bind(url)
+            .bind(remote_id)
+            .execute(&mut *conn)
+            .await?;
+        sqlx::query("DELETE FROM remote_share_track WHERE share_remote_id = ?")
+            .bind(placeholder)
+            .execute(&mut *conn)
+            .await?;
+        sqlx::query("DELETE FROM remote_share WHERE remote_id = ?")
+            .bind(placeholder)
+            .execute(&mut *conn)
+            .await?;
+    } else {
+        // Copied, re-pointed, dropped — for the same foreign-key reason as
+        // the playlist above.
+        sqlx::query(
+            "INSERT INTO remote_share
+                (remote_id, description, expires_at, visit_count, url, created_at, updated_at)
+             SELECT ?, description, expires_at, visit_count, COALESCE(?, url), created_at, updated_at
+               FROM remote_share WHERE remote_id = ?",
+        )
         .bind(remote_id)
+        .bind(url)
         .bind(placeholder)
         .execute(&mut *conn)
         .await?;
-    sqlx::query("DELETE FROM remote_share WHERE remote_id = ?")
-        .bind(placeholder)
-        .execute(&mut *conn)
-        .await?;
+        sqlx::query("UPDATE remote_share_track SET share_remote_id = ? WHERE share_remote_id = ?")
+            .bind(remote_id)
+            .bind(placeholder)
+            .execute(&mut *conn)
+            .await?;
+        sqlx::query("DELETE FROM remote_share WHERE remote_id = ?")
+            .bind(placeholder)
+            .execute(&mut *conn)
+            .await?;
+    }
 
     rewrite_queued_references(conn, placeholder, remote_id).await
 }
@@ -596,9 +659,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_payload_this_build_cannot_read_is_skipped_not_fatal() {
-        // A row written by a newer build must not stall every entry
-        // behind it.
+    async fn a_payload_this_build_cannot_read_stops_the_pass_and_is_marked_failed() {
+        // A row written by a newer build can never be sent by this one.
+        // FIFO is load-bearing, so it must not be skipped over — the pass
+        // stops at it, it is marked permanently failed, and the next pass
+        // resumes past it. That way the later entry is still sent, just one
+        // pass later, and never *before* something it might depend on.
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
         sqlx::query(
@@ -610,9 +676,121 @@ mod tests {
         .unwrap();
         enqueue(&mut conn, &favorite(true)).await.unwrap();
 
-        let queued = pending(&mut conn, 10).await.unwrap();
-        assert_eq!(queued.len(), 1);
-        assert_eq!(queued[0].mutation, favorite(true));
+        // First pass stops at the unreadable row — nothing behind it slips
+        // past — and marks it failed.
+        let first = pending(&mut conn, 10).await.unwrap();
+        assert!(first.is_empty(), "the pass must stop at the unreadable row");
+        let failed: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM remote_mutation WHERE failed_at IS NOT NULL")
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap();
+        assert_eq!(failed, 1);
+
+        // Next pass resumes past it and returns the readable entry.
+        let second = pending(&mut conn, 10).await.unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].mutation, favorite(true));
+    }
+
+    #[tokio::test]
+    async fn resolving_a_placeholder_the_projection_already_created_is_idempotent() {
+        // A `/changes` echo can materialize the real playlist under its
+        // server id before the drain resolves the placeholder. Resolving
+        // must then not collide on the primary key or duplicate tracks —
+        // it drops the placeholder side and keeps the projected row.
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let local_id = new_placeholder();
+        // Placeholder projection (what the user saw offline).
+        sqlx::query("INSERT INTO remote_playlist (remote_id, name) VALUES (?, 'Offline mix')")
+            .bind(&local_id)
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO remote_playlist_track VALUES (?, 0, 't1')")
+            .bind(&local_id)
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        // The real row, already projected from the server's echo.
+        sqlx::query(
+            "INSERT INTO remote_playlist (remote_id, name) VALUES ('server-uuid', 'Offline mix')",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO remote_playlist_track VALUES ('server-uuid', 0, 't1')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+
+        resolve_placeholder(&mut conn, &local_id, "server-uuid")
+            .await
+            .expect("resolving over an already-projected row must not error");
+
+        // Exactly one playlist row (the real one), one track, no placeholder.
+        let playlists: i64 = sqlx::query_scalar("SELECT count(*) FROM remote_playlist")
+            .fetch_one(&mut *conn)
+            .await
+            .unwrap();
+        assert_eq!(playlists, 1);
+        let placeholder_gone: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM remote_playlist WHERE remote_id = ?")
+                .bind(&local_id)
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap();
+        assert_eq!(placeholder_gone, 0);
+        let tracks: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM remote_playlist_track WHERE playlist_remote_id = 'server-uuid'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(tracks, 1, "the projected track must not be duplicated");
+    }
+
+    #[tokio::test]
+    async fn resolving_a_share_the_projection_already_created_still_captures_the_url() {
+        // The share URL is learned only from the creation response. If the
+        // real share was already projected (without a URL — the journal
+        // never carries one), resolving must still write the URL in.
+        let pool = pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        let local_id = new_placeholder();
+        sqlx::query("INSERT INTO remote_share (remote_id, description) VALUES (?, 'My mix')")
+            .bind(&local_id)
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        // Real share already projected, URL still null.
+        sqlx::query(
+            "INSERT INTO remote_share (remote_id, description) VALUES ('share-uuid', 'My mix')",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        resolve_share_placeholder(&mut conn, &local_id, "share-uuid", Some("https://x/y"))
+            .await
+            .expect("resolving over an already-projected share must not error");
+
+        let url: Option<String> =
+            sqlx::query_scalar("SELECT url FROM remote_share WHERE remote_id = 'share-uuid'")
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap();
+        assert_eq!(url.as_deref(), Some("https://x/y"));
+        let placeholder_gone: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM remote_share WHERE remote_id = ?")
+                .bind(&local_id)
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap();
+        assert_eq!(placeholder_gone, 0);
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/remote/mutation.rs
+++ b/src-tauri/crates/app/src/remote/mutation.rs
@@ -199,6 +199,9 @@ pub struct QueuedMutation {
     pub id: i64,
     pub operation_id: String,
     pub mutation: Mutation,
+    // Surfaced for diagnostics and asserted by the tests; the drain itself
+    // doesn't branch on the try count.
+    #[allow(dead_code)]
     pub attempt_count: i64,
 }
 

--- a/src-tauri/crates/app/src/remote/probe.rs
+++ b/src-tauri/crates/app/src/remote/probe.rs
@@ -79,6 +79,11 @@ pub enum ServerFlavour {
 
 impl ServerFlavour {
     /// Whether the optional synchronization surface exists here.
+    ///
+    /// Not currently called — the sync paths gate on the `Waveflow`
+    /// binding variant directly — but kept as the named capability check
+    /// the flavour exists to express.
+    #[allow(dead_code)]
     pub fn supports_sync(&self) -> bool {
         matches!(self, ServerFlavour::Waveflow { .. })
     }

--- a/src-tauri/crates/app/src/remote/socket.rs
+++ b/src-tauri/crates/app/src/remote/socket.rs
@@ -139,7 +139,9 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
 
     // Reconnecting is itself a reason to ask: anything that happened
     // while we were away arrived through no frame at all.
-    catch_up_and_notify(handle, state).await;
+    if !catch_up_and_notify(handle, state, profile_id).await {
+        return Ok(false);
+    }
 
     let mut delivered = false;
     // When the first still-un-caught-up notice arrived. While one is
@@ -155,7 +157,9 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
         // the catch-up could be postponed indefinitely.
         if pending_since.is_some_and(|since| since.elapsed() >= MAX_COALESCE_DELAY) {
             pending_since = None;
-            catch_up_and_notify(handle, state).await;
+            if !catch_up_and_notify(handle, state, profile_id).await {
+                break;
+            }
             continue;
         }
         let wait = match pending_since {
@@ -191,7 +195,9 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
                 if pending_since.is_some() {
                     // The burst settled (or hit the cap): one catch-up.
                     pending_since = None;
-                    catch_up_and_notify(handle, state).await;
+                    if !catch_up_and_notify(handle, state, profile_id).await {
+                        break;
+                    }
                 } else {
                     // Genuine inactivity — the link is likely half-open.
                     // End the session so the loop reconnects and catches
@@ -203,15 +209,28 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
         }
     }
 
-    // Flush a notice that arrived just before the stream closed.
+    // Flush a notice that arrived just before the stream closed. The
+    // profile guard inside is a no-op sync if it switched.
     if pending_since.is_some() {
-        catch_up_and_notify(handle, state).await;
+        catch_up_and_notify(handle, state, profile_id).await;
     }
 
     Ok(delivered)
 }
 
-async fn catch_up_and_notify(handle: &AppHandle, state: &AppState) {
+/// Drain, then pull. Returns `false` when the active profile no longer
+/// matches `profile_id` — a switch happened mid-session, and this socket
+/// (built for the old profile) must not drive the new profile's sync or
+/// advance its cursor. The caller ends the session so the loop reconnects
+/// for whatever profile is now active.
+async fn catch_up_and_notify(handle: &AppHandle, state: &AppState, profile_id: i64) -> bool {
+    // Bail before syncing if the profile switched under us. `sync_now`
+    // itself operates on the active profile, so gating on the captured id
+    // is what keeps profile A's socket from syncing / advancing profile B.
+    match state.require_profile_id().await {
+        Ok(active) if active == profile_id => {}
+        _ => return false,
+    }
     match sync::sync_now(state).await {
         Ok(report) => {
             // Only wake the UI when something actually changed. Emitting
@@ -223,6 +242,7 @@ async fn catch_up_and_notify(handle: &AppHandle, state: &AppState) {
         }
         Err(error) => tracing::debug!(%error, "catch-up after a socket notice failed"),
     }
+    true
 }
 
 /// Read the cursor out of a notice frame.

--- a/src-tauri/crates/app/src/remote/socket.rs
+++ b/src-tauri/crates/app/src/remote/socket.rs
@@ -138,8 +138,9 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
     let (_writer, mut reader) = stream.split();
 
     // Reconnecting is itself a reason to ask: anything that happened
-    // while we were away arrived through no frame at all.
-    if !catch_up_and_notify(handle, state, profile_id).await {
+    // while we were away arrived through no frame at all. A sync failure
+    // here propagates (backoff); a profile switch ends the session cleanly.
+    if !catch_up_and_notify(handle, state, profile_id).await? {
         return Ok(false);
     }
 
@@ -157,7 +158,7 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
         // the catch-up could be postponed indefinitely.
         if pending_since.is_some_and(|since| since.elapsed() >= MAX_COALESCE_DELAY) {
             pending_since = None;
-            if !catch_up_and_notify(handle, state, profile_id).await {
+            if !catch_up_and_notify(handle, state, profile_id).await? {
                 break;
             }
             continue;
@@ -195,7 +196,7 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
                 if pending_since.is_some() {
                     // The burst settled (or hit the cap): one catch-up.
                     pending_since = None;
-                    if !catch_up_and_notify(handle, state, profile_id).await {
+                    if !catch_up_and_notify(handle, state, profile_id).await? {
                         break;
                     }
                 } else {
@@ -209,47 +210,42 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
         }
     }
 
-    // Flush a notice that arrived just before the stream closed. The
-    // profile guard inside is a no-op sync if it switched.
+    // Flush a notice that arrived just before the stream closed. A profile
+    // switch here is a no-op; a sync failure propagates so the supervisor
+    // backs off.
     if pending_since.is_some() {
-        catch_up_and_notify(handle, state, profile_id).await;
+        catch_up_and_notify(handle, state, profile_id).await?;
     }
 
     Ok(delivered)
 }
 
-/// Drain, then pull. Returns `false` when the active profile no longer
-/// matches `profile_id` — a switch happened mid-session, and this socket
-/// (built for the old profile) must not drive the new profile's sync or
-/// advance its cursor. The caller ends the session so the loop reconnects
-/// for whatever profile is now active.
-async fn catch_up_and_notify(handle: &AppHandle, state: &AppState, profile_id: i64) -> bool {
-    // Bail before syncing if the profile switched under us. `sync_now`
-    // itself operates on the active profile, so gating on the captured id
-    // is what keeps profile A's socket from syncing / advancing profile B.
+/// Drain, then pull. The result separates the two reasons a session ends:
+///
+/// - `Ok(true)`: synchronized (or nothing to do); the session is healthy.
+/// - `Ok(false)`: the active profile switched under us — end the session
+///   benignly so the loop reconnects for the new profile, with no backoff.
+/// - `Err`: the sync itself failed — propagated so the supervisor backs
+///   off before reconnecting instead of hammering a failing server.
+///
+/// Gating on the captured `profile_id` is what keeps profile A's socket
+/// from syncing / advancing profile B after a switch.
+async fn catch_up_and_notify(
+    handle: &AppHandle,
+    state: &AppState,
+    profile_id: i64,
+) -> AppResult<bool> {
     match state.require_profile_id().await {
         Ok(active) if active == profile_id => {}
-        _ => return false,
+        _ => return Ok(false),
     }
-    match sync::sync_now(state).await {
-        Ok(report) => {
-            // Only wake the UI when something actually changed. Emitting
-            // on every empty page would re-render the library on a timer
-            // for no reason.
-            if report.applied > 0 || report.resnapshotted {
-                let _ = handle.emit(SYNCED_EVENT, report.cursor);
-            }
-            true
-        }
-        Err(error) => {
-            // The catch-up is the whole point of the socket, so a failing
-            // one means holding the connection open buys nothing. End the
-            // session and let the loop reconnect (with backoff) and retry
-            // from a fresh connection.
-            tracing::debug!(%error, "catch-up after a socket notice failed; ending session");
-            false
-        }
+    let report = sync::sync_now(state).await?;
+    // Only wake the UI when something actually changed. Emitting on every
+    // empty page would re-render the library on a timer for no reason.
+    if report.applied > 0 || report.resnapshotted {
+        let _ = handle.emit(SYNCED_EVENT, report.cursor);
     }
+    Ok(true)
 }
 
 /// Read the cursor out of a notice frame.

--- a/src-tauri/crates/app/src/remote/socket.rs
+++ b/src-tauri/crates/app/src/remote/socket.rs
@@ -25,7 +25,7 @@
 //! escalating, because escalating would delay the reconnect that follows
 //! the user signing back in.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::StreamExt;
 use tauri::{AppHandle, Emitter, Manager};
@@ -61,6 +61,12 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 /// of edits on another device collapses into a single `/sync/changes`
 /// round-trip instead of one per frame.
 const COALESCE_WINDOW: Duration = Duration::from_millis(250);
+
+/// Hard cap on how long coalescing may defer a catch-up. A steady stream
+/// of notices less than [`COALESCE_WINDOW`] apart would otherwise reset the
+/// window forever and starve the fetch; once the first pending notice is
+/// this old, catch up regardless.
+const MAX_COALESCE_DELAY: Duration = Duration::from_secs(2);
 
 /// Start the subscriber. Returns immediately; the loop runs for the
 /// lifetime of the app.
@@ -122,7 +128,7 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
         );
     }
 
-    let request = build_request(&url, client.access_token())?;
+    let request = build_request(&url, &client.access_token())?;
     let (stream, _response) = tokio_tungstenite::connect_async(request)
         .await
         .map_err(|err| AppError::Other(format!("sync socket upgrade failed: {err}")))?;
@@ -133,15 +139,18 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
     catch_up_and_notify(handle, state).await;
 
     let mut delivered = false;
-    // A notice seen but not yet caught up on. While one is pending we wait
-    // only the short coalesce window for more frames, so a burst fires a
-    // single catch-up; otherwise we wait the full idle timeout.
-    let mut pending_notice = false;
+    // When the first still-un-caught-up notice arrived. While one is
+    // pending we wait only the short coalesce window for more frames — but
+    // never past `MAX_COALESCE_DELAY` from that first notice, so a steady
+    // stream can't starve the fetch. Otherwise we wait the full idle
+    // timeout.
+    let mut pending_since: Option<Instant> = None;
     loop {
-        let wait = if pending_notice {
-            COALESCE_WINDOW
-        } else {
-            IDLE_TIMEOUT
+        let wait = match pending_since {
+            Some(since) => {
+                COALESCE_WINDOW.min(MAX_COALESCE_DELAY.saturating_sub(since.elapsed()))
+            }
+            None => IDLE_TIMEOUT,
         };
         match tokio::time::timeout(wait, reader.next()).await {
             Ok(Some(Ok(Message::Text(text)))) => {
@@ -150,10 +159,11 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
                 // cheap when there is nothing new: one request answering
                 // an empty page. Trusting the hint enough to skip the
                 // fetch would make a stale or reordered frame lose an
-                // event. Don't catch up yet — coalesce the burst first.
+                // event. Don't catch up yet — coalesce the burst first,
+                // anchoring the cap on the first notice.
                 let _ = notice_cursor(&text);
                 delivered = true;
-                pending_notice = true;
+                pending_since.get_or_insert_with(Instant::now);
             }
             Ok(Some(Ok(Message::Close(_)))) => break,
             // Ping and Pong are handled by the library; anything else is
@@ -166,9 +176,9 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
             // Stream closed cleanly.
             Ok(None) => break,
             Err(_elapsed) => {
-                if pending_notice {
-                    // The burst settled: one catch-up for all of it.
-                    pending_notice = false;
+                if pending_since.is_some() {
+                    // The burst settled (or hit the cap): one catch-up.
+                    pending_since = None;
                     catch_up_and_notify(handle, state).await;
                 } else {
                     // Genuine inactivity — the link is likely half-open.
@@ -182,7 +192,7 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
     }
 
     // Flush a notice that arrived just before the stream closed.
-    if pending_notice {
+    if pending_since.is_some() {
         catch_up_and_notify(handle, state).await;
     }
 

--- a/src-tauri/crates/app/src/remote/socket.rs
+++ b/src-tauri/crates/app/src/remote/socket.rs
@@ -101,13 +101,16 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
     if offline::is_offline() {
         return Ok(false);
     }
-    let Some(client) = RemoteClient::try_build(state).await? else {
+    // Pin the client and the cursor read to the same profile: capture the
+    // id once so a switch landing mid-connect can't build the client from
+    // one profile and read another's cursor.
+    let profile_id = state.require_profile_id().await?;
+    let Some(client) = RemoteClient::try_build_for(state, profile_id).await? else {
         // Unbound, signed out, or a server with no journal.
         return Ok(false);
     };
 
     let cursor = {
-        let profile_id = state.require_profile_id().await?;
         let pool = state.require_profile_pool_for(Some(profile_id)).await?;
         let mut conn = pool.acquire().await?;
         binding::read(&mut conn)
@@ -146,6 +149,15 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
     // timeout.
     let mut pending_since: Option<Instant> = None;
     loop {
+        // Fire the coalesced catch-up the moment the cap is reached, before
+        // awaiting again. Relying on a zero-duration timeout instead would
+        // lose the race to an already-ready frame under a steady stream, so
+        // the catch-up could be postponed indefinitely.
+        if pending_since.is_some_and(|since| since.elapsed() >= MAX_COALESCE_DELAY) {
+            pending_since = None;
+            catch_up_and_notify(handle, state).await;
+            continue;
+        }
         let wait = match pending_since {
             Some(since) => {
                 COALESCE_WINDOW.min(MAX_COALESCE_DELAY.saturating_sub(since.elapsed()))

--- a/src-tauri/crates/app/src/remote/socket.rs
+++ b/src-tauri/crates/app/src/remote/socket.rs
@@ -49,6 +49,19 @@ const BASE_BACKOFF: Duration = Duration::from_secs(5);
 /// it returns.
 const MAX_BACKOFF: Duration = Duration::from_secs(300);
 
+/// End the session and reconnect if not a single frame — notice or
+/// keep-alive — arrives within this window. A half-open TCP connection
+/// otherwise leaves `reader.next()` blocked forever; the reconnect (and
+/// its catch-up) is how a silently-dead socket recovers. Longer than any
+/// reasonable server keep-alive interval so a merely quiet-but-live
+/// connection is not torn down needlessly.
+const IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// After a notice, wait this long for more before catching up, so a burst
+/// of edits on another device collapses into a single `/sync/changes`
+/// round-trip instead of one per frame.
+const COALESCE_WINDOW: Duration = Duration::from_millis(250);
+
 /// Start the subscriber. Returns immediately; the loop runs for the
 /// lifetime of the app.
 pub fn spawn(handle: AppHandle) {
@@ -120,28 +133,57 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
     catch_up_and_notify(handle, state).await;
 
     let mut delivered = false;
-    while let Some(message) = reader.next().await {
-        match message {
-            Ok(Message::Text(text)) => {
+    // A notice seen but not yet caught up on. While one is pending we wait
+    // only the short coalesce window for more frames, so a burst fires a
+    // single catch-up; otherwise we wait the full idle timeout.
+    let mut pending_notice = false;
+    loop {
+        let wait = if pending_notice {
+            COALESCE_WINDOW
+        } else {
+            IDLE_TIMEOUT
+        };
+        match tokio::time::timeout(wait, reader.next()).await {
+            Ok(Some(Ok(Message::Text(text)))) => {
                 // The cursor in the frame is deliberately not compared
                 // against ours. It is a hint, and `/sync/changes` is
                 // cheap when there is nothing new: one request answering
                 // an empty page. Trusting the hint enough to skip the
                 // fetch would make a stale or reordered frame lose an
-                // event.
+                // event. Don't catch up yet — coalesce the burst first.
                 let _ = notice_cursor(&text);
                 delivered = true;
-                catch_up_and_notify(handle, state).await;
+                pending_notice = true;
             }
-            Ok(Message::Close(_)) => break,
+            Ok(Some(Ok(Message::Close(_)))) => break,
             // Ping and Pong are handled by the library; anything else is
             // not part of this protocol and is ignored rather than
             // treated as an error.
-            Ok(_) => {}
-            Err(error) => {
+            Ok(Some(Ok(_))) => {}
+            Ok(Some(Err(error))) => {
                 return Err(AppError::Other(format!("sync socket read failed: {error}")));
             }
+            // Stream closed cleanly.
+            Ok(None) => break,
+            Err(_elapsed) => {
+                if pending_notice {
+                    // The burst settled: one catch-up for all of it.
+                    pending_notice = false;
+                    catch_up_and_notify(handle, state).await;
+                } else {
+                    // Genuine inactivity — the link is likely half-open.
+                    // End the session so the loop reconnects and catches
+                    // up on the way back in.
+                    tracing::debug!("sync socket idle for {IDLE_TIMEOUT:?}; reconnecting");
+                    break;
+                }
+            }
         }
+    }
+
+    // Flush a notice that arrived just before the stream closed.
+    if pending_notice {
+        catch_up_and_notify(handle, state).await;
     }
 
     Ok(delivered)

--- a/src-tauri/crates/app/src/remote/socket.rs
+++ b/src-tauri/crates/app/src/remote/socket.rs
@@ -239,10 +239,17 @@ async fn catch_up_and_notify(handle: &AppHandle, state: &AppState, profile_id: i
             if report.applied > 0 || report.resnapshotted {
                 let _ = handle.emit(SYNCED_EVENT, report.cursor);
             }
+            true
         }
-        Err(error) => tracing::debug!(%error, "catch-up after a socket notice failed"),
+        Err(error) => {
+            // The catch-up is the whole point of the socket, so a failing
+            // one means holding the connection open buys nothing. End the
+            // session and let the loop reconnect (with backoff) and retry
+            // from a fresh connection.
+            tracing::debug!(%error, "catch-up after a socket notice failed; ending session");
+            false
+        }
     }
-    true
 }
 
 /// Read the cursor out of a notice frame.

--- a/src-tauri/crates/app/src/remote/stream.rs
+++ b/src-tauri/crates/app/src/remote/stream.rs
@@ -30,7 +30,7 @@ struct StreamTicketResponse {
     url: String,
 }
 
-async fn client(state: &AppState) -> AppResult<RemoteClient> {
+async fn client(state: &AppState) -> AppResult<RemoteClient<'_>> {
     RemoteClient::try_build(state)
         .await?
         .ok_or_else(|| AppError::Other("not signed in to a remote server".into()))

--- a/src-tauri/crates/app/src/remote/sync.rs
+++ b/src-tauri/crates/app/src/remote/sync.rs
@@ -126,7 +126,7 @@ async fn read_binding(state: &AppState, profile_id: i64) -> AppResult<RemoteBind
 pub async fn bootstrap(
     state: &AppState,
     profile_id: i64,
-    client: &RemoteClient,
+    client: &RemoteClient<'_>,
 ) -> AppResult<i64> {
     let snapshot: SyncSnapshot = client
         .send_json(client.get("/api/v2/sync/snapshot"))
@@ -153,7 +153,7 @@ pub async fn bootstrap(
 pub async fn catch_up(
     state: &AppState,
     profile_id: i64,
-    client: &RemoteClient,
+    client: &RemoteClient<'_>,
     after: i64,
 ) -> AppResult<SyncReport> {
     let mut report = SyncReport {
@@ -210,6 +210,25 @@ pub async fn catch_up(
         report.pages += 1;
         let has_more = page.has_more;
         let next_cursor = page.next_cursor;
+
+        // A page whose cursor does not move forward cannot make progress:
+        // with `has_more` set it would spin to MAX_PAGES, and a cursor that
+        // went backwards is a server fault we must not persist. Stop the
+        // pass and leave the cursor where it is — the next sync retries
+        // from here. The common case (nothing new: an empty tail page with
+        // `next_cursor == after`) lands here too and simply ends the walk.
+        if next_cursor <= report.cursor {
+            if !page.changes.is_empty() || has_more {
+                tracing::warn!(
+                    cursor = report.cursor,
+                    next_cursor,
+                    has_more,
+                    changes = page.changes.len(),
+                    "a journal page did not advance the cursor; stopping the pass"
+                );
+            }
+            break;
+        }
 
         let pool = state.require_profile_pool_for(Some(profile_id)).await?;
         let mut tx = pool.begin().await?;
@@ -268,7 +287,7 @@ pub async fn catch_up(
 ///
 /// Deliberately infallible from the caller's point of view: a failed ACK
 /// is an observability gap, never a reason to stop synchronizing.
-async fn acknowledge(state: &AppState, profile_id: i64, client: &RemoteClient, cursor: i64) {
+async fn acknowledge(state: &AppState, profile_id: i64, client: &RemoteClient<'_>, cursor: i64) {
     let Ok(binding) = read_binding(state, profile_id).await else {
         return;
     };
@@ -317,7 +336,7 @@ async fn acknowledge(state: &AppState, profile_id: i64, client: &RemoteClient, c
 /// Best-effort by design. The projection is already correct without it —
 /// ordering and identity are stored — and a failure here costs a
 /// placeholder row, not a wrong one.
-async fn backfill_missing_tracks(state: &AppState, profile_id: i64, client: &RemoteClient) {
+async fn backfill_missing_tracks(state: &AppState, profile_id: i64, client: &RemoteClient<'_>) {
     let missing = {
         let Ok(pool) = state.require_profile_pool_for(Some(profile_id)).await else {
             return;
@@ -383,8 +402,11 @@ async fn backfill_missing_tracks(state: &AppState, profile_id: i64, client: &Rem
     let Ok(mut tx) = pool.begin().await else { return };
     for song in &fetched {
         if let Err(error) = projection::cache_song(&mut tx, song).await {
-            tracing::debug!(%error, "could not cache track metadata");
-            return;
+            // Skip the one song we could not cache rather than abandoning
+            // the whole batch before commit — the others are valid, and
+            // this one stays a placeholder until the next pass, which is
+            // the honest rendering.
+            tracing::debug!(%error, track = %song.id, "could not cache track metadata; skipping");
         }
     }
     let _ = tx.commit().await;

--- a/src-tauri/crates/app/src/remote/write.rs
+++ b/src-tauri/crates/app/src/remote/write.rs
@@ -54,8 +54,7 @@ pub async fn set_favorite(
     entity_id: &str,
     starred: bool,
 ) -> AppResult<()> {
-    let (pool, profile_id) = lease(state).await?;
-    let _ = profile_id;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     set_favorite_in_tx(&mut tx, entity_type, entity_id, starred).await?;
     tx.commit().await?;
@@ -106,7 +105,7 @@ pub async fn set_rating(
     entity_id: &str,
     rating: u8,
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     set_rating_in_tx(&mut tx, entity_type, entity_id, rating).await?;
     tx.commit().await?;
@@ -172,7 +171,7 @@ pub async fn create_playlist(
     name: &str,
     track_ids: &[String],
 ) -> AppResult<String> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     let id = create_playlist_in_tx(&mut tx, name, track_ids).await?;
     tx.commit().await?;
@@ -235,7 +234,7 @@ pub async fn update_playlist(
     public: Option<bool>,
     clear_comment: bool,
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     update_playlist_in_tx(&mut tx, playlist_id, name, comment, public, clear_comment).await?;
     tx.commit().await?;
@@ -311,7 +310,7 @@ pub async fn remove_playlist_tracks(
     playlist_id: &str,
     indexes: &[usize],
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     remove_playlist_tracks_in_tx(&mut tx, playlist_id, indexes).await?;
     tx.commit().await?;
@@ -394,7 +393,7 @@ pub async fn add_playlist_tracks(
     playlist_id: &str,
     track_ids: &[String],
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     add_playlist_tracks_in_tx(&mut tx, playlist_id, track_ids).await?;
     tx.commit().await?;
@@ -461,7 +460,7 @@ pub async fn reorder_playlist(
     from: usize,
     to: usize,
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     reorder_playlist_in_tx(&mut tx, playlist_id, from, to).await?;
     tx.commit().await?;
@@ -539,7 +538,7 @@ pub async fn reorder_playlist_in_tx(
 
 /// Delete a playlist.
 pub async fn delete_playlist(state: &AppState, playlist_id: &str) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     delete_playlist_in_tx(&mut tx, playlist_id).await?;
     tx.commit().await?;
@@ -602,7 +601,7 @@ pub async fn scrobble(
     submission: bool,
     played_at: Option<i64>,
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     scrobble_in_tx(&mut tx, track_id, submission, played_at).await?;
     tx.commit().await?;
@@ -652,7 +651,7 @@ pub async fn save_queue(
     position_ms: i64,
     client: Option<String>,
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     save_queue_in_tx(&mut tx, track_ids, current, position_ms, client).await?;
     tx.commit().await?;
@@ -719,7 +718,7 @@ pub async fn create_share(
     description: Option<String>,
     expires_at: Option<i64>,
 ) -> AppResult<String> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     let id = create_share_in_tx(&mut tx, track_ids, description, expires_at).await?;
     tx.commit().await?;
@@ -783,7 +782,7 @@ pub async fn update_share(
     clear_description: bool,
     clear_expires_at: bool,
 ) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     update_share_in_tx(
         &mut tx,
@@ -856,7 +855,7 @@ pub async fn update_share_in_tx(
 /// Withdraw a share. Same placeholder handling as a playlist: one that
 /// never reached the server takes its queued creation with it.
 pub async fn delete_share(state: &AppState, share_id: &str) -> AppResult<()> {
-    let (pool, _) = lease(state).await?;
+    let pool = lease(state).await?;
     let mut tx = pool.begin().await?;
     delete_share_in_tx(&mut tx, share_id).await?;
     tx.commit().await?;
@@ -894,10 +893,10 @@ pub async fn delete_share_in_tx(
 /// The active profile's pool, pinned to the profile it was resolved
 /// from, so a switch landing mid-write fails the call instead of
 /// applying one profile's gesture to another's data.
-async fn lease(state: &AppState) -> AppResult<(crate::state::ProfilePool, i64)> {
+async fn lease(state: &AppState) -> AppResult<crate::state::ProfilePool> {
     let profile_id = state.require_profile_id().await?;
     let pool = state.require_profile_pool_for(Some(profile_id)).await?;
-    Ok((pool, profile_id))
+    Ok(pool)
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/app/src/remote_playback.rs
+++ b/src-tauri/crates/app/src/remote_playback.rs
@@ -71,6 +71,15 @@ pub struct RemoteQueue {
     pub index: usize,
 }
 
+/// A one-lock snapshot of what the decoder stamps on a remote track's
+/// `player:radio-metadata` emit. See [`RemotePlayback::current_stream_meta`].
+#[derive(Debug, Clone, Default)]
+pub struct RemoteStreamMeta {
+    pub is_remote: bool,
+    pub duration_ms: Option<i64>,
+    pub artwork_hash: Option<String>,
+}
+
 /// Process-wide handle on the active remote play queue, if any. Held on
 /// [`crate::state::AppState`]. A `std::sync::Mutex` (not tokio) so the
 /// synchronous control seams — `emit_track_changed`, the player commands
@@ -108,25 +117,20 @@ impl RemotePlayback {
         guard.as_ref().and_then(|q| q.entries.get(q.index).cloned())
     }
 
-    /// Duration of the entry under the cursor, if known. Lets the decoder
-    /// stamp a bounded timeline on the radio-metadata event for a remote
-    /// track (radio has none). `None` when no session is active.
-    pub fn current_duration_ms(&self) -> Option<i64> {
+    /// The three facts the decoder stamps on a remote track's
+    /// `player:radio-metadata` emit — whether a session is active, and the
+    /// cursor entry's duration and artwork hash — read under a single lock.
+    /// Three separate calls could straddle a `clear()` and emit
+    /// `is_remote = true` with a `None` duration/artwork (or the reverse),
+    /// so they must come from one guard.
+    pub fn current_stream_meta(&self) -> RemoteStreamMeta {
         let guard = self.inner.lock().expect("remote_playback poisoned");
-        guard
-            .as_ref()
-            .and_then(|q| q.entries.get(q.index))
-            .and_then(|e| e.duration_ms)
-    }
-
-    /// Artwork hash of the entry under the cursor, if any. The frontend
-    /// fetches it (Bearer-only) as a data URL to paint the PlayerBar cover.
-    pub fn current_artwork_hash(&self) -> Option<String> {
-        let guard = self.inner.lock().expect("remote_playback poisoned");
-        guard
-            .as_ref()
-            .and_then(|q| q.entries.get(q.index))
-            .and_then(|e| e.artwork_hash.clone())
+        let entry = guard.as_ref().and_then(|q| q.entries.get(q.index));
+        RemoteStreamMeta {
+            is_remote: guard.is_some(),
+            duration_ms: entry.and_then(|e| e.duration_ms),
+            artwork_hash: entry.and_then(|e| e.artwork_hash.clone()),
+        }
     }
 
     /// A snapshot of the whole queue and its cursor, for the queue panel.

--- a/src-tauri/crates/app/src/state.rs
+++ b/src-tauri/crates/app/src/state.rs
@@ -523,14 +523,18 @@ impl AppState {
             let mut guard = self.profile.write().await;
             let previous = guard.take();
             *guard = Some(ActiveProfile::new(profile_id, pool));
+            // Drop any remote play session *under the same lock* as the
+            // swap, so no concurrent `profile.read()` can observe the new
+            // profile alongside the previous one's playback state (queue,
+            // cursor) (RFC-005). The fallible setup above runs before the
+            // lock, so a failed `ensure_profile_dirs` / `open` still leaves
+            // the current session intact. The clear only takes the
+            // `remote_playback` mutex briefly and never re-enters the
+            // profile lock, so the profile→remote_playback order is
+            // consistent and deadlock-free.
+            self.remote_playback.clear();
             previous
         };
-        // Only now that the swap has actually happened: drop any remote play
-        // session so the incoming profile can't observe playback state (queue,
-        // cursor) belonging to the previous one (RFC-005). Done after the
-        // fallible setup above so a failed `ensure_profile_dirs` / `open`
-        // leaves the current session intact.
-        self.remote_playback.clear();
         if let Some(previous) = previous {
             previous.close_when_idle().await;
         }
@@ -541,12 +545,16 @@ impl AppState {
     /// Close the active profile pool, if any, leaving no profile active.
     /// Waits for outstanding leases first, same as [`Self::activate_profile`].
     pub async fn deactivate_profile(&self) {
-        // Same reason as activate_profile: no remote session may outlive the
-        // profile whose tracks it points at (RFC-005).
-        self.remote_playback.clear();
         let previous = {
             let mut guard = self.profile.write().await;
-            guard.take()
+            let previous = guard.take();
+            // Same reason as activate_profile: no remote session may outlive
+            // the profile whose tracks it points at (RFC-005). Cleared under
+            // the profile write lock so the session and the profile go away
+            // together; the clear only touches the `remote_playback` mutex,
+            // never the profile lock, so the ordering stays deadlock-free.
+            self.remote_playback.clear();
+            previous
         };
         if let Some(previous) = previous {
             previous.close_when_idle().await;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ProfileProvider } from "./contexts/ProfileContext";
 import { LibraryProvider } from "./contexts/LibraryContext";
 import { PlaylistProvider } from "./contexts/PlaylistContext";
 import { SpotifyProvider } from "./contexts/SpotifyContext";
+import { RemoteSourceProvider } from "./contexts/RemoteSourceContext";
 import { AppLayout } from "./components/layout/AppLayout";
 
 export default function App() {
@@ -29,7 +30,12 @@ export default function App() {
             <PlaylistProvider>
               <SpotifyProvider>
                 <PlayerProvider>
-                  <AppLayout />
+                  {/* One owner of the remote-source state so a single
+                      `waveflow:remote-changed` event fans out one refresh
+                      to every consumer (sidebar, create-playlist modal). */}
+                  <RemoteSourceProvider>
+                    <AppLayout />
+                  </RemoteSourceProvider>
                 </PlayerProvider>
               </SpotifyProvider>
             </PlaylistProvider>

--- a/src/components/common/RemoteArtwork.tsx
+++ b/src/components/common/RemoteArtwork.tsx
@@ -10,17 +10,40 @@ import { remoteArtwork } from "../../lib/tauri/remoteServer";
  * URL, and two components mounting the same hash at once share one fetch
  * instead of racing two.
  */
+/** Cap the resolved-artwork cache so a long session browsing many remote
+ *  tracks can't grow it without bound. */
+const ARTWORK_CACHE_CAPACITY = 256;
 const artworkCache = new Map<string, string>();
 const inFlight = new Map<string, Promise<string | null>>();
 
+/** LRU read: `Map` preserves insertion order, so re-inserting on a hit
+ *  marks the entry most-recently-used. */
+function cacheGet(hash: string): string | undefined {
+  const url = artworkCache.get(hash);
+  if (url !== undefined) {
+    artworkCache.delete(hash);
+    artworkCache.set(hash, url);
+  }
+  return url;
+}
+
+function cacheSet(hash: string, url: string) {
+  artworkCache.set(hash, url);
+  if (artworkCache.size > ARTWORK_CACHE_CAPACITY) {
+    // Evict the least-recently-used entry (the oldest insertion).
+    const oldest = artworkCache.keys().next().value;
+    if (oldest !== undefined) artworkCache.delete(oldest);
+  }
+}
+
 function loadArtwork(hash: string): Promise<string | null> {
-  const cached = artworkCache.get(hash);
-  if (cached) return Promise.resolve(cached);
+  const cached = cacheGet(hash);
+  if (cached !== undefined) return Promise.resolve(cached);
   const pending = inFlight.get(hash);
   if (pending) return pending;
   const promise = remoteArtwork(hash)
     .then((url) => {
-      artworkCache.set(hash, url);
+      cacheSet(hash, url);
       inFlight.delete(hash);
       return url;
     })
@@ -61,11 +84,14 @@ export function RemoteArtwork({
       setSrc(null);
       return;
     }
-    const cached = artworkCache.get(hash);
-    if (cached) {
+    const cached = cacheGet(hash);
+    if (cached !== undefined) {
       setSrc(cached);
       return;
     }
+    // Uncached new hash: clear the previous cover up front so a changed
+    // hash can't keep showing the old artwork while the new one loads.
+    setSrc(null);
     let cancelled = false;
     void loadArtwork(hash).then((url) => {
       if (!cancelled) setSrc(url);

--- a/src/components/common/RemoteArtwork.tsx
+++ b/src/components/common/RemoteArtwork.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { ListMusic } from "lucide-react";
 import { remoteArtwork } from "../../lib/tauri/remoteServer";
 
@@ -78,7 +78,10 @@ export function RemoteArtwork({
   const [src, setSrc] = useState<string | null>(() =>
     hash ? (artworkCache.get(hash) ?? null) : null,
   );
-  useEffect(() => {
+  // Layout effect so a cached hash (or the reset below) updates `src`
+  // synchronously before paint, avoiding a one-frame flash of the previous
+  // cover when the hash changes.
+  useLayoutEffect(() => {
     if (!hash) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSrc(null);

--- a/src/components/common/RemoteArtwork.tsx
+++ b/src/components/common/RemoteArtwork.tsx
@@ -3,10 +3,41 @@ import { ListMusic } from "lucide-react";
 import { remoteArtwork } from "../../lib/tauri/remoteServer";
 
 /**
+ * Process-wide cache of resolved `data:` URLs, keyed by artwork hash, plus
+ * a registry of in-flight fetches. The artwork is content-addressed and
+ * immutable, so a hash resolves to the same bytes forever — every remount
+ * (scrolling a virtualized list, reopening a view) then reuses the cached
+ * URL, and two components mounting the same hash at once share one fetch
+ * instead of racing two.
+ */
+const artworkCache = new Map<string, string>();
+const inFlight = new Map<string, Promise<string | null>>();
+
+function loadArtwork(hash: string): Promise<string | null> {
+  const cached = artworkCache.get(hash);
+  if (cached) return Promise.resolve(cached);
+  const pending = inFlight.get(hash);
+  if (pending) return pending;
+  const promise = remoteArtwork(hash)
+    .then((url) => {
+      artworkCache.set(hash, url);
+      inFlight.delete(hash);
+      return url;
+    })
+    .catch(() => {
+      inFlight.delete(hash);
+      return null;
+    });
+  inFlight.set(hash, promise);
+  return promise;
+}
+
+/**
  * A remote track's cover, fetched by hash as a `data:` URL. The artwork
  * endpoint is Bearer-only, so a bare `<img src>` pointed at it would 401 —
- * we fetch it once and cache the result in state. Falls back to a neutral
- * tile while it resolves or when there is no hash.
+ * we fetch it once, cache the result process-wide (see {@link loadArtwork})
+ * and reuse it across remounts. Falls back to a neutral tile while it
+ * resolves or when there is no hash.
  *
  * Shared by the remote playlist view and the remote queue panel (RFC-005).
  */
@@ -19,21 +50,26 @@ export function RemoteArtwork({
   className?: string;
   iconSize?: number;
 }) {
-  const [src, setSrc] = useState<string | null>(null);
+  // Seed synchronously from the cache so a remount of an already-resolved
+  // hash paints the cover on the first frame instead of flashing the tile.
+  const [src, setSrc] = useState<string | null>(() =>
+    hash ? (artworkCache.get(hash) ?? null) : null,
+  );
   useEffect(() => {
     if (!hash) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSrc(null);
       return;
     }
+    const cached = artworkCache.get(hash);
+    if (cached) {
+      setSrc(cached);
+      return;
+    }
     let cancelled = false;
-    remoteArtwork(hash)
-      .then((url) => {
-        if (!cancelled) setSrc(url);
-      })
-      .catch(() => {
-        if (!cancelled) setSrc(null);
-      });
+    void loadArtwork(hash).then((url) => {
+      if (!cancelled) setSrc(url);
+    });
     return () => {
       cancelled = true;
     };

--- a/src/components/layout/RemoteQueueView.tsx
+++ b/src/components/layout/RemoteQueueView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { usePlayer } from "../../hooks/usePlayer";
 import {
   remoteGetPlayQueue,
@@ -7,6 +8,10 @@ import {
 } from "../../lib/tauri/remoteServer";
 import { formatDuration } from "../../lib/tauri/track";
 import { RemoteArtwork } from "../common/RemoteArtwork";
+
+/** Row height (px) the Up Next virtualizer estimates with — the button's
+ *  `p-2` (16px) around a `h-10` (40px) cover. */
+const REMOTE_QUEUE_ROW_HEIGHT = 56;
 
 /**
  * Queue panel body for a remote play session (RFC-005). The remote queue
@@ -50,6 +55,22 @@ export function RemoteQueueView() {
     );
   }, []);
 
+  // Virtualize the Up Next list against its own scroll container (the
+  // QueuePanel scrolls independently of the page). Hook runs
+  // unconditionally, before the early return, with a count derived from the
+  // queue so a remote session of any length renders ~a screenful of rows.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const upNextCount = queue
+    ? Math.max(0, queue.entries.length - queue.index - 1)
+    : 0;
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const rowVirtualizer = useVirtualizer({
+    count: upNextCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => REMOTE_QUEUE_ROW_HEIGHT,
+    overscan: 6,
+  });
+
   if (!queue || queue.entries.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center text-sm text-zinc-500">
@@ -59,7 +80,7 @@ export function RemoteQueueView() {
   }
 
   const nowPlaying = queue.entries[queue.index] ?? null;
-  const upNext = queue.entries.slice(queue.index + 1);
+  const upNextStart = queue.index + 1;
 
   return (
     <div className="flex-1 flex flex-col min-h-0 -mx-2 px-2 space-y-5">
@@ -71,22 +92,37 @@ export function RemoteQueueView() {
           <RemoteQueueRow entry={nowPlaying} isCurrent />
         </section>
       )}
-      {upNext.length > 0 && (
+      {upNextCount > 0 && (
         <section className="flex-1 flex flex-col min-h-0">
           <div className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase mb-2 px-1">
-            Up next · {upNext.length}
+            Up next · {upNextCount}
           </div>
-          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-hide space-y-0.5">
-            {upNext.map((entry, i) => {
-              const absoluteIndex = queue.index + 1 + i;
-              return (
-                <RemoteQueueRow
-                  key={`${entry.id}-${absoluteIndex}`}
-                  entry={entry}
-                  onJump={() => handleJump(absoluteIndex)}
-                />
-              );
-            })}
+          <div
+            ref={scrollRef}
+            className="flex-1 min-h-0 overflow-y-auto scrollbar-hide"
+          >
+            <div
+              style={{
+                height: `${rowVirtualizer.getTotalSize()}px`,
+                position: "relative",
+                width: "100%",
+              }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const absoluteIndex = upNextStart + virtualRow.index;
+                const entry = queue.entries[absoluteIndex];
+                if (!entry) return null;
+                return (
+                  <RemoteQueueRow
+                    key={`${entry.id}-${absoluteIndex}`}
+                    entry={entry}
+                    top={virtualRow.start}
+                    rowHeight={REMOTE_QUEUE_ROW_HEIGHT}
+                    onJump={() => handleJump(absoluteIndex)}
+                  />
+                );
+              })}
+            </div>
           </div>
         </section>
       )}
@@ -98,16 +134,33 @@ function RemoteQueueRow({
   entry,
   isCurrent = false,
   onJump,
+  top,
+  rowHeight,
 }: {
   entry: RemotePlayQueue["entries"][number];
   isCurrent?: boolean;
   onJump?: () => void;
+  /** Absolute offset within the virtualized Up Next list. Omitted for the
+   *  static Now Playing row. */
+  top?: number;
+  rowHeight?: number;
 }) {
+  const style: React.CSSProperties | undefined =
+    top != null && rowHeight != null
+      ? {
+          position: "absolute",
+          top: `${top}px`,
+          left: 0,
+          width: "100%",
+          height: `${rowHeight}px`,
+        }
+      : undefined;
   return (
     <button
       type="button"
       onClick={onJump}
       disabled={isCurrent}
+      style={style}
       className={`w-full flex items-center space-x-3 p-2 rounded-lg text-left transition-colors select-none ${
         isCurrent
           ? "bg-emerald-50 dark:bg-emerald-900/20 cursor-default"

--- a/src/components/views/RemotePlaylistView.tsx
+++ b/src/components/views/RemotePlaylistView.tsx
@@ -401,7 +401,19 @@ export function RemotePlaylistView({
     ro.observe(parent);
     ro.observe(scroller);
     return () => ro.disconnect();
-  }, [pageScrollRef, displayTracks.length]);
+    // Also recompute when content *above* the list changes height without
+    // resizing the list itself — the add-tracks panel opening, an error or
+    // the playlist comment appearing, the sort bar toggling — since that
+    // shifts the list's top within the scroller (which a ResizeObserver on
+    // the list alone wouldn't catch).
+  }, [
+    pageScrollRef,
+    displayTracks.length,
+    adding,
+    error,
+    sortMode,
+    summary?.comment,
+  ]);
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const rowVirtualizer = useVirtualizer({

--- a/src/components/views/RemotePlaylistView.tsx
+++ b/src/components/views/RemotePlaylistView.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 import {
   ArrowUpDown,
   Check,
@@ -18,11 +27,14 @@ import {
 } from "lucide-react";
 import {
   DndContext,
+  DragOverlay,
+  MeasuringStrategy,
   PointerSensor,
   closestCenter,
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
 import {
   arrayMove,
@@ -32,6 +44,8 @@ import {
 } from "@dnd-kit/sortable";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { usePageScroll } from "../../hooks/usePageScroll";
 import {
   remoteDeletePlaylist,
   remoteListPlaylists,
@@ -148,6 +162,10 @@ export function RemotePlaylistView({
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<RemoteTrack[]>([]);
   const [searching, setSearching] = useState(false);
+  // Index (as a string) of the row currently being dragged, for the
+  // DragOverlay copy — the in-place row can scroll out of the virtual
+  // window mid-drag, so the overlay is what the user actually follows.
+  const [activeId, setActiveId] = useState<string | null>(null);
 
   const seqRef = useRef(0);
   const load = useCallback(async () => {
@@ -173,7 +191,6 @@ export function RemotePlaylistView({
   useEffect(() => {
     // `load` flips `loading` on synchronously — the intended initial
     // state for a freshly-opened playlist, not a cascading-render smell.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void load();
   }, [load]);
 
@@ -196,7 +213,6 @@ export function RemotePlaylistView({
   const currentSentinelId = currentTrack?.id ?? null;
   useEffect(() => {
     if (!currentIsRemote) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPlayingRemoteId(null);
       return;
     }
@@ -349,8 +365,13 @@ export function RemotePlaylistView({
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
   );
+  const onDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(String(event.active.id));
+  }, []);
+  const onDragCancel = useCallback(() => setActiveId(null), []);
   const onDragEnd = useCallback(
     (event: DragEndEvent) => {
+      setActiveId(null);
       const { active, over } = event;
       if (!over || active.id === over.id) return;
       handleReorder(Number(active.id), Number(over.id));
@@ -358,13 +379,45 @@ export function RemotePlaylistView({
     [handleReorder],
   );
 
+  // Virtualize the track list against the page scroller (same contract as
+  // the local PlaylistView, and the repo's "virtual scroll everywhere"
+  // invariant) so a large remote playlist doesn't mount thousands of rows.
+  // SortableContext still holds the full index array, so dnd-kit knows the
+  // ordering even for rows outside the window.
+  const pageScrollRef = usePageScroll();
+  const listParentRef = useRef<HTMLDivElement>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+  useLayoutEffect(() => {
+    const parent = listParentRef.current;
+    const scroller = pageScrollRef?.current;
+    if (!parent || !scroller) return;
+    const recompute = () => {
+      const parentRect = parent.getBoundingClientRect();
+      const scrollerRect = scroller.getBoundingClientRect();
+      setScrollMargin(parentRect.top - scrollerRect.top + scroller.scrollTop);
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(parent);
+    ro.observe(scroller);
+    return () => ro.disconnect();
+  }, [pageScrollRef, displayTracks.length]);
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const rowVirtualizer = useVirtualizer({
+    count: displayTracks.length,
+    getScrollElement: () => pageScrollRef?.current ?? null,
+    estimateSize: () => REMOTE_ROW_HEIGHT,
+    overscan: 8,
+    scrollMargin,
+  });
+
   // Debounced catalogue search while the add panel is open.
   const searchSeqRef = useRef(0);
   useEffect(() => {
     if (!adding) return;
     const q = query.trim();
     if (!q) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setResults([]);
       setSearching(false);
       return;
@@ -508,9 +561,14 @@ export function RemotePlaylistView({
               <input
                 autoFocus
                 value={nameDraft}
+                aria-label="Playlist name"
                 onChange={(e) => setNameDraft(e.target.value)}
                 onBlur={() => void commitRename()}
                 onKeyDown={(e) => {
+                  // Ignore the Enter/Escape that closes an IME composition
+                  // (Japanese, Chinese, …) — committing or cancelling on it
+                  // would fire mid-word, before the character is chosen.
+                  if (e.nativeEvent.isComposing) return;
                   if (e.key === "Enter") void commitRename();
                   if (e.key === "Escape") setRenaming(false);
                 }}
@@ -699,34 +757,64 @@ export function RemotePlaylistView({
             sensors={sensors}
             collisionDetection={closestCenter}
             modifiers={[restrictToVerticalAxis]}
+            // Always-measure pairs with virtualization: rows entering the
+            // window during a drag-scroll get measured on the fly.
+            measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+            onDragStart={onDragStart}
             onDragEnd={onDragEnd}
+            onDragCancel={onDragCancel}
           >
             <SortableContext
               items={displayTracks.map((_, i) => String(i))}
               strategy={verticalListSortingStrategy}
             >
-              <ul>
-                {displayTracks.map((track, index) => (
-                  <RemoteTrackRow
-                    key={`${track.id}-${index}`}
-                    id={String(index)}
-                    track={track}
-                    index={index + 1}
-                    busy={busy}
-                    dragEnabled={isCustomOrder && !busy}
-                    isCurrent={
-                      playingRemoteId != null && track.id === playingRemoteId
-                    }
-                    isPlaying={isPlaying}
-                    onPlay={() => void playFrom(index)}
-                    onRemove={() => void removeTrack(index)}
-                    onNavigateToRemoteAlbum={onNavigateToRemoteAlbum}
-                    onNavigateToRemoteArtist={onNavigateToRemoteArtist}
-                    onToggleLike={() => toggleLike(track)}
-                  />
-                ))}
-              </ul>
+              <div
+                ref={listParentRef}
+                style={{
+                  height: `${rowVirtualizer.getTotalSize()}px`,
+                  position: "relative",
+                  width: "100%",
+                }}
+              >
+                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                  const index = virtualRow.index;
+                  const track = displayTracks[index];
+                  if (!track) return null;
+                  return (
+                    <RemoteTrackRow
+                      key={`${track.id}-${index}`}
+                      id={String(index)}
+                      track={track}
+                      index={index + 1}
+                      rowHeight={REMOTE_ROW_HEIGHT}
+                      top={virtualRow.start - scrollMargin}
+                      busy={busy}
+                      dragEnabled={isCustomOrder && !busy}
+                      isCurrent={
+                        playingRemoteId != null && track.id === playingRemoteId
+                      }
+                      isPlaying={isPlaying}
+                      onPlay={() => void playFrom(index)}
+                      onRemove={() => void removeTrack(index)}
+                      onNavigateToRemoteAlbum={onNavigateToRemoteAlbum}
+                      onNavigateToRemoteArtist={onNavigateToRemoteArtist}
+                      onToggleLike={() => toggleLike(track)}
+                    />
+                  );
+                })}
+              </div>
             </SortableContext>
+            {/* Portal the overlay to <body> so a future `transform`/
+                `backdrop-filter` ancestor can't become its containing block
+                and pin it off-screen (repo overlay invariant). */}
+            {createPortal(
+              <DragOverlay dropAnimation={null}>
+                {activeId != null && displayTracks[Number(activeId)] ? (
+                  <RemoteRowPreview track={displayTracks[Number(activeId)]} />
+                ) : null}
+              </DragOverlay>,
+              document.body,
+            )}
           </DndContext>
         </div>
       )}
@@ -741,10 +829,16 @@ export function RemotePlaylistView({
 const GRID_COLS =
   "grid-cols-[1.5rem_3rem_2.75rem_1fr_1fr_1fr_5rem_2rem_2rem]";
 
-function RemoteTrackRow({
+/** Row height (px) the virtualizer estimates with — matches the old
+ *  `h-14` (3.5rem = 56px), now set via inline style for absolute layout. */
+const REMOTE_ROW_HEIGHT = 56;
+
+const RemoteTrackRow = memo(function RemoteTrackRow({
   id,
   track,
   index,
+  rowHeight,
+  top,
   busy,
   dragEnabled,
   isCurrent,
@@ -758,6 +852,11 @@ function RemoteTrackRow({
   id: string;
   track: RemoteTrack;
   index: number;
+  /** Slot height, driven by the virtualizer's estimate. */
+  rowHeight: number;
+  /** Absolute offset of this row's slot within the virtualized container,
+   *  already corrected for the container's `scrollMargin`. */
+  top: number;
   busy: boolean;
   /** False while a display sort is active — the grip and ×-remove are
    *  hidden and dnd-kit is detached so neither can act on a position that
@@ -771,19 +870,34 @@ function RemoteTrackRow({
   onNavigateToRemoteArtist: (artistId: string) => void;
   onToggleLike: () => void;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id, disabled: !dragEnabled });
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useSortable({
+      id,
+      // Skip layout-shift animations: on a long virtualized list the
+      // per-neighbour transitions are what make a drag feel sluggish.
+      animateLayoutChanges: () => false,
+      disabled: !dragEnabled,
+    });
+  // Position via CSS `top`, not a translateY transform: dnd-kit resolves
+  // drop targets from `offsetTop`, which ignores transforms — anchoring
+  // every row at the container top would collapse all collisions to the
+  // first DOM row. useSortable's own transform (intra-drag displacement)
+  // stays the only `transform` so it composes with `top` cleanly.
   const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.6 : 1,
+    position: "absolute",
+    top: `${top}px`,
+    left: 0,
+    width: "100%",
+    height: `${rowHeight}px`,
+    transform: CSS.Transform.toString(transform) || undefined,
+    opacity: isDragging ? 0 : 1,
   };
   return (
-    <li
+    <div
       ref={setNodeRef}
       style={style}
       onDoubleClick={onPlay}
-      className={`group grid ${GRID_COLS} gap-4 items-center px-5 h-14 border-b border-zinc-100 dark:border-zinc-800/60 transition-colors ${
+      className={`group grid ${GRID_COLS} gap-4 items-center px-5 border-b border-zinc-100 dark:border-zinc-800/60 transition-colors ${
         isCurrent
           ? "bg-emerald-50 dark:bg-emerald-900/20"
           : "hover:bg-zinc-50 dark:hover:bg-zinc-800/60"
@@ -901,7 +1015,26 @@ function RemoteTrackRow({
       ) : (
         <span aria-hidden="true" />
       )}
-    </li>
+    </div>
+  );
+});
+
+/** A lightweight copy of a row for the drag overlay: cover + title +
+ *  artist, no controls. It follows the cursor while the in-place row (which
+ *  can scroll out of the virtual window) stays hidden. */
+function RemoteRowPreview({ track }: { track: RemoteTrack }) {
+  return (
+    <div className="flex items-center gap-3 px-5 h-14 rounded-lg bg-white dark:bg-zinc-800 shadow-lg ring-1 ring-black/5 dark:ring-white/10">
+      <RemoteArtwork hash={track.artwork_hash} className="w-10 h-10 rounded-md" />
+      <div className="min-w-0">
+        <div className="text-sm truncate text-zinc-800 dark:text-zinc-200">
+          {track.title ?? "Awaiting metadata…"}
+        </div>
+        {track.artist && (
+          <div className="text-xs text-zinc-500 truncate">{track.artist}</div>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/src/components/views/settings/RemoteServerCard.tsx
+++ b/src/components/views/settings/RemoteServerCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CloudOff, Loader2, RefreshCw, Server, Unplug } from "lucide-react";
 import {
   remoteBeginLogin,
@@ -48,34 +48,47 @@ export function RemoteServerCard() {
   const [probe, setProbe] = useState<RemoteProbeResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<
-    null | "probe" | "login" | "sync" | "forget"
+    null | "probe" | "login" | "signout" | "sync" | "forget"
   >(null);
+  const mountedRef = useRef(false);
 
   const refresh = useCallback(async () => {
-    const [next, counts] = await Promise.all([
-      remoteGetStatus(),
-      remoteGetOverview(),
-    ]);
+    // Status is availability-critical; the overview is only counts. Read
+    // them independently so a transient overview failure never blanks the
+    // card, and neither call clobbers state after unmount.
+    const next = await remoteGetStatus();
+    if (!mountedRef.current) return;
     setStatus(next);
-    setOverview(counts);
     if (next.server_url) setUrlDraft(next.server_url);
+    try {
+      const counts = await remoteGetOverview();
+      if (mountedRef.current) setOverview(counts);
+    } catch {
+      // Informational only — keep the last counts.
+    }
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
+    mountedRef.current = true;
     void (async () => {
       try {
+        // Availability hinges on this one call alone: if it rejects, the
+        // command is not registered (sync_v2 off) and the card hides.
         await remoteGetStatus();
-        if (cancelled) return;
+        if (!mountedRef.current) return;
         setAvailable(true);
-        await refresh();
+        try {
+          await refresh();
+        } catch {
+          // A transient status failure right after the probe must not flip
+          // availability back off — the command clearly exists.
+        }
       } catch {
-        // The command is not registered: this build has sync_v2 off.
-        if (!cancelled) setAvailable(false);
+        if (mountedRef.current) setAvailable(false);
       }
     })();
     return () => {
-      cancelled = true;
+      mountedRef.current = false;
     };
   }, [refresh]);
 
@@ -89,9 +102,9 @@ export function RemoteServerCard() {
         // The sidebar remote-source section reads the same binding.
         notifyRemoteChanged();
       } catch (err) {
-        setError(String(err));
+        if (mountedRef.current) setError(String(err));
       } finally {
-        setBusy(null);
+        if (mountedRef.current) setBusy(null);
       }
     },
     [refresh],
@@ -185,11 +198,15 @@ export function RemoteServerCard() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => void run("login", remoteSignOut)}
+                  onClick={() => void run("signout", remoteSignOut)}
                   disabled={busy !== null}
                   className="px-3 py-1.5 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 inline-flex items-center gap-1.5 disabled:opacity-50"
                 >
-                  <Unplug size={14} aria-hidden="true" />
+                  {busy === "signout" ? (
+                    <Spinner />
+                  ) : (
+                    <Unplug size={14} aria-hidden="true" />
+                  )}
                   Sign out
                 </button>
               </>

--- a/src/contexts/RemoteSourceContext.tsx
+++ b/src/contexts/RemoteSourceContext.tsx
@@ -1,0 +1,104 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { remoteGetStatus, remoteListPlaylists } from "../lib/tauri/remoteServer";
+import {
+  RemoteSourceContext,
+  type RemoteSourceState,
+} from "../hooks/useRemoteSource";
+
+/**
+ * Single owner of the "Remote source" state (RFC-005). Holds the status +
+ * playlist list and the one `waveflow:remote-changed` listener, so every
+ * consumer — the sidebar section, the create-playlist modal — reads the
+ * same snapshot and one event triggers one refresh, not one per mounted
+ * `useRemoteSource` caller.
+ *
+ * Mounted unconditionally: in a stock build `remote_get_status` is not a
+ * registered command, so `available` stays `false` and every consumer
+ * renders nothing.
+ */
+export function RemoteSourceProvider({ children }: { children: ReactNode }) {
+  const [available, setAvailable] = useState(false);
+  const [serverName, setServerName] = useState<string | null>(null);
+  const [playlists, setPlaylists] = useState<RemoteSourceState["playlists"]>([]);
+  // Monotonic token so a slow pass can't overwrite a newer one: bursts of
+  // `waveflow:remote-changed` fire overlapping refreshes, and without this
+  // an older status/list response landing last would clobber fresher data.
+  const seqRef = useRef(0);
+  // Once we've resolved as available, sync_v2 is compiled in — so a later
+  // status failure is transient (never "command absent"), and must not
+  // make the section vanish under the user.
+  const everAvailableRef = useRef(false);
+
+  const refresh = useCallback(() => {
+    const seq = ++seqRef.current;
+    const isCurrent = () => seq === seqRef.current;
+    void (async () => {
+      try {
+        const status = await remoteGetStatus();
+        if (!isCurrent()) return;
+        if (!status.signed_in) {
+          setAvailable(false);
+          setServerName(null);
+          setPlaylists([]);
+          return;
+        }
+        everAvailableRef.current = true;
+        setAvailable(true);
+        setServerName(hostOf(status.server_url) ?? status.username ?? "Remote");
+        try {
+          const list = await remoteListPlaylists();
+          if (isCurrent()) setPlaylists(list);
+        } catch {
+          // Signed in but the list call failed (offline, transient): keep
+          // the section visible with whatever we last had rather than
+          // making it vanish under the user.
+        }
+      } catch {
+        if (!isCurrent()) return;
+        // Only hide when we've never resolved: the command may be absent
+        // (sync_v2 off). Once we've been available, this is a transient
+        // status failure — keep the last state instead of flipping off.
+        if (!everAvailableRef.current) {
+          setAvailable(false);
+          setServerName(null);
+          setPlaylists([]);
+        }
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const onChange = () => refresh();
+    window.addEventListener("waveflow:remote-changed", onChange);
+    return () =>
+      window.removeEventListener("waveflow:remote-changed", onChange);
+  }, [refresh]);
+
+  const value = useMemo<RemoteSourceState>(
+    () => ({ available, serverName, playlists, refresh }),
+    [available, serverName, playlists, refresh],
+  );
+
+  return (
+    <RemoteSourceContext.Provider value={value}>
+      {children}
+    </RemoteSourceContext.Provider>
+  );
+}
+
+function hostOf(url: string | null): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}

--- a/src/hooks/useRemoteSource.ts
+++ b/src/hooks/useRemoteSource.ts
@@ -1,9 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  remoteGetStatus,
-  remoteListPlaylists,
-  type RemotePlaylistSummary,
-} from "../lib/tauri/remoteServer";
+import { createContext, useContext } from "react";
+import type { RemotePlaylistSummary } from "../lib/tauri/remoteServer";
 
 export interface RemoteSourceState {
   /**
@@ -11,7 +7,7 @@ export interface RemoteSourceState {
    * is bound and signed in. A stock build (feature off) makes
    * `remote_get_status` an unregistered command, which rejects and lands
    * us on `false` — the whole sidebar section then renders nothing, the
-   * same self-hiding contract as {@link RemoteServerCard}.
+   * same self-hiding contract as `RemoteServerCard`.
    */
   available: boolean;
   /** Host of the bound server, shown as the sidebar section header. */
@@ -21,84 +17,34 @@ export interface RemoteSourceState {
 }
 
 /**
- * Drives the "Remote source" sidebar section and keeps it in step with
- * the rest of the UI. Any mutation of remote data (create / rename /
- * delete a remote playlist, sign in / out) should dispatch a
- * `waveflow:remote-changed` window event; every consumer refreshes on it
- * so the sidebar, the settings card and the open view never drift apart.
+ * Shared remote-source state, owned by `RemoteSourceProvider`. Lives here
+ * (with the hook) rather than in the provider file so the provider module
+ * can stay a components-only file for fast refresh — the same split as
+ * `PlayerContext` / `usePlayer`.
+ */
+export const RemoteSourceContext = createContext<RemoteSourceState | null>(
+  null,
+);
+
+/**
+ * Read the shared remote-source state — one `waveflow:remote-changed` event
+ * refreshes every consumer once, since the provider owns the single
+ * listener. Falls back to an inert snapshot outside the provider so a stray
+ * consumer degrades to "nothing here" rather than throwing; the section is
+ * optional by design.
  */
 export function useRemoteSource(): RemoteSourceState {
-  const [available, setAvailable] = useState(false);
-  const [serverName, setServerName] = useState<string | null>(null);
-  const [playlists, setPlaylists] = useState<RemotePlaylistSummary[]>([]);
-  // Monotonic token so a slow pass can't overwrite a newer one: bursts of
-  // `waveflow:remote-changed` fire overlapping refreshes, and without this
-  // an older status/list response landing last would clobber fresher data.
-  const seqRef = useRef(0);
-  // Once we've resolved as available, sync_v2 is compiled in — so a later
-  // status failure is transient (never "command absent"), and must not
-  // make the section vanish under the user.
-  const everAvailableRef = useRef(false);
-
-  const refresh = useCallback(() => {
-    const seq = ++seqRef.current;
-    const isCurrent = () => seq === seqRef.current;
-    void (async () => {
-      try {
-        const status = await remoteGetStatus();
-        if (!isCurrent()) return;
-        if (!status.signed_in) {
-          setAvailable(false);
-          setServerName(null);
-          setPlaylists([]);
-          return;
-        }
-        everAvailableRef.current = true;
-        setAvailable(true);
-        setServerName(hostOf(status.server_url) ?? status.username ?? "Remote");
-        try {
-          const list = await remoteListPlaylists();
-          if (isCurrent()) setPlaylists(list);
-        } catch {
-          // Signed in but the list call failed (offline, transient): keep
-          // the section visible with whatever we last had rather than
-          // making it vanish under the user.
-        }
-      } catch {
-        if (!isCurrent()) return;
-        // Only hide when we've never resolved: the command may be absent
-        // (sync_v2 off). Once we've been available, this is a transient
-        // status failure — keep the last state instead of flipping off.
-        if (!everAvailableRef.current) {
-          setAvailable(false);
-          setServerName(null);
-          setPlaylists([]);
-        }
-      }
-    })();
-  }, []);
-
-  useEffect(() => {
-    refresh();
-    const onChange = () => refresh();
-    window.addEventListener("waveflow:remote-changed", onChange);
-    return () =>
-      window.removeEventListener("waveflow:remote-changed", onChange);
-  }, [refresh]);
-
-  return { available, serverName, playlists, refresh };
+  return useContext(RemoteSourceContext) ?? INERT;
 }
+
+const INERT: RemoteSourceState = {
+  available: false,
+  serverName: null,
+  playlists: [],
+  refresh: () => {},
+};
 
 /** Signal every remote-source consumer to re-read. */
 export function notifyRemoteChanged() {
   window.dispatchEvent(new Event("waveflow:remote-changed"));
-}
-
-function hostOf(url: string | null): string | null {
-  if (!url) return null;
-  try {
-    return new URL(url).host;
-  } catch {
-    return url;
-  }
 }

--- a/src/hooks/useRemoteSource.ts
+++ b/src/hooks/useRemoteSource.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   remoteGetStatus,
   remoteListPlaylists,
@@ -31,31 +31,49 @@ export function useRemoteSource(): RemoteSourceState {
   const [available, setAvailable] = useState(false);
   const [serverName, setServerName] = useState<string | null>(null);
   const [playlists, setPlaylists] = useState<RemotePlaylistSummary[]>([]);
+  // Monotonic token so a slow pass can't overwrite a newer one: bursts of
+  // `waveflow:remote-changed` fire overlapping refreshes, and without this
+  // an older status/list response landing last would clobber fresher data.
+  const seqRef = useRef(0);
+  // Once we've resolved as available, sync_v2 is compiled in — so a later
+  // status failure is transient (never "command absent"), and must not
+  // make the section vanish under the user.
+  const everAvailableRef = useRef(false);
 
   const refresh = useCallback(() => {
+    const seq = ++seqRef.current;
+    const isCurrent = () => seq === seqRef.current;
     void (async () => {
       try {
         const status = await remoteGetStatus();
+        if (!isCurrent()) return;
         if (!status.signed_in) {
           setAvailable(false);
           setServerName(null);
           setPlaylists([]);
           return;
         }
+        everAvailableRef.current = true;
         setAvailable(true);
         setServerName(hostOf(status.server_url) ?? status.username ?? "Remote");
         try {
-          setPlaylists(await remoteListPlaylists());
+          const list = await remoteListPlaylists();
+          if (isCurrent()) setPlaylists(list);
         } catch {
           // Signed in but the list call failed (offline, transient): keep
           // the section visible with whatever we last had rather than
           // making it vanish under the user.
         }
       } catch {
-        // `remote_get_status` is not a registered command: sync_v2 off.
-        setAvailable(false);
-        setServerName(null);
-        setPlaylists([]);
+        if (!isCurrent()) return;
+        // Only hide when we've never resolved: the command may be absent
+        // (sync_v2 off). Once we've been available, this is a transient
+        // status failure — keep the last state instead of flipping off.
+        if (!everAvailableRef.current) {
+          setAvailable(false);
+          setServerName(null);
+          setPlaylists([]);
+        }
       }
     })();
   }, []);

--- a/src/hooks/useTrackLyrics.ts
+++ b/src/hooks/useTrackLyrics.ts
@@ -116,9 +116,11 @@ export function useTrackLyrics(): TrackLyrics {
     trackIdRef.current = trackId;
   }, [trackId]);
 
-  // Previous `isRadio` so the fetch effect can tell a context switch
-  // (library ↔ radio) from a same-context track change.
-  const prevIsRadioRef = useRef(isRadio);
+  // Previous streaming state (radio OR remote) so the fetch effect can
+  // tell a context switch — into, out of, or between streaming sources —
+  // from a same-context library track change.
+  const isStream = isRadio || isRemote;
+  const prevIsStreamRef = useRef(isStream);
 
   // ── Fetch when the focused track changes ─────────────────────────
   useEffect(() => {
@@ -129,21 +131,21 @@ export function useTrackLyrics(): TrackLyrics {
       // Clear the spinner too — without this a fetch in flight when the
       // track drops to null leaves `isFetching` stuck true.
       setIsFetching(false);
-      prevIsRadioRef.current = isRadio;
+      prevIsStreamRef.current = isStream;
       return;
     }
     let cancelled = false;
-    // Drop the previous payload up front on any transition that involves
-    // radio — entering radio (library→radio), leaving it (radio→library),
-    // or a new song on the same station (radio→radio, where the sentinel
-    // trackId is unchanged so the swap-on-resolve below wouldn't fire).
-    // Without this the previous lyrics linger under the new identity for
-    // the duration of the fetch. Library→library is deliberately exempt:
-    // it keeps the swap-on-resolve so a fast cache hit doesn't flash an
-    // intermediate "loading" state.
-    const wasRadio = prevIsRadioRef.current;
-    prevIsRadioRef.current = isRadio;
-    if (isRadio || wasRadio) {
+    // Drop the previous payload up front on any transition that involves a
+    // streaming source — entering one (library→radio/remote), leaving it
+    // (radio/remote→library), switching between them, or a new song on the
+    // same station / remote queue (where the sentinel trackId is unchanged
+    // so the swap-on-resolve below wouldn't fire). Without this the previous
+    // lyrics linger under the new identity for the duration of the fetch.
+    // Library→library is deliberately exempt: it keeps the swap-on-resolve
+    // so a fast cache hit doesn't flash an intermediate "loading" state.
+    const wasStream = prevIsStreamRef.current;
+    prevIsStreamRef.current = isStream;
+    if (isStream || wasStream) {
       setPayload(null);
     }
     setIsFetching(true);
@@ -197,6 +199,7 @@ export function useTrackLyrics(): TrackLyrics {
     radioArtist,
     radioTitle,
     isRemote,
+    isStream,
     remoteArtist,
     remoteTitle,
     remoteDurationMs,


### PR DESCRIPTION
Follow-up to #502 (RFC-005 remote source): the CodeRabbit findings deferred
at merge time, split across backend robustness and frontend polish. Each
was verified against the code; two were consciously scoped down (noted
below).

## Backend (lot 2)

- **client**: refresh-and-replay once on a 401 in-band (closes the narrow
  race where a token lapses between the pre-emptive refresh and the server
  reading it); stop the refresh when a concurrent sign-out cleared the
  tokens instead of resurrecting them; commit the rotated token pair + the
  device-id correction in one transaction.
- **drain / write / remote_auth**: resolve the leased profile pool once per
  pass and keep the handle bound; `lease` returns just the pool;
  `optional_conn` → `optional_pool` so reads keep the lease bound while
  their connection is live.
- **mutation**: `resolve_placeholder` / `resolve_share_placeholder` are
  idempotent when a `/changes` echo already projected the real row (a share
  still captures its creation URL on that path); `pending` stops at the
  first unreadable payload and marks it failed so FIFO order can't be
  jumped. Tests added.
- **catalogue**: preserve the HTTP status in surfaced errors (a lapsed
  session is distinguishable); cache songs in one transaction.
- **socket**: idle timeout so a half-open connection reconnects; coalesce a
  burst of notice frames into one catch-up.
- **sync**: stop the pass on a non-advancing/backwards cursor; log-and-skip
  one uncacheable track instead of rolling back the batch.
- **auth**: `wait_for_code` ignores non-callback requests (favicon probes)
  and shares one global deadline across retries.
- **audio**: validate the `Content-Range` start byte on a seek 206 (parser
  + tests).
- **analytics / decoder / remote_playback**: handle `RemoteTrackEnded`
  before acquiring the profile pool; read is_remote/duration/artwork_hash
  from a single `RemotePlayback` lock.
- **deezer**: match the by-name cache through `select_by_name` +
  `normalize_name`.
- **state**: clear the remote session under the profile write lock.
- **binding / mod / dead_code**: drop the module-level `#![allow(dead_code)]`
  and annotate the few intentional symbols individually; add an
  account-switch integration test.

## Frontend (lot 3)

- Virtualize `RemotePlaylistView` (page scroller, dnd-kit preserved via a
  body-portalled DragOverlay) and `RemoteQueueView` (own scroll container).
- `RemoteArtwork`: process-wide per-hash cache + in-flight dedup.
- `useRemoteSource` → a single `RemoteSourceProvider` (one listener, one
  refresh per event); monotonic stale-pass guard; don't hide the section on
  a transient status failure.
- `RemoteServerCard`: availability from `remote_get_status` alone, unmount
  guards, a dedicated sign-out busy state.
- Rename input: IME-composition guard + aria-label.
- `useTrackLyrics`: extend the context reset to remote transitions.

## Scoped down (documented inline)

- **http_source inter-read timeout on the seek reopen**: `reqwest::blocking`
  exposes no per-read timeout and a total one would cap a long file's
  playback, so a stalled read unwinds via Stop like radio rather than
  pulling in a watchdog thread. Content-Range validation (the companion
  finding) is done.
- **state.rs lifecycle race**: narrowed by clearing under the profile write
  lock; the full cross-lock coordination is left out to avoid the
  deadlock-prone ordering, and the residual case still fails cleanly on the
  next advance.

## Validation

`typecheck`, `lint`, and `cargo clippy --all-targets -D warnings` on both
the default (`sync_v2`) and `--no-default-features` configs. App-crate unit
tests (mutation idempotency, binding account-switch, Content-Range) compile
via `--all-targets`; they run in CI Linux (the Tauri DLL blocks running them
on Windows).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Actualisation automatique des jetons, reconnexion et synchronisation distante plus fiables.
  - Listes de lecture et files d’attente virtualisées pour de meilleures performances.
  - Cache partagé des illustrations et état des sources distantes centralisé.
  - Lecture distante avec avancement automatique plus réactive.

- **Améliorations**
  - Gestion plus robuste des recherches, flux et déplacements dans les pistes.
  - Meilleure gestion des erreurs réseau, réponses HTTP et sessions expirées.
  - Changement de profil et déconnexion plus fiables.
  - Synchronisation, mutations, paroles et catalogues distants mieux protégés.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->