### PR TITLE
feat(release): embed AppImage update information and ship a .zsync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,7 @@ jobs:
             librsvg2-dev \
             libfuse2 \
             squashfs-tools \
+            zsync \
             libasound2-dev
 
       - name: Setup Rust toolchain
@@ -376,6 +377,26 @@ jobs:
         # fixed bundle. See the script header for the full diagnosis.
         run: bash scripts/fix-appimage.sh
 
+      - name: Embed AppImage update information (Linux)
+        if: matrix.platform == 'linux' && env.IS_PRERELEASE != 'true'
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        # Fills the runtime's `.upd_info` section so AppImageUpdate,
+        # AppImageLauncher and AM can offer delta updates (#527). Runs
+        # after the unbundling step because both rewrite the image and
+        # each re-signs; running last means the `.sig` covers the final
+        # bytes.
+        #
+        # Stable only. The string points at the repository's *latest*
+        # release, and GitHub excludes pre-releases from that — a beta
+        # carrying it would walk its user back to the newest stable. Beta
+        # builds keep an empty section, so those clients honestly report
+        # "no update information" and the in-app beta channel stays the
+        # only path.
+        run: bash scripts/appimage-update-info.sh
+
       - name: Scrub Authenticode secrets (Windows)
         if: always() && matrix.platform == 'windows'
         shell: pwsh
@@ -493,6 +514,31 @@ jobs:
           }, indent=2))
           PY
           ls -la dist-release/
+
+      - name: Build the AppImage zsync control file (Linux)
+        if: matrix.platform == 'linux' && env.IS_PRERELEASE != 'true'
+        shell: bash
+        # Built from the dist-release copy, after the rename: the control
+        # file names its target, and zsync clients resolve that name
+        # relative to the URL they fetched the .zsync from. Both are
+        # assets of the same release, so a bare filename lands on the
+        # right image — pointing it at the bundler's own name would send
+        # every client to a 404.
+        #
+        # Last of the Linux steps that touch the payload, and it must
+        # stay there: the checksums it records describe the file byte for
+        # byte, so any later rewrite would silently invalidate it.
+        run: |
+          img="dist-release/WaveFlow_${VERSION}_linux-x86_64.AppImage"
+          if [ ! -f "$img" ]; then
+            echo "::error::$img is missing — the AppImage rename must run first"
+            exit 1
+          fi
+          zsyncmake -u "$(basename "$img")" -o "$img.zsync" "$img"
+          # The header is the whole contract with the client; print it so
+          # a wrong Filename/URL is visible in the log rather than in a
+          # user's failed update.
+          sed -n '1,8p' "$img.zsync"
 
       - name: Prepare release assets (Windows)
         if: matrix.platform == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,6 +540,30 @@ jobs:
           # user's failed update.
           sed -n '1,8p' "$img.zsync"
 
+          # The string burned into the image names the asset it expects to
+          # find; this step names the asset. Two files, one contract, and
+          # nothing else couples them — rename the asset here and the
+          # mismatch surfaces only when a user's client asks for a .zsync
+          # that was never published. So read the pattern back out of the
+          # image we are about to ship and check it actually matches.
+          pattern=$(readelf -p .upd_info "$img" 2>/dev/null |
+            awk -F'|' '/gh-releases-zsync/ { gsub(/[[:space:]]+$/, "", $5); print $5; exit }')
+          if [ -z "$pattern" ]; then
+            echo "::error::no update information found in $img — the embed step has to run before this one"
+            exit 1
+          fi
+          # Unquoted on purpose: $pattern is a glob (the version is a `*`),
+          # and it comes from the image this same job just wrote.
+          case "$(basename "$img").zsync" in
+            $pattern)
+              echo "asset name matches the embedded pattern: $pattern"
+              ;;
+            *)
+              echo "::error::embedded update information expects '$pattern' but this release ships '$(basename "$img").zsync'"
+              exit 1
+              ;;
+          esac
+
       - name: Prepare release assets (Windows)
         if: matrix.platform == 'windows'
         shell: bash

