### PR TITLE
fix(release): unbundle libwayland-client from the AppImage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,9 @@
 *.md        text eol=lf
 *.html      text eol=lf
 *.css       text eol=lf
+# Shell scripts run on CI runners: a CRLF checkout makes bash fail on the
+# shebang with a `\r` nobody can see in the error message.
+*.sh        text eol=lf
 
 # Lockfiles change frequently and benefit from native diff/merge handling,
 # but should still stay LF so CI builds on Linux runners don't see noisy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libfuse2 \
+            squashfs-tools \
             libasound2-dev
 
       - name: Setup Rust toolchain
@@ -262,6 +263,19 @@ jobs:
           else
             bun run tauri build --bundles "$BUNDLES"
           fi
+
+      - name: Unbundle libwayland-client from the AppImage (Linux)
+        if: matrix.platform == 'linux'
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        # Tauri's bundler ships a library the official AppImage
+        # excludelist forbids, and the result doesn't start on any host
+        # with a newer Mesa than this runner. Runs before "Prepare release
+        # assets" so the renamed copy and its .sig are taken from the
+        # fixed bundle. See the script header for the full diagnosis.
+        run: bash scripts/fix-appimage.sh
 
       - name: Scrub Authenticode secrets (Windows)
         if: always() && matrix.platform == 'windows'

--- a/.github/workflows/test-appimage.yml
+++ b/.github/workflows/test-appimage.yml
@@ -45,6 +45,7 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libfuse2 \
+            squashfs-tools \
             libasound2-dev
 
       - name: Setup Rust toolchain
@@ -93,6 +94,12 @@ jobs:
         # the build fails after producing the AppImage, so the upload
         # step never runs.
         run: bun run tauri build --bundles appimage -c '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      - name: Unbundle libwayland-client from the AppImage
+        # Same post-processing the real release applies, so an artifact
+        # downloaded from here behaves like the shipped one. No updater
+        # signature is produced above, so the script skips re-signing.
+        run: bash scripts/fix-appimage.sh
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -242,6 +242,20 @@ pre-release; the beta manifest's payload URLs point there.
 > creates the tag, you don't). The rule's intent (don't bypass
 > release-please for _stable_ versions) is preserved.
 
