### PR TITLE
ci: fail when the toolchain pin disagrees with itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Runs on every pull request, outside the paths filter below, because
+  # that filter only lets `ci.yml` wake the Rust job. A pull request that
+  # touches `release.yml` alone — exactly the one that forgets a site
+  # when bumping the pin — would otherwise be checked by nothing.
+  #
+  # Kept as its own job rather than folded into the Rust matrix for the
+  # same reason it isn't in the filter: this is a text comparison that
+  # costs a checkout and a second, and the Rust job costs thirteen
+  # minutes (#535). Widening the filter would have spent those minutes
+  # on every workflow tweak.
+  toolchain-pin:
+    name: Toolchain pin
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - run: python3 scripts/check-toolchain-pin.py
+
   changes:
     name: Detect changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # The script this job runs comes from the pull request. Leave
+          # no token behind in `.git/config` for it to find — the same
+          # reason the Flatpak-sources job already does this.
+          persist-credentials: false
       - run: python3 scripts/check-toolchain-pin.py
 
   changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
           # no token behind in `.git/config` for it to find — the same
           # reason the Flatpak-sources job already does this.
           persist-credentials: false
+      # The self-test first: if the parsing is broken, the check below
+      # reports "consistent" for reasons that have nothing to do with
+      # the workflows. It caught two real splitter bugs during review.
+      - run: python3 scripts/check-toolchain-pin.py --self-test
       - run: python3 scripts/check-toolchain-pin.py
 
   changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,11 @@ cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -
 cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets
 ```
 
+If you bump the pinned compiler, change `rust-toolchain.toml` **and** the
+`toolchain:` input of every workflow that installs Rust, then run
+`python3 scripts/check-toolchain-pin.py` — it is what CI runs, and it is
+there because missing one of the six sites otherwise fails silently.
+
 `rust-toolchain.toml` decides which compiler those run under, so a local
 answer and the CI answer are the same answer. Let rustup install it rather
 than reaching for your default toolchain.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,6 +11,11 @@
 # release.yml, release-please-lockfile-build.yml and test-appimage.yml.
 # They name the version rather than reading this file so a runner installs
 # exactly one toolchain instead of downloading a second on first use.
+#
+# Six places, and forgetting one is silent: CI stays green while a job
+# quietly answers under a different compiler. `scripts/check-toolchain-pin.py`
+# compares them on every pull request, so the omission fails instead.
+# Run it after bumping — it takes a second and needs no network.
 [toolchain]
 channel = "1.98.0"
 components = ["rustfmt", "clippy"]

--- a/scripts/check-toolchain-pin.py
+++ b/scripts/check-toolchain-pin.py
@@ -16,11 +16,22 @@ Checks two directions:
 
 - every `toolchain:` input across `.github/workflows/` equals the
   pinned channel;
-- every workflow that installs Rust actually passes one, so a step
+- every *step* that installs Rust passes one of its own, so a step
   cannot drift back to an implicit `stable`.
 
-A line ending in `# toolchain-pin: exempt` is skipped, for the day a
-workflow genuinely needs a different compiler.
+The second is per-step on purpose. Asking only whether the file
+contains a `toolchain:` somewhere would let a workflow with two Rust
+steps pass while one of them pins nothing, and would let an unrelated
+`toolchain:` input belonging to another action stand in for the missing
+one.
+
+The equality check stays file-wide, which is the conservative
+direction: an unrelated `toolchain:` would be flagged rather than
+ignored, and the exemption marker is how you say so.
+
+A line ending in `# toolchain-pin: exempt` opts out, for the day a
+workflow genuinely needs a different compiler. It has to *end* the
+line — a marker buried mid-line is a typo, not a decision.
 
 Runs offline in well under a second: no network, no YAML dependency.
 """
@@ -38,6 +49,7 @@ WORKFLOW_DIR = ROOT / ".github" / "workflows"
 CHANNEL_RE = re.compile(r'^\s*channel\s*=\s*"([^"]+)"', re.MULTILINE)
 TOOLCHAIN_INPUT_RE = re.compile(r"^\s*toolchain:\s*(\S+)")
 INSTALLS_RUST_RE = re.compile(r"dtolnay/rust-toolchain|actions-rs/toolchain")
+LIST_ITEM_RE = re.compile(r"^(\s*)-\s")
 EXEMPT = "# toolchain-pin: exempt"
 
 
@@ -46,8 +58,40 @@ def pinned_channel() -> str:
         sys.exit(f"missing {TOOLCHAIN_FILE.relative_to(ROOT)}")
     match = CHANNEL_RE.search(TOOLCHAIN_FILE.read_text(encoding="utf-8"))
     if not match:
-        sys.exit(f"no `channel = \"...\"` in {TOOLCHAIN_FILE.relative_to(ROOT)}")
+        sys.exit(f'no `channel = "..."` in {TOOLCHAIN_FILE.relative_to(ROOT)}')
     return match.group(1)
+
+
+def is_exempt(line: str) -> bool:
+    """The marker has to end the line. Anywhere else it is a typo."""
+    return line.rstrip().endswith(EXEMPT)
+
+
+def steps(text: str):
+    """Yield `(line_number, block)` for each YAML list item.
+
+    A crude split, and deliberately so: pulling in a YAML parser to read
+    five workflow files would trade a dependency for a check that has to
+    keep working on a bare runner. Steps are list items, so a new item
+    at the same indentation or shallower ends the previous block.
+    Non-step lists — a paths filter, a matrix — come out as blocks too
+    and are simply never Rust steps.
+    """
+    block: list[str] = []
+    start = 0
+    indent = None
+
+    for number, line in enumerate(text.splitlines(), start=1):
+        match = LIST_ITEM_RE.match(line)
+        if match and (indent is None or len(match.group(1)) <= indent):
+            if block:
+                yield start, "\n".join(block)
+            block, start, indent = [line], number, len(match.group(1))
+        elif block:
+            block.append(line)
+
+    if block:
+        yield start, "\n".join(block)
 
 
 def main() -> int:
@@ -55,22 +99,14 @@ def main() -> int:
     problems: list[str] = []
     checked = 0
 
-    for workflow in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+    workflows = sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml"))
+    for workflow in workflows:
         rel = workflow.relative_to(ROOT).as_posix()
         text = workflow.read_text(encoding="utf-8")
-        installs_rust = bool(INSTALLS_RUST_RE.search(text))
-        found_here = 0
 
         for number, line in enumerate(text.splitlines(), start=1):
             match = TOOLCHAIN_INPUT_RE.match(line)
-            if not match:
-                continue
-            # Counted before the exemption is honoured: an exempted line
-            # is still a `toolchain:` input, so it must satisfy the
-            # "installs Rust without pinning" rule below. Skipping it
-            # outright made the escape hatch trip the other check.
-            found_here += 1
-            if EXEMPT in line:
+            if not match or is_exempt(line):
                 continue
             checked += 1
             value = match.group(1).strip("\"'")
@@ -79,10 +115,14 @@ def main() -> int:
                     f"{rel}:{number}: installs {value}, but rust-toolchain.toml pins {channel}"
                 )
 
-        if installs_rust and found_here == 0:
+        for number, block in steps(text):
+            if not INSTALLS_RUST_RE.search(block):
+                continue
+            if any(TOOLCHAIN_INPUT_RE.match(line) for line in block.splitlines()):
+                continue
             problems.append(
-                f"{rel}: installs Rust without a `toolchain:` input, so it resolves "
-                f"to whatever the action defaults to instead of {channel}"
+                f"{rel}:{number}: installs Rust without a `toolchain:` input of its own, "
+                f"so it resolves to whatever the action defaults to instead of {channel}"
             )
 
     if problems:
@@ -91,7 +131,7 @@ def main() -> int:
             print(f"  {problem}", file=sys.stderr)
         print(
             f"\nBump every site together, or mark a deliberate exception with "
-            f"`{EXEMPT}` on the line.",
+            f"`{EXEMPT}` at the end of the line.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/check-toolchain-pin.py
+++ b/scripts/check-toolchain-pin.py
@@ -50,6 +50,8 @@ CHANNEL_RE = re.compile(r'^\s*channel\s*=\s*"([^"]+)"', re.MULTILINE)
 TOOLCHAIN_INPUT_RE = re.compile(r"^\s*toolchain:\s*(\S+)")
 INSTALLS_RUST_RE = re.compile(r"dtolnay/rust-toolchain|actions-rs/toolchain")
 LIST_ITEM_RE = re.compile(r"^(\s*)-\s")
+WITH_KEY_RE = re.compile(r"^( *)with: *(#.*)?$")
+MAPPING_KEY_RE = re.compile(r"^( *)([A-Za-z0-9_-]+): *(.*)$")
 EXEMPT = "# toolchain-pin: exempt"
 
 
@@ -117,26 +119,67 @@ def steps(text: str):
             yield start, "\n".join(block)
 
 
+def with_inputs(text: str):
+    """Yield `(line_number, key, value, line)` for direct children of `with:`.
+
+    An action's inputs are the keys directly under its `with:` mapping,
+    and only those. Matching `toolchain:` wherever it appeared on a line
+    let a sibling mapping stand in for the real input: an `env:` block
+    carrying a key of that name satisfied the pin without pinning
+    anything, and was then compared against the channel as though it
+    were one.
+    """
+    lines = text.splitlines()
+    index = 0
+
+    while index < len(lines):
+        header = WITH_KEY_RE.match(lines[index])
+        if not header:
+            index += 1
+            continue
+
+        with_indent = len(header.group(1))
+        index += 1
+        child_indent = None
+
+        while index < len(lines):
+            line = lines[index]
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                index += 1
+                continue
+
+            indent = len(line) - len(line.lstrip())
+            if indent <= with_indent:
+                break
+            if child_indent is None:
+                child_indent = indent
+            if indent == child_indent:
+                entry = MAPPING_KEY_RE.match(line)
+                if entry:
+                    yield index + 1, entry.group(2), entry.group(3).strip(), line
+            index += 1
+
+
 def unpinned_rust_steps(text: str) -> list[int]:
     """Line numbers of steps that install Rust without pinning it."""
     offenders = []
     for number, block in steps(text):
         if not INSTALLS_RUST_RE.search(block):
             continue
-        if any(TOOLCHAIN_INPUT_RE.match(line) for line in block.splitlines()):
+        if any(key == "toolchain" for _, key, _, _ in with_inputs(block)):
             continue
         offenders.append(number)
     return offenders
 
 
 def mismatched_inputs(text: str, channel: str) -> list[tuple[int, str]]:
-    """`(line, value)` for every non-exempt `toolchain:` off the pin."""
+    """`(line, value)` for every non-exempt `toolchain:` input off the pin."""
     wrong = []
-    for number, line in enumerate(text.splitlines(), start=1):
-        match = TOOLCHAIN_INPUT_RE.match(line)
-        if not match or is_exempt(line):
+    for number, key, value, line in with_inputs(text):
+        if key != "toolchain" or is_exempt(line):
             continue
-        value = match.group(1).strip("\"'")
+        value = value.strip('"').strip("'")
         if value != channel:
             wrong.append((number, value))
     return wrong
@@ -145,8 +188,8 @@ def mismatched_inputs(text: str, channel: str) -> list[tuple[int, str]]:
 def count_inputs(text: str) -> int:
     return sum(
         1
-        for line in text.splitlines()
-        if TOOLCHAIN_INPUT_RE.match(line) and not is_exempt(line)
+        for _, key, _, line in with_inputs(text)
+        if key == "toolchain" and not is_exempt(line)
     )
 
 
@@ -190,6 +233,17 @@ jobs:
           components: clippy
 """
 
