### PR TITLE
chore(deps): bump lofty to 0.25

### DIFF
--- a/packaging/flatpak/generated/cargo-sources.json
+++ b/packaging/flatpak/generated/cargo-sources.json
@@ -4116,27 +4116,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lofty/lofty-0.24.0.crate",
-        "sha256": "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca",
-        "dest": "cargo/vendor/lofty-0.24.0"
+        "url": "https://static.crates.io/crates/lofty/lofty-0.25.1.crate",
+        "sha256": "e0f052e8f93a76f4b2cd551c38a77d3025c7be1dc473f7acbac0ef1663c9f33b",
+        "dest": "cargo/vendor/lofty-0.25.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca\", \"files\": {}}",
-        "dest": "cargo/vendor/lofty-0.24.0",
+        "contents": "{\"package\": \"e0f052e8f93a76f4b2cd551c38a77d3025c7be1dc473f7acbac0ef1663c9f33b\", \"files\": {}}",
+        "dest": "cargo/vendor/lofty-0.25.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lofty_attr/lofty_attr-0.12.0.crate",
-        "sha256": "458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557",
-        "dest": "cargo/vendor/lofty_attr-0.12.0"
+        "url": "https://static.crates.io/crates/lofty_attr/lofty_attr-0.13.0.crate",
+        "sha256": "fdbca1b60ba7cea959ffc84ac27f3dbdbacd6dfda168c7eabbc00e48654bb9fd",
+        "dest": "cargo/vendor/lofty_attr-0.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557\", \"files\": {}}",
-        "dest": "cargo/vendor/lofty_attr-0.12.0",
+        "contents": "{\"package\": \"fdbca1b60ba7cea959ffc84ac27f3dbdbacd6dfda168c7eabbc00e48654bb9fd\", \"files\": {}}",
+        "dest": "cargo/vendor/lofty_attr-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3190,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.24.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
+checksum = "e0f052e8f93a76f4b2cd551c38a77d3025c7be1dc473f7acbac0ef1663c9f33b"
 dependencies = [
  "byteorder",
  "data-encoding",
@@ -3205,13 +3205,13 @@ dependencies = [
 
 [[package]]
 name = "lofty_attr"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557"
+checksum = "fdbca1b60ba7cea959ffc84ac27f3dbdbacd6dfda168c7eabbc00e48654bb9fd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -107,7 +107,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Library scanning
 walkdir = "2"
-lofty = "0.24"
+lofty = "0.25"
 # Standalone ID3v2 parser used to read the metadata blob embedded in
 # the DSF container's footer. Lofty doesn't accept a raw byte buffer
 # (it wants a full file), so the simpler `id3` crate is the cleanest

--- a/src-tauri/crates/app/src/commands/lyrics.rs
+++ b/src-tauri/crates/app/src/commands/lyrics.rs
@@ -762,7 +762,7 @@ fn read_vorbis_comment(path: &Path, file_type: FileType, keys: &[&str]) -> Optio
     use lofty::config::ParseOptions;
     use lofty::file::AudioFile;
 
-    fn pick(comments: &lofty::ogg::VorbisComments, keys: &[&str]) -> Option<String> {
+    fn pick(comments: &lofty::ogg::tag::VorbisComments, keys: &[&str]) -> Option<String> {
         for key in keys {
             if let Some(s) = comments.get(key) {
                 let trimmed = s.trim();
@@ -2883,7 +2883,7 @@ mod tests {
 
     #[test]
     fn synced_keys_match_vorbis_comments_case_insensitively() {
-        use lofty::ogg::VorbisComments;
+        use lofty::ogg::tag::VorbisComments;
 
         // Validates the reader mechanism: our key constants resolve a real
         // VorbisComments case-insensitively, and a plain-only file yields

--- a/src-tauri/crates/app/src/remote/binding.rs
+++ b/src-tauri/crates/app/src/remote/binding.rs
@@ -356,10 +356,15 @@ mod tests {
         .execute(&mut *conn)
         .await
         .unwrap();
-        sqlx::query("INSERT INTO remote_track (remote_id, title) VALUES ('t1', 'Acc1 song')")
-            .execute(&mut *conn)
-            .await
-            .unwrap();
+        // `cached_at` is NOT NULL in the real schema this fixture runs, like
+        // the `starred_at` / `created_at` the neighbouring inserts already pass.
+        sqlx::query(
+            "INSERT INTO remote_track (remote_id, title, cached_at) \
+             VALUES ('t1', 'Acc1 song', 0)",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
         sqlx::query(
             "INSERT INTO remote_mutation (operation_id, kind, payload, created_at) \
              VALUES ('op-1', 'set_favorite', '{}', 0)",

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -142,7 +142,7 @@ chrono = { version = "0.4", features = ["serde"] }
 # Tag parser used by the scanner extract helpers (`crate::scanner::extract`).
 # Same minor as the desktop crate so the workspace's effective lofty
 # build stays cached.
-lofty = "0.24"
+lofty = "0.25"
 # DSF container footer carries an embedded ID3v2 blob; lofty doesn't
 # accept a raw byte buffer (it wants a full file), so `audio_format::dsd::metadata`
 # parses it via the lower-level `id3` crate.


### PR DESCRIPTION
Supersedes #508.

## Why a new PR
Dependabot's #508 was opened against a `main` that predates the sync_v2 work; its branch no longer rebases cleanly (the diff against today's `main` is ~22k lines of unrelated churn). This is the same bump, rebased, plus the two things #508 was missing.

## What it takes to land the bump

**1. The moved `VorbisComments` path.** lofty 0.25 dropped the `lofty::ogg::VorbisComments` re-export; the type now lives in `lofty::ogg::tag`. That was the compile error on both `Rust (ubuntu-latest)` and `Rust (windows-latest)` in #508.

Nothing else in 0.25's breaking set touches this codebase — `Frame` becoming an enum, `remove_from` taking `WriteOptions`, the `ItemKey::FileType` / `MusicianCredits` removals and MP4 properties becoming `Option` would each be a compile error, and the workspace builds clean on both feature configs. 0.25.1 is bug fixes only (FLAC writes no longer read the whole file into memory, ID3v2 UTF-16 BOM handling).

Worth noting the import is load-bearing rather than incidental: we read Vorbis comments through the concrete tag precisely because the generic `Tag` drops custom keys like `SYNCEDLYRICS` and `REPLAYGAIN_*`.

**2. The Flatpak offline sources.** Flathub builds with the network off, so the two new crates need source entries. `cargo-sources.json` regenerated with the pinned upstream generator — the diff is exactly the two bumped crates.

The rest of the `Flatpak sources` failure on #508 was pre-existing drift on `main` (~58 uncovered crates + npm spec drift), fixed separately in #517.

## Checks
- `cargo clippy --workspace --all-targets` ✅ (default features)
- `cargo clippy -p waveflow --no-default-features --features updater --all-targets` ✅
- `cargo test -p waveflow-core` ✅ 102 passed
- `packaging/flatpak/check-sources.py` ✅ 793/793 crates, node + npm manifest in sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance**
  * Mise à jour de la prise en charge des métadonnées audio Vorbis vers une version plus récente.
  * Amélioration de la compatibilité avec les fichiers audio utilisant des commentaires Vorbis.
  * Renforcement de la fiabilité lors du changement de compte.
  * Aucun changement visible dans l’interface ou le fonctionnement général de l’application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->