### PR TITLE
fix(db): explain a downgrade instead of dying on the splash

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -80,6 +80,14 @@ sqlx records a SHA-384 checksum in `_sqlx_migrations.checksum` at apply time, so
 
 **Line-ending drift is a non-event.** [`db::migration_heal`](../../src-tauri/crates/app/src/db/migration_heal.rs) reconciles stored checksums against the compiled-in migrator before each `Migrator::run`: when the stored hash matches the LF or CRLF variant of the same SQL (the Windows `core.autocrlf=true` regression), it silently rewrites the row to the canonical hash and logs a warning. A real SQL change still panics, because neither LF nor CRLF normalization will rescue it.
 
+**A database from a newer build is refused, out loud.** Because migrations only ever get appended, a database records the newest build that ever touched it, and an older binary finds a `_sqlx_migrations` row it has no migration for. Refusing is right — replaying a newer schema through older code corrupts it — but the refusal used to leave `AppState::init`, and an error out of the Tauri `setup` hook is a panic: the splash painted, the process died with it, nothing explained (#526). [`db::schema_guard`](../../src-tauri/crates/app/src/db/schema_guard.rs) now detects the case ahead of the migrator, and startup turns it into a native dialog and a clean exit.
+
+Three rules come out of that, in order:
+
+- **Guard before heal, heal before run.** The guard runs first because the heal pass _writes_ — no rewriting checksums into a database this build has already decided not to touch.
+- **The guard must not outlive its reason.** `the_guard_fires_on_exactly_what_sqlx_refuses` pins it to sqlx's own `VersionMissing`; if sqlx ever stops refusing, the guard has started deciding policy on its own and that test says so.
+- **Nothing you queue from `setup` will happen.** `setup` runs from inside the event loop (`RuntimeRunEvent::Ready`), so while it blocks, the loop dispatches nothing — and a fatal path never returns. Three consequences, all measured, all in [`report_fatal_and_exit`](../../src-tauri/crates/app/src/lib.rs): `tauri-plugin-dialog` is unusable because it dispatches through `run_on_main_thread`; the splash must be `hide()`n, not `close()`d, because a close is delivered as an _event_ while `hide` takes the runtime's same-thread fast path; and the dialog needs its own thread, because `TaskDialogIndirect` on the main thread creates its window and never shows it (`WS_VISIBLE` stays clear) and the process hangs there. The splash has to go regardless — it's `alwaysOnTop` and would sit over the dialog. Text is English like the tray's seed labels: the language preference lives in the database we just refused to open.
+
 ### Single writer to SQLite
 
 WAL mode allows concurrent reads but only one writer.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -99,6 +99,7 @@ Both follow the same `INSERT … ON CONFLICT DO UPDATE` typed-value pattern (`va
 - One numbered SQL file per change, name format `YYYYMMDDHHMMSS_<short_description>.sql`. Sequential; sqlx records applied versions in `_sqlx_migrations`.
 - Migrations are **append-only** in normal use. Schema is never re-baselined — new columns are added with `ALTER TABLE`, defaults provided so existing rows stay valid.
 - Destructive changes (drop / rename) only after a backwards-compat shim has been live long enough that the worst-case downgrade window is closed.
+- **Downgrades are refused, not survived.** Append-only means a database names the newest build that ever opened it, so an older binary always finds a `_sqlx_migrations` row it has no migration for. [`db::schema_guard`](../../src-tauri/crates/app/src/db/schema_guard.rs) catches that before the migrator runs — and before the checksum heal pass writes anything — so startup can show a dialog and exit instead of panicking out of the Tauri `setup` hook (#526). It applies to both databases and to every path that opens one, so importing a profile archive exported by a newer build says so too, rather than failing on a checksum.
 
 ## Asset protocol scope
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7619,6 +7619,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "resvg",
+ "rfd",
  "rtrb",
  "rubato",
  "rustls",

--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -57,6 +57,22 @@ waveflow-syncedlyrics = { path = "../syncedlyrics" }
 tauri = { version = "2", features = ["protocol-asset", "tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+# The dialog plugin's own backend, taken as a direct dependency for the
+# one dialog that cannot go through the plugin: a fatal error inside the
+# Tauri `setup` hook (issue #526). `setup` runs from inside the event
+# loop, so a dialog that dispatches through `run_on_main_thread` — which
+# is what the plugin does — lands in a queue nobody drains until we
+# return, and we never return. `blocking_show` documents itself as
+# unsafe from the main thread for that reason. rfd is called directly,
+# on a thread of its own.
+#
+# Version and features are pinned to match what tauri-plugin-dialog
+# already requests, so Cargo unifies them into the single copy that is
+# in the lockfile — no new crate, no Flatpak source regeneration.
+rfd = { version = "0.16", default-features = false, features = [
+    "gtk3",
+    "common-controls-v6",
+] }
 tauri-plugin-updater = { version = "2", optional = true }
 # Single-instance lock: a second `waveflow` invocation surrenders to the
 # first, which surfaces and focuses its main window. Prevents two audio

--- a/src-tauri/crates/app/src/db/app_db.rs
+++ b/src-tauri/crates/app/src/db/app_db.rs
@@ -30,12 +30,23 @@ pub async fn open(path: &Path) -> AppResult<SqlitePool> {
         .connect_with(opts)
         .await?;
 
+    let migrator = sqlx::migrate!("../../migrations/app");
+
+    // Refuse a database from a newer build before anything else touches
+    // it — including the heal pass below, which writes. See
+    // [`crate::db::schema_guard`].
+    super::schema_guard::ensure_not_from_the_future(
+        &pool,
+        &migrator,
+        super::schema_guard::DbScope::App,
+    )
+    .await?;
+
     // Reconcile any line-ending drift in `_sqlx_migrations` BEFORE
     // running the migrator — without this, a Windows working tree that
     // briefly held CRLF when a new migration was first applied will
     // panic at every subsequent boot once the file is restored to LF.
     // See [`crate::db::migration_heal`] for the full backstory.
-    let migrator = sqlx::migrate!("../../migrations/app");
     super::migration_heal::heal_line_ending_drift(&pool, &migrator).await?;
     migrator.run(&pool).await?;
 

--- a/src-tauri/crates/app/src/db/mod.rs
+++ b/src-tauri/crates/app/src/db/mod.rs
@@ -9,6 +9,7 @@ pub mod app_db;
 pub mod migration_heal;
 pub mod profile_db;
 pub mod profile_meta;
+pub mod schema_guard;
 
 #[cfg(test)]
 mod rfc003_hlc_tests;

--- a/src-tauri/crates/app/src/db/profile_db.rs
+++ b/src-tauri/crates/app/src/db/profile_db.rs
@@ -56,10 +56,20 @@ pub async fn open(path: &Path, app_db_path: &Path) -> AppResult<SqlitePool> {
         .connect_with(opts)
         .await?;
 
+    let migrator = sqlx::migrate!("../../migrations/profile");
+
+    // Same guard-then-heal order as `app_db::open`: refuse a profile a
+    // newer build wrote before the heal pass writes anything to it.
+    super::schema_guard::ensure_not_from_the_future(
+        &pool,
+        &migrator,
+        super::schema_guard::DbScope::Profile,
+    )
+    .await?;
+
     // Same self-healing dance as `app_db::open` — line-ending drift
     // in the working tree gets reconciled before sqlx's strict
     // checksum check fires. Details in [`crate::db::migration_heal`].
-    let migrator = sqlx::migrate!("../../migrations/profile");
     super::migration_heal::heal_line_ending_drift(&pool, &migrator).await?;
     migrator.run(&pool).await?;
 

--- a/src-tauri/crates/app/src/db/schema_guard.rs
+++ b/src-tauri/crates/app/src/db/schema_guard.rs
@@ -1,0 +1,263 @@
+//! Refuse a database written by a newer build — and say why.
+//!
+//! ## The problem
+//!
+//! Migrations only ever get appended, so a database carries a record of
+//! the newest build that ever touched it. Point an older binary at it
+//! and sqlx notices a row in `_sqlx_migrations` it has no migration
+//! for, and fails:
+//!
+//! > `migration 20260802120000 was previously applied but is missing in
+//! > the resolved migrations`
+//!
+//! Refusing is correct — replaying a newer schema through older code is
+//! how databases get corrupted. The trouble was *where* it surfaced:
+//! the error propagated out of the Tauri `setup` hook, which panics.
+//! The splash window is created before `setup` runs, so the user saw it
+//! paint and the whole process vanish with it — indistinguishable from
+//! a crash on launch, with nothing to act on (issue #526).
+//!
+//! None of the ways to get here are exotic: trying a beta then going
+//! back to stable, double-clicking an older AppImage still sitting in
+//! `~/Downloads`, a distro package rolled back after a bad update, or
+//! two versions sharing one `~/.local/share/app.waveflow`.
+//!
+//! ## What this module does
+//!
+//! Detect the case *before* the migrator runs, so the caller can turn
+//! it into a sentence instead of a panic. This is deliberately distinct
+//! from [`super::migration_heal`]: that one reconciles checksum drift on
+//! a migration we *do* ship, where there is something to repair. Here
+//! the migration genuinely isn't in this binary and there is nothing to
+//! do but explain.
+//!
+//! Running before the heal pass also keeps us from writing canonical
+//! checksums into a database this build has already decided it won't
+//! touch.
+
+use std::collections::HashSet;
+
+use sqlx::{migrate::Migrator, SqlitePool};
+
+use crate::error::{AppError, AppResult};
+
+/// Which database a guard failure is about. Decides what the user can
+/// actually do: another profile is a way out of a profile database
+/// from the future, and no way out of `app.db`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DbScope {
+    /// The global `app.db` — profile list and app-wide settings.
+    App,
+    /// A per-profile `data.db`.
+    Profile,
+}
+
+impl DbScope {
+    /// Names the database. Capitalised because every use — the error's
+    /// `Display`, the startup dialog — puts it first in a sentence.
+    pub fn label(self) -> &'static str {
+        match self {
+            DbScope::App => "WaveFlow's application database",
+            DbScope::Profile => "This profile's library",
+        }
+    }
+
+    /// What the user can do about it. Switching profiles is a way out
+    /// of a profile database from the future and no help at all against
+    /// `app.db`, which every profile goes through.
+    pub fn remedy(self) -> &'static str {
+        match self {
+            DbScope::App => {
+                "Install WaveFlow again from the version you were using before."
+            }
+            DbScope::Profile => {
+                "Install WaveFlow again from the version you were using before, \
+                 or start WaveFlow with a different profile."
+            }
+        }
+    }
+}
+
+/// Fail with [`AppError::SchemaFromTheFuture`] if `_sqlx_migrations`
+/// holds a version this binary doesn't ship.
+///
+/// Reports the **highest** unknown version, which is the one that names
+/// how far ahead the database is. Short-circuits on a fresh database,
+/// where `_sqlx_migrations` doesn't exist yet — the migrator creates it.
+pub async fn ensure_not_from_the_future(
+    pool: &SqlitePool,
+    migrator: &Migrator,
+    scope: DbScope,
+) -> AppResult<()> {
+    let table_present: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'",
+    )
+    .fetch_optional(pool)
+    .await?;
+    if table_present.is_none() {
+        return Ok(());
+    }
+
+    // `installed_on` is declared TIMESTAMP and filled by SQLite's
+    // CURRENT_TIMESTAMP, so it lands as `YYYY-MM-DD HH:MM:SS` text. The
+    // CAST keeps that true whatever a future sqlx decides to store.
+    let applied: Vec<(i64, Option<String>)> = sqlx::query_as(
+        "SELECT version, CAST(installed_on AS TEXT) FROM _sqlx_migrations ORDER BY version DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let known: HashSet<i64> = migrator.iter().map(|m| m.version).collect();
+    let Some((version, installed_on)) = applied.into_iter().find(|(v, _)| !known.contains(v))
+    else {
+        return Ok(());
+    };
+
+    tracing::error!(
+        version,
+        ?installed_on,
+        scope = ?scope,
+        "database carries a migration this build does not ship — refusing to open it"
+    );
+
+    Err(AppError::SchemaFromTheFuture {
+        scope,
+        version,
+        installed_on,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use std::str::FromStr;
+
+    async fn fresh_pool() -> SqlitePool {
+        let opts = SqliteConnectOptions::from_str(":memory:")
+            .unwrap()
+            .foreign_keys(true);
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .unwrap()
+    }
+
+    /// Forge a row for a migration no build ships. Mirrors what sqlx
+    /// itself writes, so the guard is exercised against the real table
+    /// shape rather than a convenient stand-in.
+    async fn record_applied(pool: &SqlitePool, version: i64) {
+        sqlx::query(
+            "INSERT INTO _sqlx_migrations
+                 (version, description, installed_on, success, checksum, execution_time)
+             VALUES (?, 'from the future', '2099-01-01 00:00:00', 1, X'00', 0)",
+        )
+        .bind(version)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn fresh_database_has_nothing_to_refuse() {
+        let pool = fresh_pool().await;
+        let migrator = sqlx::migrate!("../../migrations/profile");
+        // No `_sqlx_migrations` yet — the migrator hasn't run.
+        ensure_not_from_the_future(&pool, &migrator, DbScope::Profile)
+            .await
+            .expect("a fresh database is not from the future");
+    }
+
+    #[tokio::test]
+    async fn a_database_this_build_wrote_is_accepted() {
+        let pool = fresh_pool().await;
+        let migrator = sqlx::migrate!("../../migrations/profile");
+        migrator.run(&pool).await.unwrap();
+
+        ensure_not_from_the_future(&pool, &migrator, DbScope::Profile)
+            .await
+            .expect("our own migrations must not read as newer");
+    }
+
+    #[tokio::test]
+    async fn an_unknown_version_is_refused_and_named() {
+        let pool = fresh_pool().await;
+        let migrator = sqlx::migrate!("../../migrations/profile");
+        migrator.run(&pool).await.unwrap();
+        record_applied(&pool, 29990101000000).await;
+
+        let err = ensure_not_from_the_future(&pool, &migrator, DbScope::Profile)
+            .await
+            .expect_err("a migration we don't ship must be refused");
+
+        match err {
+            AppError::SchemaFromTheFuture {
+                version,
+                installed_on,
+                ..
+            } => {
+                assert_eq!(version, 29990101000000);
+                assert_eq!(installed_on.as_deref(), Some("2099-01-01 00:00:00"));
+            }
+            other => panic!("expected SchemaFromTheFuture, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_guard_fires_on_exactly_what_sqlx_refuses() {
+        // The guard's job is to get in front of sqlx, not to invent a
+        // rule of its own. If a future sqlx stops refusing this — or
+        // refuses it differently — the guard has drifted into deciding
+        // policy by itself, and this is where that shows up.
+        let pool = fresh_pool().await;
+        let migrator = sqlx::migrate!("../../migrations/profile");
+        migrator.run(&pool).await.unwrap();
+        record_applied(&pool, 29990101000000).await;
+
+        let verdict = migrator.run(&pool).await;
+        assert!(
+            matches!(
+                verdict,
+                Err(sqlx::migrate::MigrateError::VersionMissing(v)) if v == 29990101000000
+            ),
+            "expected sqlx to refuse the unknown version, got {verdict:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_highest_unknown_version_is_the_one_reported() {
+        // Two builds ahead of us. Naming the newest is what tells the
+        // user how far forward they have to go to open this again.
+        let pool = fresh_pool().await;
+        let migrator = sqlx::migrate!("../../migrations/profile");
+        migrator.run(&pool).await.unwrap();
+        record_applied(&pool, 29990101000000).await;
+        record_applied(&pool, 29990202000000).await;
+
+        let err = ensure_not_from_the_future(&pool, &migrator, DbScope::Profile)
+            .await
+            .expect_err("a migration we don't ship must be refused");
+
+        match err {
+            AppError::SchemaFromTheFuture { version, .. } => {
+                assert_eq!(version, 29990202000000)
+            }
+            other => panic!("expected SchemaFromTheFuture, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_app_migrator_guards_the_app_database() {
+        // The two databases have independent migration timelines, so
+        // the guard has to be run with the matching migrator — pairing
+        // app.db with the profile migrator would refuse every install.
+        let pool = fresh_pool().await;
+        let migrator = sqlx::migrate!("../../migrations/app");
+        migrator.run(&pool).await.unwrap();
+
+        ensure_not_from_the_future(&pool, &migrator, DbScope::App)
+            .await
+            .expect("app.db written by this build must be accepted");
+    }
+}

--- a/src-tauri/crates/app/src/error.rs
+++ b/src-tauri/crates/app/src/error.rs
@@ -29,6 +29,27 @@ pub enum AppError {
     #[error("migration error: {0}")]
     Migration(#[from] sqlx::migrate::MigrateError),
 
+    /// The database holds a migration this build doesn't ship — it was
+    /// written by a newer version of WaveFlow. Split out of the generic
+    /// `Migration` variant because it's the one migration failure with
+    /// a remedy the user can act on, and startup turns it into a dialog
+    /// instead of a panic (issue #526). Raised by
+    /// [`crate::db::schema_guard::ensure_not_from_the_future`].
+    #[error(
+        "{} was written by a newer version of WaveFlow (database schema {version})",
+        scope.label()
+    )]
+    SchemaFromTheFuture {
+        /// Which database — decides what the user can actually do about
+        /// it, so startup branches the remedy on it.
+        scope: crate::db::schema_guard::DbScope,
+        /// The highest applied migration this build doesn't know.
+        version: i64,
+        /// When that migration was applied, `YYYY-MM-DD HH:MM:SS` as
+        /// SQLite recorded it. `None` if the column was NULL.
+        installed_on: Option<String>,
+    },
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -62,6 +62,7 @@ use tauri::{
 };
 
 use audio::{AudioCmd, AudioEngine};
+use error::AppError;
 use state::AppState;
 use watcher::WatcherManager;
 
@@ -138,7 +139,21 @@ pub fn run() {
             // Block on the async init — this runs once at startup before any
             // command can be dispatched, so blocking here is acceptable.
             let state =
-                tauri::async_runtime::block_on(async move { AppState::init(&init_handle).await })?;
+                match tauri::async_runtime::block_on(async move { AppState::init(&init_handle).await })
+                {
+                    Ok(state) => state,
+                    Err(err) => {
+                        // One failure has a remedy the user can act on:
+                        // the database was written by a newer build.
+                        // Everything else keeps propagating into Tauri's
+                        // "Failed to setup app" panic, which is the
+                        // right shape for a bug.
+                        if matches!(err, AppError::SchemaFromTheFuture { .. }) {
+                            report_fatal_and_exit(app.handle(), &err);
+                        }
+                        return Err(Box::new(err));
+                    }
+                };
 
             // Hydrate the close-to-tray flag once at boot. The atomic
             // is the source of truth for `WindowEvent::CloseRequested`
@@ -1039,6 +1054,94 @@ async fn restore_bounds_and_reveal(app: AppHandle) -> bool {
         }
     }
     reveal_main_close_splash(&app)
+}
+
+/// Tell the user why WaveFlow is stopping, then stop.
+///
+/// Called from the `setup` hook for the one startup failure a user can
+/// act on: the database was written by a newer build. Everything else
+/// keeps propagating into Tauri's `"Failed to setup app"` panic, which
+/// is the right shape for a bug — but was the wrong shape for this,
+/// where the splash painted and the process vanished with it, leaving
+/// nothing on screen to act on (issue #526).
+///
+/// Three constraints shape this, and all three come from the same fact:
+/// **`setup` runs from inside the event loop**, dispatched on
+/// `RuntimeRunEvent::Ready`, so nothing we queue can be processed until
+/// we return — and we never return.
+///
+/// - **`tauri-plugin-dialog` can't be used.** It dispatches through
+///   `run_on_main_thread`, straight into the queue nobody is draining;
+///   `blocking_show` documents itself as unsafe from the main thread for
+///   exactly that reason. `rfd` — the plugin's own backend — is called
+///   directly instead.
+/// - **The splash is hidden, not closed.** `close()` posts a
+///   `CloseRequested` *event*, so it is a silent no-op here; `hide()`
+///   lands on the runtime's same-thread fast path and applies
+///   immediately. It has to go: it's `alwaysOnTop` and would otherwise
+///   sit over the dialog.
+/// - **The dialog runs on its own thread.** Measured on Windows,
+///   `TaskDialogIndirect` called on the main thread from here creates
+///   its window and never shows it — `WS_VISIBLE` stays clear and the
+///   process hangs. A spawned thread carries its own message pump and
+///   displays normally.
+///
+/// The message is English, like the tray menu's seed labels: there is no
+/// frontend yet, so no i18next — and no readable language preference,
+/// because that setting lives in the database we just refused to open.
+fn report_fatal_and_exit(app: &AppHandle, err: &AppError) -> ! {
+    tracing::error!(%err, "fatal startup error, exiting");
+
+    if let Some(splash) = app.get_webview_window("splashscreen") {
+        let _ = splash.hide();
+    }
+
+    let (title, body) = match err {
+        AppError::SchemaFromTheFuture {
+            scope,
+            version,
+            installed_on,
+        } => {
+            let stamp = match installed_on {
+                Some(when) => format!("Database schema {version}, applied on {when}."),
+                None => format!("Database schema {version}."),
+            };
+            (
+                "WaveFlow can't open this library".to_string(),
+                format!(
+                    "{} was written by a newer version of WaveFlow.\n\n\
+                     Opening it with this older build could corrupt it, so WaveFlow \
+                     stopped before touching anything.\n\n\
+                     {}\n\n\
+                     {stamp}",
+                    scope.label(),
+                    scope.remedy(),
+                ),
+            )
+        }
+        // Not reachable today — the caller filters — but a `match` that
+        // can't fall over is one less way for a future variant to reach
+        // the user as an empty dialog.
+        other => ("WaveFlow can't start".to_string(), other.to_string()),
+    };
+
+    // Joined, so the process outlives the dialog: `show()` blocks the
+    // spawned thread until the user dismisses it.
+    let _ = std::thread::spawn(move || {
+        rfd::MessageDialog::new()
+            .set_level(rfd::MessageLevel::Error)
+            .set_title(&title)
+            .set_description(&body)
+            .set_buttons(rfd::MessageButtons::Ok)
+            .show()
+    })
+    .join();
+
+    // Straight out rather than unwinding through `setup`: there is no
+    // state to tear down (the pools that opened are WAL, which is
+    // crash-consistent by construction) and returning would hand Tauri
+    // the panic we just replaced.
+    std::process::exit(1);
 }
 
 /// Bring the main window back to the front (used by the tray's left


### PR DESCRIPTION
Closes #526.

## What went wrong

Migrations only ever get appended, so a database records the newest build that ever opened it. Point an older binary at it and sqlx finds a `_sqlx_migrations` row it has no migration for:

```text
migration 20260802120000 was previously applied but is missing in the resolved migrations
```

Refusing is **right** — replaying a newer schema through older code is how databases get corrupted. The bug was that the refusal left `AppState::init`, and an error out of the Tauri `setup` hook is a panic. The splash window is created before `setup` runs, so it painted and the process died with it: indistinguishable from a crash on launch, nothing on screen to act on.

None of the ways in are exotic — a beta then back to stable, an older AppImage still in `~/Downloads`, a distro package rolled back, two versions sharing one data directory.

## The guard

`db::schema_guard` looks for applied versions this binary doesn't ship, and reports the highest one. It runs **before the migrator, and before the checksum heal pass** — the heal writes, and there's no reason to rewrite checksums into a database this build has already decided not to touch. Wired into both `app_db::open` and `profile_db::open`, so it covers every path that opens a database: importing a profile archive exported by a newer build now says so instead of failing on a checksum.

Distinct from `migration_heal`, which reconciles drift on a migration we *do* ship. Here the migration genuinely isn't in this binary and there is nothing to repair, only something to explain.

## Presenting it

This turned out to be the hard half, and all of it follows from one fact: **`setup` runs from inside the event loop** (`RuntimeRunEvent::Ready`), so nothing queued from there is dispatched until `setup` returns — and a fatal path never returns. Three consequences, each measured on Windows rather than assumed:

| | |
|---|---|
| `tauri-plugin-dialog` | Dispatches through `run_on_main_thread` → queued, never drained. `blocking_show` documents itself as unsafe from the main thread for that reason. |
| `splash.close()` | Silent no-op — a close arrives as an *event*. `hide()` takes the runtime's same-thread fast path and applies immediately. The splash has to go: it's `alwaysOnTop` and would sit over the dialog. |
| Dialog on the main thread | `TaskDialogIndirect` creates its window and never shows it — `WS_VISIBLE` stays clear — and the process hangs there forever. A spawned thread carries its own pump and displays normally. |

So: `rfd` called directly (the dialog plugin's own backend), on its own thread, after hiding the splash. The message is English like the tray's seed labels — there's no i18next yet, and no readable language preference, because that setting lives in the database we just refused to open.

`rfd` is pinned to the version and features `tauri-plugin-dialog` already requests, so Cargo unifies it into the copy already in the lockfile: the only `Cargo.lock` change is one line adding it to this crate's dependency list. No new package, and `check-sources.py` passes without regenerating the Flatpak sources.

## Validation

- **6 unit tests** on `schema_guard`, run against the **real** migration trees. Includes `the_guard_fires_on_exactly_what_sqlx_refuses`, which pins the guard to sqlx's own `VersionMissing` — if sqlx ever stops refusing, the guard has started deciding policy by itself and that test says so.
- **End to end on Windows**, against a throwaway app identifier so no real library was touched: fresh profile boots normally with zero errors (the guard is a no-op on a healthy database), then with a forged future migration the splash disappears and this comes up:

```text
WaveFlow can't open this library

This profile's library was written by a newer version of WaveFlow.

Opening it with this older build could corrupt it, so WaveFlow stopped
before touching anything.

Install WaveFlow again from the version you were using before, or start
WaveFlow with a different profile.

Database schema 29990101000000, applied on 2099-01-01 00:00:00.
```

`typecheck` / `lint` untouched (no frontend changes); `cargo clippy --all-targets -D warnings` clean on both feature configs; `cargo check --workspace --all-targets` clean.

**Not verified on macOS or Linux.** The three findings above are Windows measurements. The guard itself is platform-independent, and the dialog is the same `rfd` call the app already makes for file pickers, but the "hidden window / own thread" behaviour was only observed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Détection des bases de données créées par une version plus récente de l’application.
  * Affichage d’une boîte de dialogue native indiquant la version concernée et la marche à suivre.
  * Arrêt propre de l’application afin d’éviter toute modification ou corruption de la base.

* **Documentation**
  * Clarification de la politique de migration : les rétrogradations sont refusées pour les bases globales et les profils, y compris lors de l’import d’archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->