+TOOLCHAIN_UNDER_ENV = """\
+jobs:
+  build:
+    steps:
+      - uses: dtolnay/rust-toolchain@sha
+        env:
+          toolchain: 1.98.0
+        with:
+          components: clippy
+"""
+
 PINNED = """\
 jobs:
   build:
@@ -197,6 +251,23 @@ jobs:
       - uses: dtolnay/rust-toolchain@sha
         with:
           toolchain: 1.98.0
+"""
+
+
+OFF_PIN = """jobs:
+  build:
+    steps:
+      - uses: dtolnay/rust-toolchain@sha
+        with:
+          toolchain: 1.97.0
+"""
+
+EXEMPT_VALUE = """jobs:
+  build:
+    steps:
+      - uses: dtolnay/rust-toolchain@sha
+        with:
+          toolchain: nightly # toolchain-pin: exempt
 """
 
 
@@ -229,6 +300,11 @@ def self_test() -> int:
         unpinned_rust_steps(UNRELATED_INPUT),
         [7],
     )
+    expect(
+        "a toolchain: under env is not an input",
+        unpinned_rust_steps(TOOLCHAIN_UNDER_ENV),
+        [4],
+    )
     expect("a pinned step is accepted", unpinned_rust_steps(PINNED), [])
 
     expect("marker at end of line exempts", is_exempt(f"  toolchain: nightly {EXEMPT}"), True)