--- a/.github/workflows/test-appimage.yml
+++ b/.github/workflows/test-appimage.yml
@@ -101,6 +101,16 @@ jobs:
         # signature is produced above, so the script skips re-signing.
         run: bash scripts/fix-appimage.sh
 
+      - name: Embed AppImage update information
+        # Also part of what a release ships, and the reason this workflow
+        # exists is that the artifact behaves like the shipped one — an
+        # AppImage without it reports "no update information available"
+        # and would read as a regression during manual testing. Again no
+        # updater signature exists here, so no re-signing happens.
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/appimage-update-info.sh
+
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -307,6 +307,8 @@ The section is written with `dd conv=notrunc` at the offset `readelf` reports, n
 
 Step 3's placement matters twice. Its checksums describe the payload byte for byte, so any later rewrite would silently invalidate it. And the control file names its target, which clients resolve *relative to the URL they fetched the `.zsync` from* — both are assets of the same release, so the bare renamed filename lands on the right image, while the bundler's own name would send every client to a 404.
 
+**If you rename the Linux release assets, the embedded pattern has to move with them.** `WaveFlow_*_linux-x86_64.AppImage.zsync` lives in the script, the asset name lives in `release.yml`, and they are two halves of one contract: rename one and clients ask for a `.zsync` that was never published — visible to users, invisible in CI. Step 3 therefore reads the string back out of the image it is about to ship and fails the release when the two disagree. That check fires on a tag, which is a poor moment to discover it, so treat it as a backstop and change both together.
+
 > **Stable only.** The update information points at the repository's latest release, and GitHub excludes pre-releases from "latest" — a beta carrying that string would walk its user *back* to the newest stable. Beta builds keep an empty section, so those clients honestly report no update information and the [in-app beta channel](#beta-channel) stays the only path.
 
 ## Flatpak sources are generated, and they go stale silently

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -285,6 +285,30 @@ The Rust side is unaffected: the app starts, creates its profile, opens its audi
 
 Both `release.yml` and `test-appimage.yml` run it right after `tauri build`. **If you ever restructure the Linux build, that step has to survive** — dropping it silently produces a release that installs fine and never opens, on exactly the distributions least likely to be in your test matrix. The script no-ops (and says so) if a future Tauri stops bundling the library, so it's safe to leave in place.
 