+## The AppImage is post-processed, and it has to stay that way
+
+Tauri's AppImage bundler copies the webview's dependency closure into the AppDir, and that closure contains `libwayland-client.so.0` — a library the [official AppImage excludelist](https://github.com/AppImage/pkg2appimage/blob/master/excludelist) explicitly forbids bundling, because [Mesa breaks against a bundled copy](https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316).
+
+We build on Ubuntu. On any host with a newer Mesa — Fedora 44 ships Mesa 26 and libwayland 1.25 — the bundled copy wins the lookup and WebKit's WebProcess dies before painting anything:
+
+```text
+Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
+```
+
+The Rust side is unaffected: the app starts, creates its profile, opens its audio device, and shows an empty window. That asymmetry is why this was misread for months as a WebKitGTK 2.52 incompatibility, with users told to install a native package instead. It is not a WebKit problem, and it is not unfixable — [`scripts/fix-appimage.sh`](../scripts/fix-appimage.sh) removes the one file, repacks the squashfs with the compressor the bundler used, verifies the result re-extracts, and re-signs when an updater `.sig` is present.
+
+Both `release.yml` and `test-appimage.yml` run it right after `tauri build`. **If you ever restructure the Linux build, that step has to survive** — dropping it silently produces a release that installs fine and never opens, on exactly the distributions least likely to be in your test matrix. The script no-ops (and says so) if a future Tauri stops bundling the library, so it's safe to leave in place.
+
 ## Flatpak sources are generated, and they go stale silently
 
 Flathub builds with the network disabled, so **every crate and npm tarball must be pre-declared** in [`packaging/flatpak/generated/`](../packaging/flatpak/generated/) by [`generate-sources.sh`](../packaging/flatpak/generate-sources.sh).

--- a/scripts/fix-appimage.sh
+++ b/scripts/fix-appimage.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Drop the bundled `libwayland-client.so.0` from a freshly built AppImage.
+#
+# Why this exists
+# ---------------
+# Tauri's AppImage bundler copies the webview's dependency closure into
+# the AppDir, and that closure includes `libwayland-client.so.0`. That
+# library is on the **official AppImage excludelist**:
+#
+#   libwayland-client.so.0
+#   # https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316
+#   # New version of Mesa has some dependency issues with libwayland-client
+#   # if it is bundled
+#
+# On a host with a newer Mesa than the build runner (Fedora 44 ships Mesa
+# 26 and libwayland 1.25; we build on Ubuntu), the bundled copy wins the
+# lookup and WebKit's WebProcess dies before it renders a single frame:
+#
+#   Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
+#
+# The Rust side is unaffected — the app starts, opens its audio device and
+# shows an empty window, which is what made this look like a WebKitGTK
+# version problem for months. It isn't: removing this one file from the
+# bundle is enough, verified on Fedora 44 / GNOME Wayland / Mesa 26.1.6
+# against the released v1.7.0 AppImage.
+#
+# Repacking is done with `mksquashfs` + the AppImage's own runtime header
+# rather than `appimagetool`: nothing to download, no FUSE needed (the
+# runner images don't all carry libfuse2), and the result is verified by
+# re-extracting it before it replaces the original.
+#
+# Usage: scripts/fix-appimage.sh [path/to/App.AppImage]
+#   With no argument, finds the single AppImage under
+#   src-tauri/target/release/bundle/appimage/.
+#
+# Re-signs afterwards when the build produced an updater signature — the
+# `.sig` covers the bytes we just rewrote, so a stale one would make every
+# updater client reject the release. Signing reads the key from
+# TAURI_SIGNING_PRIVATE_KEY / TAURI_SIGNING_PRIVATE_KEY_PASSWORD (env, so
+# the key never reaches the process list).
+
+set -euo pipefail
+
+BUNDLE_DIR="src-tauri/target/release/bundle/appimage"
+EXCLUDED_LIB="libwayland-client.so.0"
+
+log() { printf '[fix-appimage] %s\n' "$*"; }
+die() { printf '[fix-appimage] error: %s\n' "$*" >&2; exit 1; }
+
+img="${1:-}"
+if [ -z "$img" ]; then
+  shopt -s nullglob
+  candidates=("$BUNDLE_DIR"/*.AppImage)
+  shopt -u nullglob
+  [ ${#candidates[@]} -eq 0 ] && die "no .AppImage under $BUNDLE_DIR"
+  [ ${#candidates[@]} -gt 1 ] && die "several AppImages under $BUNDLE_DIR, pass one explicitly"
+  img="${candidates[0]}"
+fi
+[ -f "$img" ] || die "no such file: $img"
+img="$(cd "$(dirname "$img")" && pwd)/$(basename "$img")"
+chmod +x "$img"
+
+command -v mksquashfs >/dev/null || die "mksquashfs not found (apt install squashfs-tools)"
+command -v unsquashfs >/dev/null || die "unsquashfs not found (apt install squashfs-tools)"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+log "unpacking $(basename "$img")"
+( cd "$work" && "$img" --appimage-extract >/dev/null )
+appdir="$work/squashfs-root"
+[ -d "$appdir" ] || die "extraction produced no squashfs-root"
+
+# `usr/lib/libwayland-client.so.0` is the one that matters; the glob also
+# catches a versioned sibling should the bundler ever emit one.
+found=0
+while IFS= read -r -d '' lib; do
+  log "removing ${lib#$appdir/}"
+  rm -f "$lib"
+  found=1
+done < <(find "$appdir" -name "${EXCLUDED_LIB}*" -print0)
+
+if [ "$found" -eq 0 ]; then
+  log "$EXCLUDED_LIB is not bundled — nothing to do (did the bundler stop shipping it?)"
+  exit 0
+fi
+
+# Type-2 AppImage = runtime ELF header followed by a squashfs image, so a
+# repack is: keep the original runtime, rebuild the filesystem behind it.
+offset="$("$img" --appimage-offset)"
+[ -n "$offset" ] || die "could not read the AppImage runtime offset"
+head -c "$offset" "$img" > "$work/runtime"
+
+# Repack with the compressor and block size the original used, read back
+# from its own superblock. Forcing gzip here cost 11 MB on a 95 MB
+# bundle — the runtime already mounts whatever the bundler chose, so
+# there's no reason to second-guess it.
+comp="$(unsquashfs -o "$offset" -s "$img" 2>/dev/null | awk '/^Compression/ {print $2; exit}')"
+block="$(unsquashfs -o "$offset" -s "$img" 2>/dev/null | awk '/^Block size/ {print $3; exit}')"
+comp="${comp:-gzip}"
+block="${block:-131072}"
+
+log "repacking (squashfs, $comp, ${block}B blocks)"
+# -root-owned / -noappend match what appimagetool itself passes.
+mksquashfs "$appdir" "$work/fs.squashfs" \
+  -root-owned -noappend -comp "$comp" -b "$block" -no-progress >/dev/null
+cat "$work/runtime" "$work/fs.squashfs" > "$work/out.AppImage"
+chmod +x "$work/out.AppImage"
+
+# Verify before overwriting: an AppImage that can't be re-opened, or that
+# still carries the library, must never reach a release.
+log "verifying the repacked image"
+mkdir -p "$work/verify"
+( cd "$work/verify" && "$work/out.AppImage" --appimage-extract >/dev/null ) \
+  || die "the repacked AppImage does not extract"
+if find "$work/verify/squashfs-root" -name "${EXCLUDED_LIB}*" | grep -q .; then
+  die "$EXCLUDED_LIB survived the repack"
+fi
+[ -x "$work/verify/squashfs-root/AppRun" ] || die "the repacked AppImage has no AppRun"
+
+mv "$work/out.AppImage" "$img"
+log "$(basename "$img") rewritten ($(du -h "$img" | cut -f1))"
+
+# The updater signature covers the bytes we just replaced.
+if [ -f "$img.sig" ]; then
+  [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ] \
+    || die "an updater signature exists but TAURI_SIGNING_PRIVATE_KEY is unset — refusing to leave a stale .sig"
+  log "re-signing for the updater"
+  rm -f "$img.sig"
+  bun run tauri signer sign "$img" >/dev/null
+  [ -f "$img.sig" ] || die "signing produced no $img.sig"
+  log "signature refreshed"
+else
+  log "no updater signature alongside the bundle — nothing to re-sign"
+fi


### PR DESCRIPTION
The AppImage doesn't start on any Linux whose Mesa is newer than the build runner's. WebKit's WebProcess dies before painting anything, the Rust side carries on regardless, and the user gets an empty window:

```text
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

## Cause

Tauri's bundler copies the webview's dependency closure into the AppDir, and that closure contains `libwayland-client.so.0`. That library is on the [official AppImage excludelist](https://github.com/AppImage/pkg2appimage/blob/master/excludelist), with this comment:

> `libwayland-client.so.0`
> `# https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316`
> `# New version of Mesa has some dependency issues with libwayland-client if it is bundled`

We build on Ubuntu. Fedora 44 ships Mesa 26.1.6 and libwayland 1.25, the bundled copy wins the lookup, and EGL refuses.

## Evidence

Run against the **released v1.7.0 AppImage** on Fedora 44 / GNOME Wayland / Mesa 26.1.6 / webkitgtk 2.52.5:

| Variant | Result |
| --- | --- |
| As shipped | `EGL_BAD_PARAMETER` ×2, splash safety-net fires at 15 s, empty window |
| `GDK_BACKEND=wayland` instead of the forced x11 | identical — the backend is not involved |
| All four bundled `libwayland-*` removed | WebProcess alive, **0 EGL errors**, `app://ready` fires |
| Only `libwayland-client.so.0` removed | **0 EGL errors** — culprit isolated |
| Repacked by this script, run end to end | profile created, audio device opened, `app.db` + `data.db` written, **UI visible on screen** |

The Rust side was never affected — it created its profile and opened cpal at 44.1 kHz on every single attempt, including the broken ones. That asymmetry is what made this look like a WebKit version problem.

## What this retires

The standing answer to affected users has been that the AppImage is fundamentally incompatible with WebKitGTK 2.52+, that it's a Tauri limitation rather than something we can fix, and that they should install a native package instead. All three are wrong. The engine was never the problem, and the fix is one file.

## The script

[`scripts/fix-appimage.sh`](scripts/fix-appimage.sh) runs right after `tauri build` in both `release.yml` and `test-appimage.yml`:

- removes the library, and **no-ops with a message** if a future Tauri stops bundling it;
- repacks with `mksquashfs` + the AppImage's own runtime header — nothing to download, and no FUSE, which the runner images don't all carry;
- reads the compressor and block size back from the original's superblock rather than assuming: forcing gzip cost 11 MB on a 95 MB bundle, matching zstd lands byte-for-byte on the same size;
- **verifies before overwriting** — the repacked image must re-extract, must have its `AppRun`, and must no longer contain the library, or the script fails the build;
- **re-signs** when an updater `.sig` is present. This matters: the signature covers bytes the repack rewrites, so a stale one would make every updater client reject the release. It refuses to leave a stale `.sig` behind if the signing key is missing.

`squashfs-tools` added to both workflows' apt list, and `*.sh text eol=lf` to `.gitattributes` so a CRLF checkout can't break the shebang on a runner.

## Scope and limits

Validated on one machine. The upstream excludelist entry says why it generalizes, but the repacked artefact produced *by CI* hasn't been run yet — I validated the script against the released AppImage locally on the affected box. Worth doing before the tag: run `test-appimage.yml` from this branch and launch the artifact on Fedora.

One thing I could not test from an SSH session: mounting the AppImage through FUSE. The original fails there in exactly the same way, so it's not a regression from the repack, but "double-click the file in a desktop session" remains unverified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Synchronisation en temps réel des favoris, du volume, du mode aléatoire et de la répétition entre les fenêtres de l’application.
  * Les listes de morceaux favoris se mettent automatiquement à jour après toute modification.

* **Corrections**
  * Amélioration de la compatibilité des AppImage Linux en supprimant une bibliothèque susceptible de provoquer des erreurs graphiques.

* **Documentation**
  * Mise à jour des informations sur la synchronisation de l’interface et la préparation des versions Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->