### PR TITLE
feat(remote-playback): prefer confirmed local links

### DIFF
--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -379,6 +379,127 @@ fn decoder_loop(
                     Some(path.display().to_string()),
                 );
             }
+            AudioCmd::LoadRemoteFileAndPlay {
+                path,
+                start_ms,
+                track_id,
+                duration_ms,
+                title,
+                artist,
+                artwork_url,
+                fallback_url,
+                replay_gain_db,
+            } => {
+                shared.clear_ab_loop();
+                transition_state(&shared, &app, PlayerState::Loading, Some(track_id));
+
+                if producer.slots() != super::output::RING_CAPACITY {
+                    shared.paused_output.store(false, Ordering::Release);
+                    shared.drain_silent.store(true, Ordering::Release);
+                    let start = std::time::Instant::now();
+                    while producer.slots() < super::output::RING_CAPACITY
+                        && start.elapsed() < Duration::from_millis(500)
+                    {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    shared.drain_silent.store(false, Ordering::Release);
+                } else {
+                    shared.paused_output.store(false, Ordering::Release);
+                }
+                shared.samples_played.store(0, Ordering::Relaxed);
+                shared.base_offset_ms.store(start_ms, Ordering::Relaxed);
+                shared.current_track_id.store(track_id, Ordering::Release);
+
+                let remote_meta = {
+                    let state = app.state::<crate::state::AppState>();
+                    state.remote_playback.current_stream_meta()
+                };
+                emit_radio_metadata(
+                    &app,
+                    RadioMetadataPayload {
+                        track_id,
+                        title: title.clone(),
+                        artist: artist.clone(),
+                        artwork_url: artwork_url.clone(),
+                        station_url: fallback_url.clone(),
+                        station_name: title.clone(),
+                        station_artist: artist.clone(),
+                        station_artwork: artwork_url.clone(),
+                        is_remote: true,
+                        duration_ms: remote_meta.duration_ms.or(Some(duration_ms as i64)),
+                        artwork_hash: remote_meta.artwork_hash,
+                    },
+                );
+
+                let stream = match ActiveStream::open(
+                    &path,
+                    track_id,
+                    duration_ms,
+                    "remote-local".to_string(),
+                    None,
+                    replay_gain_db,
+                    shared.dsd_taps.load(Ordering::Acquire) as usize,
+                ) {
+                    Ok(stream) => stream,
+                    Err(err) => {
+                        tracing::warn!(
+                            ?err,
+                            path = %path.display(),
+                            has_server_fallback = fallback_url.is_some(),
+                            "remote local source open failed"
+                        );
+                        if let Some(url) = fallback_url.filter(|_| !crate::offline::is_offline()) {
+                            pending_cmd = Some(AudioCmd::LoadUrlAndPlay {
+                                url,
+                                ext_hint: None,
+                                track_id,
+                                title,
+                                artist,
+                                artwork_url,
+                            });
+                            continue;
+                        }
+                        let _ = app.emit(EVENT_ERROR, ErrorPayload { message: err });
+                        transition_state(&shared, &app, PlayerState::Idle, Some(track_id));
+                        continue;
+                    }
+                };
+
+                let outcome = play_track(
+                    stream,
+                    start_ms,
+                    producer,
+                    &shared,
+                    cmd_rx,
+                    &app,
+                    &mut pending_cmd,
+                    analytics_tx,
+                );
+                if outcome.is_err() {
+                    if let Some(url) = fallback_url.filter(|_| !crate::offline::is_offline()) {
+                        tracing::warn!(
+                            path = %path.display(),
+                            "remote local decode failed; falling back to server"
+                        );
+                        pending_cmd = Some(AudioCmd::LoadUrlAndPlay {
+                            url,
+                            ext_hint: None,
+                            track_id,
+                            title,
+                            artist,
+                            artwork_url,
+                        });
+                        continue;
+                    }
+                }
+                handle_playback_outcome(
+                    outcome,
+                    &shared,
+                    &app,
+                    analytics_tx,
+                    Some(path.display().to_string()),
+                );
+            }
             AudioCmd::LoadUrlAndPlay {
                 url,
                 ext_hint,
@@ -1358,6 +1479,11 @@ fn drain_commands(
                 *pending_cmd = Some(cmd);
                 return ControlFlow::LoadNext;
             }
+            Ok(cmd @ AudioCmd::LoadRemoteFileAndPlay { .. }) => {
+                shared.paused_output.store(false, Ordering::Release);
+                *pending_cmd = Some(cmd);
+                return ControlFlow::LoadNext;
+            }
             Ok(cmd @ AudioCmd::LoadUrlAndPlay { .. }) => {
                 shared.paused_output.store(false, Ordering::Release);
                 *pending_cmd = Some(cmd);
@@ -1444,6 +1570,11 @@ fn drain_commands(
                         }
                         Ok(AudioCmd::SetSpeed(v)) => shared.set_playback_speed(v),
                         Ok(cmd @ AudioCmd::LoadAndPlay { .. }) => {
+                            shared.paused_output.store(false, Ordering::Release);
+                            *pending_cmd = Some(cmd);
+                            return ControlFlow::LoadNext;
+                        }
+                        Ok(cmd @ AudioCmd::LoadRemoteFileAndPlay { .. }) => {
                             shared.paused_output.store(false, Ordering::Release);
                             *pending_cmd = Some(cmd);
                             return ControlFlow::LoadNext;

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -42,6 +42,22 @@ pub enum AudioCmd {
         /// stays out of the SQLite path.
         replay_gain_db: Option<f64>,
     },
+    /// Play a track from the active remote queue using its confirmed local
+    /// reconciliation link. The negative `track_id` deliberately preserves
+    /// the remote queue/UI semantics; `fallback_url`, when available, lets
+    /// the decoder fall back to the server if the local file can no longer
+    /// be opened between selection and playback.
+    LoadRemoteFileAndPlay {
+        path: PathBuf,
+        start_ms: u64,
+        track_id: i64,
+        duration_ms: u64,
+        title: Option<String>,
+        artist: Option<String>,
+        artwork_url: Option<String>,
+        fallback_url: Option<String>,
+        replay_gain_db: Option<f64>,
+    },
     Pause,
     Resume,
     Stop,
@@ -122,6 +138,12 @@ impl std::fmt::Debug for AudioCmd {
             } => write!(
                 f,
                 "LoadAndPlay {{ track_id: {track_id}, start_ms: {start_ms} }}"
+            ),
+            AudioCmd::LoadRemoteFileAndPlay {
+                track_id, start_ms, ..
+            } => write!(
+                f,
+                "LoadRemoteFileAndPlay {{ track_id: {track_id}, start_ms: {start_ms} }}"
             ),
             AudioCmd::Pause => write!(f, "Pause"),
             AudioCmd::Resume => write!(f, "Resume"),
@@ -1304,6 +1326,25 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
                 });
             }
         }
