### PR TITLE
feat(scanner): play AIFF, and say why the other formats are absent

### DIFF
--- a/src-tauri/crates/app/Cargo.toml
+++ b/src-tauri/crates/app/Cargo.toml
@@ -138,6 +138,10 @@ symphonia = { version = "0.6", default-features = false, features = [
     "mp3",
     "flac",
     "wav",
+    # Same crate as `wav` — `symphonia-format-riff`, already in the graph —
+    # under a different sub-feature. AIFF is Apple's container for the PCM
+    # that `wav` already decodes, so this adds a format, not a dependency.
+    "aiff",
     "vorbis",
     "ogg",
     "aac",

--- a/src-tauri/crates/app/src/dlna/cds.rs
+++ b/src-tauri/crates/app/src/dlna/cds.rs
@@ -497,6 +497,9 @@ fn mime_for_path(path: &str) -> &'static str {
         Some("mp3") => "audio/mpeg",
         Some("flac") => "audio/flac",
         Some("wav") => "audio/wav",
+        // `x-aiff` rather than `aiff`: it is what Apple emits and what
+        // renderers actually match on.
+        Some("aiff" | "aif") => "audio/x-aiff",
         Some("ogg" | "oga") => "audio/ogg",
         Some("m4a" | "mp4" | "aac") => "audio/mp4",
         _ => "application/octet-stream",

--- a/src-tauri/crates/app/src/dlna/http.rs
+++ b/src-tauri/crates/app/src/dlna/http.rs
@@ -69,7 +69,7 @@ pub fn router(ctx: ServerCtx) -> Router {
 <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
   <s:Body>
     <u:GetProtocolInfoResponse xmlns:u="urn:schemas-upnp-org:service:ConnectionManager:1">
-      <Source>http-get:*:audio/mpeg:*,http-get:*:audio/flac:*,http-get:*:audio/wav:*,http-get:*:audio/ogg:*,http-get:*:audio/mp4:*</Source>
+      <Source>http-get:*:audio/mpeg:*,http-get:*:audio/flac:*,http-get:*:audio/wav:*,http-get:*:audio/x-aiff:*,http-get:*:audio/ogg:*,http-get:*:audio/mp4:*</Source>
       <Sink></Sink>
     </u:GetProtocolInfoResponse>
   </s:Body>
@@ -218,6 +218,9 @@ fn mime_for_path(path: &str) -> &'static str {
         Some("mp3") => "audio/mpeg",
         Some("flac") => "audio/flac",
         Some("wav") => "audio/wav",
+        // `x-aiff` rather than `aiff`: it is what Apple emits and what
+        // renderers actually match on.
+        Some("aiff" | "aif") => "audio/x-aiff",
         Some("ogg" | "oga") => "audio/ogg",
         Some("m4a" | "mp4" | "aac") => "audio/mp4",
         _ => "application/octet-stream",

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -117,6 +117,10 @@ symphonia = { version = "0.6", default-features = false, features = [
     "mp3",
     "flac",
     "wav",
+    # Same crate as `wav` — `symphonia-format-riff`, already in the graph —
+    # under a different sub-feature. AIFF is Apple's container for the PCM
+    # that `wav` already decodes, so this adds a format, not a dependency.
+    "aiff",
     "vorbis",
     "ogg",
     "aac",

--- a/src-tauri/crates/core/src/scanner/extract.rs
+++ b/src-tauri/crates/core/src/scanner/extract.rs
@@ -19,12 +19,31 @@ use super::canonical::canonical_name;
 
 /// Extensions considered "audio files" by the scanner. Limited to
 /// formats the symphonia + cpal engine can actually decode and play,
-/// so the library never displays tracks that would error at play
-/// time. Opus / WMA / AIFF are intentionally absent — symphonia
-/// doesn't ship a mainline decoder for Opus, WMA is Microsoft
-/// proprietary, and AIFF isn't in the default feature set.
+/// so the library never displays tracks that would error at play time.
+///
+/// What is absent, and why — three different reasons that are worth not
+/// confusing, because only one of them is a licence question:
+///
+/// - **Opus** is missing for a purely technical reason: symphonia ships
+///   no Opus decoder. Not a licence issue in any sense — Opus is an IETF
+///   standard (RFC 6716), royalty-free by design, and `libopus` is BSD.
+///   Playing it means an out-of-tree decoder, the way DSD is handled
+///   below. The gap that leaves — `.ogg` is accepted for Vorbis, and an
+///   extension cannot tell Vorbis from Opus inside the container — is
+///   why this list is no longer the whole filter: [`is_scannable_audio`]
+///   reads the stream of an ambiguous container before believing it.
+/// - **WMA** is genuinely proprietary: Microsoft, unpublished
+///   specification, patent-encumbered. This one stays out.
+/// - **AIFF** is neither. It is a container, not a codec — Apple's
+///   answer to WAV, holding the same PCM — and symphonia reads it from
+///   `symphonia-format-riff`, the crate `wav` already pulls in.
+///
+/// `.aifc` is deliberately not listed. symphonia's AIFC support covers
+/// the PCM-shaped compression types (`none`, `sowt`, `twos`, `fl32`,
+/// `alaw`, …) and refuses the rest, so accepting the extension would
+/// index files that cannot play, on a format nobody writes any more.
 pub const AUDIO_EXTENSIONS: &[&str] = &[
-    "mp3", "flac", "wav", "ogg", "oga", "m4a", "mp4", "aac",
+    "mp3", "flac", "wav", "aiff", "aif", "ogg", "oga", "m4a", "mp4", "aac",
     // DSD: handled by the in-tree audio::dsd pipeline (symphonia
     // doesn't decode DSD), with metadata read via audio::dsd::metadata.
     "dsf", "dff",
@@ -770,6 +789,126 @@ mod tests {
         let cover = dir.path().join("cover.jpg");
         write_bytes(&cover, TINY_JPEG);
         assert!(!is_scannable_audio(&cover));
+    }
+
+    /// A minimal but real AIFF: `FORM`/`COMM`/`SSND`, 16-bit big-endian
+    /// stereo PCM. Built here rather than committed as a fixture so the
+    /// bytes the test relies on are visible next to the assertions.
+    fn tiny_aiff(frames: u32) -> Vec<u8> {
+        let channels: u16 = 2;
+        let sample_size: u16 = 16;
+        let data_len = frames as usize * channels as usize * 2;
+
+        let mut comm = Vec::new();
+        comm.extend_from_slice(&channels.to_be_bytes());
+        comm.extend_from_slice(&frames.to_be_bytes());
+        comm.extend_from_slice(&sample_size.to_be_bytes());
+        // 44100 Hz as an IEEE 754 80-bit extended float: biased exponent
+        // 16383 + 15, then 0xAC44 (44100) left-aligned in the significand,
+        // whose leading integer bit is explicit in this format.
+        comm.extend_from_slice(&[0x40, 0x0E, 0xAC, 0x44, 0, 0, 0, 0, 0, 0]);
+
+        let mut ssnd = Vec::new();
+        ssnd.extend_from_slice(&0u32.to_be_bytes()); // offset
+        ssnd.extend_from_slice(&0u32.to_be_bytes()); // block size
+        for frame in 0..frames {
+            // A quiet ramp rather than silence: a decoder that returns the
+            // right frame count of zeroes would pass on silence alone.
+            let sample = (frame as i16).wrapping_mul(64);
+            ssnd.extend_from_slice(&sample.to_be_bytes());
+            ssnd.extend_from_slice(&sample.to_be_bytes());
+        }
+
+        let mut body = Vec::new();
+        body.extend_from_slice(b"AIFF");
+        body.extend_from_slice(b"COMM");
+        body.extend_from_slice(&(comm.len() as u32).to_be_bytes());
+        body.extend_from_slice(&comm);
+        body.extend_from_slice(b"SSND");
+        body.extend_from_slice(&((8 + data_len) as u32).to_be_bytes());
+        body.extend_from_slice(&ssnd);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"FORM");
+        out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    /// The `aiff` feature is what makes the extension list below honest:
+    /// the scanner only offers what the engine can play, so this decodes a
+    /// real file rather than asserting that a string is in a list.
+    #[test]
+    fn an_aiff_file_probes_and_decodes() {
+        use symphonia::core::codecs::audio::AudioDecoderOptions;
+        use symphonia::core::formats::probe::Hint;
+        use symphonia::core::formats::{FormatOptions, TrackType};
+        use symphonia::core::io::MediaSourceStream;
+        use symphonia::core::meta::MetadataOptions;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tone.aiff");
+        write_bytes(&path, &tiny_aiff(256));
+
+        let file = fs::File::open(&path).expect("open");
+        let mut hint = Hint::new();
+        hint.with_extension("aiff");
+        let mut format = symphonia::default::get_probe()
+            .probe(
+                &hint,
+                MediaSourceStream::new(Box::new(file), Default::default()),
+                FormatOptions::default(),
+                MetadataOptions::default(),
+            )
+            .expect("symphonia probes AIFF once the feature is on");
+
+        let track = format
+            .default_track(TrackType::Audio)
+            .expect("the AIFF carries an audio track");
+        let track_id = track.id;
+        let params = track
+            .codec_params
+            .as_ref()
+            .and_then(|p| p.audio())
+            .expect("audio codec params")
+            .clone();
+        let mut decoder = symphonia::default::get_codecs()
+            .make_audio_decoder(&params, &AudioDecoderOptions::default())
+            .expect("AIFF holds the PCM `wav` already decodes");
+
+        let mut decoded = 0u64;
+        while let Ok(Some(packet)) = format.next_packet() {
+            if packet.track_id != track_id {
+                continue;
+            }
+            let buffer = decoder.decode(&packet).expect("decode");
+            decoded += buffer.frames() as u64;
+        }
+        assert_eq!(decoded, 256, "every frame written comes back out");
+    }
+
+    /// The list states a policy, and the policy has edges that are easy to
+    /// widen by accident.
+    #[test]
+    fn the_extension_list_admits_aiff_and_still_refuses_what_cannot_play() {
+        for accepted in ["aiff", "aif", "wav", "flac", "mp3"] {
+            assert!(
+                AUDIO_EXTENSIONS.contains(&accepted),
+                "{accepted} is playable and must be indexed"
+            );
+        }
+        for refused in [
+            // No symphonia decoder at all.
+            "opus", // Proprietary, and staying out.
+            "wma",  // AIFC's compressed forms are refused by the reader, so
+            // accepting the extension would index files that cannot play.
+            "aifc",
+        ] {
+            assert!(
+                !AUDIO_EXTENSIONS.contains(&refused),
+                "{refused} cannot be played and must not be indexed"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
A user asked for Opus. Opus isn't the cheap one — **AIFF was**, and the comment that lumped the two together is what kept it closed.

## Why AIFF was one flag away

AIFF is not a codec. It's Apple's container for the same PCM `wav` already carries, and symphonia reads it from `symphonia-format-riff` — the crate the `wav` feature already pulls in:

```toml
aiff = ["dep:symphonia-format-riff", "symphonia-format-riff/aiff"]
wav  = ["dep:symphonia-format-riff", "symphonia-format-riff/wav"]
```

So enabling `aiff` adds a sub-feature of a crate already compiled into the binary. **`Cargo.lock` is untouched** — no new dependency, no new licence surface, no Flatpak source regeneration. `lofty` already mapped `FileType::Aiff` in `extract.rs`, so the scanner was waiting on the extension gate and nothing else.

`.aifc` stays out deliberately. symphonia's AIFC path handles the PCM-shaped compression types (`none`, `sowt`, `twos`, `fl32`, `alaw`, …) and returns `unsupported` for the rest, so accepting the extension would index files that cannot play — the failure this list exists to prevent.

## The comment was the actual bug

The old text read:

> Opus / WMA / AIFF are intentionally absent — symphonia doesn't ship a mainline decoder for Opus, WMA is Microsoft proprietary, and AIFF isn't in the default feature set.

Three formats, one sentence, and a reader comes away thinking the answer is licensing. It isn't:

| | Why it's absent |
| --- | --- |
| **Opus** | Purely technical — symphonia ships no decoder. It's an IETF standard (RFC 6716), royalty-free by design, `libopus` is BSD. The opposite of proprietary. |
| **WMA** | Genuinely proprietary. Stays out. |
| **AIFF** | One feature flag. |

Calling Opus proprietary next to WMA is the kind of sentence that keeps a question shut for two years.

## The gap this does not close

The comment now records it rather than leaving it to be rediscovered: `.ogg` is accepted for Vorbis, an extension cannot tell Vorbis from Opus inside the container, so **an Opus file named `.ogg` is indexed here and fails at play time** — which is exactly what the user hit. Closing that needs the codec read at scan, not a longer extension list. Separate change, and it's the one that fixes their actual complaint.

## DLNA

Indexing a format and then serving it as `application/octet-stream` is half a feature, so `audio/x-aiff` is added to both MIME tables and to the `ProtocolInfo` advertisement. `x-aiff` rather than `aiff` because it's what Apple emits and what renderers match on.

Note the two `mime_for_path` functions in `dlna/cds.rs` and `dlna/http.rs` are byte-identical and had to be edited in lockstep. Not folded here — worth its own change.

## Test

`an_aiff_file_probes_and_decodes` builds a real AIFF byte by byte — `FORM`/`COMM`/`SSND`, 16-bit big-endian stereo, 44100 Hz as an 80-bit extended float — and decodes it through the same `symphonia::default::get_probe()` path the app uses, asserting every frame written comes back out. A ramp rather than silence, so a decoder returning the right count of zeroes wouldn't pass.

Remove the feature and it fails with `Unsupported("core (probe): no suitable format reader found")` — which is what makes it a test of the flag rather than of a string in a list.

`the_extension_list_admits_aiff_and_still_refuses_what_cannot_play` pins the policy at its edges, `.aifc` and `.opus` included.

## Checks

`cargo check --workspace --all-targets`, `cargo test --workspace` (all green), and the `--no-default-features` opt-out build, matching what `ci.yml` runs. Frontend untouched.

Two things I found and deliberately did **not** touch, both pre-existing and neither blocking: `cargo clippy` reports 7 `useless_borrows_in_formatting` errors on current stable in code this PR doesn't go near (CI doesn't run clippy), and `cargo fmt --all` on current stable reformats ~40 unrelated files. Both look like the toolchain having moved under an unpinned `toolchain: stable`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Prise en charge de la lecture et de l’analyse des fichiers audio AIFF.
  * Les extensions `.aiff` et `.aif` sont désormais reconnues, tandis que `.aifc` reste exclue.
  * La diffusion audio AIFF via DLNA est maintenant annoncée et prise en charge.

* **Tests**
  * Ajout de vérifications couvrant le décodage, l’analyse et la reconnaissance des fichiers AIFF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->