### PR TITLE
feat(reconciliation): add explicit playlist conversion

### DIFF
--- a/src-tauri/crates/app/src/commands/remote_auth.rs
+++ b/src-tauri/crates/app/src/commands/remote_auth.rs
@@ -567,14 +567,24 @@ pub async fn remote_convert_playlist(
     if direction == "local_to_server" {
         crate::remote::drain::spawn(app);
     } else if let Ok(playlist_id) = result.destination_id.parse::<i64>() {
-        let profile_id = state.require_profile_id().await?;
-        crate::commands::playlist_cover::maybe_regen_auto_cover(
-            &pool,
-            &state.paths,
-            profile_id,
-            playlist_id,
-        )
-        .await;
+        match state.require_profile_id().await {
+            Ok(profile_id) => {
+                crate::commands::playlist_cover::maybe_regen_auto_cover(
+                    &pool,
+                    &state.paths,
+                    profile_id,
+                    playlist_id,
+                )
+                .await;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    playlist_id,
+                    ?err,
+                    "playlist conversion succeeded but auto-cover regeneration was skipped"
+                );
+            }
+        }
     }
     Ok(result)
 }

--- a/src-tauri/crates/app/src/commands/remote_auth.rs
+++ b/src-tauri/crates/app/src/commands/remote_auth.rs
@@ -538,6 +538,47 @@ pub async fn remote_remove_reconciliation_link(
     crate::remote::reconciliation::remove_link(&pool, local_track_id).await
 }
 