@@ -237,14 +313,10 @@ def self_test() -> int:
 
     expect(
         "an off-pin value is reported with its line",
-        mismatched_inputs("      toolchain: 1.97.0\n", "1.98.0"),
-        [(1, "1.97.0")],
+        mismatched_inputs(OFF_PIN, "1.98.0"),
+        [(6, "1.97.0")],
     )
-    expect(
-        "an exempt value is not compared",
-        mismatched_inputs(f"      toolchain: nightly {EXEMPT}\n", "1.98.0"),
-        [],
-    )
+    expect("an exempt value is not compared", mismatched_inputs(EXEMPT_VALUE, "1.98.0"), [])
 
     if failures:
         print("self-test failed:\n", file=sys.stderr)
@@ -252,7 +324,7 @@ def self_test() -> int:
             print(f"  {failure}", file=sys.stderr)
         return 1
 
-    print("self-test: 9 assertions passed")
+    print("self-test: 10 assertions passed")
     return 0
 
 

--- a/scripts/check-toolchain-pin.py
+++ b/scripts/check-toolchain-pin.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Verify every workflow installs the compiler `rust-toolchain.toml` names.
+
+`rust-toolchain.toml` is read by rustup, and the workflows deliberately
+do not read it: rustup would install `stable` first and then download
+the pinned toolchain again on the first cargo call. The version is
+therefore written in six places, and nothing made them agree.
+
+That is a silent failure, which is the only kind worth a script. Bump
+the file, forget `release.yml`, and CI stays green while the release is
+built by a compiler nobody chose — with the formatter and clippy, the
+two things the pin exists to make deterministic, quietly answering
+differently depending on which job asked.
+
+Checks two directions:
+
+- every `toolchain:` input across `.github/workflows/` equals the
+  pinned channel;
+- every workflow that installs Rust actually passes one, so a step
+  cannot drift back to an implicit `stable`.
+
+A line ending in `# toolchain-pin: exempt` is skipped, for the day a
+workflow genuinely needs a different compiler.
+
+Runs offline in well under a second: no network, no YAML dependency.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TOOLCHAIN_FILE = ROOT / "rust-toolchain.toml"
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+CHANNEL_RE = re.compile(r'^\s*channel\s*=\s*"([^"]+)"', re.MULTILINE)
+TOOLCHAIN_INPUT_RE = re.compile(r"^\s*toolchain:\s*(\S+)")
+INSTALLS_RUST_RE = re.compile(r"dtolnay/rust-toolchain|actions-rs/toolchain")
+EXEMPT = "# toolchain-pin: exempt"
+
+
+def pinned_channel() -> str:
+    if not TOOLCHAIN_FILE.exists():
+        sys.exit(f"missing {TOOLCHAIN_FILE.relative_to(ROOT)}")
+    match = CHANNEL_RE.search(TOOLCHAIN_FILE.read_text(encoding="utf-8"))
+    if not match:
+        sys.exit(f"no `channel = \"...\"` in {TOOLCHAIN_FILE.relative_to(ROOT)}")
+    return match.group(1)
+
+
+def main() -> int:
+    channel = pinned_channel()
+    problems: list[str] = []
+    checked = 0
+
+    for workflow in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        rel = workflow.relative_to(ROOT).as_posix()
+        text = workflow.read_text(encoding="utf-8")
+        installs_rust = bool(INSTALLS_RUST_RE.search(text))
+        found_here = 0
+
+        for number, line in enumerate(text.splitlines(), start=1):
+            match = TOOLCHAIN_INPUT_RE.match(line)
+            if not match:
+                continue
+            # Counted before the exemption is honoured: an exempted line
+            # is still a `toolchain:` input, so it must satisfy the
+            # "installs Rust without pinning" rule below. Skipping it
+            # outright made the escape hatch trip the other check.
+            found_here += 1
+            if EXEMPT in line:
+                continue
+            checked += 1
+            value = match.group(1).strip("\"'")
+            if value != channel:
+                problems.append(
+                    f"{rel}:{number}: installs {value}, but rust-toolchain.toml pins {channel}"
+                )
+
+        if installs_rust and found_here == 0:
+            problems.append(
+                f"{rel}: installs Rust without a `toolchain:` input, so it resolves "
+                f"to whatever the action defaults to instead of {channel}"
+            )
+
+    if problems:
+        print("Toolchain pin is not consistent:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        print(
+            f"\nBump every site together, or mark a deliberate exception with "
+            f"`{EXEMPT}` on the line.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"toolchain pin: {checked} workflow input(s) all on {channel}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-toolchain-pin.py
+++ b/scripts/check-toolchain-pin.py
@@ -68,33 +68,198 @@ def is_exempt(line: str) -> bool:
 
 
 def steps(text: str):
-    """Yield `(line_number, block)` for each YAML list item.
+    """Yield `(line_number, block)` for each step of every `steps:` list.
 
-    A crude split, and deliberately so: pulling in a YAML parser to read
+    Anchored to the `steps:` key rather than to list items in general.
+    An earlier, shallower list — `on: schedule:` and its `- cron:` is
+    the usual one — would otherwise fix the item indentation for the
+    whole file, and every step of every job would land in one block. A
+    `toolchain:` from one step would then satisfy another, which is
+    precisely the hole this function exists to close.
+
+    Still a line scanner, deliberately: importing a YAML parser to read
     five workflow files would trade a dependency for a check that has to
-    keep working on a bare runner. Steps are list items, so a new item
-    at the same indentation or shallower ends the previous block.
-    Non-step lists — a paths filter, a matrix — come out as blocks too
-    and are simply never Rust steps.
+    keep working on a bare runner.
     """
-    block: list[str] = []
-    start = 0
-    indent = None
+    lines = text.splitlines()
+    index = 0
 
+    while index < len(lines):
+        header = re.match(r"^(\s*)steps:\s*(#.*)?$", lines[index])
+        if not header:
+            index += 1
+            continue
+
+        key_indent = len(header.group(1))
+        index += 1
+        item_indent = None
+        block: list[str] = []
+        start = 0
+
+        while index < len(lines):
+            line = lines[index]
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                if len(line) - len(line.lstrip()) <= key_indent:
+                    break
+
+            item = LIST_ITEM_RE.match(line)
+            if item and (item_indent is None or len(item.group(1)) == item_indent):
+                if block:
+                    yield start, "\n".join(block)
+                item_indent = len(item.group(1))
+                block, start = [line], index + 1
+            elif block:
+                block.append(line)
+            index += 1
+
+        if block:
+            yield start, "\n".join(block)
+
+
+def unpinned_rust_steps(text: str) -> list[int]:
+    """Line numbers of steps that install Rust without pinning it."""
+    offenders = []
+    for number, block in steps(text):
+        if not INSTALLS_RUST_RE.search(block):
+            continue
+        if any(TOOLCHAIN_INPUT_RE.match(line) for line in block.splitlines()):
+            continue
+        offenders.append(number)
+    return offenders
+
+
+def mismatched_inputs(text: str, channel: str) -> list[tuple[int, str]]:
+    """`(line, value)` for every non-exempt `toolchain:` off the pin."""
+    wrong = []
     for number, line in enumerate(text.splitlines(), start=1):
-        match = LIST_ITEM_RE.match(line)
-        if match and (indent is None or len(match.group(1)) <= indent):
-            if block:
-                yield start, "\n".join(block)
-            block, start, indent = [line], number, len(match.group(1))
-        elif block:
-            block.append(line)
-
-    if block:
-        yield start, "\n".join(block)
+        match = TOOLCHAIN_INPUT_RE.match(line)
+        if not match or is_exempt(line):
+            continue
+        value = match.group(1).strip("\"'")
+        if value != channel:
+            wrong.append((number, value))
+    return wrong
 
 
-def main() -> int:
+def count_inputs(text: str) -> int:
+    return sum(
+        1
+        for line in text.splitlines()
+        if TOOLCHAIN_INPUT_RE.match(line) and not is_exempt(line)
+    )
+
+
+SCHEDULE_BEFORE_JOBS = """\
+name: Fixture
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+jobs:
+  build:
+    steps:
+      - uses: dtolnay/rust-toolchain@sha
+        with:
+          toolchain: 1.98.0
+      - uses: dtolnay/rust-toolchain@sha
+        with:
+          components: clippy
+"""
+
+TWO_JOBS = """\
+jobs:
+  one:
+    steps:
+      - uses: dtolnay/rust-toolchain@sha
+        with:
+          toolchain: 1.98.0
+  two:
+    steps:
+      - uses: dtolnay/rust-toolchain@sha
+"""
+
+UNRELATED_INPUT = """\
+jobs:
+  build:
+    steps:
+      - uses: some/other-action@v1
+        with:
+          toolchain: 1.98.0
+      - uses: dtolnay/rust-toolchain@sha
+        with:
+          components: clippy
+"""
+
+PINNED = """\
+jobs:
+  build:
+    steps:
+      - uses: dtolnay/rust-toolchain@sha
+        with:
+          toolchain: 1.98.0
+"""
+
+
+def self_test() -> int:
+    """Pin down the parsing. Both mistakes below were shipped once.
+
+    The step splitter matched any list item, then took its indentation
+    from whichever list came first in the file. Each time the check kept
+    passing something it exists to catch, which is the failure mode a
+    guard cannot afford.
+    """
+    failures: list[str] = []
+
+    def expect(label: str, actual, wanted):
+        if actual != wanted:
+            failures.append(f"{label}: got {actual!r}, wanted {wanted!r}")
+
+    expect(
+        "a shallower list before jobs must not merge the steps",
+        unpinned_rust_steps(SCHEDULE_BEFORE_JOBS),
+        [11],
+    )
+    expect(
+        "a step in another job must not satisfy this one",
+        unpinned_rust_steps(TWO_JOBS),
+        [9],
+    )
+    expect(
+        "an unrelated toolchain: input is not a pin",
+        unpinned_rust_steps(UNRELATED_INPUT),
+        [7],
+    )
+    expect("a pinned step is accepted", unpinned_rust_steps(PINNED), [])
+
+    expect("marker at end of line exempts", is_exempt(f"  toolchain: nightly {EXEMPT}"), True)
+    expect("marker mid-line does not", is_exempt(f"  toolchain: nightly {EXEMPT} # note"), False)
+    expect("no marker", is_exempt("  toolchain: 1.98.0"), False)
+
+    expect(
+        "an off-pin value is reported with its line",
+        mismatched_inputs("      toolchain: 1.97.0\n", "1.98.0"),
+        [(1, "1.97.0")],
+    )
+    expect(
+        "an exempt value is not compared",
+        mismatched_inputs(f"      toolchain: nightly {EXEMPT}\n", "1.98.0"),
+        [],
+    )
+
+    if failures:
+        print("self-test failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print("self-test: 9 assertions passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return self_test()
+
     channel = pinned_channel()
     problems: list[str] = []
     checked = 0
@@ -103,23 +268,13 @@ def main() -> int:
     for workflow in workflows:
         rel = workflow.relative_to(ROOT).as_posix()
         text = workflow.read_text(encoding="utf-8")
+        checked += count_inputs(text)
 
-        for number, line in enumerate(text.splitlines(), start=1):
-            match = TOOLCHAIN_INPUT_RE.match(line)
-            if not match or is_exempt(line):
-                continue
-            checked += 1
-            value = match.group(1).strip("\"'")
-            if value != channel:
-                problems.append(
-                    f"{rel}:{number}: installs {value}, but rust-toolchain.toml pins {channel}"
-                )
-
-        for number, block in steps(text):
-            if not INSTALLS_RUST_RE.search(block):
-                continue
-            if any(TOOLCHAIN_INPUT_RE.match(line) for line in block.splitlines()):
-                continue
+        for number, value in mismatched_inputs(text, channel):
+            problems.append(
+                f"{rel}:{number}: installs {value}, but rust-toolchain.toml pins {channel}"
+            )
+        for number in unpinned_rust_steps(text):
             problems.append(
                 f"{rel}:{number}: installs Rust without a `toolchain:` input of its own, "
                 f"so it resolves to whatever the action defaults to instead of {channel}"
@@ -141,4 +296,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Follow-up to #534.

## The gap

#534 pinned the compiler in **six** places — `rust-toolchain.toml` plus the `toolchain:` input of the five workflows that install Rust. The workflows name the version instead of reading the file, deliberately: rustup would install `stable` and then download the pinned toolchain again on the first cargo call.

Nothing made the six agree. Forgetting one is silent — CI stays green while a job builds under a compiler nobody chose, and the formatter and clippy, the two things the pin exists to make deterministic, start answering differently depending on which job asked. Dependabot does not close this: its `cargo` ecosystem has no support for `rust-toolchain.toml`, and `github-actions` bumps the action's SHA, not the value of an input it treats as an opaque string.

## The check

`scripts/check-toolchain-pin.py` — offline, no YAML dependency, well under a second — asserts two directions:

- every `toolchain:` input equals the pinned channel;
- every workflow that installs Rust passes one at all, so a step cannot drift back to an implicit `stable`.

A line ending in `# toolchain-pin: exempt` opts out, for the day a workflow genuinely needs a different compiler.

## Why its own job

The paths filter only lets `ci.yml` wake the Rust job. The four other workflows are not in it, so a pull request touching `release.yml` alone — **exactly the one that forgets a site when bumping** — would be checked by nothing.

Widening the filter would have been the other fix, and it is the wrong one: it would spend #535's thirteen-minute Rust job on every workflow tweak. This job is a checkout and a second.

## Verified against the cases it exists for

A guard never seen red proves nothing, so each was forced:

| Case | Result |
|---|---|
| A bump that forgets `release.yml` | fails, naming `release.yml:137` |
| A `toolchain:` input deleted, back to implicit default | fails, naming the workflow |
| A deliberate `# toolchain-pin: exempt` | passes |
| `main` as it stands | passes, 5 inputs on 1.98.0 |

The third case caught a bug in the first draft: exempted lines were skipped before being counted, so the escape hatch tripped the "installs Rust without pinning" rule and was unusable. Fixed, and that ordering is now commented in the loop.

`ci.yml` parses as valid YAML, five jobs, and the new one carries neither `needs` nor `if`.

## Noted, not changed

`.gitattributes` normalises fourteen extensions to LF but not `.py`, so every Python file in the repository is committed CRLF — including `packaging/flatpak/check-sources.py`, which CI runs. Harmless today because these are always invoked as `python3 <file>` and never executed through their shebang. This file matches that existing state rather than becoming a lone exception; closing the gap properly means renormalising ten unrelated i18n scripts, which does not belong in this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un contrôle automatique de cohérence de la version de Rust utilisée par les workflows CI.
  * Les vérifications s’exécutent pour chaque pull request et détectent les versions divergentes ou les configurations Rust non épinglées.
  * Le contrôle inclut un auto-test et signale clairement les incohérences détectées.

* **Documentation**
  * Mise à jour du guide de contribution avec la procédure de mise à jour du compilateur Rust.
  * Ajout de commentaires expliquant les emplacements de configuration vérifiés.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->