+        AudioCmd::LoadRemoteFileAndPlay {
+            fallback_url,
+            track_id,
+            title,
+            artist,
+            artwork_url,
+            ..
+        } => {
+            if let Ok(mut guard) = snapshot.lock() {
+                *guard = fallback_url.as_ref().map(|url| RadioResumeState {
+                    url: url.clone(),
+                    ext_hint: None,
+                    track_id: *track_id,
+                    title: title.clone(),
+                    artist: artist.clone(),
+                    artwork_url: artwork_url.clone(),
+                });
+            }
+        }
         AudioCmd::LoadAndPlay { .. } => {
             if let Ok(mut guard) = snapshot.lock() {
                 *guard = None;
@@ -1478,6 +1519,20 @@ mod radio_resume_tests {
         }
     }
 
+    fn remote_local_cmd(fallback_url: Option<&str>, track_id: i64) -> AudioCmd {
+        AudioCmd::LoadRemoteFileAndPlay {
+            path: PathBuf::from("/dev/null"),
+            start_ms: 0,
+            track_id,
+            duration_ms: 1000,
+            title: Some("Remote track".to_string()),
+            artist: Some("Remote artist".to_string()),
+            artwork_url: None,
+            fallback_url: fallback_url.map(str::to_string),
+            replay_gain_db: None,
+        }
+    }
+
     #[test]
     fn load_url_writes_snapshot_verbatim() {
         let lock: Mutex<Option<RadioResumeState>> = Mutex::new(None);
@@ -1509,6 +1564,27 @@ mod radio_resume_tests {
             lock.lock().unwrap().is_none(),
             "local-track LoadAndPlay must wipe the radio resume cache",
         );
+    }
+
+    #[test]
+    fn remote_local_playback_keeps_server_resume_when_available() {
+        let lock: Mutex<Option<RadioResumeState>> = Mutex::new(None);
+        apply_radio_resume_update(
+            &lock,
+            &remote_local_cmd(Some("https://server.invalid/stream"), -3),
+        );
+        let snap = lock.lock().unwrap().clone().expect("snapshot stored");
+        assert_eq!(snap.url, "https://server.invalid/stream");
+        assert_eq!(snap.track_id, -3);
+        assert_eq!(snap.title.as_deref(), Some("Remote track"));
+    }
+
+    #[test]
+    fn offline_remote_local_playback_clears_stale_resume() {
+        let lock: Mutex<Option<RadioResumeState>> = Mutex::new(None);
+        apply_radio_resume_update(&lock, &url_cmd("https://radio.invalid/", -1));
+        apply_radio_resume_update(&lock, &remote_local_cmd(None, -3));
+        assert!(lock.lock().unwrap().is_none());
     }
 
     #[test]

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -333,37 +333,76 @@ pub struct AudioEngine {
     /// This gate spans the whole arm → delay → run lifecycle plus a
     /// settle window, so one burst of device errors yields one rebuild.
     rebuild_gate: Mutex<RebuildGate>,
-    /// Last Web Radio session captured at the boundary of
-    /// [`Self::send`] (#230). The three output-rebuild paths
+    /// Last non-library source captured at the boundary of [`Self::send`]
+    /// (#230). The three output-rebuild paths
     /// ([`Self::set_output_device`], [`Self::set_wasapi_exclusive`],
     /// [`Self::force_rebuild_output`]) snapshot
-    /// `shared.current_track_id`; for a radio stream that id is a
+    /// `shared.current_track_id`; for radio and remote queues that id is a
     /// negative sentinel from
     /// [`crate::commands::player::next_radio_track_id`] with no
     /// matching `track` row, so a plain `WHERE id = ?` resume
     /// returns nothing and the rebuild silently drops the user
-    /// off the stream. Holding the originating
-    /// [`AudioCmd::LoadUrlAndPlay`] payload lets those paths
-    /// re-dispatch the same command instead. Cleared on the next
+    /// off the stream. Holding the originating URL or reconciled-file payload
+    /// lets those paths re-dispatch the same source instead. Cleared on the next
     /// [`AudioCmd::LoadAndPlay`] so a local-track switch doesn't
     /// resurrect the dead radio session on a later rebuild.
     radio_resume: Mutex<Option<RadioResumeState>>,
 }
 
-/// Snapshot of an active Web Radio session, retained by the
-/// engine so output-rebuild paths can re-dispatch
-/// [`AudioCmd::LoadUrlAndPlay`] verbatim. Mirrors the variant's
-/// payload one-for-one; lives behind a [`Mutex`] on
-/// [`AudioEngine`] (low contention — only set on stream start /
-/// track change, read on the rare rebuild paths).
-#[derive(Debug, Clone)]
+/// Snapshot of an active non-library source, retained by the engine so output
+/// rebuilds can resume either the server URL or a reconciled local file.
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct RadioResumeState {
-    pub url: String,
-    pub ext_hint: Option<String>,
+    pub source: RadioResumeSource,
     pub track_id: i64,
     pub title: Option<String>,
     pub artist: Option<String>,
     pub artwork_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum RadioResumeSource {
+    Url {
+        url: String,
+        ext_hint: Option<String>,
+    },
+    RemoteFile {
+        path: PathBuf,
+        duration_ms: u64,
+        fallback_url: Option<String>,
+        replay_gain_db: Option<f64>,
+    },
+}
+
+impl RadioResumeState {
+    fn into_command(self, position_ms: u64) -> AudioCmd {
+        match self.source {
+            RadioResumeSource::Url { url, ext_hint } => AudioCmd::LoadUrlAndPlay {
+                url,
+                ext_hint,
+                track_id: self.track_id,
+                title: self.title,
+                artist: self.artist,
+                artwork_url: self.artwork_url,
+            },
+            RadioResumeSource::RemoteFile {
+                path,
+                duration_ms,
+                fallback_url,
+                replay_gain_db,
+            } => AudioCmd::LoadRemoteFileAndPlay {
+                path,
+                start_ms: position_ms,
+                track_id: self.track_id,
+                duration_ms,
+                title: self.title,
+                artist: self.artist,
+                artwork_url: self.artwork_url,
+                fallback_url,
+                replay_gain_db,
+            },
+        }
+    }
 }
 
 impl AudioEngine {
@@ -851,14 +890,7 @@ impl AudioEngine {
         if was_playing {
             if track_id < 0 {
                 if let Some(state) = self.snapshot_radio_resume() {
-                    let _ = self.cmd_tx.send(AudioCmd::LoadUrlAndPlay {
-                        url: state.url,
-                        ext_hint: state.ext_hint,
-                        track_id: state.track_id,
-                        title: state.title,
-                        artist: state.artist,
-                        artwork_url: state.artwork_url,
-                    });
+                    let _ = self.cmd_tx.send(state.into_command(position_ms));
                 }
             } else if track_id > 0 {
                 let app = self.app.clone();
@@ -1015,14 +1047,7 @@ impl AudioEngine {
         if was_playing {
             if track_id < 0 {
                 if let Some(state) = self.snapshot_radio_resume() {
-                    let _ = self.cmd_tx.send(AudioCmd::LoadUrlAndPlay {
-                        url: state.url,
-                        ext_hint: state.ext_hint,
-                        track_id: state.track_id,
-                        title: state.title,
-                        artist: state.artist,
-                        artwork_url: state.artwork_url,
-                    });
+                    let _ = self.cmd_tx.send(state.into_command(position_ms));
                 }
             } else if track_id > 0 {
                 // Best-effort: pull file path + RG from the active profile
@@ -1241,14 +1266,7 @@ impl AudioEngine {
         if was_playing {
             if track_id < 0 {
                 if let Some(state) = self.snapshot_radio_resume() {
-                    let _ = self.cmd_tx.send(AudioCmd::LoadUrlAndPlay {
-                        url: state.url,
-                        ext_hint: state.ext_hint,
-                        track_id: state.track_id,
-                        title: state.title,
-                        artist: state.artist,
-                        artwork_url: state.artwork_url,
-                    });
+                    let _ = self.cmd_tx.send(state.into_command(position_ms));
                 }
             } else if track_id > 0 {
                 let app = self.app.clone();
@@ -1317,8 +1335,10 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
         } => {
             if let Ok(mut guard) = snapshot.lock() {
                 *guard = Some(RadioResumeState {
-                    url: url.clone(),
-                    ext_hint: ext_hint.clone(),
+                    source: RadioResumeSource::Url {
+                        url: url.clone(),
+                        ext_hint: ext_hint.clone(),
+                    },
                     track_id: *track_id,
                     title: title.clone(),
                     artist: artist.clone(),
@@ -1327,7 +1347,10 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
             }
         }
         AudioCmd::LoadRemoteFileAndPlay {
+            path,
+            duration_ms,
             fallback_url,
+            replay_gain_db,
             track_id,
             title,
             artist,
@@ -1335,9 +1358,13 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
             ..
         } => {
             if let Ok(mut guard) = snapshot.lock() {
-                *guard = fallback_url.as_ref().map(|url| RadioResumeState {
-                    url: url.clone(),
-                    ext_hint: None,
+                *guard = Some(RadioResumeState {
+                    source: RadioResumeSource::RemoteFile {
+                        path: path.clone(),
+                        duration_ms: *duration_ms,
+                        fallback_url: fallback_url.clone(),
+                        replay_gain_db: *replay_gain_db,
+                    },
                     track_id: *track_id,
                     title: title.clone(),
                     artist: artist.clone(),
@@ -1529,7 +1556,7 @@ mod radio_resume_tests {
             artist: Some("Remote artist".to_string()),
             artwork_url: None,
             fallback_url: fallback_url.map(str::to_string),
-            replay_gain_db: None,
+            replay_gain_db: Some(-4.0),
         }
     }
 
@@ -1538,10 +1565,15 @@ mod radio_resume_tests {
         let lock: Mutex<Option<RadioResumeState>> = Mutex::new(None);
         apply_radio_resume_update(&lock, &url_cmd("https://radio.invalid/live", -1));
         let snap = lock.lock().unwrap().clone().expect("snapshot stored");
-        assert_eq!(snap.url, "https://radio.invalid/live");
         assert_eq!(snap.track_id, -1);
-        assert_eq!(snap.ext_hint.as_deref(), Some("mp3"));
         assert_eq!(snap.title.as_deref(), Some("Test stream"));
+        match snap.source {
+            RadioResumeSource::Url { url, ext_hint } => {
+                assert_eq!(url, "https://radio.invalid/live");
+                assert_eq!(ext_hint.as_deref(), Some("mp3"));
+            }
+            RadioResumeSource::RemoteFile { .. } => panic!("expected URL resume"),
+        }
     }
 
     #[test]
@@ -1550,8 +1582,11 @@ mod radio_resume_tests {
         apply_radio_resume_update(&lock, &url_cmd("https://first.invalid/", -1));
         apply_radio_resume_update(&lock, &url_cmd("https://second.invalid/", -2));
         let snap = lock.lock().unwrap().clone().expect("snapshot present");
-        assert_eq!(snap.url, "https://second.invalid/");
         assert_eq!(snap.track_id, -2);
+        assert!(matches!(
+            snap.source,
+            RadioResumeSource::Url { ref url, .. } if url == "https://second.invalid/"
+        ));
     }
 
     #[test]
@@ -1567,24 +1602,56 @@ mod radio_resume_tests {
     }
 
     #[test]
-    fn remote_local_playback_keeps_server_resume_when_available() {
+    fn online_device_change_reemits_remote_local_command_with_fallback() {
         let lock: Mutex<Option<RadioResumeState>> = Mutex::new(None);
         apply_radio_resume_update(
             &lock,
             &remote_local_cmd(Some("https://server.invalid/stream"), -3),
         );
         let snap = lock.lock().unwrap().clone().expect("snapshot stored");
-        assert_eq!(snap.url, "https://server.invalid/stream");
-        assert_eq!(snap.track_id, -3);
-        assert_eq!(snap.title.as_deref(), Some("Remote track"));
+        match snap.into_command(4_321) {
+            AudioCmd::LoadRemoteFileAndPlay {
+                path,
+                start_ms,
+                track_id,
+                duration_ms,
+                fallback_url,
+                replay_gain_db,
+                ..
+            } => {
+                assert_eq!(path, PathBuf::from("/dev/null"));
+                assert_eq!(start_ms, 4_321);
+                assert_eq!(track_id, -3);
+                assert_eq!(duration_ms, 1_000);
+                assert_eq!(
+                    fallback_url.as_deref(),
+                    Some("https://server.invalid/stream")
+                );
+                assert_eq!(replay_gain_db, Some(-4.0));
+            }
+            _ => panic!("device change must resume the reconciled local file"),
+        }
     }
 
     #[test]
-    fn offline_remote_local_playback_clears_stale_resume() {
+    fn offline_device_change_reemits_remote_local_command_without_fallback() {
         let lock: Mutex<Option<RadioResumeState>> = Mutex::new(None);
         apply_radio_resume_update(&lock, &url_cmd("https://radio.invalid/", -1));
         apply_radio_resume_update(&lock, &remote_local_cmd(None, -3));
-        assert!(lock.lock().unwrap().is_none());
+        let snap = lock.lock().unwrap().clone().expect("local snapshot stored");
+        match snap.into_command(7_654) {
+            AudioCmd::LoadRemoteFileAndPlay {
+                path,
+                start_ms,
+                fallback_url,
+                ..
+            } => {
+                assert_eq!(path, PathBuf::from("/dev/null"));
+                assert_eq!(start_ms, 7_654);
+                assert_eq!(fallback_url, None);
+            }
+            _ => panic!("offline device change must still resume locally"),
+        }
     }
 
     #[test]
@@ -1603,9 +1670,9 @@ mod radio_resume_tests {
             apply_radio_resume_update(&lock, &cmd);
         }
         let after = lock.lock().unwrap().clone();
-        assert!(
-            matches!((&baseline, &after), (Some(a), Some(b)) if a.url == b.url && a.track_id == b.track_id),
-            "non-Load* commands must not touch the snapshot",
+        assert_eq!(
+            baseline, after,
+            "non-Load* commands must not touch the snapshot"
         );
     }
 }

--- a/src-tauri/crates/app/src/audio/events.rs
+++ b/src-tauri/crates/app/src/audio/events.rs
@@ -41,13 +41,10 @@ pub struct RadioMetadataPayload {
     pub station_name: Option<String>,
     pub station_artist: Option<String>,
     pub station_artwork: Option<String>,
-    /// `true` when this URL stream is a track from the remote play queue
-    /// (RFC-005), not a live radio station. Both share the `LoadUrlAndPlay`
-    /// path and a negative id, so the frontend cannot tell them apart from
-    /// the payload alone: a radio session is a single stream with next /
-    /// previous disabled, a remote track is one entry of a queue that
-    /// advances. The decoder sets this by reading whether a remote session
-    /// is active at emit time.
+    /// `true` when this source is a track from the remote play queue
+    /// (RFC-005), not a live radio station. A remote track may be read from a
+    /// server URL or a confirmed local reconciliation link; both retain a
+    /// negative id so the frontend keeps the remote queue semantics.
     pub is_remote: bool,
     /// Track length in ms for a remote-queue entry, when known — lets the
     /// PlayerBar draw a bounded progress bar with a total time. `None` for

--- a/src-tauri/crates/app/src/remote/playback.rs
+++ b/src-tauri/crates/app/src/remote/playback.rs
@@ -3,9 +3,8 @@
 //! The queue itself — its entries and cursor — lives in
 //! [`crate::remote_playback`], which is plain in-memory data compiled into
 //! every build. This module is the `sync_v2`-gated half: it fills that
-//! queue from the projection, mints a stream ticket for the current entry,
-//! and hands the resulting URL to the audio engine over the same
-//! `LoadUrlAndPlay` path Web Radio uses.
+//! queue from the projection, selects a confirmed local reconciliation link
+//! when requested, and otherwise mints a stream ticket for the current entry.
 //!
 //! Advancing is safe to do here because it runs entirely in the async
 //! layer — both the manual next/previous seams and the auto-advance on
@@ -158,21 +157,54 @@ pub async fn advance(app: &AppHandle, direction: Direction) -> AppResult<bool> {
     }
 }
 
-/// Mint a ticket for the entry under the cursor and hand its URL to the
-/// engine. The decoder emits `player:radio-metadata` off this command, so
-/// the PlayerBar picks up the title / artist without a separate push.
+/// Prefer a confirmed local reconciliation link for the entry under the
+/// cursor, otherwise mint a server ticket. Local playback keeps the negative
+/// remote sentinel and metadata path, so queue controls and auto-advance stay
+/// remote. When online, a best-effort ticket accompanies the local command as
+/// a decoder-level fallback if the file disappears or fails to decode.
 async fn play_current(app: &AppHandle) -> AppResult<()> {
     let state = app.state::<AppState>();
     let Some(entry) = state.remote_playback.current() else {
         return Ok(());
     };
 
-    let url = crate::remote::stream::ticket_url(&state, &entry.id).await?;
     // Reuse the negative sentinel id space radio uses: no library row, and
     // a fresh id per load so overlays can tell back-to-back tracks apart.
     let track_id = crate::commands::player::next_radio_track_id();
 
     let engine = app.state::<Arc<AudioEngine>>();
+    let pool = state.require_profile_pool().await?;
+    if let Some(local) =
+        crate::remote::reconciliation::preferred_local_playback(&pool, &entry.id).await?
+    {
+        let replay_gain_db =
+            crate::commands::player::fetch_replay_gain_db(&pool, local.track_id).await;
+        let fallback_url = if crate::offline::is_offline() {
+            None
+        } else {
+            match crate::remote::stream::ticket_url(&state, &entry.id).await {
+                Ok(url) => Some(url),
+                Err(_) => {
+                    tracing::warn!("remote local playback has no server fallback ticket");
+                    None
+                }
+            }
+        };
+        engine.send(AudioCmd::LoadRemoteFileAndPlay {
+            path: local.path,
+            start_ms: 0,
+            track_id,
+            duration_ms: local.duration_ms,
+            title: entry.title.clone(),
+            artist: entry.artist.clone(),
+            artwork_url: None,
+            fallback_url,
+            replay_gain_db,
+        })?;
+        return Ok(());
+    }
+
+    let url = crate::remote::stream::ticket_url(&state, &entry.id).await?;
     engine.send(AudioCmd::LoadUrlAndPlay {
         url,
         ext_hint: None,

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -8,7 +8,7 @@
 //! a human decision.
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use serde::Serialize;
@@ -94,6 +94,13 @@ pub struct ReconciliationLink {
     pub playback_preference: String,
     pub confirmed_at: i64,
     pub verified_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreferredLocalPlayback {
+    pub track_id: i64,
+    pub path: PathBuf,
+    pub duration_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -628,6 +635,41 @@ pub async fn set_playback_preference(
     Ok(())
 }
 
+/// Resolve a remote track to the confirmed, available local file selected by
+/// the user's playback preference. A missing file is treated like no local
+/// candidate so callers can immediately fall back to the server.
+pub async fn preferred_local_playback(
+    pool: &SqlitePool,
+    remote_track_id: &str,
+) -> AppResult<Option<PreferredLocalPlayback>> {
+    let row = sqlx::query(
+        "SELECT t.id, t.file_path, t.duration_ms
+           FROM remote_track_link l
+           JOIN track t ON t.id = l.local_track_id
+          WHERE l.remote_track_id = ?
+            AND l.status = 'confirmed'
+            AND l.playback_preference = 'local_first'
+            AND t.is_available = 1
+          LIMIT 1",
+    )
+    .bind(remote_track_id)
+    .fetch_optional(pool)
+    .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(row.try_get::<String, _>("file_path")?);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let duration_ms = row.try_get::<i64, _>("duration_ms")?.max(0) as u64;
+    Ok(Some(PreferredLocalPlayback {
+        track_id: row.try_get("id")?,
+        path,
+        duration_ms,
+    }))
+}
+
 pub async fn remove_link(pool: &SqlitePool, local_track_id: i64) -> AppResult<()> {
     let mut tx = pool.begin().await?;
     // Capture the link's matching evidence before deleting it and record a
@@ -693,6 +735,7 @@ mod tests {
                  file_path TEXT NOT NULL,
                  file_size INTEGER NOT NULL,
                  title TEXT NOT NULL,
+                 duration_ms INTEGER NOT NULL DEFAULT 0,
                  is_available INTEGER NOT NULL DEFAULT 1
              );
              CREATE TABLE track_artist (
@@ -881,5 +924,68 @@ mod tests {
         let report = discover(&pool).await.unwrap();
         assert_eq!(report.verified_links, 1);
         assert_eq!(links(&pool).await.unwrap()[0].status, "confirmed");
+    }
+
+    #[tokio::test]
+    async fn playback_uses_only_confirmed_available_local_first_links() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local.flac");
+        fs::write(&path, b"same bytes").unwrap();
+        insert_local(&pool, 1, &path, "Local").await;
+        sqlx::query("UPDATE track SET duration_ms = 12_345 WHERE id = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        insert_remote(&pool, "remote-1", b"same bytes", "Remote").await;
+        assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
+
+        let selected = preferred_local_playback(&pool, "remote-1")
+            .await
+            .unwrap()
+            .expect("confirmed local-first link selected");
+        assert_eq!(selected.track_id, 1);
+        assert_eq!(selected.path, path);
+        assert_eq!(selected.duration_ms, 12_345);
+
+        set_playback_preference(&pool, 1, "server_first")
+            .await
+            .unwrap();
+        assert!(preferred_local_playback(&pool, "remote-1")
+            .await
+            .unwrap()
+            .is_none());
+
+        set_playback_preference(&pool, 1, "local_first")
+            .await
+            .unwrap();
+        sqlx::query("UPDATE track SET is_available = 0 WHERE id = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(preferred_local_playback(&pool, "remote-1")
+            .await
+            .unwrap()
+            .is_none());
+
+        sqlx::query("UPDATE track SET is_available = 1 WHERE id = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        fs::remove_file(&path).unwrap();
+        assert!(preferred_local_playback(&pool, "remote-1")
+            .await
+            .unwrap()
+            .is_none());
+
+        fs::write(&path, b"same bytes").unwrap();
+        sqlx::query("UPDATE remote_track_link SET status = 'stale' WHERE local_track_id = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(preferred_local_playback(&pool, "remote-1")
+            .await
+            .unwrap()
+            .is_none());
     }
 }

--- a/src-tauri/crates/app/src/remote_playback.rs
+++ b/src-tauri/crates/app/src/remote_playback.rs
@@ -23,7 +23,7 @@
 //! ## The discriminator
 //!
 //! Playback tells a remote session apart from a library track by the
-//! sign of the engine's `current_track_id` (negative = URL stream), and
+//! sign of the engine's `current_track_id` (negative = non-library source), and
 //! a remote session apart from a *plain radio* stream by
 //! [`RemotePlayback::is_active`]. The session is cleared the instant a
 //! library track becomes current (see `emit_track_changed`) or a radio


### PR DESCRIPTION
## Summary
- resolve remote queue entries through confirmed `local_first` reconciliation links
- preserve remote queue metadata, controls, seek and auto-advance while decoding the local file
- fall back to a server stream ticket when the local file cannot be opened or decoded
- keep local-first playback usable offline and retain a server resume URL when available

## Validation
- `cargo check -p waveflow --all-targets --all-features`
- `cargo clippy -p waveflow --all-targets --all-features -- -D warnings`
- 8 reconciliation tests passed
- 6 radio-resume tests passed
- full library suite: 336 passed, 1 unrelated existing failure in `remote::binding::tests::switching_accounts_leaves_no_inherited_metadata` (`remote_track.cached_at` NOT NULL)

## Notes
- Windows test binaries were run after injecting the Common Controls v6 manifest required by the existing Tauri test-loader workaround; no temporary manifest is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La lecture des titres distants privilégie automatiquement une copie locale confirmée lorsqu’elle est disponible.
  * Les métadonnées, la durée et le gain audio sont conservés lors de la lecture locale.
  * En cas d’échec, la lecture bascule vers la source distante de secours.
* **Améliorations**
  * Les changements de piste restent fiables pendant le chargement, y compris lorsque la lecture est en pause.
  * En mode hors ligne, les erreurs sont conservées sans tentative de connexion distante.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->