+## AppImage delta updates: three steps in one order
+
+The AppImage runtime reserves a 1024-byte `.upd_info` section for a single string saying where updates come from. `appimagetool -u` fills it; Tauri builds the AppImage itself and exposes no equivalent, so it shipped zeroed and every ecosystem tool — AppImageUpdate, AppImageLauncher, AM, AppManager — reported *no update information available* ([#527](https://github.com/InstaZDLL/WaveFlow/issues/527)).
+
+[`scripts/appimage-update-info.sh`](../scripts/appimage-update-info.sh) writes it:
+
+```text
+gh-releases-zsync|InstaZDLL|WaveFlow|latest|WaveFlow_*_linux-x86_64.AppImage.zsync
+```
+
+`latest` is a literal the transport resolves through the GitHub API on every check, so the string stays correct for all future versions. Paired with the `.zsync` control file `zsyncmake` emits, a client reuses what it already has and fetches only the changed blocks — measured on a synthetic release: **3 080 192 bytes reused locally, 65 774 fetched**, reconstructed file identical to the published one.
+
+The section is written with `dd conv=notrunc` at the offset `readelf` reports, never `objcopy --update-section`. This file is an ELF *with a squashfs appended* that the runtime locates by a fixed offset; rebuilding the container would move that boundary and produce an image that no longer mounts. The script asserts the file size and the `--appimage-offset` are unchanged afterwards, so that mistake cannot ship quietly.
+
+**The order is load-bearing, and all three steps mutate or describe the same bytes:**
+
+1. `fix-appimage.sh` — repacks the squashfs (keeps the runtime header verbatim, so anything written into it survives)
+2. `appimage-update-info.sh` — writes `.upd_info`, then re-signs, because the `.sig` covers the bytes it just changed
+3. `zsyncmake` — runs **last**, on the renamed `dist-release/` copy
+
+Step 3's placement matters twice. Its checksums describe the payload byte for byte, so any later rewrite would silently invalidate it. And the control file names its target, which clients resolve *relative to the URL they fetched the `.zsync` from* — both are assets of the same release, so the bare renamed filename lands on the right image, while the bundler's own name would send every client to a 404.
+
+> **Stable only.** The update information points at the repository's latest release, and GitHub excludes pre-releases from "latest" — a beta carrying that string would walk its user *back* to the newest stable. Beta builds keep an empty section, so those clients honestly report no update information and the [in-app beta channel](#beta-channel) stays the only path.
+
 ## Flatpak sources are generated, and they go stale silently
 
 Flathub builds with the network disabled, so **every crate and npm tarball must be pre-declared** in [`packaging/flatpak/generated/`](../packaging/flatpak/generated/) by [`generate-sources.sh`](../packaging/flatpak/generate-sources.sh).

--- a/scripts/appimage-update-info.sh
+++ b/scripts/appimage-update-info.sh
@@ -69,6 +69,14 @@ if [ -z "$update_info" ]; then
   # The `*` stands in for the version in our asset naming. Both the
   # `.zsync` and the image it describes are assets of the same release,
   # so the relative URL zsyncmake records resolves alongside it.
+  #
+  # This filename is half a contract: release.yml names the asset, and
+  # this names what clients will look for. Change either and the other
+  # has to follow. The zsync step there reads this string back out of
+  # the built image and fails the release when the two disagree, so the
+  # coupling is enforced rather than merely written down — but it is
+  # enforced at release time, on a tag, which is a bad moment to find
+  # out. Change them together.
   [ -n "${GITHUB_REPOSITORY:-}" ] \
     || die "no --update-info and GITHUB_REPOSITORY is unset — nothing to compose from"
   owner="${GITHUB_REPOSITORY%%/*}"
@@ -96,8 +104,20 @@ command -v readelf >/dev/null || die "readelf not found (apt install binutils)"
 
 # Offsets come from the image itself rather than a constant: the runtime
 # is fetched by the bundler and its layout is not ours to assume.
+#
+# The section index has to be stripped before the fields line up, and
+# stripping it is not optional: readelf pads single-digit indices to a
+# fixed width, so `[ 1]` splits into two fields where `[23]` splits into
+# one, and every column after it shifts. Ours sits at 23 today, which is
+# exactly the kind of accident that holds until a runtime ships with
+# fewer sections. Everything up to the first `]` is that prefix; what
+# follows is Name Type Address Off Size.
 read -r sec_off sec_size <<EOF
-$(readelf -S -W "$img" 2>/dev/null | awk -v s="$SECTION" '$2 == s { print $5, $6; exit }')
+$(readelf -S -W "$img" 2>/dev/null | awk -v s="$SECTION" '
+  { bracket = index($0, "]")
+    line = bracket > 0 ? substr($0, bracket + 1) : $0
+    split(line, f)
+    if (f[1] == s) { print f[4], f[5]; exit } }')
 EOF
 if [ -z "${sec_off:-}" ] || [ -z "${sec_size:-}" ]; then
   die "no $SECTION section — this runtime does not support update information"

--- a/scripts/appimage-update-info.sh
+++ b/scripts/appimage-update-info.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Write AppImage update information into a built AppImage.
+#
+# Why this exists
+# ---------------
+# A type-2 AppImage is an ELF runtime with a squashfs appended, and the
+# runtime carries an empty 1024-byte `.upd_info` section reserved for a
+# single string describing where updates come from. `appimagetool -u`
+# fills it at build time; Tauri's bundler builds the AppImage itself and
+# offers no way to pass that string, so the section ships zeroed and
+# AppImageUpdate, AppImageLauncher, AM and friends all report "no update
+# information available" (#527).
+#
+# Filling it is what makes delta updates possible: the client reads the
+# string, fetches the matching `.zsync` control file, and downloads only
+# the blocks that changed instead of the whole ~95 MB image.
+#
+# Written with `dd conv=notrunc` at the section's own file offset rather
+# than `objcopy --update-section`. objcopy rebuilds the ELF, and this
+# file is not just an ELF — everything after the runtime is a squashfs
+# the runtime locates by a fixed offset. Rewriting the container would
+# move that boundary and produce an AppImage that no longer mounts.
+# Writing in place cannot: the section already exists, at a known offset,
+# with room reserved.
+#
+# Ordering (release.yml depends on this)
+# --------------------------------------
+# This mutates the image, so it must run BEFORE the updater signature is
+# computed and BEFORE `zsyncmake`. It runs after scripts/fix-appimage.sh,
+# which repacks the squashfs — that script preserves the runtime header
+# verbatim, so the order could be reversed, except its "nothing to do"
+# early exit would then skip the re-signing this rewrite requires.
+# Re-signs afterwards for the same reason fix-appimage.sh does: the `.sig`
+# covers the bytes we just changed.
+#
+# Usage: scripts/appimage-update-info.sh [--update-info <string>] [path/to/App.AppImage]
+#   Without --update-info, composes the GitHub-releases form from
+#   GITHUB_REPOSITORY. With no path, finds the single AppImage under
+#   src-tauri/target/release/bundle/appimage/.
+
+set -euo pipefail
+
+BUNDLE_DIR="src-tauri/target/release/bundle/appimage"
+SECTION=".upd_info"
+
+log() { printf '[update-info] %s\n' "$*"; }
+die() { printf '[update-info] error: %s\n' "$*" >&2; exit 1; }
+
+update_info=""
+img=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update-info) shift; [ $# -gt 0 ] || die "--update-info needs a value"; update_info="$1" ;;
+    -*) die "unknown option: $1" ;;
+    *) img="$1" ;;
+  esac
+  shift
+done
+
+if [ -z "$update_info" ]; then
+  # gh-releases-zsync|<user>|<repo>|<release>|<filename>
+  #
+  # `latest` is a literal the transport understands: the client asks the
+  # GitHub API for the latest release each time, so the string stays
+  # correct for every future version. GitHub excludes pre-releases from
+  # "latest", which is why release.yml only calls this on stable builds —
+  # a beta pointing here would be walked *back* to the newest stable.
+  #
+  # The `*` stands in for the version in our asset naming. Both the
+  # `.zsync` and the image it describes are assets of the same release,
+  # so the relative URL zsyncmake records resolves alongside it.
+  [ -n "${GITHUB_REPOSITORY:-}" ] \
+    || die "no --update-info and GITHUB_REPOSITORY is unset — nothing to compose from"
+  owner="${GITHUB_REPOSITORY%%/*}"
+  repo="${GITHUB_REPOSITORY##*/}"
+  # The third test is the one that matters: without a slash both
+  # expansions return the whole string unchanged, so they look valid.
+  if [ -z "$owner" ] || [ -z "$repo" ] || [ "$owner" = "$GITHUB_REPOSITORY" ]; then
+    die "GITHUB_REPOSITORY is not owner/repo: $GITHUB_REPOSITORY"
+  fi
+  update_info="gh-releases-zsync|${owner}|${repo}|latest|WaveFlow_*_linux-x86_64.AppImage.zsync"
+fi
+
+if [ -z "$img" ]; then
+  shopt -s nullglob
+  candidates=("$BUNDLE_DIR"/*.AppImage)
+  shopt -u nullglob
+  [ ${#candidates[@]} -eq 0 ] && die "no .AppImage under $BUNDLE_DIR"
+  [ ${#candidates[@]} -gt 1 ] && die "several AppImages under $BUNDLE_DIR, pass one explicitly"
+  img="${candidates[0]}"
+fi
+[ -f "$img" ] || die "no such file: $img"
+img="$(cd "$(dirname "$img")" && pwd)/$(basename "$img")"
+
+command -v readelf >/dev/null || die "readelf not found (apt install binutils)"
+
+# Offsets come from the image itself rather than a constant: the runtime
+# is fetched by the bundler and its layout is not ours to assume.
+read -r sec_off sec_size <<EOF
+$(readelf -S -W "$img" 2>/dev/null | awk -v s="$SECTION" '$2 == s { print $5, $6; exit }')
+EOF
+if [ -z "${sec_off:-}" ] || [ -z "${sec_size:-}" ]; then
+  die "no $SECTION section — this runtime does not support update information"
+fi
+sec_off=$((16#$sec_off))
+sec_size=$((16#$sec_size))
+log "$SECTION at offset $sec_off, $sec_size bytes"
+
+# One byte is reserved for the terminator: the section is read as a
+# C string, and a value filling it exactly would run into whatever
+# follows.
+len=${#update_info}
+[ "$len" -lt "$sec_size" ] \
+  || die "update information is $len bytes and $SECTION holds $sec_size"
+
+# A rewrite that changed the file size, or moved the squashfs boundary,
+# would produce an image that no longer mounts. Both are checked below
+# rather than assumed.
+size_before=$(wc -c < "$img")
+offset_before=""
+if [ -x "$img" ]; then
+  offset_before="$("$img" --appimage-offset 2>/dev/null || true)"
+fi
+
+log "writing: $update_info"
+# Zero the section first: a shorter string over a longer one would
+# otherwise leave the old tail in place, and the reader stops at the
+# first NUL, not at ours.
+dd if=/dev/zero of="$img" bs=1 seek="$sec_off" count="$sec_size" conv=notrunc status=none
+printf '%s' "$update_info" | dd of="$img" bs=1 seek="$sec_off" conv=notrunc status=none
+
+written="$(dd if="$img" bs=1 skip="$sec_off" count="$sec_size" status=none | tr -d '\0')"
+[ "$written" = "$update_info" ] \
+  || die "read back '$written' after writing '$update_info'"
+
+size_after=$(wc -c < "$img")
+[ "$size_after" -eq "$size_before" ] \
+  || die "the image changed size ($size_before -> $size_after)"
+
+if [ -n "$offset_before" ]; then
+  offset_after="$("$img" --appimage-offset 2>/dev/null || true)"
+  [ "$offset_after" = "$offset_before" ] \
+    || die "the squashfs offset moved ($offset_before -> $offset_after)"
+  log "squashfs offset unchanged ($offset_before)"
+fi
+
+log "update information embedded"
+
+# The updater signature covers the bytes we just replaced.
+if [ -f "$img.sig" ]; then
+  [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ] \
+    || die "an updater signature exists but TAURI_SIGNING_PRIVATE_KEY is unset — refusing to leave a stale .sig"
+  log "re-signing for the updater"
+  rm -f "$img.sig"
+  bun run tauri signer sign "$img" >/dev/null
+  [ -f "$img.sig" ] || die "signing produced no $img.sig"
+  log "signature refreshed"
+else
+  log "no updater signature alongside the bundle — nothing to re-sign"
+fi


### PR DESCRIPTION
Closes #527.

The AppImage runtime reserves a 1024-byte `.upd_info` section for one
string saying where updates come from. `appimagetool` fills it with
`-u`; Tauri builds the AppImage itself and exposes no equivalent, so
ours shipped **zeroed** — which is why AppImageUpdate, AppImageLauncher,
AM and AppManager all report *no update information available*.

Confirmed against the image we actually publish rather than assumed —
the section is there, and empty:

```text
[23] .upd_info   PROGBITS  00000000000e3910  0e3910  000400  WA
non-zero bytes in .upd_info: 0
```

## What ships

[`scripts/appimage-update-info.sh`](../blob/feat/appimage-update-info/scripts/appimage-update-info.sh) writes:

```text
gh-releases-zsync|InstaZDLL|WaveFlow|latest|WaveFlow_*_linux-x86_64.AppImage.zsync
```

`latest` is a literal the transport re-resolves through the GitHub API on
every check, so the string stays correct for all future versions.
`release.yml` pairs it with a `.zsync` control file, and that is what
buys the delta.

## Measured, not asserted

Full client run against a real runtime, served over HTTP with range
support (`http.server` alone is not enough — it ignores `Range` and
answers 200, which zsync rejects):

```text
reading seed file WaveFlow_1.7.0...AppImage: Target 97.9% complete.
downloading from .../WaveFlow_1.8.0...AppImage: 100.0% DONE
verifying download...checksum matches OK
used 3080192 local, fetched 65774
```

`sha256sum` of the reconstructed file matches the published one exactly.

## Why `dd`, not `objcopy`

`objcopy --update-section` rebuilds the ELF. This file is an ELF *with a
squashfs appended* that the runtime locates by a fixed offset, so
rewriting the container moves that boundary and yields an image that no
longer mounts. Writing in place cannot: the section exists, at a known
offset, with room reserved. The script asserts the file size and
`--appimage-offset` are unchanged afterwards, so that mistake cannot
ship quietly.

## The order is load-bearing

Three steps now touch or describe the same bytes:

1. `fix-appimage.sh` — repacks the squashfs, keeping the runtime header
   verbatim, so what we write into it survives
2. `appimage-update-info.sh` — writes `.upd_info`, then **re-signs**:
   the `.sig` covers the bytes it just changed
3. `zsyncmake` — **last**, on the renamed `dist-release/` copy

Step 3 has to be last twice over. Its checksums describe the payload
byte for byte, so any later rewrite invalidates it silently. And the
control file names its target, which clients resolve *relative to the
URL they fetched the `.zsync` from* — both are assets of the same
release, so the renamed filename lands on the right image where the
bundler's own name would 404 every client.

## Stable only, deliberately

The string points at the repository's **latest** release, and GitHub
excludes pre-releases from that. A beta carrying it would walk its user
*back* to the newest stable. Beta builds keep an empty section, honestly
report no update information, and the in-app beta channel stays the only
path there.

## Verification

- `.upd_info` present and zeroed in the released v1.7.0 image (above)
- default composition, and an explicit `--update-info`, both read back
  byte-identical
- a **shorter** value leaves no tail behind (the section is zeroed first;
  a reader stops at the first NUL, not at ours)
- **1023 bytes accepted, 1024 refused** — and refused *before* writing,
  so the previous value survives a bad call
- a binary without the section, and a malformed `GITHUB_REPOSITORY`,
  both fail loudly
- `shellcheck` clean; all four workflow files parse
- downstream unaffected: `apt-publish` downloads by `*.deb` pattern, and
  no other workflow touches the AppImage

Also wired into `test-appimage.yml`, whose whole purpose is an artifact
that behaves like the shipped one — without it a tester would see the
missing update information and read it as a regression.

**Not exercised here:** the release workflow itself only runs on a tag,
so the first real `.zsync` appears with the next release. The three
pieces it depends on — the section write, the `zsyncmake` invocation and
the client round-trip — are each verified above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les AppImages stables prennent désormais en charge les mises à jour delta, afin de réduire la quantité de données téléchargées.
  * Les fichiers nécessaires aux mises à jour sont automatiquement générés et publiés avec les versions stables.
* **Améliorations**
  * Les AppImages conservent leur intégrité et leur signature après l’ajout des informations de mise à jour.
  * Les préversions et versions bêta ne proposent pas de mises à jour delta.
* **Documentation**
  * Le processus de publication et de mise à jour des AppImages est désormais documenté.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->