### PR TITLE
ci: pin the toolchain, and make the formatter and clippy gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,18 @@ jobs:
         # the Rust build. Locale-only / docs-only PRs skip the Rust matrix
         # entirely to save Actions minutes (the windows matrix slot is 2× per
         # minute). The workflow file itself is part of the filter so CI tweaks
-        # still re-run the job.
+        # still re-run the job. So are the three configuration files at the
+        # repository root: they decide which compiler runs and what the
+        # formatter and clippy accept, so a pull request that changes only
+        # one of them is exactly the pull request the Rust job has to see.
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: |
             rust:
               - 'src-tauri/**'
+              - 'rust-toolchain.toml'
+              - 'rustfmt.toml'
+              - 'clippy.toml'
               - '.github/workflows/ci.yml'
             flatpak:
               - 'src-tauri/Cargo.lock'
@@ -81,10 +87,33 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
           toolchain: 1.98.0
+          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
+
+      - name: cargo fmt
+        # Both checks run on one runner only: their answer cannot differ by
+        # operating system, and `rustfmt.toml` names the version-independent
+        # settings they read. Linux because it is the slot that already runs
+        # everything else.
+        if: runner.os == 'Linux'
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
+
+      - name: cargo clippy
+        # `-D warnings` rather than a warning count: a lint nobody has to fix
+        # is a lint everybody scrolls past. The thresholds that would make
+        # that unbearable — argument counts, function length, type
+        # complexity — are already relaxed in `clippy.toml` to match what the
+        # audio engine and the Tauri commands actually look like.
+        if: runner.os == 'Linux'
+        run: >-
+          cargo clippy
+          --manifest-path src-tauri/Cargo.toml
+          --workspace
+          --all-targets
+          -- -D warnings
 
       - name: cargo check
         run: cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
-          toolchain: stable
+          toolchain: 1.98.0
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -104,7 +104,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
-          toolchain: stable
+          toolchain: 1.98.0
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/release-please-lockfile-build.yml
+++ b/.github/workflows/release-please-lockfile-build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
-          toolchain: stable
+          toolchain: 1.98.0
 
       - name: Cache Cargo build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