+/// Preview an explicit playlist conversion. No rows are written; every source
+/// position is returned with its reconciliation status so the UI can require a
+/// deliberate confirmation.
+#[tauri::command]
+pub async fn remote_preview_playlist_conversion(
+    state: tauri::State<'_, AppState>,
+    direction: String,
+    source_id: String,
+) -> AppResult<crate::remote::reconciliation::PlaylistConversionPreview> {
+    let pool = state.require_profile_pool().await?;
+    crate::remote::reconciliation::preview_playlist_conversion(&pool, &direction, &source_id).await
+}
+
+/// Convert a playlist only when every source row still has a confirmed link.
+/// The backend rebuilds the preview inside the write transaction so a stale
+/// browser confirmation cannot silently omit tracks.
+#[tauri::command]
+pub async fn remote_convert_playlist(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    direction: String,
+    source_id: String,
+) -> AppResult<crate::remote::reconciliation::PlaylistConversionResult> {
+    let pool = state.require_profile_pool().await?;
+    let result =
+        crate::remote::reconciliation::convert_playlist(&pool, &direction, &source_id).await?;
+    if direction == "local_to_server" {
+        crate::remote::drain::spawn(app);
+    } else if let Ok(playlist_id) = result.destination_id.parse::<i64>() {
+        let profile_id = state.require_profile_id().await?;
+        crate::commands::playlist_cover::maybe_regen_auto_cover(
+            &pool,
+            &state.paths,
+            profile_id,
+            playlist_id,
+        )
+        .await;
+    }
+    Ok(result)
+}
+
 /// The leased pool of the active profile, or `None` when there is no
 /// active profile.
 ///

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -784,6 +784,10 @@ pub fn run() {
             #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_remove_reconciliation_link,
             #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_preview_playlist_conversion,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_convert_playlist,
+            #[cfg(feature = "sync_v2")]
             commands::lyrics::fetch_remote_lyrics,
             commands::offline::get_offline_mode,
             commands::offline::set_offline_mode,

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -787,7 +787,8 @@ async fn preview_playlist_conversion_on(
                 "SELECT rpt.position, rpt.track_remote_id, rt.title,
                         l.local_track_id, l.status,
                         rt.remote_id IS NOT NULL AS remote_visible,
-                        EXISTS(SELECT 1 FROM track t WHERE t.id = l.local_track_id) AS local_visible
+                        EXISTS(SELECT 1 FROM track t
+                                WHERE t.id = l.local_track_id AND t.is_available = 1) AS local_visible
                    FROM remote_playlist_track rpt
                    LEFT JOIN remote_track rt ON rt.remote_id = rpt.track_remote_id
                    LEFT JOIN remote_track_link l ON l.remote_track_id = rpt.track_remote_id
@@ -1378,6 +1379,28 @@ mod tests {
             .unwrap();
         assert!(!duplicate.can_convert);
         assert_eq!(duplicate.items[1].status, "duplicate");
+
+        sqlx::query("UPDATE track SET is_available = 0 WHERE id = 2")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let unavailable = preview_playlist_conversion(&pool, "server_to_local", "valid")
+            .await
+            .unwrap();
+        assert!(!unavailable.can_convert);
+        assert_eq!(unavailable.items[0].status, "unlinked_or_ambiguous");
+        assert!(convert_playlist(&pool, "server_to_local", "valid")
+            .await
+            .is_err());
+        let local_playlists: i64 = sqlx::query_scalar("SELECT count(*) FROM playlist")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(local_playlists, 0, "a blocked copy must remain atomic");
+        sqlx::query("UPDATE track SET is_available = 1 WHERE id = 2")
+            .execute(&pool)
+            .await
+            .unwrap();
 
         sqlx::query("DELETE FROM remote_track WHERE remote_id = 'remote-1'")
             .execute(&pool)

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -737,7 +737,7 @@ async fn preview_playlist_conversion_on(
                 ));
             }
             let rows = sqlx::query(
-                "SELECT pt.position, t.id AS local_track_id, t.title,
+                "SELECT pt.position, t.id AS local_track_id, t.title, t.is_available,
                         l.remote_track_id, l.status,
                         EXISTS(SELECT 1 FROM remote_track rt
                                 WHERE rt.remote_id = l.remote_track_id) AS remote_visible
@@ -755,9 +755,11 @@ async fn preview_playlist_conversion_on(
                 .map(|row| {
                     let remote_track_id: Option<String> = row.try_get("remote_track_id")?;
                     let link_status: Option<String> = row.try_get("status")?;
+                    let local_available = row.try_get::<i64, _>("is_available")? != 0;
                     let remote_visible = row.try_get::<i64, _>("remote_visible")? != 0;
                     let status = if link_status.as_deref() == Some(STATUS_CONFIRMED)
                         && remote_track_id.is_some()
+                        && local_available
                         && remote_visible
                     {
                         STATUS_CONFIRMED
@@ -1324,6 +1326,24 @@ mod tests {
 
         insert_remote(&pool, "remote-2", b"second bytes", "Second remote").await;
         assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
+
+        sqlx::query("UPDATE track SET is_available = 0 WHERE id = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let unavailable = preview_playlist_conversion(&pool, "local_to_server", "10")
+            .await
+            .unwrap();
+        assert!(!unavailable.can_convert);
+        assert_eq!(unavailable.items[0].status, "unlinked_or_ambiguous");
+        assert!(convert_playlist(&pool, "local_to_server", "10")
+            .await
+            .is_err());
+        sqlx::query("UPDATE track SET is_available = 1 WHERE id = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
         let ready = preview_playlist_conversion(&pool, "local_to_server", "10")
             .await
             .unwrap();

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -12,7 +12,12 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use serde::Serialize;
-use sqlx::{Row, SqlitePool};
+use sqlx::{Row, SqliteConnection, SqlitePool};
+
+use waveflow_core::repository::{
+    playlist::PlaylistDraft,
+    sqlite::playlist::{append_tracks_conn, insert_custom_conn},
+};
 
 use crate::error::{AppError, AppResult};
 
@@ -101,6 +106,35 @@ pub struct PreferredLocalPlayback {
     pub track_id: i64,
     pub path: PathBuf,
     pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PlaylistConversionItem {
+    pub position: i64,
+    pub title: String,
+    pub local_track_id: Option<i64>,
+    pub remote_track_id: Option<String>,
+    /// `confirmed`, `stale`, `unlinked_or_ambiguous`, or `duplicate`.
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PlaylistConversionPreview {
+    pub direction: String,
+    pub source_id: String,
+    pub source_name: String,
+    pub total_tracks: usize,
+    pub convertible_tracks: usize,
+    pub blocked_tracks: usize,
+    pub can_convert: bool,
+    pub items: Vec<PlaylistConversionItem>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PlaylistConversionResult {
+    pub direction: String,
+    pub destination_id: String,
+    pub converted_tracks: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -670,6 +704,220 @@ pub async fn preferred_local_playback(
     }))
 }
 
+/// Preview an explicit playlist conversion without mutating either source.
+/// Only confirmed links are convertible; stale, missing and ambiguous pairs
+/// remain visible in their original positions and block conversion.
+pub async fn preview_playlist_conversion(
+    pool: &SqlitePool,
+    direction: &str,
+    source_id: &str,
+) -> AppResult<PlaylistConversionPreview> {
+    let mut conn = pool.acquire().await?;
+    preview_playlist_conversion_on(&mut conn, direction, source_id).await
+}
+
+async fn preview_playlist_conversion_on(
+    conn: &mut SqliteConnection,
+    direction: &str,
+    source_id: &str,
+) -> AppResult<PlaylistConversionPreview> {
+    let (source_name, mut items) = match direction {
+        "local_to_server" => {
+            let playlist_id = source_id
+                .parse::<i64>()
+                .map_err(|_| AppError::Other("invalid local playlist id".into()))?;
+            let row = sqlx::query("SELECT name, is_smart FROM playlist WHERE id = ?")
+                .bind(playlist_id)
+                .fetch_optional(&mut *conn)
+                .await?
+                .ok_or_else(|| AppError::Other("local playlist not found".into()))?;
+            if row.try_get::<i64, _>("is_smart")? != 0 {
+                return Err(AppError::Other(
+                    "smart playlists must be materialized locally before conversion".into(),
+                ));
+            }
+            let rows = sqlx::query(
+                "SELECT pt.position, t.id AS local_track_id, t.title,
+                        l.remote_track_id, l.status,
+                        EXISTS(SELECT 1 FROM remote_track rt
+                                WHERE rt.remote_id = l.remote_track_id) AS remote_visible
+                   FROM playlist_track pt
+                   JOIN track t ON t.id = pt.track_id
+                   LEFT JOIN remote_track_link l ON l.local_track_id = t.id
+                  WHERE pt.playlist_id = ?
+                  ORDER BY pt.position, t.id",
+            )
+            .bind(playlist_id)
+            .fetch_all(&mut *conn)
+            .await?;
+            let items = rows
+                .into_iter()
+                .map(|row| {
+                    let remote_track_id: Option<String> = row.try_get("remote_track_id")?;
+                    let link_status: Option<String> = row.try_get("status")?;
+                    let remote_visible = row.try_get::<i64, _>("remote_visible")? != 0;
+                    let status = if link_status.as_deref() == Some(STATUS_CONFIRMED)
+                        && remote_track_id.is_some()
+                        && remote_visible
+                    {
+                        STATUS_CONFIRMED
+                    } else if link_status.as_deref() == Some(STATUS_STALE) {
+                        STATUS_STALE
+                    } else {
+                        "unlinked_or_ambiguous"
+                    };
+                    Ok(PlaylistConversionItem {
+                        position: row.try_get("position")?,
+                        title: row.try_get("title")?,
+                        local_track_id: Some(row.try_get("local_track_id")?),
+                        remote_track_id,
+                        status: status.to_string(),
+                    })
+                })
+                .collect::<AppResult<Vec<_>>>()?;
+            (row.try_get("name")?, items)
+        }
+        "server_to_local" => {
+            let row = sqlx::query("SELECT name FROM remote_playlist WHERE remote_id = ?")
+                .bind(source_id)
+                .fetch_optional(&mut *conn)
+                .await?
+                .ok_or_else(|| AppError::Other("server playlist not found".into()))?;
+            let rows = sqlx::query(
+                "SELECT rpt.position, rpt.track_remote_id, rt.title,
+                        l.local_track_id, l.status,
+                        rt.remote_id IS NOT NULL AS remote_visible,
+                        EXISTS(SELECT 1 FROM track t WHERE t.id = l.local_track_id) AS local_visible
+                   FROM remote_playlist_track rpt
+                   LEFT JOIN remote_track rt ON rt.remote_id = rpt.track_remote_id
+                   LEFT JOIN remote_track_link l ON l.remote_track_id = rpt.track_remote_id
+                  WHERE rpt.playlist_remote_id = ?
+                  ORDER BY rpt.position",
+            )
+            .bind(source_id)
+            .fetch_all(&mut *conn)
+            .await?;
+            let mut seen_local = HashSet::new();
+            let items = rows
+                .into_iter()
+                .map(|row| {
+                    let local_track_id: Option<i64> = row.try_get("local_track_id")?;
+                    let link_status: Option<String> = row.try_get("status")?;
+                    let remote_visible = row.try_get::<i64, _>("remote_visible")? != 0;
+                    let local_visible = row.try_get::<i64, _>("local_visible")? != 0;
+                    let status = if let Some(local_track_id) = local_track_id.filter(|_| {
+                        link_status.as_deref() == Some(STATUS_CONFIRMED)
+                            && remote_visible
+                            && local_visible
+                    }) {
+                        if seen_local.insert(local_track_id) {
+                            STATUS_CONFIRMED
+                        } else {
+                            "duplicate"
+                        }
+                    } else if link_status.as_deref() == Some(STATUS_STALE) {
+                        STATUS_STALE
+                    } else {
+                        "unlinked_or_ambiguous"
+                    };
+                    let remote_track_id: String = row.try_get("track_remote_id")?;
+                    let title = row
+                        .try_get::<Option<String>, _>("title")?
+                        .unwrap_or_else(|| remote_track_id.clone());
+                    Ok(PlaylistConversionItem {
+                        position: row.try_get("position")?,
+                        title,
+                        local_track_id,
+                        remote_track_id: Some(remote_track_id),
+                        status: status.to_string(),
+                    })
+                })
+                .collect::<AppResult<Vec<_>>>()?;
+            (row.try_get("name")?, items)
+        }
+        _ => {
+            return Err(AppError::Other(
+                "invalid playlist conversion direction".into(),
+            ))
+        }
+    };
+
+    let total_tracks = items.len();
+    let convertible_tracks = items
+        .iter()
+        .filter(|item| item.status == STATUS_CONFIRMED)
+        .count();
+    let blocked_tracks = total_tracks.saturating_sub(convertible_tracks);
+    // Keep the original order in the response even if future status
+    // enrichment appends rows from another source.
+    items.sort_by_key(|item| item.position);
+    Ok(PlaylistConversionPreview {
+        direction: direction.to_string(),
+        source_id: source_id.to_string(),
+        source_name,
+        total_tracks,
+        convertible_tracks,
+        blocked_tracks,
+        can_convert: blocked_tracks == 0,
+        items,
+    })
+}
+
+/// Execute a previously previewable playlist conversion. The preview is
+/// rebuilt inside the same transaction, preventing a link becoming stale or
+/// disappearing between confirmation and mutation.
+pub async fn convert_playlist(
+    pool: &SqlitePool,
+    direction: &str,
+    source_id: &str,
+) -> AppResult<PlaylistConversionResult> {
+    let mut tx = pool.begin().await?;
+    let preview = preview_playlist_conversion_on(&mut tx, direction, source_id).await?;
+    if !preview.can_convert {
+        return Err(AppError::Other(format!(
+            "playlist conversion blocked by {} unlinked, stale, ambiguous, or duplicate tracks",
+            preview.blocked_tracks
+        )));
+    }
+
+    let destination_id = match direction {
+        "local_to_server" => {
+            let track_ids = preview
+                .items
+                .iter()
+                .filter_map(|item| item.remote_track_id.clone())
+                .collect::<Vec<_>>();
+            crate::remote::write::create_playlist_in_tx(&mut tx, &preview.source_name, &track_ids)
+                .await?
+        }
+        "server_to_local" => {
+            let now = now_ms();
+            let draft = PlaylistDraft {
+                name: preview.source_name.clone(),
+                description: Some("Materialized from WaveFlow Server".into()),
+                color_id: "violet".into(),
+                icon_id: "music".into(),
+                now_ms: now,
+            };
+            let playlist_id = insert_custom_conn(&mut tx, &draft).await?;
+            let track_ids = preview
+                .items
+                .iter()
+                .filter_map(|item| item.local_track_id)
+                .collect::<Vec<_>>();
+            append_tracks_conn(&mut tx, playlist_id, &track_ids, now).await?;
+            playlist_id.to_string()
+        }
+        _ => unreachable!("direction validated by preview"),
+    };
+    tx.commit().await?;
+    Ok(PlaylistConversionResult {
+        direction: direction.to_string(),
+        destination_id,
+        converted_tracks: preview.total_tracks,
+    })
+}
+
 pub async fn remove_link(pool: &SqlitePool, local_track_id: i64) -> AppResult<()> {
     let mut tx = pool.begin().await?;
     // Capture the link's matching evidence before deleting it and record a
@@ -750,6 +998,49 @@ mod tests {
                  album TEXT,
                  size INTEGER,
                  full_hash TEXT
+             );
+             CREATE TABLE playlist (
+                 id INTEGER PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 description TEXT,
+                 color_id TEXT NOT NULL DEFAULT 'violet',
+                 icon_id TEXT NOT NULL DEFAULT 'music',
+                 is_smart INTEGER NOT NULL DEFAULT 0,
+                 position INTEGER NOT NULL DEFAULT 0,
+                 created_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL
+             );
+             CREATE TABLE playlist_track (
+                 playlist_id INTEGER NOT NULL REFERENCES playlist(id) ON DELETE CASCADE,
+                 track_id INTEGER NOT NULL REFERENCES track(id) ON DELETE CASCADE,
+                 position INTEGER NOT NULL,
+                 added_at INTEGER NOT NULL,
+                 PRIMARY KEY (playlist_id, track_id)
+             );
+             CREATE TABLE remote_playlist (
+                 remote_id TEXT PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 comment TEXT,
+                 is_public INTEGER NOT NULL DEFAULT 0,
+                 created_at INTEGER,
+                 updated_at INTEGER
+             );
+             CREATE TABLE remote_playlist_track (
+                 playlist_remote_id TEXT NOT NULL REFERENCES remote_playlist(remote_id) ON DELETE CASCADE,
+                 position INTEGER NOT NULL,
+                 track_remote_id TEXT NOT NULL,
+                 PRIMARY KEY (playlist_remote_id, position)
+             );
+             CREATE TABLE remote_mutation (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 operation_id TEXT NOT NULL UNIQUE,
+                 kind TEXT NOT NULL,
+                 payload TEXT NOT NULL,
+                 created_at INTEGER NOT NULL,
+                 attempt_count INTEGER NOT NULL DEFAULT 0,
+                 last_attempt_at INTEGER,
+                 last_error TEXT,
+                 failed_at INTEGER
              );",
         )
         .execute(&pool)
@@ -987,5 +1278,118 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn local_playlist_conversion_blocks_until_every_track_is_linked() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.flac");
+        let second = dir.path().join("second.mp3");
+        fs::write(&first, b"first bytes").unwrap();
+        fs::write(&second, b"second bytes").unwrap();
+        insert_local(&pool, 1, &first, "First").await;
+        insert_local(&pool, 2, &second, "Second").await;
+        insert_remote(&pool, "remote-1", b"first bytes", "First remote").await;
+        assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
+        sqlx::raw_sql(
+            "INSERT INTO playlist (id, name, created_at, updated_at) VALUES (10, 'Local mix', 1, 1);
+             INSERT INTO playlist_track VALUES (10, 1, 0, 1), (10, 2, 1, 1);",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let blocked = preview_playlist_conversion(&pool, "local_to_server", "10")
+            .await
+            .unwrap();
+        assert!(!blocked.can_convert);
+        assert_eq!(blocked.convertible_tracks, 1);
+        assert_eq!(blocked.items[1].status, "unlinked_or_ambiguous");
+        assert!(convert_playlist(&pool, "local_to_server", "10")
+            .await
+            .is_err());
+
+        insert_remote(&pool, "remote-2", b"second bytes", "Second remote").await;
+        assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
+        let ready = preview_playlist_conversion(&pool, "local_to_server", "10")
+            .await
+            .unwrap();
+        assert!(ready.can_convert);
+
+        let result = convert_playlist(&pool, "local_to_server", "10")
+            .await
+            .unwrap();
+        assert_eq!(result.converted_tracks, 2);
+        let copied: Vec<String> = sqlx::query_scalar(
+            "SELECT track_remote_id FROM remote_playlist_track
+              WHERE playlist_remote_id = ? ORDER BY position",
+        )
+        .bind(&result.destination_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(copied, vec!["remote-1", "remote-2"]);
+        let mutations: i64 = sqlx::query_scalar("SELECT count(*) FROM remote_mutation")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(mutations, 1);
+    }
+
+    #[tokio::test]
+    async fn server_playlist_conversion_preserves_order_and_rejects_duplicates() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.wav");
+        let second = dir.path().join("second.aac");
+        fs::write(&first, b"first bytes").unwrap();
+        fs::write(&second, b"second bytes").unwrap();
+        insert_local(&pool, 1, &first, "First").await;
+        insert_local(&pool, 2, &second, "Second").await;
+        insert_remote(&pool, "remote-1", b"first bytes", "First remote").await;
+        insert_remote(&pool, "remote-2", b"second bytes", "Second remote").await;
+        assert_eq!(discover(&pool).await.unwrap().auto_linked, 2);
+        sqlx::raw_sql(
+            "INSERT INTO remote_playlist (remote_id, name) VALUES ('valid', 'Server mix');
+             INSERT INTO remote_playlist_track VALUES
+                 ('valid', 0, 'remote-2'), ('valid', 1, 'remote-1');
+             INSERT INTO remote_playlist (remote_id, name) VALUES ('duplicate', 'Duplicate mix');
+             INSERT INTO remote_playlist_track VALUES
+                 ('duplicate', 0, 'remote-1'), ('duplicate', 1, 'remote-1');",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let duplicate = preview_playlist_conversion(&pool, "server_to_local", "duplicate")
+            .await
+            .unwrap();
+        assert!(!duplicate.can_convert);
+        assert_eq!(duplicate.items[1].status, "duplicate");
+
+        sqlx::query("DELETE FROM remote_track WHERE remote_id = 'remote-1'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let inaccessible = preview_playlist_conversion(&pool, "server_to_local", "valid")
+            .await
+            .unwrap();
+        assert!(!inaccessible.can_convert);
+        assert_eq!(inaccessible.items[1].status, "unlinked_or_ambiguous");
+        insert_remote(&pool, "remote-1", b"first bytes", "First remote").await;
+
+        let result = convert_playlist(&pool, "server_to_local", "valid")
+            .await
+            .unwrap();
+        let playlist_id = result.destination_id.parse::<i64>().unwrap();
+        let copied: Vec<i64> = sqlx::query_scalar(
+            "SELECT track_id FROM playlist_track WHERE playlist_id = ? ORDER BY position",
+        )
+        .bind(playlist_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(copied, vec![2, 1]);
     }
 }

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -1310,6 +1310,17 @@ mod tests {
             .await
             .is_err());
 
+        fs::write(&first, b"other bytes").unwrap();
+        assert_eq!(discover(&pool).await.unwrap().stale_links, 1);
+        let stale = preview_playlist_conversion(&pool, "local_to_server", "10")
+            .await
+            .unwrap();
+        assert!(!stale.can_convert);
+        assert_eq!(stale.items[0].status, "stale");
+
+        fs::write(&first, b"first bytes").unwrap();
+        assert_eq!(discover(&pool).await.unwrap().stale_links, 0);
+
         insert_remote(&pool, "remote-2", b"second bytes", "Second remote").await;
         assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
         let ready = preview_playlist_conversion(&pool, "local_to_server", "10")

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -144,6 +144,14 @@ struct ExistingLink {
     verified_full_hash: Option<String>,
 }
 
+#[derive(Debug)]
+struct PlaylistLinkProof {
+    local_track_id: i64,
+    file_path: String,
+    verified_full_hash: Option<String>,
+    remote_full_hash: Option<String>,
+}
+
 fn now_ms() -> i64 {
     Utc::now().timestamp_millis()
 }
@@ -265,6 +273,45 @@ fn hash_local_tracks(tracks: Vec<LocalTrack>) -> (Vec<HashedLocalTrack>, usize) 
         }
     }
     (hashed, unreadable)
+}
+
+async fn playlist_link_freshness(proofs: Vec<PlaylistLinkProof>) -> AppResult<HashMap<i64, bool>> {
+    tokio::task::spawn_blocking(move || {
+        let mut freshness = HashMap::new();
+        for proof in proofs {
+            if freshness.contains_key(&proof.local_track_id) {
+                continue;
+            }
+            let expected = proof
+                .verified_full_hash
+                .as_deref()
+                .filter(|value| valid_full_hash(value));
+            let remote = proof
+                .remote_full_hash
+                .as_deref()
+                .filter(|value| valid_full_hash(value));
+            let fresh = match (expected, remote) {
+                (Some(expected), Some(remote)) if expected.eq_ignore_ascii_case(remote) => {
+                    match waveflow_core::scanner::hash_file_full(Path::new(&proof.file_path)) {
+                        Ok(current) => current.eq_ignore_ascii_case(expected),
+                        Err(err) => {
+                            tracing::warn!(
+                                local_track_id = proof.local_track_id,
+                                error = %err,
+                                "playlist conversion could not revalidate local track"
+                            );
+                            false
+                        }
+                    }
+                }
+                _ => false,
+            };
+            freshness.insert(proof.local_track_id, fresh);
+        }
+        freshness
+    })
+    .await
+    .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))
 }
 
 async fn reconcile(
@@ -737,33 +784,50 @@ async fn preview_playlist_conversion_on(
                 ));
             }
             let rows = sqlx::query(
-                "SELECT pt.position, t.id AS local_track_id, t.title, t.is_available,
-                        l.remote_track_id, l.status,
-                        EXISTS(SELECT 1 FROM remote_track rt
-                                WHERE rt.remote_id = l.remote_track_id) AS remote_visible
+                "SELECT pt.position, t.id AS local_track_id, t.title, t.file_path,
+                        t.is_available, l.remote_track_id, l.status,
+                        l.verified_full_hash, rt.full_hash AS remote_full_hash,
+                        rt.remote_id IS NOT NULL AS remote_visible
                    FROM playlist_track pt
                    JOIN track t ON t.id = pt.track_id
                    LEFT JOIN remote_track_link l ON l.local_track_id = t.id
+                   LEFT JOIN remote_track rt ON rt.remote_id = l.remote_track_id
                   WHERE pt.playlist_id = ?
                   ORDER BY pt.position, t.id",
             )
             .bind(playlist_id)
             .fetch_all(&mut *conn)
             .await?;
+            let mut proofs = Vec::new();
+            for row in &rows {
+                if row.try_get::<i64, _>("is_available")? != 0 {
+                    proofs.push(PlaylistLinkProof {
+                        local_track_id: row.try_get("local_track_id")?,
+                        file_path: row.try_get("file_path")?,
+                        verified_full_hash: row.try_get("verified_full_hash")?,
+                        remote_full_hash: row.try_get("remote_full_hash")?,
+                    });
+                }
+            }
+            let freshness = playlist_link_freshness(proofs).await?;
             let items = rows
                 .into_iter()
                 .map(|row| {
+                    let local_track_id: i64 = row.try_get("local_track_id")?;
                     let remote_track_id: Option<String> = row.try_get("remote_track_id")?;
                     let link_status: Option<String> = row.try_get("status")?;
                     let local_available = row.try_get::<i64, _>("is_available")? != 0;
                     let remote_visible = row.try_get::<i64, _>("remote_visible")? != 0;
-                    let status = if link_status.as_deref() == Some(STATUS_CONFIRMED)
+                    let confirmed_context = link_status.as_deref() == Some(STATUS_CONFIRMED)
                         && remote_track_id.is_some()
                         && local_available
-                        && remote_visible
-                    {
+                        && remote_visible;
+                    let fresh = freshness.get(&local_track_id).copied().unwrap_or(false);
+                    let status = if confirmed_context && fresh {
                         STATUS_CONFIRMED
-                    } else if link_status.as_deref() == Some(STATUS_STALE) {
+                    } else if link_status.as_deref() == Some(STATUS_STALE)
+                        || (confirmed_context && !fresh)
+                    {
                         STATUS_STALE
                     } else {
                         "unlinked_or_ambiguous"
@@ -771,7 +835,7 @@ async fn preview_playlist_conversion_on(
                     Ok(PlaylistConversionItem {
                         position: row.try_get("position")?,
                         title: row.try_get("title")?,
-                        local_track_id: Some(row.try_get("local_track_id")?),
+                        local_track_id: Some(local_track_id),
                         remote_track_id,
                         status: status.to_string(),
                     })
@@ -787,19 +851,32 @@ async fn preview_playlist_conversion_on(
                 .ok_or_else(|| AppError::Other("server playlist not found".into()))?;
             let rows = sqlx::query(
                 "SELECT rpt.position, rpt.track_remote_id, rt.title,
-                        l.local_track_id, l.status,
+                        l.local_track_id, l.status, l.verified_full_hash,
+                        rt.full_hash AS remote_full_hash, t.file_path,
                         rt.remote_id IS NOT NULL AS remote_visible,
-                        EXISTS(SELECT 1 FROM track t
-                                WHERE t.id = l.local_track_id AND t.is_available = 1) AS local_visible
+                        t.id IS NOT NULL AND t.is_available = 1 AS local_visible
                    FROM remote_playlist_track rpt
                    LEFT JOIN remote_track rt ON rt.remote_id = rpt.track_remote_id
                    LEFT JOIN remote_track_link l ON l.remote_track_id = rpt.track_remote_id
+                   LEFT JOIN track t ON t.id = l.local_track_id
                   WHERE rpt.playlist_remote_id = ?
                   ORDER BY rpt.position",
             )
             .bind(source_id)
             .fetch_all(&mut *conn)
             .await?;
+            let mut proofs = Vec::new();
+            for row in &rows {
+                if row.try_get::<i64, _>("local_visible")? != 0 {
+                    proofs.push(PlaylistLinkProof {
+                        local_track_id: row.try_get("local_track_id")?,
+                        file_path: row.try_get("file_path")?,
+                        verified_full_hash: row.try_get("verified_full_hash")?,
+                        remote_full_hash: row.try_get("remote_full_hash")?,
+                    });
+                }
+            }
+            let freshness = playlist_link_freshness(proofs).await?;
             let mut seen_local = HashSet::new();
             let items = rows
                 .into_iter()
@@ -808,17 +885,23 @@ async fn preview_playlist_conversion_on(
                     let link_status: Option<String> = row.try_get("status")?;
                     let remote_visible = row.try_get::<i64, _>("remote_visible")? != 0;
                     let local_visible = row.try_get::<i64, _>("local_visible")? != 0;
-                    let status = if let Some(local_track_id) = local_track_id.filter(|_| {
-                        link_status.as_deref() == Some(STATUS_CONFIRMED)
-                            && remote_visible
-                            && local_visible
-                    }) {
+                    let fresh = local_track_id
+                        .and_then(|id| freshness.get(&id).copied())
+                        .unwrap_or(false);
+                    let confirmed_context = link_status.as_deref() == Some(STATUS_CONFIRMED)
+                        && remote_visible
+                        && local_visible;
+                    let status = if let Some(local_track_id) =
+                        local_track_id.filter(|_| confirmed_context && fresh)
+                    {
                         if seen_local.insert(local_track_id) {
                             STATUS_CONFIRMED
                         } else {
                             "duplicate"
                         }
-                    } else if link_status.as_deref() == Some(STATUS_STALE) {
+                    } else if link_status.as_deref() == Some(STATUS_STALE)
+                        || (confirmed_context && !fresh)
+                    {
                         STATUS_STALE
                     } else {
                         "unlinked_or_ambiguous"
@@ -1349,6 +1432,17 @@ mod tests {
             .unwrap();
         assert!(ready.can_convert);
 
+        fs::write(&first, b"other bytes").unwrap();
+        let changed_without_discover = preview_playlist_conversion(&pool, "local_to_server", "10")
+            .await
+            .unwrap();
+        assert!(!changed_without_discover.can_convert);
+        assert_eq!(changed_without_discover.items[0].status, "stale");
+        assert!(convert_playlist(&pool, "local_to_server", "10")
+            .await
+            .is_err());
+        fs::write(&first, b"first bytes").unwrap();
+
         let result = convert_playlist(&pool, "local_to_server", "10")
             .await
             .unwrap();
@@ -1399,6 +1493,18 @@ mod tests {
             .unwrap();
         assert!(!duplicate.can_convert);
         assert_eq!(duplicate.items[1].status, "duplicate");
+
+        fs::write(&first, b"other bytes").unwrap();
+        let changed_without_discover =
+            preview_playlist_conversion(&pool, "server_to_local", "valid")
+                .await
+                .unwrap();
+        assert!(!changed_without_discover.can_convert);
+        assert_eq!(changed_without_discover.items[1].status, "stale");
+        assert!(convert_playlist(&pool, "server_to_local", "valid")
+            .await
+            .is_err());
+        fs::write(&first, b"first bytes").unwrap();
 
         sqlx::query("UPDATE track SET is_available = 0 WHERE id = 2")
             .execute(&pool)

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -957,6 +957,18 @@ pub async fn convert_playlist(
     direction: &str,
     source_id: &str,
 ) -> AppResult<PlaylistConversionResult> {
+    convert_playlist_with_post_validation(pool, direction, source_id, || {}).await
+}
+
+async fn convert_playlist_with_post_validation<F>(
+    pool: &SqlitePool,
+    direction: &str,
+    source_id: &str,
+    post_validation: F,
+) -> AppResult<PlaylistConversionResult>
+where
+    F: FnOnce(),
+{
     let mut tx = pool.begin().await?;
     let preview = preview_playlist_conversion_on(&mut tx, direction, source_id).await?;
     if !preview.can_convert {
@@ -965,6 +977,7 @@ pub async fn convert_playlist(
             preview.blocked_tracks
         )));
     }
+    post_validation();
 
     let destination_id = match direction {
         "local_to_server" => {
@@ -996,6 +1009,13 @@ pub async fn convert_playlist(
         }
         _ => unreachable!("direction validated by preview"),
     };
+    let final_preview = preview_playlist_conversion_on(&mut tx, direction, source_id).await?;
+    if !final_preview.can_convert {
+        return Err(AppError::Other(format!(
+            "playlist conversion blocked by {} tracks that changed during conversion",
+            final_preview.blocked_tracks
+        )));
+    }
     tx.commit().await?;
     Ok(PlaylistConversionResult {
         direction: direction.to_string(),
@@ -1443,6 +1463,18 @@ mod tests {
             .is_err());
         fs::write(&first, b"first bytes").unwrap();
 
+        let raced = convert_playlist_with_post_validation(&pool, "local_to_server", "10", || {
+            fs::write(&first, b"other bytes").unwrap();
+        })
+        .await;
+        assert!(raced.is_err());
+        let rolled_back: i64 = sqlx::query_scalar("SELECT count(*) FROM remote_playlist")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rolled_back, 0, "the raced destination must roll back");
+        fs::write(&first, b"first bytes").unwrap();
+
         let result = convert_playlist(&pool, "local_to_server", "10")
             .await
             .unwrap();
@@ -1538,6 +1570,19 @@ mod tests {
         assert!(!inaccessible.can_convert);
         assert_eq!(inaccessible.items[1].status, "unlinked_or_ambiguous");
         insert_remote(&pool, "remote-1", b"first bytes", "First remote").await;
+
+        let raced =
+            convert_playlist_with_post_validation(&pool, "server_to_local", "valid", || {
+                fs::write(&first, b"other bytes").unwrap();
+            })
+            .await;
+        assert!(raced.is_err());
+        let rolled_back: i64 = sqlx::query_scalar("SELECT count(*) FROM playlist")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rolled_back, 0, "the raced destination must roll back");
+        fs::write(&first, b"first bytes").unwrap();
 
         let result = convert_playlist(&pool, "server_to_local", "valid")
             .await

--- a/src/components/views/settings/ReconciliationCard.tsx
+++ b/src/components/views/settings/ReconciliationCard.tsx
@@ -252,31 +252,27 @@ function PlaylistConversion() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  const loadPlaylists = useCallback(async () => {
+  const loadPlaylists = useCallback(async (isCancelled?: () => boolean) => {
     const [local, remote] = await Promise.all([
       listPlaylists(),
       remoteListPlaylists(),
     ]);
+    if (isCancelled?.()) return;
     setLocalPlaylists(local.filter((playlist) => playlist.is_smart === 0));
     setRemotePlaylists(remote);
-    return { local, remote };
   }, []);
 
   useEffect(() => {
     let cancelled = false;
-    void Promise.all([listPlaylists(), remoteListPlaylists()])
-      .then(([local, remote]) => {
-        if (cancelled) return;
-        setLocalPlaylists(local.filter((playlist) => playlist.is_smart === 0));
-        setRemotePlaylists(remote);
-      })
+    void Promise.resolve()
+      .then(() => loadPlaylists(() => cancelled))
       .catch((err) => {
         if (!cancelled) setError(String(err));
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadPlaylists]);
 
   const sources =
     direction === "local_to_server" ? localPlaylists : remotePlaylists;
@@ -308,6 +304,7 @@ function PlaylistConversion() {
     if (!selectedSourceId || !preview?.can_convert) return;
     setBusy(true);
     setError(null);
+    setSuccess(null);
     try {
       const result = await remoteConvertPlaylist(direction, selectedSourceId);
       setSuccess(
@@ -425,12 +422,22 @@ function PlaylistConversion() {
       )}
 
       {success && (
-        <p className="text-xs text-emerald-600 dark:text-emerald-400">
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-xs text-emerald-600 dark:text-emerald-400"
+        >
           {success}
         </p>
       )}
       {error && (
-        <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-xs text-red-600 dark:text-red-400"
+        >
+          {error}
+        </p>
       )}
     </div>
   );

--- a/src/components/views/settings/ReconciliationCard.tsx
+++ b/src/components/views/settings/ReconciliationCard.tsx
@@ -1,16 +1,31 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Link2, Loader2, RefreshCw, Unlink, X } from "lucide-react";
 import {
+  ArrowLeftRight,
+  Check,
+  Link2,
+  Loader2,
+  RefreshCw,
+  Unlink,
+  X,
+} from "lucide-react";
+import { listPlaylists, type Playlist } from "../../../lib/tauri/playlist";
+import {
+  remoteConvertPlaylist,
   remoteConfirmReconciliation,
   remoteGetStatus,
   remoteListReconciliationLinks,
+  remoteListPlaylists,
+  remotePreviewPlaylistConversion,
   remoteReconcileScan,
   remoteRejectReconciliation,
   remoteRemoveReconciliationLink,
   remoteSetReconciliationPreference,
   type MatchCandidateGroup,
+  type PlaylistConversionDirection,
+  type PlaylistConversionPreview,
   type ReconciliationLink,
   type ReconciliationReport,
+  type RemotePlaylistSummary,
 } from "../../../lib/tauri/remoteServer";
 
 /** M5 identity links. Kept beside the connection card because it only makes
@@ -205,6 +220,8 @@ export function ReconciliationCard() {
             </div>
           )}
 
+          <PlaylistConversion />
+
           {error && (
             <p
               role="status"
@@ -216,6 +233,205 @@ export function ReconciliationCard() {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function PlaylistConversion() {
+  const [direction, setDirection] =
+    useState<PlaylistConversionDirection>("local_to_server");
+  const [localPlaylists, setLocalPlaylists] = useState<Playlist[]>([]);
+  const [remotePlaylists, setRemotePlaylists] = useState<
+    RemotePlaylistSummary[]
+  >([]);
+  const [sourceId, setSourceId] = useState("");
+  const [preview, setPreview] = useState<PlaylistConversionPreview | null>(
+    null,
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const loadPlaylists = useCallback(async () => {
+    const [local, remote] = await Promise.all([
+      listPlaylists(),
+      remoteListPlaylists(),
+    ]);
+    setLocalPlaylists(local.filter((playlist) => playlist.is_smart === 0));
+    setRemotePlaylists(remote);
+    return { local, remote };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([listPlaylists(), remoteListPlaylists()])
+      .then(([local, remote]) => {
+        if (cancelled) return;
+        setLocalPlaylists(local.filter((playlist) => playlist.is_smart === 0));
+        setRemotePlaylists(remote);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sources =
+    direction === "local_to_server" ? localPlaylists : remotePlaylists;
+  const selectedSourceId = sources.some(
+    (playlist) => String(playlist.id) === sourceId,
+  )
+    ? sourceId
+    : sources[0]
+      ? String(sources[0].id)
+      : "";
+
+  const inspect = useCallback(async () => {
+    if (!selectedSourceId) return;
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      setPreview(
+        await remotePreviewPlaylistConversion(direction, selectedSourceId),
+      );
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [direction, selectedSourceId]);
+
+  const convert = useCallback(async () => {
+    if (!selectedSourceId || !preview?.can_convert) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await remoteConvertPlaylist(direction, selectedSourceId);
+      setSuccess(
+        `${result.converted_tracks} tracks copied to ${
+          direction === "local_to_server" ? "the server" : "the local library"
+        }.`,
+      );
+      setPreview(null);
+      await loadPlaylists();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [direction, loadPlaylists, preview?.can_convert, selectedSourceId]);
+
+  return (
+    <div className="border-t border-zinc-200 dark:border-zinc-800 pt-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <ArrowLeftRight
+          size={15}
+          className="text-zinc-400"
+          aria-hidden="true"
+        />
+        <div>
+          <p className="text-xs font-medium text-zinc-800 dark:text-zinc-100">
+            Explicit playlist copy
+          </p>
+          <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+            A preview must confirm every identity link. Nothing is merged or
+            omitted silently.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-[180px_minmax(0,1fr)_auto] gap-2">
+        <select
+          value={direction}
+          onChange={(event) => {
+            setDirection(event.target.value as PlaylistConversionDirection);
+            setSourceId("");
+            setPreview(null);
+            setSuccess(null);
+          }}
+          disabled={busy}
+          aria-label="Playlist copy direction"
+          className="px-2 py-1.5 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+        >
+          <option value="local_to_server">Local → server</option>
+          <option value="server_to_local">Server → local</option>
+        </select>
+        <select
+          value={selectedSourceId}
+          onChange={(event) => {
+            setSourceId(event.target.value);
+            setPreview(null);
+            setSuccess(null);
+          }}
+          disabled={busy || sources.length === 0}
+          aria-label="Source playlist"
+          className="min-w-0 px-2 py-1.5 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+        >
+          {sources.length === 0 && <option value="">No playlists</option>}
+          {sources.map((playlist) => (
+            <option key={playlist.id} value={String(playlist.id)}>
+              {playlist.name} · {playlist.track_count} tracks
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void inspect()}
+          disabled={busy || !selectedSourceId}
+          className="px-3 py-1.5 text-xs rounded-md border border-zinc-200 dark:border-zinc-700 disabled:opacity-50"
+        >
+          Preview
+        </button>
+      </div>
+
+      {preview && (
+        <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 p-3 space-y-3">
+          <p className="text-xs text-zinc-600 dark:text-zinc-300">
+            {preview.source_name}: {preview.convertible_tracks}/
+            {preview.total_tracks} tracks have confirmed links
+            {preview.blocked_tracks > 0
+              ? ` · ${preview.blocked_tracks} blocked`
+              : ""}
+          </p>
+          {preview.blocked_tracks > 0 && (
+            <div className="max-h-40 overflow-auto space-y-1">
+              {preview.items
+                .filter((item) => item.status !== "confirmed")
+                .map((item) => (
+                  <div
+                    key={`${item.position}:${item.remote_track_id ?? item.local_track_id}`}
+                    className="flex items-center justify-between gap-3 text-[11px]"
+                  >
+                    <span className="truncate">{item.title}</span>
+                    <span className="shrink-0 text-amber-600 dark:text-amber-400">
+                      {item.status.replace(/_/g, " ")}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => void convert()}
+            disabled={busy || !preview.can_convert}
+            className="px-3 py-1.5 text-xs rounded-md bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900 disabled:opacity-40"
+          >
+            Confirm copy
+          </button>
+        </div>
+      )}
+
+      {success && (
+        <p className="text-xs text-emerald-600 dark:text-emerald-400">
+          {success}
+        </p>
+      )}
+      {error && (
+        <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+      )}
     </div>
   );
 }
@@ -255,7 +471,9 @@ function CandidateEditor({
   // at a track the rescan removed. Derive the effective ids from the current
   // group, falling back to the first entry, so the selects and the
   // confirm/reject handlers only ever act on ids still present.
-  const effectiveLocalId = group.local_tracks.some((t) => t.track_id === localId)
+  const effectiveLocalId = group.local_tracks.some(
+    (t) => t.track_id === localId,
+  )
     ? localId
     : (group.local_tracks[0]?.track_id ?? 0);
   const effectiveRemoteId = group.remote_tracks.some(

--- a/src/lib/tauri/remoteServer.ts
+++ b/src/lib/tauri/remoteServer.ts
@@ -585,6 +585,33 @@ export interface ReconciliationLink {
   verified_at: number;
 }
 
+export type PlaylistConversionDirection = "local_to_server" | "server_to_local";
+
+export interface PlaylistConversionItem {
+  position: number;
+  title: string;
+  local_track_id: number | null;
+  remote_track_id: string | null;
+  status: "confirmed" | "stale" | "unlinked_or_ambiguous" | "duplicate";
+}
+
+export interface PlaylistConversionPreview {
+  direction: PlaylistConversionDirection;
+  source_id: string;
+  source_name: string;
+  total_tracks: number;
+  convertible_tracks: number;
+  blocked_tracks: number;
+  can_convert: boolean;
+  items: PlaylistConversionItem[];
+}
+
+export interface PlaylistConversionResult {
+  direction: PlaylistConversionDirection;
+  destination_id: string;
+  converted_tracks: number;
+}
+
 /**
  * Find local/server identity links. The backend hashes only local files whose
  * byte size exists in the remote cache; unique exact matches are persisted,
@@ -632,4 +659,24 @@ export function remoteRemoveReconciliationLink(
   localTrackId: number,
 ): Promise<void> {
   return invoke<void>("remote_remove_reconciliation_link", { localTrackId });
+}
+
+export function remotePreviewPlaylistConversion(
+  direction: PlaylistConversionDirection,
+  sourceId: string,
+): Promise<PlaylistConversionPreview> {
+  return invoke<PlaylistConversionPreview>(
+    "remote_preview_playlist_conversion",
+    { direction, sourceId },
+  );
+}
+
+export function remoteConvertPlaylist(
+  direction: PlaylistConversionDirection,
+  sourceId: string,
+): Promise<PlaylistConversionResult> {
+  return invoke<PlaylistConversionResult>("remote_convert_playlist", {
+    direction,
+    sourceId,
+  });
 }


### PR DESCRIPTION
## Summary

- add an explicit local-to-server and server-to-local playlist conversion flow for M5
- require a preview where every source position has a confirmed, still-visible identity link; stale, missing, ambiguous, inaccessible, and unrepresentable duplicate rows block the copy
- rebuild the preview inside the conversion transaction, preserve playlist order, and expose the workflow in the existing reconciliation settings card

## How I tested

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `cargo check -p waveflow --all-targets --all-features`
- `cargo clippy -p waveflow --all-targets --all-features -- -D warnings`
- `waveflow_lib-00b8ef75f90a3be2.exe remote::reconciliation::tests --nocapture` (10 passed)
- `rustfmt --edition 2021 --check` on both modified Rust implementation files

## Screenshots / clips

Not included yet; this is a draft for review before interactive validation with a connected server.

## Checklist

- [x] Title uses Conventional Commits (`type(scope): subject`, kebab-case scope)
- [x] `bun run lint` + `bun run typecheck` pass locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --all-targets` passes locally
- [ ] If UI strings changed: every locale in `src/i18n/locales/` updated — the unfinished M5 remote/reconciliation surface remains English-only, as before this PR
- [x] If cross-cutting pattern changed: the accepted server-side RFC-004 already defines this explicit conversion contract
- [x] Breaking change? No

## Linked issues

Part of M5 local/server reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Conversion explicite des playlists entre la bibliothèque locale et le serveur, dans les deux sens.
  * Prévisualisation des correspondances, pistes convertibles et éléments bloquants avant toute modification.
  * Confirmation requise avant conversion, avec conservation de l’ordre des pistes.
  * Les conversions sont sécurisées et bloquées en présence de pistes incompatibles ou ambiguës.
  * Synchronisation automatique ou régénération de la couverture selon le sens choisi.
  * Les playlists intelligentes locales ne sont pas proposées à la conversion.
  * Affichage des états de chargement, de réussite et d’erreur pendant l’opération.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->