### PR TITLE
style(remote): format mirror.rs and put cargo fmt in the checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,12 @@ bun run typecheck            # tsc --noEmit
 bun run lint                 # eslint
 bun run build                # tsc + Vite prod build
 
+cargo fmt   --manifest-path src-tauri/Cargo.toml --all -- --check
 cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets
 cargo test  --manifest-path src-tauri/Cargo.toml --workspace
 ```
 
-The PR checklist is the `typecheck` / `lint` / `cargo check` triple.
+The PR checklist is `typecheck` / `lint` / `cargo fmt --check` / `cargo check`. **`cargo fmt` is not optional** — CI runs it as the first step of the Rust job, so an unformatted file fails the whole job before a single test runs, and neither `cargo check` nor `clippy` will have warned you.
 
 ## Architecture
 

--- a/src-tauri/crates/app/src/remote/mirror.rs
+++ b/src-tauri/crates/app/src/remote/mirror.rs
@@ -171,7 +171,10 @@ struct MirrorProgress {
 fn emit(app: &AppHandle, phase: &'static str, done: i64, total: i64) {
     // Progress is decoration: a listener that has gone away must not turn a
     // successful walk into an error.
-    let _ = app.emit("remote:mirror-progress", MirrorProgress { phase, done, total });
+    let _ = app.emit(
+        "remote:mirror-progress",
+        MirrorProgress { phase, done, total },
+    );
 }
 
 /// One library the account can see.
@@ -402,10 +405,14 @@ async fn walk_albums(
             return Ok(());
         }
         let page: Vec<AlbumListItem> = client
-            .send_json(client.request(reqwest::Method::GET, "/api/v2/albums").query(&[
-                ("offset", offset.to_string()),
-                ("limit", ALBUM_PAGE.to_string()),
-            ]))
+            .send_json(
+                client
+                    .request(reqwest::Method::GET, "/api/v2/albums")
+                    .query(&[
+                        ("offset", offset.to_string()),
+                        ("limit", ALBUM_PAGE.to_string()),
+                    ]),
+            )
             .await
             .map_err(|err| AppError::Other(format!("album listing failed: {err}")))?;
         if page.is_empty() {
@@ -742,7 +749,9 @@ pub async fn clear(pool: &SqlitePool) -> AppResult<()> {
     sqlx::query("UPDATE remote_track SET in_catalogue = 0 WHERE in_catalogue = 1")
         .execute(&mut *tx)
         .await?;
-    sqlx::query("DELETE FROM remote_album").execute(&mut *tx).await?;
+    sqlx::query("DELETE FROM remote_album")
+        .execute(&mut *tx)
+        .await?;
     sqlx::query("UPDATE remote_library SET mirrored_at = NULL")
         .execute(&mut *tx)
         .await?;
@@ -891,10 +900,12 @@ mod tests {
         let pool = pool().await;
         mirrored_track(&pool, "t-keep").await;
         mirrored_track(&pool, "t-drop").await;
-        sqlx::query("INSERT INTO remote_playlist (remote_id, name, updated_at) VALUES ('p1','P',1)")
-            .execute(&pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "INSERT INTO remote_playlist (remote_id, name, updated_at) VALUES ('p1','P',1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
         sqlx::query(
             "INSERT INTO remote_playlist_track (playlist_remote_id, position, track_remote_id)
              VALUES ('p1', 0, 't-keep')",


### PR DESCRIPTION
`main` is red. The catalogue mirror went in unformatted, and `cargo fmt --check` is the **first** step of the Rust job — so it failed before a single test ran.

## Why it got through

`CLAUDE.md` calls the PR checklist "the `typecheck` / `lint` / `cargo check` triple" and never mentions formatting. Neither `cargo check` nor `clippy -D warnings` says a word about it, so following the documented checklist to the letter still produces a red build. The checklist now names `cargo fmt --check` and says why it is not optional.

## Contents

- `cargo fmt --all` over the workspace. Only `mirror.rs` moved — everything else was already clean.
- The checklist correction in `CLAUDE.md`.

No behaviour change: the diff is line breaks.

## Checks

`cargo fmt --check` clean, `cargo clippy --workspace --all-targets -D warnings` with `--features sync_v2`, mirror tests green.

https://claude.ai/code/session_01Ls4aG74DPcE4UUQtrPc5ji


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Mise à jour des consignes de développement et de la checklist de pull request.
  - Ajout des vérifications de formatage, de compilation et des tests Rust aux contrôles recommandés.

- **Refactorisation**
  - Réorganisation interne de certaines opérations liées aux albums, sans changement de fonctionnalité visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->