-          toolchain: stable
+          toolchain: 1.98.0
           targets: ${{ matrix.platform == 'macos' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Cache Cargo build

--- a/.github/workflows/test-appimage.yml
+++ b/.github/workflows/test-appimage.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
-          toolchain: stable
+          toolchain: 1.98.0
 
       - name: Cache Cargo build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,19 @@ cargo test  --manifest-path src-tauri/Cargo.toml --workspace
 
 ## Before you open a PR
 
-Run the triple-check — CI runs the same three, so save yourself a round-trip:
+Run the check — CI runs the same commands, so save yourself a round-trip:
 
 ```bash
 bun run typecheck
 bun run lint
+cargo fmt --manifest-path src-tauri/Cargo.toml --all
+cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
 cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets
 ```
+
+`rust-toolchain.toml` decides which compiler those run under, so a local
+answer and the CI answer are the same answer. Let rustup install it rather
+than reaching for your default toolchain.
 
 If you touched a cross-cutting pattern (a context, the audio pipeline, a
 migration, a sync wire shape), **update the docs in the same PR** — `CLAUDE.md`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,17 @@
+# The compiler every check in this repository runs under.
+#
+# `stable` used to mean "whatever shipped last Thursday": a release built
+# here and a release built in CI could be two different compilers, and
+# `cargo fmt` reformatted files nobody had touched the day rustfmt's
+# defaults moved. Naming the version makes a local run and a CI run the
+# same run, and makes a compiler bump a reviewed commit like any other.
+#
+# Bumping it: change the channel here, then the `toolchain:` input of the
+# workflows that install Rust — .github/workflows/ci.yml, codeql.yml,
+# release.yml, release-please-lockfile-build.yml and test-appimage.yml.
+# They name the version rather than reading this file so a runner installs
+# exactly one toolchain instead of downloading a second on first use.
+[toolchain]
+channel = "1.98.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/src-tauri/crates/app/src/audio/alsa_exclusive.rs
+++ b/src-tauri/crates/app/src/audio/alsa_exclusive.rs
@@ -150,10 +150,20 @@ fn output_thread_main(
         }
 
         if shared.paused_output.load(Ordering::Acquire) {
-            super::dop_pack::render_dop_silence_i32(channels, period_frames, &mut marker_phase, &mut buf);
+            super::dop_pack::render_dop_silence_i32(
+                channels,
+                period_frames,
+                &mut marker_phase,
+                &mut buf,
+            );
         } else if shared.drain_silent.load(Ordering::Acquire) {
             while consumer.pop().is_ok() {}
-            super::dop_pack::render_dop_silence_i32(channels, period_frames, &mut marker_phase, &mut buf);
+            super::dop_pack::render_dop_silence_i32(
+                channels,
+                period_frames,
+                &mut marker_phase,
+                &mut buf,
+            );
         } else {
             let written = super::dop_pack::fill_dop_period_i32(
                 channels,
@@ -217,7 +227,11 @@ fn output_thread_main(
         }
         ExitReason::DeviceLost(reason) => {
             tracing::warn!(%reason, "alsa dop output thread lost the device; requesting rebuild");
-            super::output::notify_device_lost(&app, &shared, format!("audio device error: {reason}"));
+            super::output::notify_device_lost(
+                &app,
+                &shared,
+                format!("audio device error: {reason}"),
+            );
             super::output::schedule_device_rebuild(&app, super::output::RebuildTarget::Resolve);
         }
     }
@@ -278,7 +292,8 @@ fn open_pcm(dev: &str, dop: DopFormat) -> AppResult<(PCM, usize)> {
         .map_err(|e| AppError::Audio(format!("alsa open {dev}: {e}")))?;
 
     {
-        let hwp = HwParams::any(&pcm).map_err(|e| AppError::Audio(format!("alsa hwparams: {e}")))?;
+        let hwp =
+            HwParams::any(&pcm).map_err(|e| AppError::Audio(format!("alsa hwparams: {e}")))?;
         hwp.set_channels(dop.channels as u32)
             .map_err(|e| AppError::Audio(format!("alsa set_channels: {e}")))?;
         // DoP demands the exact rate — no resampling. `Nearest` lets ALSA

--- a/src-tauri/crates/app/src/audio/coreaudio_exclusive.rs
+++ b/src-tauri/crates/app/src/audio/coreaudio_exclusive.rs
@@ -152,7 +152,11 @@ fn output_thread_main(
                 %reason,
                 "coreaudio dop output thread lost the device; requesting rebuild"
             );
-            super::output::notify_device_lost(&app, &shared, format!("audio device error: {reason}"));
+            super::output::notify_device_lost(
+                &app,
+                &shared,
+                format!("audio device error: {reason}"),
+            );
             super::output::schedule_device_rebuild(&app, super::output::RebuildTarget::Resolve);
         }
         Err(err) => tracing::warn!(%err, "coreaudio dop output thread stopped on error"),
@@ -239,7 +243,9 @@ fn open_and_run(
     audio_unit
         .set_render_callback(move |args: Args<data::Interleaved<i32>>| {
             let Args {
-                data: data::Interleaved { buffer, channels, .. },
+                data: data::Interleaved {
+                    buffer, channels, ..
+                },
                 num_frames,
                 ..
             } = args;
@@ -372,7 +378,9 @@ impl Drop for PhysicalFormatGuard {
 /// device supports, but never hands back the one in force — its setter
 /// reads it internally and drops it. So the only way to restore what we
 /// found is to make the same HAL call ourselves.
-fn read_physical_stream_format(device_id: AudioDeviceID) -> Result<AudioStreamBasicDescription, String> {
+fn read_physical_stream_format(
+    device_id: AudioDeviceID,
+) -> Result<AudioStreamBasicDescription, String> {
     let address = AudioObjectPropertyAddress {
         mSelector: kAudioStreamPropertyPhysicalFormat,
         mScope: kAudioObjectPropertyScopeGlobal,

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -827,7 +827,10 @@ pub struct FinishedTrack {
 /// (a few reads, no decode). `None` for a non-DSD path or an unreadable
 /// header (the caller then stays on the PCM path).
 fn dop_format_for(path: &Path) -> Option<DopFormat> {
-    let ext = path.extension().and_then(|s| s.to_str())?.to_ascii_lowercase();
+    let ext = path
+        .extension()
+        .and_then(|s| s.to_str())?
+        .to_ascii_lowercase();
     let mut file = File::open(path).ok()?;
     let layout = match ext.as_str() {
         "dsf" => parse_dsf(&mut file).ok()?,
@@ -1003,7 +1006,8 @@ fn play_dop_track(
     // Both halves of the output format are needed: the ring is drained in
     // whole frames, so a zero channel count would make the backend read
     // frames of nothing and the position clock divide by a placeholder.
-    if shared.sample_rate.load(Ordering::Relaxed) == 0 || shared.channels.load(Ordering::Relaxed) == 0
+    if shared.sample_rate.load(Ordering::Relaxed) == 0
+        || shared.channels.load(Ordering::Relaxed) == 0
     {
         return Err("dop output not initialized (sample_rate / channels unset)".into());
     }
@@ -1033,7 +1037,14 @@ fn play_dop_track(
     transition_state(shared, app, PlayerState::Playing, Some(stream.track_id));
 
     'pkt: loop {
-        match drain_commands(cmd_rx, shared, app, stream.track_id, pending_cmd, &mut no_prefetch) {
+        match drain_commands(
+            cmd_rx,
+            shared,
+            app,
+            stream.track_id,
+            pending_cmd,
+            &mut no_prefetch,
+        ) {
             ControlFlow::Continue => {}
             ControlFlow::Break => break 'pkt,
             ControlFlow::Shutdown => {
@@ -1088,7 +1099,12 @@ fn play_dop_track(
             }
             Ok(false) => {}
             Err(err) => {
-                let _ = app.emit(EVENT_ERROR, ErrorPayload { message: err.clone() });
+                let _ = app.emit(
+                    EVENT_ERROR,
+                    ErrorPayload {
+                        message: err.clone(),
+                    },
+                );
                 return Err(err);
             }
         }

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -696,10 +696,7 @@ mod tests {
 
     #[test]
     fn parse_content_range_start_reads_the_offset() {
-        assert_eq!(
-            parse_content_range_start("bytes 200-1023/1024"),
-            Some(200)
-        );
+        assert_eq!(parse_content_range_start("bytes 200-1023/1024"), Some(200));
         assert_eq!(parse_content_range_start("bytes 0-99/100"), Some(0));
         // Unknown total ("*") is fine as long as both bounds are present.
         assert_eq!(parse_content_range_start("bytes 512-1023/*"), Some(512));

--- a/src-tauri/crates/app/src/audio/mod.rs
+++ b/src-tauri/crates/app/src/audio/mod.rs
@@ -14,7 +14,11 @@
 
 #![allow(dead_code)]
 
+#[cfg(target_os = "linux")]
+pub mod alsa_exclusive;
 pub mod analytics;
+#[cfg(target_os = "macos")]
+pub mod coreaudio_exclusive;
 pub mod crossfade;
 pub mod decoder;
 pub mod dop_pack;
@@ -28,10 +32,6 @@ pub mod spectrum;
 pub mod state;
 #[cfg(target_os = "windows")]
 pub mod wasapi_exclusive;
-#[cfg(target_os = "linux")]
-pub mod alsa_exclusive;
-#[cfg(target_os = "macos")]
-pub mod coreaudio_exclusive;
 
 pub use engine::{AudioCmd, AudioEngine};
 pub use output::list_output_devices;

--- a/src-tauri/crates/app/src/audio/output.rs
+++ b/src-tauri/crates/app/src/audio/output.rs
@@ -279,11 +279,7 @@ pub fn spawn_output_with_mode(
             device_name,
             dop,
         );
-        #[cfg(not(any(
-            target_os = "windows",
-            target_os = "linux",
-            target_os = "macos"
-        )))]
+        #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
         {
             let _ = (dop, &shared, &app, &device_name);
             return Err(AppError::Audio(

--- a/src-tauri/crates/app/src/commands/browse.rs
+++ b/src-tauri/crates/app/src/commands/browse.rs
@@ -459,7 +459,9 @@ async fn expand_artist_rows(
                 // `<hash>.jpg` naming pattern, so we can drop a `picture_hash`
                 // when the source file is missing — the frontend won't have
                 // anything to point a thumbnail variant at either.
-                let picture_hash = r.picture_hash.filter(|h| crate::metadata_artwork::existing_path(&metadata_dir, h).is_some());
+                let picture_hash = r
+                    .picture_hash
+                    .filter(|h| crate::metadata_artwork::existing_path(&metadata_dir, h).is_some());
                 let (picture_has_1x, picture_has_2x) = match picture_hash.as_deref() {
                     Some(h) => {
                         let (p1, p2) = crate::thumbnails::thumbnail_paths_for(&metadata_dir, h);

--- a/src-tauri/crates/app/src/commands/browse.rs
+++ b/src-tauri/crates/app/src/commands/browse.rs
@@ -459,13 +459,7 @@ async fn expand_artist_rows(
                 // `<hash>.jpg` naming pattern, so we can drop a `picture_hash`
                 // when the source file is missing — the frontend won't have
                 // anything to point a thumbnail variant at either.
-                let picture_hash = r.picture_hash.and_then(|h| {
-                    if crate::metadata_artwork::existing_path(&metadata_dir, &h).is_some() {
-                        Some(h)
-                    } else {
-                        None
-                    }
-                });
+                let picture_hash = r.picture_hash.filter(|h| crate::metadata_artwork::existing_path(&metadata_dir, h).is_some());
                 let (picture_has_1x, picture_has_2x) = match picture_hash.as_deref() {
                     Some(h) => {
                         let (p1, p2) = crate::thumbnails::thumbnail_paths_for(&metadata_dir, h);

--- a/src-tauri/crates/app/src/commands/canvas.rs
+++ b/src-tauri/crates/app/src/commands/canvas.rs
@@ -239,7 +239,10 @@ pub async fn fetch_track_canvas(
                         // target the cache path just refused to follow. Skip
                         // this plugin and keep looking.
                         Err(motion_cache::CacheError::UnsafeUrl) => {
-                            tracing::warn!(plugin_id, "canvas cache refused an unsafe url/redirect; skipping");
+                            tracing::warn!(
+                                plugin_id,
+                                "canvas cache refused an unsafe url/redirect; skipping"
+                            );
                             continue;
                         }
                         // Ordinary failure (network / HTTP / disk): degrade to

--- a/src-tauri/crates/app/src/commands/deezer.rs
+++ b/src-tauri/crates/app/src/commands/deezer.rs
@@ -142,10 +142,7 @@ pub(crate) async fn enrich_album_inner(
             // album's needs — otherwise a cover-less row for an art-less album
             // would block a re-fetch until the TTL lapsed (issue #493).
             let usable = expires_at > now
-                && metadata_album_cache_complete(
-                    cover_hash.as_deref(),
-                    local_artwork_id.is_some(),
-                );
+                && metadata_album_cache_complete(cover_hash.as_deref(), local_artwork_id.is_some());
             if usable {
                 let cover_path = cover_hash
                     .as_deref()

--- a/src-tauri/crates/app/src/commands/motion_artwork.rs
+++ b/src-tauri/crates/app/src/commands/motion_artwork.rs
@@ -176,7 +176,10 @@ pub async fn fetch_album_motion_artwork(
                             // raw url — that would hand the webview <video> the
                             // target the cache path just refused. Skip.
                             Err(motion_cache::CacheError::UnsafeUrl) => {
-                                tracing::warn!(plugin_id, "motion cache refused an unsafe url/redirect; skipping");
+                                tracing::warn!(
+                                    plugin_id,
+                                    "motion cache refused an unsafe url/redirect; skipping"
+                                );
                                 continue;
                             }
                             // Ordinary failure: degrade to the remote URL.

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -969,7 +969,10 @@ pub async fn player_set_volume(
     // behind them: without this the mini-player and the main window would
     // show different volumes while driving the same output. Emitted after
     // the clamp so every listener adopts the value the engine really got.
-    let _ = app.emit("player:volume-changed", VolumeChangedPayload { volume: clamped });
+    let _ = app.emit(
+        "player:volume-changed",
+        VolumeChangedPayload { volume: clamped },
+    );
 
     // Best-effort persist — not fatal if the profile pool is gone.
     if let Ok(pool) = state.require_profile_pool().await {

--- a/src-tauri/crates/app/src/commands/plugin_store.rs
+++ b/src-tauri/crates/app/src/commands/plugin_store.rs
@@ -638,7 +638,10 @@ mod tests {
             r#""description": "Animated album covers.",
                "description_i18n": { "fr": "Pochettes animées." }"#,
         );
-        assert_eq!(resolve_description(&json, "fr").as_deref(), Some("Pochettes animées."));
+        assert_eq!(
+            resolve_description(&json, "fr").as_deref(),
+            Some("Pochettes animées.")
+        );
         // The plain string takes the `en` slot, so untranslated
         // languages still read the author's original text.
         assert_eq!(

--- a/src-tauri/crates/app/src/commands/plugins.rs
+++ b/src-tauri/crates/app/src/commands/plugins.rs
@@ -1020,10 +1020,7 @@ struct ArtistSnapshotRow {
 /// like the other manifest reads. A missing / unparsable / mismatched
 /// manifest yields `false` — the host gate would deny the read anyway,
 /// so we default closed.
-async fn plugin_grants_library_read(
-    state: &AppState,
-    plugin_id: &str,
-) -> AppResult<bool> {
+async fn plugin_grants_library_read(state: &AppState, plugin_id: &str) -> AppResult<bool> {
     let paths = state.paths.plugin_paths();
     let manifest_path = match paths.manifest_path(plugin_id) {
         Ok(p) => p,
@@ -1062,8 +1059,7 @@ async fn load_library_artist_snapshot(
         return Ok(Vec::new());
     }
     let pool = state.require_profile_pool().await?;
-    let capped =
-        limit.min(waveflow_core::plugin::host_impl::MAX_LIBRARY_ARTISTS) as i64;
+    let capped = limit.min(waveflow_core::plugin::host_impl::MAX_LIBRARY_ARTISTS) as i64;
     let rows = sqlx::query_as::<_, ArtistSnapshotRow>(
         "SELECT ar.id AS id,
                 ar.name AS name,

--- a/src-tauri/crates/app/src/commands/stats.rs
+++ b/src-tauri/crates/app/src/commands/stats.rs
@@ -637,7 +637,8 @@ pub async fn export_stats_json(
 
     let overview = stats_overview_inner(&pool, &range).await?;
     let top_tracks = stats_top_tracks_inner(&pool, &artwork_dir, &range, 100).await?;
-    let top_artists = stats_top_artists_inner(&pool, &artwork_dir, metadata_dir, &range, 100).await?;
+    let top_artists =
+        stats_top_artists_inner(&pool, &artwork_dir, metadata_dir, &range, 100).await?;
     let top_albums = stats_top_albums_inner(&pool, &artwork_dir, &range, 100).await?;
     let top_genres = stats_top_genres_inner(&pool, &range, 100).await?;
     let listening_by_day = stats_listening_by_day_inner(&pool, &range).await?;

--- a/src-tauri/crates/app/src/db/schema_guard.rs
+++ b/src-tauri/crates/app/src/db/schema_guard.rs
@@ -73,9 +73,7 @@ impl DbScope {
     /// `app.db`, which every profile goes through.
     pub fn remedy(self) -> &'static str {
         match self {
-            DbScope::App => {
-                "Install WaveFlow again from the version you were using before."
-            }
+            DbScope::App => "Install WaveFlow again from the version you were using before.",
             DbScope::Profile => {
                 "Install WaveFlow again from the version you were using before, \
                  or start WaveFlow with a different profile."
@@ -132,7 +130,6 @@ pub async fn ensure_not_from_the_future(
         installed_on,
     })
 }
-
 
 /// Vet the databases this launch is about to open, **before**
 /// `tauri::Builder::run`.
@@ -485,7 +482,10 @@ mod tests {
         let paths = AppPaths::from_root(root.clone(), None);
 
         assert!(preflight(&paths).await.is_none());
-        assert!(!root.exists(), "pre-flight must not create the app-data tree");
+        assert!(
+            !root.exists(),
+            "pre-flight must not create the app-data tree"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/mpd/commands.rs
+++ b/src-tauri/crates/app/src/mpd/commands.rs
@@ -475,8 +475,10 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
                     if p >= len {
                         return Err(ack_arg("play", "Bad song index"));
                     }
-                    player_actions::play_at_index_with(&ctx.app, &pool, profile_id, p as i64, SURFACE)
-                        .await;
+                    player_actions::play_at_index_with(
+                        &ctx.app, &pool, profile_id, p as i64, SURFACE,
+                    )
+                    .await;
                 }
             }
             ctx.idle.notify(Subsystem::Player);
@@ -564,8 +566,10 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
             // differs from the current cursor. Scrubbing the progress bar is
             // exactly this case.
             if !is_current_track(ctx, &pool, pos as i64).await {
-                player_actions::play_at_index_with(&ctx.app, &pool, profile_id, pos as i64, SURFACE)
-                    .await;
+                player_actions::play_at_index_with(
+                    &ctx.app, &pool, profile_id, pos as i64, SURFACE,
+                )
+                .await;
             }
             let _ = ctx.engine().send(AudioCmd::Seek(seconds_to_ms(seconds)));
             ctx.idle.notify(Subsystem::Player);

--- a/src-tauri/crates/app/src/mpd/config.rs
+++ b/src-tauri/crates/app/src/mpd/config.rs
@@ -100,11 +100,7 @@ async fn read_key(pool: &SqlitePool, key: &str) -> AppResult<Option<String>> {
     Ok(value)
 }
 
-async fn write_key(
-    conn: &mut sqlx::SqliteConnection,
-    key: &str,
-    value: &str,
-) -> AppResult<()> {
+async fn write_key(conn: &mut sqlx::SqliteConnection, key: &str, value: &str) -> AppResult<()> {
     // `app_setting.value_type` + `updated_at` are NOT NULL (no default), so a
     // brand-new key (the `mpd.*` keys aren't seeded) must supply both or the
     // INSERT fails the constraint. Everything here is stored as text and

--- a/src-tauri/crates/app/src/mpd/idle.rs
+++ b/src-tauri/crates/app/src/mpd/idle.rs
@@ -57,12 +57,7 @@ impl Subsystem {
 
     /// Every subsystem, for the `commands`/`tagtypes`-style listings and
     /// for a bare `idle` with no arguments (which means "any").
-    pub const ALL: [Subsystem; 4] = [
-        Self::Player,
-        Self::Playlist,
-        Self::Mixer,
-        Self::Options,
-    ];
+    pub const ALL: [Subsystem; 4] = [Self::Player, Self::Playlist, Self::Mixer, Self::Options];
 }
 
 /// Fan-out channel. Cloned into every connection task.

--- a/src-tauri/crates/app/src/mpd/mod.rs
+++ b/src-tauri/crates/app/src/mpd/mod.rs
@@ -114,11 +114,8 @@ impl MpdServer {
                         Cmd::Start(cfg, app) => runtime.block_on(state.start(cfg, app)),
                         Cmd::Stop => runtime.block_on(state.stop()),
                         Cmd::Status(reply) => {
-                            let snapshot = state
-                                .status
-                                .lock()
-                                .map(|s| s.clone())
-                                .unwrap_or_default();
+                            let snapshot =
+                                state.status.lock().map(|s| s.clone()).unwrap_or_default();
                             let _ = reply.send(snapshot);
                         }
                     }

--- a/src-tauri/crates/app/src/paths.rs
+++ b/src-tauri/crates/app/src/paths.rs
@@ -85,7 +85,10 @@ impl AppPaths {
             }
         };
 
-        Ok(Self::from_root(data_dir.join("waveflow"), bundled_plugins_dir))
+        Ok(Self::from_root(
+            data_dir.join("waveflow"),
+            bundled_plugins_dir,
+        ))
     }
 
     /// Same layout, resolved from the app-data root alone.

--- a/src-tauri/crates/app/src/remote/binding.rs
+++ b/src-tauri/crates/app/src/remote/binding.rs
@@ -301,8 +301,12 @@ mod tests {
                 "../../../../migrations/profile/20260810120000_remote_source_projection.sql"
             ),
             include_str!("../../../../migrations/profile/20260810140000_remote_track_cache.sql"),
-            include_str!("../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"),
-            include_str!("../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"),
+            include_str!(
+                "../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"
+            ),
+            include_str!(
+                "../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"
+            ),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -392,14 +396,26 @@ mod tests {
         async fn count(conn: &mut SqliteConnection, sql: &'static str) -> i64 {
             sqlx::query_scalar(sql).fetch_one(&mut *conn).await.unwrap()
         }
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_playlist").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_playlist").await,
+            0
+        );
         assert_eq!(
             count(&mut conn, "SELECT count(*) FROM remote_playlist_track").await,
             0
         );
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_favorite").await, 0);
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_track").await, 0);
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_mutation").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_favorite").await,
+            0
+        );
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_track").await,
+            0
+        );
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_mutation").await,
+            0
+        );
 
         // And the binding is now account 2.
         let bound = read(&mut conn).await.unwrap().unwrap();
@@ -457,7 +473,10 @@ mod tests {
         // A catch-up pass that started earlier finishing later.
         advance_cursor(&mut conn, 11).await.unwrap();
 
-        assert_eq!(read(&mut conn).await.unwrap().unwrap().identity.cursor(), Some(42));
+        assert_eq!(
+            read(&mut conn).await.unwrap().unwrap().identity.cursor(),
+            Some(42)
+        );
     }
 
     #[tokio::test]
@@ -486,7 +505,10 @@ mod tests {
         // Signing into a different account must not inherit a cursor
         // into a journal it never belonged to.
         write(&mut conn, &waveflow_binding(0)).await.unwrap();
-        assert_eq!(read(&mut conn).await.unwrap().unwrap().identity.cursor(), Some(0));
+        assert_eq!(
+            read(&mut conn).await.unwrap().unwrap().identity.cursor(),
+            Some(0)
+        );
     }
 
     #[tokio::test]
@@ -527,12 +549,11 @@ mod tests {
         ] {
             // `AssertSqlSafe` because the table name comes from the
             // literal list above, never from input.
-            let count: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
-                "SELECT count(*) FROM {table}"
-            )))
-            .fetch_one(&mut *conn)
-            .await
-            .unwrap();
+            let count: i64 =
+                sqlx::query_scalar(sqlx::AssertSqlSafe(format!("SELECT count(*) FROM {table}")))
+                    .fetch_one(&mut *conn)
+                    .await
+                    .unwrap();
             assert_eq!(count, 0, "{table} still holds rows");
         }
     }

--- a/src-tauri/crates/app/src/remote/client.rs
+++ b/src-tauri/crates/app/src/remote/client.rs
@@ -254,10 +254,7 @@ impl<'a> RemoteClient<'a> {
     /// acquisition to the *same* profile across an operation, so a switch
     /// landing mid-way fails cleanly instead of reading one profile's
     /// tokens and writing another's data.
-    pub async fn try_build_for(
-        state: &'a AppState,
-        profile_id: i64,
-    ) -> AppResult<Option<Self>> {
+    pub async fn try_build_for(state: &'a AppState, profile_id: i64) -> AppResult<Option<Self>> {
         let (binding, pair) = {
             let pool = state.require_profile_pool_for(Some(profile_id)).await?;
             let mut conn = pool.acquire().await?;
@@ -475,9 +472,7 @@ impl<'a> RemoteClient<'a> {
     /// still available. The code is kept as a field, not formatted away:
     /// callers branch on it, and a substring match on a message would be a
     /// fragile way to make a destructive decision.
-    async fn interpret(
-        response: reqwest::Response,
-    ) -> Result<reqwest::Response, RemoteFailure> {
+    async fn interpret(response: reqwest::Response) -> Result<reqwest::Response, RemoteFailure> {
         let status = response.status().as_u16();
         match classify_status(status) {
             None => Ok(response),

--- a/src-tauri/crates/app/src/remote/lyrics.rs
+++ b/src-tauri/crates/app/src/remote/lyrics.rs
@@ -175,11 +175,9 @@ mod tests {
 
     #[test]
     fn partially_stamped_track_falls_back_to_plain_keeping_all_lines() {
-        let got = structured_to_lyrics(&[track(
-            true,
-            vec![line(Some(0), "one"), line(None, "two")],
-        )])
-        .unwrap();
+        let got =
+            structured_to_lyrics(&[track(true, vec![line(Some(0), "one"), line(None, "two")])])
+                .unwrap();
         assert!(!got.synced);
         // Both lines survive, without any `[mm:ss.xx]` tag.
         assert_eq!(got.content, "one\ntwo");
@@ -189,7 +187,10 @@ mod tests {
     fn a_complete_synced_track_wins_over_an_earlier_partial_one() {
         let got = structured_to_lyrics(&[
             track(true, vec![line(Some(0), "partial"), line(None, "gap")]),
-            track(true, vec![line(Some(0), "full"), line(Some(1000), "stamped")]),
+            track(
+                true,
+                vec![line(Some(0), "full"), line(Some(1000), "stamped")],
+            ),
         ])
         .unwrap();
         assert!(got.synced);

--- a/src-tauri/crates/app/src/remote/mutation.rs
+++ b/src-tauri/crates/app/src/remote/mutation.rs
@@ -496,11 +496,10 @@ async fn rewrite_queued_references(
     placeholder: &str,
     remote_id: &str,
 ) -> AppResult<()> {
-    let rows = sqlx::query(
-        "SELECT id, payload FROM remote_mutation WHERE failed_at IS NULL ORDER BY id",
-    )
-    .fetch_all(&mut *conn)
-    .await?;
+    let rows =
+        sqlx::query("SELECT id, payload FROM remote_mutation WHERE failed_at IS NULL ORDER BY id")
+            .fetch_all(&mut *conn)
+            .await?;
     for row in rows {
         let id: i64 = row.try_get("id")?;
         let payload: String = row.try_get("payload")?;
@@ -580,8 +579,12 @@ mod tests {
                 "../../../../migrations/profile/20260810120000_remote_source_projection.sql"
             ),
             include_str!("../../../../migrations/profile/20260810140000_remote_track_cache.sql"),
-            include_str!("../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"),
-            include_str!("../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"),
+            include_str!(
+                "../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"
+            ),
+            include_str!(
+                "../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"
+            ),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -653,8 +656,12 @@ mod tests {
         enqueue(&mut conn, &favorite(true)).await.unwrap();
         let queued = pending(&mut conn, 10).await.unwrap();
 
-        record_attempt(&mut conn, queued[0].id, "503").await.unwrap();
-        record_attempt(&mut conn, queued[0].id, "503").await.unwrap();
+        record_attempt(&mut conn, queued[0].id, "503")
+            .await
+            .unwrap();
+        record_attempt(&mut conn, queued[0].id, "503")
+            .await
+            .unwrap();
 
         let again = pending(&mut conn, 10).await.unwrap();
         assert_eq!(again.len(), 1);
@@ -964,9 +971,7 @@ mod tests {
         let queued = pending(&mut conn, 10).await.unwrap();
         assert_eq!(
             queued[0].mutation,
-            Mutation::DeletePlaylist {
-                playlist_id: other
-            }
+            Mutation::DeletePlaylist { playlist_id: other }
         );
     }
 

--- a/src-tauri/crates/app/src/remote/probe.rs
+++ b/src-tauri/crates/app/src/remote/probe.rs
@@ -151,9 +151,8 @@ pub async fn detect(base_url: &str) -> AppResult<ServerFlavour> {
 /// Parse a ping body into a flavour. Split out from the request so the
 /// interesting half is testable without a server.
 pub fn classify_ping_body(body: &str) -> AppResult<ServerFlavour> {
-    let envelope: PingEnvelope = serde_json::from_str(body).map_err(|_| {
-        AppError::Other("this URL did not answer like a music server".to_string())
-    })?;
+    let envelope: PingEnvelope = serde_json::from_str(body)
+        .map_err(|_| AppError::Other("this URL did not answer like a music server".to_string()))?;
 
     let Some(response) = envelope.response else {
         return Err(AppError::Other(

--- a/src-tauri/crates/app/src/remote/projection.rs
+++ b/src-tauri/crates/app/src/remote/projection.rs
@@ -315,9 +315,7 @@ pub async fn missing_track_ids(conn: &mut SqliteConnection) -> AppResult<Vec<Str
 /// with no artist at all is left alone — it has nothing to link to anyway.
 /// Kept separate from [`missing_track_ids`] so the overview's
 /// "awaiting metadata" count keeps meaning "no metadata at all".
-pub async fn tracks_missing_artist_id(
-    conn: &mut SqliteConnection,
-) -> AppResult<Vec<String>> {
+pub async fn tracks_missing_artist_id(conn: &mut SqliteConnection) -> AppResult<Vec<String>> {
     let rows: Vec<String> = sqlx::query_scalar(
         "SELECT remote_id FROM remote_track
           WHERE artist_id IS NULL AND artist IS NOT NULL",
@@ -610,7 +608,10 @@ async fn apply_playlist_upsert(
 /// for one specific reason: updating a share's description emits a
 /// payload with **no** `track_ids`, so writing them unconditionally
 /// would empty the share.
-async fn apply_share_upsert(conn: &mut SqliteConnection, change: &SyncChange) -> AppResult<Outcome> {
+async fn apply_share_upsert(
+    conn: &mut SqliteConnection,
+    change: &SyncChange,
+) -> AppResult<Outcome> {
     let id = payload_str(&change.payload, "id")
         .unwrap_or(&change.entity_id)
         .to_string();
@@ -713,8 +714,12 @@ mod tests {
                 "../../../../migrations/profile/20260810120000_remote_source_projection.sql"
             ),
             include_str!("../../../../migrations/profile/20260810140000_remote_track_cache.sql"),
-            include_str!("../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"),
-            include_str!("../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"),
+            include_str!(
+                "../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"
+            ),
+            include_str!(
+                "../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"
+            ),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -734,11 +739,12 @@ mod tests {
     }
 
     async fn playlist_row(conn: &mut SqliteConnection, id: &str) -> (String, Option<String>, i64) {
-        let row = sqlx::query("SELECT name, comment, is_public FROM remote_playlist WHERE remote_id = ?")
-            .bind(id)
-            .fetch_one(&mut *conn)
-            .await
-            .unwrap();
+        let row =
+            sqlx::query("SELECT name, comment, is_public FROM remote_playlist WHERE remote_id = ?")
+                .bind(id)
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap();
         (
             row.try_get("name").unwrap(),
             row.try_get("comment").unwrap(),
@@ -874,11 +880,12 @@ mod tests {
         .await
         .unwrap();
 
-        let count: i64 =
-            sqlx::query_scalar("SELECT count(*) FROM remote_share_track WHERE share_remote_id='s1'")
-                .fetch_one(&mut *conn)
-                .await
-                .unwrap();
+        let count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM remote_share_track WHERE share_remote_id='s1'",
+        )
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
         assert_eq!(count, 2, "the share lost its tracks on a description edit");
     }
 
@@ -1108,12 +1115,13 @@ mod tests {
                 .unwrap();
         assert_eq!(survived, 1, "an unsent offline playlist was destroyed");
 
-        let tracks: i64 =
-            sqlx::query_scalar("SELECT count(*) FROM remote_playlist_track WHERE playlist_remote_id = ?")
-                .bind(&local_id)
-                .fetch_one(&mut *conn)
-                .await
-                .unwrap();
+        let tracks: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM remote_playlist_track WHERE playlist_remote_id = ?",
+        )
+        .bind(&local_id)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
         assert_eq!(tracks, 1, "its tracks went with it");
     }
 
@@ -1290,7 +1298,12 @@ mod tests {
             .fetch_one(&mut *conn)
             .await
             .unwrap();
-        assert_eq!(row.try_get::<Option<String>, _>("artist").unwrap().as_deref(), Some("A"));
+        assert_eq!(
+            row.try_get::<Option<String>, _>("artist")
+                .unwrap()
+                .as_deref(),
+            Some("A")
+        );
         assert_eq!(row.try_get::<i64, _>("duration_ms").unwrap(), 1234);
     }
 }

--- a/src-tauri/crates/app/src/remote/read.rs
+++ b/src-tauri/crates/app/src/remote/read.rs
@@ -219,8 +219,12 @@ mod tests {
                 "../../../../migrations/profile/20260810120000_remote_source_projection.sql"
             ),
             include_str!("../../../../migrations/profile/20260810140000_remote_track_cache.sql"),
-            include_str!("../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"),
-            include_str!("../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"),
+            include_str!(
+                "../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"
+            ),
+            include_str!(
+                "../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"
+            ),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -255,7 +259,10 @@ mod tests {
     async fn an_unbound_profile_reads_as_all_zeroes_rather_than_failing() {
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
-        assert_eq!(overview(&mut conn).await.unwrap(), RemoteOverview::default());
+        assert_eq!(
+            overview(&mut conn).await.unwrap(),
+            RemoteOverview::default()
+        );
         assert!(playlists(&mut conn).await.unwrap().is_empty());
     }
 

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -345,10 +345,11 @@ async fn discover_inner(
 
     let local_tracks = load_local_candidates(pool).await?;
     let total = local_tracks.len();
-    let scan =
-        tokio::task::spawn_blocking(move || hash_local_tracks(local_tracks, app.as_ref(), total, cancellable))
-            .await
-            .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))?;
+    let scan = tokio::task::spawn_blocking(move || {
+        hash_local_tracks(local_tracks, app.as_ref(), total, cancellable)
+    })
+    .await
+    .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))?;
 
     if scan.cancelled {
         // A partial scan could auto-link the unique matches it happened to
@@ -357,7 +358,14 @@ async fn discover_inner(
         return Ok(empty_report(true));
     }
 
-    reconcile(pool, scan.hashed, scan.unreadable, remote_tracks, cancellable).await
+    reconcile(
+        pool,
+        scan.hashed,
+        scan.unreadable,
+        remote_tracks,
+        cancellable,
+    )
+    .await
 }
 
 async fn load_remote_tracks(pool: &SqlitePool) -> AppResult<Vec<RemoteTrack>> {
@@ -1463,9 +1471,15 @@ mod tests {
         // Once committing, or when idle, a cancel is too late / a no-op and must
         // report the authoritative `false`.
         RECONCILE_PHASE.store(PHASE_COMMITTING, Ordering::SeqCst);
-        assert!(!request_cancel(), "cancel after commit started must be rejected");
+        assert!(
+            !request_cancel(),
+            "cancel after commit started must be rejected"
+        );
         RECONCILE_PHASE.store(PHASE_IDLE, Ordering::SeqCst);
-        assert!(!request_cancel(), "cancel with nothing running must be rejected");
+        assert!(
+            !request_cancel(),
+            "cancel with nothing running must be rejected"
+        );
     }
 
     /// A cancel latched while the scan is still staging stops the hashing loop
@@ -1503,7 +1517,10 @@ mod tests {
         let pool = pool().await;
         RECONCILE_PHASE.store(PHASE_CANCELLED, Ordering::SeqCst);
         let report = discover_inner(&pool, None, true).await.unwrap();
-        assert!(report.cancelled, "a cancel racing the empty-remote path is reported");
+        assert!(
+            report.cancelled,
+            "a cancel racing the empty-remote path is reported"
+        );
         RECONCILE_PHASE.store(PHASE_IDLE, Ordering::SeqCst);
     }
 
@@ -1537,7 +1554,10 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(rows, 0, "a cancel during reconcile must roll back before commit");
+        assert_eq!(
+            rows, 0,
+            "a cancel during reconcile must roll back before commit"
+        );
         RECONCILE_PHASE.store(PHASE_IDLE, Ordering::SeqCst);
     }
 
@@ -1561,10 +1581,12 @@ mod tests {
             .await
             .unwrap();
         // Every `track` row FKs `library(id)`, so seed one library up front.
-        sqlx::query("INSERT INTO library (id, name, created_at, updated_at) VALUES (1, 'Test', 0, 0)")
-            .execute(&pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "INSERT INTO library (id, name, created_at, updated_at) VALUES (1, 'Test', 0, 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
         pool
     }
 

--- a/src-tauri/crates/app/src/remote/socket.rs
+++ b/src-tauri/crates/app/src/remote/socket.rs
@@ -164,9 +164,7 @@ async fn run_session(handle: &AppHandle, state: &AppState) -> AppResult<bool> {
             continue;
         }
         let wait = match pending_since {
-            Some(since) => {
-                COALESCE_WINDOW.min(MAX_COALESCE_DELAY.saturating_sub(since.elapsed()))
-            }
+            Some(since) => COALESCE_WINDOW.min(MAX_COALESCE_DELAY.saturating_sub(since.elapsed())),
             None => IDLE_TIMEOUT,
         };
         match tokio::time::timeout(wait, reader.next()).await {

--- a/src-tauri/crates/app/src/remote/sync.rs
+++ b/src-tauri/crates/app/src/remote/sync.rs
@@ -106,7 +106,15 @@ pub async fn sync_now(state: &AppState) -> AppResult<SyncReport> {
                 ..Default::default()
             })
         }
-        Some(_) => catch_up(state, profile_id, &client, binding.identity.cursor().unwrap_or(0)).await,
+        Some(_) => {
+            catch_up(
+                state,
+                profile_id,
+                &client,
+                binding.identity.cursor().unwrap_or(0),
+            )
+            .await
+        }
     }
 }
 
@@ -399,7 +407,9 @@ async fn backfill_missing_tracks(state: &AppState, profile_id: i64, client: &Rem
     let Ok(pool) = state.require_profile_pool_for(Some(profile_id)).await else {
         return;
     };
-    let Ok(mut tx) = pool.begin().await else { return };
+    let Ok(mut tx) = pool.begin().await else {
+        return;
+    };
     for song in &fetched {
         if let Err(error) = projection::cache_song(&mut tx, song).await {
             // Skip the one song we could not cache rather than abandoning

--- a/src-tauri/crates/app/src/remote/tokens.rs
+++ b/src-tauri/crates/app/src/remote/tokens.rs
@@ -97,7 +97,9 @@ pub async fn read(conn: &mut SqliteConnection) -> AppResult<Option<TokenPair>> {
     // long-lived API token pasted by hand. Both are unusable for the v2
     // flow, which cannot recover the session once the access token
     // lapses — treating it as signed out is the honest answer.
-    let Some(refresh_token) = refresh.map(|bytes| decode(bytes, "refresh token")).transpose()?
+    let Some(refresh_token) = refresh
+        .map(|bytes| decode(bytes, "refresh token"))
+        .transpose()?
     else {
         return Ok(None);
     };

--- a/src-tauri/crates/app/src/remote/write.rs
+++ b/src-tauri/crates/app/src/remote/write.rs
@@ -862,10 +862,7 @@ pub async fn delete_share(state: &AppState, share_id: &str) -> AppResult<()> {
     Ok(())
 }
 
-pub async fn delete_share_in_tx(
-    conn: &mut SqliteConnection,
-    share_id: &str,
-) -> AppResult<()> {
+pub async fn delete_share_in_tx(conn: &mut SqliteConnection, share_id: &str) -> AppResult<()> {
     sqlx::query("DELETE FROM remote_share_track WHERE share_remote_id = ?")
         .bind(share_id)
         .execute(&mut *conn)
@@ -917,8 +914,12 @@ mod tests {
                 "../../../../migrations/profile/20260810120000_remote_source_projection.sql"
             ),
             include_str!("../../../../migrations/profile/20260810140000_remote_track_cache.sql"),
-            include_str!("../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"),
-            include_str!("../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"),
+            include_str!(
+                "../../../../migrations/profile/20260813090000_remote_track_full_hash.sql"
+            ),
+            include_str!(
+                "../../../../migrations/profile/20260816120000_remote_track_artist_id.sql"
+            ),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -943,7 +944,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_favorite").await, 1);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_favorite").await,
+            1
+        );
         let queued = pending(&mut conn, 10).await.unwrap();
         assert_eq!(
             queued[0].mutation,
@@ -959,10 +963,17 @@ mod tests {
     async fn unstarring_removes_the_row_and_still_queues() {
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
-        set_favorite_in_tx(&mut conn, "track", "t1", true).await.unwrap();
-        set_favorite_in_tx(&mut conn, "track", "t1", false).await.unwrap();
+        set_favorite_in_tx(&mut conn, "track", "t1", true)
+            .await
+            .unwrap();
+        set_favorite_in_tx(&mut conn, "track", "t1", false)
+            .await
+            .unwrap();
 
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_favorite").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_favorite").await,
+            0
+        );
         assert_eq!(
             pending(&mut conn, 10).await.unwrap().len(),
             2,
@@ -977,7 +988,10 @@ mod tests {
         set_rating_in_tx(&mut conn, "track", "t1", 4).await.unwrap();
         set_rating_in_tx(&mut conn, "track", "t1", 0).await.unwrap();
 
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_rating").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_rating").await,
+            0
+        );
         let queued = pending(&mut conn, 10).await.unwrap();
         assert_eq!(
             queued[1].mutation,
@@ -996,7 +1010,10 @@ mod tests {
 
         assert!(set_rating_in_tx(&mut conn, "track", "t1", 6).await.is_err());
 
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_rating").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_rating").await,
+            0
+        );
         assert_eq!(
             count(&mut conn, "SELECT count(*) FROM remote_mutation").await,
             0,
@@ -1088,7 +1105,10 @@ mod tests {
 
         delete_playlist_in_tx(&mut conn, &id).await.unwrap();
 
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_playlist").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_playlist").await,
+            0
+        );
         assert_eq!(
             count(&mut conn, "SELECT count(*) FROM remote_playlist_track").await,
             0
@@ -1204,12 +1224,20 @@ mod tests {
         // projection write must take the queued mutation with it.
         let pool = pool().await;
         let mut tx = pool.begin().await.unwrap();
-        set_favorite_in_tx(&mut tx, "track", "t1", true).await.unwrap();
+        set_favorite_in_tx(&mut tx, "track", "t1", true)
+            .await
+            .unwrap();
         tx.rollback().await.unwrap();
 
         let mut conn = pool.acquire().await.unwrap();
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_favorite").await, 0);
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_mutation").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_favorite").await,
+            0
+        );
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_mutation").await,
+            0
+        );
     }
 
     #[tokio::test]
@@ -1219,12 +1247,22 @@ mod tests {
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
 
-        scrobble_in_tx(&mut conn, "t1", false, Some(1_000)).await.unwrap();
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_history").await, 0);
+        scrobble_in_tx(&mut conn, "t1", false, Some(1_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_history").await,
+            0
+        );
         assert_eq!(pending(&mut conn, 10).await.unwrap().len(), 1);
 
-        scrobble_in_tx(&mut conn, "t1", true, Some(2_000)).await.unwrap();
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_history").await, 1);
+        scrobble_in_tx(&mut conn, "t1", true, Some(2_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_history").await,
+            1
+        );
     }
 
     #[tokio::test]
@@ -1232,9 +1270,15 @@ mod tests {
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
 
-        save_queue_in_tx(&mut conn, &["a".into(), "b".into()], Some("a".into()), 0, None)
-            .await
-            .unwrap();
+        save_queue_in_tx(
+            &mut conn,
+            &["a".into(), "b".into()],
+            Some("a".into()),
+            0,
+            None,
+        )
+        .await
+        .unwrap();
         save_queue_in_tx(&mut conn, &["c".into()], Some("c".into()), 4200, None)
             .await
             .unwrap();
@@ -1245,7 +1289,10 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(ids, vec!["c"]);
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_queue").await, 1);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_queue").await,
+            1
+        );
     }
 
     #[tokio::test]
@@ -1290,7 +1337,9 @@ mod tests {
     async fn an_empty_share_is_refused() {
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
-        assert!(create_share_in_tx(&mut conn, &[], None, None).await.is_err());
+        assert!(create_share_in_tx(&mut conn, &[], None, None)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -1315,7 +1364,13 @@ mod tests {
                 .unwrap();
         assert_eq!(expires, None);
 
-        match &pending(&mut conn, 10).await.unwrap().last().unwrap().mutation {
+        match &pending(&mut conn, 10)
+            .await
+            .unwrap()
+            .last()
+            .unwrap()
+            .mutation
+        {
             Mutation::UpdateShare {
                 clear_expires_at,
                 expires_at,
@@ -1338,7 +1393,10 @@ mod tests {
 
         delete_share_in_tx(&mut conn, &id).await.unwrap();
 
-        assert_eq!(count(&mut conn, "SELECT count(*) FROM remote_share").await, 0);
+        assert_eq!(
+            count(&mut conn, "SELECT count(*) FROM remote_share").await,
+            0
+        );
         assert!(pending(&mut conn, 10).await.unwrap().is_empty());
     }
 
@@ -1349,13 +1407,24 @@ mod tests {
         let pool = pool().await;
         let mut conn = pool.acquire().await.unwrap();
 
-        set_favorite_in_tx(&mut conn, "track", "t1", true).await.unwrap();
-        set_rating_in_tx(&mut conn, "track", "t1", 3).await.unwrap();
-        let playlist = create_playlist_in_tx(&mut conn, "Mix", &[]).await.unwrap();
-        update_playlist_in_tx(&mut conn, &playlist, Some("Renamed".into()), None, None, false)
+        set_favorite_in_tx(&mut conn, "track", "t1", true)
             .await
             .unwrap();
-        scrobble_in_tx(&mut conn, "t1", true, Some(1_000)).await.unwrap();
+        set_rating_in_tx(&mut conn, "track", "t1", 3).await.unwrap();
+        let playlist = create_playlist_in_tx(&mut conn, "Mix", &[]).await.unwrap();
+        update_playlist_in_tx(
+            &mut conn,
+            &playlist,
+            Some("Renamed".into()),
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+        scrobble_in_tx(&mut conn, "t1", true, Some(1_000))
+            .await
+            .unwrap();
         save_queue_in_tx(&mut conn, &["t1".into()], None, 0, None)
             .await
             .unwrap();

--- a/src-tauri/crates/app/src/remote_playback.rs
+++ b/src-tauri/crates/app/src/remote_playback.rs
@@ -177,7 +177,12 @@ impl RemotePlayback {
 ///   - repeat-one replays the same slot in either direction;
 ///   - next stops (`None`) at the end with repeat off, else wraps;
 ///   - previous clamps at 0 with repeat off, else wraps to the end.
-fn advance_index(len: usize, index: usize, direction: Direction, repeat: RepeatMode) -> Option<usize> {
+fn advance_index(
+    len: usize,
+    index: usize,
+    direction: Direction,
+    repeat: RepeatMode,
+) -> Option<usize> {
     if len == 0 {
         return None;
     }
@@ -208,14 +213,23 @@ mod tests {
 
     #[test]
     fn next_off_stops_at_the_end() {
-        assert_eq!(advance_index(3, 0, Direction::Next, RepeatMode::Off), Some(1));
-        assert_eq!(advance_index(3, 1, Direction::Next, RepeatMode::Off), Some(2));
+        assert_eq!(
+            advance_index(3, 0, Direction::Next, RepeatMode::Off),
+            Some(1)
+        );
+        assert_eq!(
+            advance_index(3, 1, Direction::Next, RepeatMode::Off),
+            Some(2)
+        );
         assert_eq!(advance_index(3, 2, Direction::Next, RepeatMode::Off), None);
     }
 
     #[test]
     fn next_all_wraps() {
-        assert_eq!(advance_index(3, 2, Direction::Next, RepeatMode::All), Some(0));
+        assert_eq!(
+            advance_index(3, 2, Direction::Next, RepeatMode::All),
+            Some(0)
+        );
     }
 
     #[test]
@@ -240,7 +254,10 @@ mod tests {
 
     #[test]
     fn repeat_one_holds_the_slot() {
-        assert_eq!(advance_index(3, 1, Direction::Next, RepeatMode::One), Some(1));
+        assert_eq!(
+            advance_index(3, 1, Direction::Next, RepeatMode::One),
+            Some(1)
+        );
         assert_eq!(
             advance_index(3, 1, Direction::Previous, RepeatMode::One),
             Some(1)

--- a/src-tauri/crates/core/src/artwork/motion_cache.rs
+++ b/src-tauri/crates/core/src/artwork/motion_cache.rs
@@ -214,13 +214,13 @@ pub async fn cache_mp4(dir: &Path, url: &str, max_cache_bytes: u64) -> Result<Pa
     // slip a request past that check.
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
-        .redirect(reqwest::redirect::Policy::custom(|attempt| {
-            match redirect_decision(attempt.previous().len(), attempt.url().as_str()) {
+        .redirect(reqwest::redirect::Policy::custom(
+            |attempt| match redirect_decision(attempt.previous().len(), attempt.url().as_str()) {
                 RedirectDecision::Follow => attempt.follow(),
                 RedirectDecision::TooMany => attempt.error("too many redirects"),
                 RedirectDecision::Unsafe => attempt.error("unsafe redirect target"),
-            }
-        }))
+            },
+        ))
         .build()
         .map_err(|e| CacheError::Other(format!("http client: {e}")))?;
     let mut resp = match client.get(url).send().await {
@@ -264,7 +264,8 @@ pub async fn cache_mp4(dir: &Path, url: &str, max_cache_bytes: u64) -> Result<Pa
         bytes.extend_from_slice(&chunk);
     }
 
-    std::fs::create_dir_all(dir).map_err(|e| CacheError::Other(format!("create cache dir: {e}")))?;
+    std::fs::create_dir_all(dir)
+        .map_err(|e| CacheError::Other(format!("create cache dir: {e}")))?;
     // Unique temp per attempt (pid + monotonic seq) so concurrent downloads of
     // the SAME url can't clobber each other's partial write. Each stages its
     // own complete file then renames over the shared final name (a file rename
@@ -496,7 +497,10 @@ mod tests {
             redact_url("https://cdn.example.com/a.mp4"),
             "https://cdn.example.com/a.mp4"
         );
-        assert_eq!(redact_url("https://cdn.example.com"), "https://cdn.example.com");
+        assert_eq!(
+            redact_url("https://cdn.example.com"),
+            "https://cdn.example.com"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/core/src/audio_format/dsd/dop.rs
+++ b/src-tauri/crates/core/src/audio_format/dsd/dop.rs
@@ -110,9 +110,7 @@ impl DsdToDop {
     /// sample and restarts the marker cadence — the DAC re-locks within
     /// a frame or two, inaudible.
     pub fn reset(&mut self) {
-        for p in &mut self.pending {
-            *p = None;
-        }
+        self.pending.fill(None);
         self.frame_counter = 0;
     }
 
@@ -295,7 +293,7 @@ mod tests {
         let mut enc = DsdToDop::new(&layout(2_822_400, None, false));
         let mut out = Vec::new();
         // 4 frames × 2 ch × 2 bytes = 16 bytes.
-        enc.encode_block(&vec![0u8; 16], &mut out);
+        enc.encode_block(&[0u8; 16], &mut out);
         assert_eq!(out.len(), 8, "4 stereo frames");
         let marker = |w: u32| w >> 16;
         for f in 0..4 {

--- a/src-tauri/crates/core/src/audio_format/dsd/dop.rs
+++ b/src-tauri/crates/core/src/audio_format/dsd/dop.rs
@@ -254,9 +254,18 @@ mod tests {
     #[test]
     fn output_rate_is_dsd_rate_over_sixteen() {
         // DSD64 → 176.4 kHz, DSD128 → 352.8, DSD256 → 705.6.
-        assert_eq!(DsdToDop::new(&layout(2_822_400, None, false)).output_rate_hz, 176_400);
-        assert_eq!(DsdToDop::new(&layout(5_644_800, None, false)).output_rate_hz, 352_800);
-        assert_eq!(DsdToDop::new(&layout(11_289_600, None, false)).output_rate_hz, 705_600);
+        assert_eq!(
+            DsdToDop::new(&layout(2_822_400, None, false)).output_rate_hz,
+            176_400
+        );
+        assert_eq!(
+            DsdToDop::new(&layout(5_644_800, None, false)).output_rate_hz,
+            352_800
+        );
+        assert_eq!(
+            DsdToDop::new(&layout(11_289_600, None, false)).output_rate_hz,
+            705_600
+        );
     }
 
     #[test]
@@ -297,7 +306,11 @@ mod tests {
         assert_eq!(out.len(), 8, "4 stereo frames");
         let marker = |w: u32| w >> 16;
         for f in 0..4 {
-            let expected = if f % 2 == 0 { DOP_MARKER_A } else { DOP_MARKER_B };
+            let expected = if f % 2 == 0 {
+                DOP_MARKER_A
+            } else {
+                DOP_MARKER_B
+            };
             assert_eq!(marker(out[f * 2]), expected, "L frame {f}");
             assert_eq!(marker(out[f * 2 + 1]), expected, "R frame {f}");
         }
@@ -351,7 +364,11 @@ mod tests {
         out.clear();
         // After reset the pending 0x55/0x66 are gone and marker is A again.
         enc.encode_block(&[0xAA, 0xBB, 0xCC, 0xDD], &mut out);
-        assert_eq!(out[0], (DOP_MARKER_A << 16) | 0xAACC, "L uses fresh bytes only");
+        assert_eq!(
+            out[0],
+            (DOP_MARKER_A << 16) | 0xAACC,
+            "L uses fresh bytes only"
+        );
         assert_eq!(out[1], (DOP_MARKER_A << 16) | 0xBBDD);
     }
 

--- a/src-tauri/crates/core/src/plugin/manifest.rs
+++ b/src-tauri/crates/core/src/plugin/manifest.rs
@@ -388,8 +388,10 @@ impl Manifest {
                 let base = std::mem::replace(&mut opt.label, LocalizedString::Plain(String::new()));
                 opt.label = base.merged_with(opt.label_i18n.take());
             }
-            opt.description =
-                LocalizedString::merge_optional(opt.description.take(), opt.description_i18n.take());
+            opt.description = LocalizedString::merge_optional(
+                opt.description.take(),
+                opt.description_i18n.take(),
+            );
         }
     }
 
@@ -448,7 +450,9 @@ impl Manifest {
         // so every pre-existing manifest still validates.
         if let Some(desc) = &self.plugin.description {
             if desc.is_empty_map() {
-                return Err(ManifestError::EmptyLocalizedMap("plugin.description".into()));
+                return Err(ManifestError::EmptyLocalizedMap(
+                    "plugin.description".into(),
+                ));
             }
         }
 
@@ -661,7 +665,10 @@ en = "Bigger files."
         let desc = m.plugin.description.as_ref().unwrap();
         assert_eq!(desc.resolve("fr"), Some("Pochettes animées."));
         assert_eq!(desc.resolve("en"), Some("Animated album covers."));
-        assert_eq!(m.options[0].label.resolve("fr"), Some("Préférer les pochettes 4K HEVC"));
+        assert_eq!(
+            m.options[0].label.resolve("fr"),
+            Some("Préférer les pochettes 4K HEVC")
+        );
         // Missing locale on an option description falls back to `en`.
         assert_eq!(
             m.options[0].description.as_ref().unwrap().resolve("ja"),
@@ -677,14 +684,22 @@ en = "Bigger files."
         map.insert("pt-BR".to_string(), "português do Brasil".to_string());
         let s = LocalizedString::Localized(map);
 
-        assert_eq!(s.resolve("pt-BR"), Some("português do Brasil"), "exact wins");
+        assert_eq!(
+            s.resolve("pt-BR"),
+            Some("português do Brasil"),
+            "exact wins"
+        );
         assert_eq!(s.resolve("pt"), Some("português"), "exact base code wins");
         assert_eq!(
             s.resolve("fr-CA"),
             Some("english"),
             "unknown regional code falls through base to en"
         );
-        assert_eq!(s.resolve("ja"), Some("english"), "unknown code falls back to en");
+        assert_eq!(
+            s.resolve("ja"),
+            Some("english"),
+            "unknown code falls back to en"
+        );
 
         // No `en` at all: any entry beats rendering nothing. BTreeMap
         // ordering makes the pick deterministic.
@@ -706,7 +721,11 @@ en = "Bigger files."
             ("de".to_string(), "   ".to_string()),
             ("en".to_string(), "english".to_string()),
         ]));
-        assert_eq!(s.resolve("fr"), Some("english"), "empty falls through to en");
+        assert_eq!(
+            s.resolve("fr"),
+            Some("english"),
+            "empty falls through to en"
+        );
         assert_eq!(s.resolve("de"), Some("english"), "whitespace-only too");
 
         // Nothing renderable anywhere: report None so the caller can
@@ -764,7 +783,10 @@ fr = "Fichiers plus lourds."
             m.options[0].label.resolve("fr"),
             Some("Préférer les pochettes 4K HEVC")
         );
-        assert_eq!(m.options[0].label.resolve("de"), Some("Prefer 4K HEVC covers"));
+        assert_eq!(
+            m.options[0].label.resolve("de"),
+            Some("Prefer 4K HEVC covers")
+        );
         assert_eq!(
             m.options[0].description.as_ref().unwrap().resolve("fr"),
             Some("Fichiers plus lourds.")

--- a/src-tauri/crates/core/src/plugin/runtime.rs
+++ b/src-tauri/crates/core/src/plugin/runtime.rs
@@ -559,7 +559,10 @@ pub struct AlbumInfo {
     pub motion_cover_tall_url: Option<String>,
 }
 
-define_instantiate!(instantiate_metadata, crate::plugin::bindings::metadata::Plugin);
+define_instantiate!(
+    instantiate_metadata,
+    crate::plugin::bindings::metadata::Plugin
+);
 
 /// Call the guest's `album-info(artist, title)`.
 pub fn metadata_album_info(

--- a/src-tauri/crates/core/src/scanner/extract.rs
+++ b/src-tauri/crates/core/src/scanner/extract.rs
@@ -293,7 +293,7 @@ pub fn extract_cover(tag: &Tag, artwork_dir: &Path) -> Option<ExtractedCover> {
     }
     let hash = blake3::hash(bytes).to_hex().to_string();
     let format = extension_for_mime(picture.mime_type()).to_string();
-    let out_path = artwork_dir.join(format!("{}.{}", &hash, &format));
+    let out_path = artwork_dir.join(format!("{}.{}", hash, format));
     if !out_path.exists() {
         if let Err(err) = fs::write(&out_path, bytes) {
             tracing::warn!(path = %out_path.display(), error = %err, "failed to write artwork");
@@ -384,7 +384,7 @@ pub fn extract_folder_cover(track_path: &Path, artwork_dir: &Path) -> Option<Ext
         format
     };
 
-    let out_path = artwork_dir.join(format!("{}.{}", &hash, &format));
+    let out_path = artwork_dir.join(format!("{}.{}", hash, format));
     if !out_path.exists() {
         if let Err(err) = fs::write(&out_path, &bytes) {
             tracing::warn!(path = %out_path.display(), error = %err, "failed to write folder cover");
@@ -583,7 +583,7 @@ pub fn write_artist_image(picked: &Path, artwork_dir: &Path) -> Option<Extracted
         format
     };
 
-    let out_path = artwork_dir.join(format!("{}.{}", &hash, &format));
+    let out_path = artwork_dir.join(format!("{}.{}", hash, format));
     if !out_path.exists() {
         if let Err(err) = fs::write(&out_path, &bytes) {
             tracing::warn!(

--- a/src-tauri/crates/core/tests/plugin_canvas.rs
+++ b/src-tauri/crates/core/tests/plugin_canvas.rs
@@ -97,7 +97,15 @@ fn canvas_fixture_surfaces_a_provider_error() {
     // then logs + skips — fail-soft).
     let (_tmp, paths) = stage_fixture();
     let runtime = PluginRuntime::new(RuntimeConfig::default()).expect("engine");
-    match canvas_track_canvas(&runtime, &paths, "canvas-fixture", "Artist", "boom", None, None) {
+    match canvas_track_canvas(
+        &runtime,
+        &paths,
+        "canvas-fixture",
+        "Artist",
+        "boom",
+        None,
+        None,
+    ) {
         Err(SourceError::Plugin(msg)) => assert_eq!(msg, "provider failure"),
         Ok(other) => panic!("expected a provider error, got Ok({other:?})"),
         Err(other) => panic!("expected SourceError::Plugin, got {other:?}"),

--- a/src-tauri/crates/core/tests/plugin_ui.rs
+++ b/src-tauri/crates/core/tests/plugin_ui.rs
@@ -62,9 +62,14 @@ fn stage_fixture(manifest: &str) -> (tempfile::TempDir, PluginPaths) {
     let plugin_dir = paths.plugin_dir("ui-fixture").expect("dir");
     std::fs::create_dir_all(&plugin_dir).expect("mkdir");
 
-    let fixture_root: PathBuf = [env!("CARGO_MANIFEST_DIR"), "tests", "fixtures", "ui-fixture"]
-        .iter()
-        .collect();
+    let fixture_root: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "tests",
+        "fixtures",
+        "ui-fixture",
+    ]
+    .iter()
+    .collect();
     std::fs::copy(
         fixture_root.join("plugin.wasm"),
         plugin_dir.join("plugin.wasm"),


### PR DESCRIPTION
`rustfmt.toml` and `clippy.toml` have both been configured since this
repository was young. Nothing has ever run either one.

## What that cost, measured

- `cargo fmt --all` rewrites **39 files**. Nearly all of it is one call
  argument list wrapped — lines a few characters past the hundred
  `rustfmt.toml` has always asked for — carrying the trailing commas the
  wrap brings. Beyond that: a handful of single-expression match arms
  lose their braces, one closure body flattens into its `match`, and the
  two platform-conditional `mod` declarations in `audio/mod.rs` sort,
  which is the `reorder_modules = true` that file has always asked for.
  Nothing renamed, no logic moved.
- `cargo clippy --workspace --all-targets` reports **9 findings**, all
  with the tool's own suggestion.

It reads like a formatter bump and is not one: the same run under 1.95
and under 1.98 produces the same set. This is code that was never
formatted, not code that drifted.

## Four commits, in the order they have to land

1. **Pin the toolchain.** Every workflow asked for `stable`, so the
   compiler a release was built with was whichever one shipped that
   week. `rust-toolchain.toml` names 1.98.0 — today's stable, and what
   the runners already resolved to, so no compiler and no output
   changes. The five workflows name the same version rather than reading
   the file: rustup would otherwise install `stable` and then download
   the pinned toolchain again on the first cargo call.
2. **Clear clippy.** Nine machine-suggested fixes, no behaviour moved. A
   gate that starts red teaches everyone to ignore it.
3. **Format the tree.** The 39 files.
4. **Add the gates.** Both on the Linux slot only — their answer cannot
   differ by operating system — and clippy with `-D warnings`, because a
   lint nobody has to fix is a lint everybody scrolls past. The
   thresholds that would make that unbearable (argument counts, function
   length, type complexity) are already relaxed in `clippy.toml`.

`CONTRIBUTING.md` gains the two commands and a line saying the pinned
toolchain is what decides the answer.

## Rebased once already

The first push was cut before #530 merged, so the `fmt` gate failed on
its own merge result: #530 brought in `schema_guard.rs` and `paths.rs`
unformatted, which is exactly what this branch exists to catch. The
branch was rebuilt on the current `main` and the formatter re-run —
that is where the 38th and 39th files come from. The gate caught a real
gap on its very first run, which is the argument for having it.

Full workspace tests pass; `cargo fmt --check` and
`cargo clippy -D warnings` are both clean on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance**
  * Stabilisation de l’environnement de compilation Rust pour des builds plus reproductibles.
  * Renforcement automatique des contrôles de formatage et de qualité, avec les avertissements traités comme des erreurs.
  * Amélioration de la compatibilité audio selon le système d’exploitation.
  * Nettoyage et harmonisation internes sans changement des fonctionnalités existantes.

* **Documentation**
  * Mise à jour des consignes de contribution et des vérifications recommandées avant soumission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->