### PR TITLE
feat(library): browse both sources from one playlist list

### DIFF
--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -480,8 +480,16 @@ comparable rather than merely concatenated:
 
 A server album keeps none of the local gestures — no playlist, no cover picker,
 no context menu — because none of them can accept it, and it opens the remote
-detail view rather than the local one. The artists and tracks tabs work the same
-way, on the same filter.
+detail view rather than the local one. The artists, tracks and playlists tabs
+work the same way, on the same filter.
+
+Playlists are the one tab whose halves are merged **in the browser**. The grid
+already sorted there — locale-aware, with `Intl.Collator` — so there is no SQL
+ordering to unify and a compound select would buy nothing. Two of its sort keys
+exist on the local half only: the server's summary carries no modification time,
+and manual order is the sidebar's, which a server playlist is not in. Those rows
+file last and settle among themselves by name, on the same reading as the
+unratable tracks — absent is not smallest.
 
 The tracks tab adds one consequence worth stating plainly: **playing a row
 queues the run of rows from its own source.** Decision 9 keeps the remote queue

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -529,6 +529,7 @@ export function AppLayout() {
             onNavigateToRemoteAlbum={navigateToRemoteAlbum}
             onNavigateToArtist={navigateToArtist}
             onNavigateToRemoteArtist={navigateToRemoteArtist}
+            onNavigateToRemotePlaylist={navigateToRemotePlaylist}
             onNavigateToGenre={navigateToGenre}
             onNavigateToPlaylist={navigateToPlaylist}
           />

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -8,7 +8,10 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
-import { PlaylistGrid } from "./library/PlaylistGrid";
+import {
+  PlaylistGrid,
+  type LibraryPlaylistRow,
+} from "./library/PlaylistGrid";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   Music2,
@@ -111,6 +114,7 @@ interface LibraryViewProps {
    *  never merged, so they are never the same page. */
   onNavigateToRemoteAlbum: (remoteAlbumId: string) => void;
   onNavigateToRemoteArtist: (remoteArtistId: string) => void;
+  onNavigateToRemotePlaylist: (remotePlaylistId: string) => void;
   onNavigateToArtist: (artistId: number) => void;
   onNavigateToGenre: (genreId: number) => void;
   onNavigateToPlaylist: (playlistId: number) => void;
@@ -152,6 +156,7 @@ export function LibraryView({
   onNavigateToRemoteAlbum,
   onNavigateToArtist,
   onNavigateToRemoteArtist,
+  onNavigateToRemotePlaylist,
   onNavigateToGenre,
   onNavigateToPlaylist,
 }: LibraryViewProps) {
@@ -209,6 +214,9 @@ export function LibraryView({
   const [tracks, setTracks] = useState<LibraryTrackRow[]>([]);
   const [albums, setAlbums] = useState<LibraryAlbumRow[]>([]);
   const librarySource = useLibrarySource();
+  // Read here as well as inside `SourceFilter`: the playlists tab merges the
+  // two halves in the browser and needs the remote one.
+  const remote = useRemoteSource();
   const [artists, setArtists] = useState<LibraryArtistRow[]>([]);
   const [genres, setGenres] = useState<GenreRow[]>([]);
   const [folders, setFolders] = useState<FolderRow[]>([]);
@@ -608,6 +616,56 @@ export function LibraryView({
     }
   };
 
+  // Playlists is the one tab whose two halves are merged in the browser: the
+  // grid already sorted there, so there is no SQL ordering to unify and a
+  // compound select would buy nothing.
+  const libraryPlaylists = useMemo<LibraryPlaylistRow[]>(() => {
+    const wanted = librarySource.source;
+    const rows: LibraryPlaylistRow[] = [];
+    if (wanted !== "remote") {
+      for (const playlist of userPlaylists) {
+        rows.push({
+          source: "local",
+          id: String(playlist.id),
+          name: playlist.name,
+          track_count: playlist.track_count,
+          total_duration_ms: playlist.total_duration_ms,
+          updated_at: playlist.updated_at,
+          position: playlist.position,
+          color_id: playlist.color_id,
+          icon_id: playlist.icon_id,
+          cover_path: playlist.cover_path,
+          pending_creation: false,
+        });
+      }
+    }
+    if (wanted !== "local" && remote.available) {
+      for (const playlist of remote.playlists) {
+        rows.push({
+          source: "remote",
+          id: playlist.id,
+          name: playlist.name,
+          track_count: playlist.track_count,
+          total_duration_ms: playlist.duration_ms,
+          // The server's summary carries neither; the grid files them last
+          // rather than reading a missing key as zero.
+          updated_at: null,
+          position: null,
+          color_id: "",
+          icon_id: null,
+          cover_path: null,
+          pending_creation: playlist.pending_creation,
+        });
+      }
+    }
+    return rows;
+  }, [
+    userPlaylists,
+    remote.available,
+    remote.playlists,
+    librarySource.source,
+  ]);
+
   // The albums tab can be empty for two different reasons, and they deserve
   // two different answers.
   const sourceFilterEmptied =
@@ -615,6 +673,9 @@ export function LibraryView({
     ((activeTab === "morceaux" && tracks.length === 0) ||
       (activeTab === "albums" && albums.length === 0) ||
       (activeTab === "artistes" && artists.length === 0));
+  // Playlists is not in that list on purpose: `PlaylistGrid` owns its own
+  // empty state and never falls through to the generic one, so a narrowed
+  // source there is already explained where the user is looking.
 
   // The two engines keep separate queues by design (RFC-005 decision 9), so a
   // mixed list cannot produce a mixed queue. Playing a row therefore queues the
@@ -796,7 +857,8 @@ export function LibraryView({
           problem — it did not cause the emptiness — so it stays gated. */}
       {(activeTab === "morceaux" ||
         activeTab === "albums" ||
-        activeTab === "artistes") && (
+        activeTab === "artistes" ||
+        activeTab === "playlists") && (
         <div className="flex items-center justify-end space-x-3 -mt-4">
           <SourceFilter
             current={librarySource.source}
@@ -816,6 +878,14 @@ export function LibraryView({
               options={albumSortOptions(t)}
               current={albumsSort.sort}
               onChange={albumsSort.setSort}
+              t={t}
+            />
+          )}
+          {activeTab === "playlists" && libraryPlaylists.length > 0 && (
+            <SortDropdown
+              options={playlistSortOptions(t)}
+              current={playlistsSort.sort}
+              onChange={playlistsSort.setSort}
               t={t}
             />
           )}
@@ -979,20 +1049,13 @@ export function LibraryView({
           )}
           {activeTab === "playlists" && (
             <>
-              {userPlaylists.length > 0 && (
-                <div className="flex items-center justify-end space-x-3 -mt-4">
-                  <SortDropdown
-                    options={playlistSortOptions(t)}
-                    current={playlistsSort.sort}
-                    onChange={playlistsSort.setSort}
-                    t={t}
-                  />
-                </div>
-              )}
+
               <PlaylistGrid
-                playlists={userPlaylists}
+                playlists={libraryPlaylists}
                 sort={playlistsSort.sort}
                 onOpen={onNavigateToPlaylist}
+                onOpenRemote={onNavigateToRemotePlaylist}
+                sourceFiltered={librarySource.source !== "all"}
               />
             </>
           )}

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -480,6 +480,56 @@ export function LibraryView({
       .catch((err) => console.error("[LibraryView] liked ids failed", err));
   }, [librariesSignature]);
 
+  // Playlists is the one tab whose two halves are merged in the browser: the
+  // grid already sorted there, so there is no SQL ordering to unify and a
+  // compound select would buy nothing.
+  const libraryPlaylists = useMemo<LibraryPlaylistRow[]>(() => {
+    const wanted = librarySource.source;
+    const rows: LibraryPlaylistRow[] = [];
+    if (wanted !== "remote") {
+      for (const playlist of userPlaylists) {
+        rows.push({
+          source: "local",
+          id: String(playlist.id),
+          name: playlist.name,
+          track_count: playlist.track_count,
+          total_duration_ms: playlist.total_duration_ms,
+          updated_at: playlist.updated_at,
+          position: playlist.position,
+          color_id: playlist.color_id,
+          icon_id: playlist.icon_id,
+          cover_path: playlist.cover_path,
+          pending_creation: false,
+        });
+      }
+    }
+    if (wanted !== "local" && remote.available) {
+      for (const playlist of remote.playlists) {
+        rows.push({
+          source: "remote",
+          id: playlist.id,
+          name: playlist.name,
+          track_count: playlist.track_count,
+          total_duration_ms: playlist.duration_ms,
+          // The server's summary carries neither; the grid files them last
+          // rather than reading a missing key as zero.
+          updated_at: null,
+          position: null,
+          color_id: "",
+          icon_id: null,
+          cover_path: null,
+          pending_creation: playlist.pending_creation,
+        });
+      }
+    }
+    return rows;
+  }, [
+    userPlaylists,
+    remote.available,
+    remote.playlists,
+    librarySource.source,
+  ]);
+
   // Per-tab header subtext uses the fetched data lengths since we
   // aggregate across all libraries (no single Library to read counts from).
   const countForTab = (tab: LibraryTab): number => {
@@ -493,7 +543,9 @@ export function LibraryView({
       case "genres":
         return genres.length;
       case "playlists":
-        return userPlaylists.length;
+        // The merged list, not the local one: the header would otherwise
+        // count a different set from the grid right below it.
+        return libraryPlaylists.length;
       case "dossiers":
         return folders.length;
     }
@@ -615,56 +667,6 @@ export function LibraryView({
       setDeepRescanFolderId(null);
     }
   };
-
-  // Playlists is the one tab whose two halves are merged in the browser: the
-  // grid already sorted there, so there is no SQL ordering to unify and a
-  // compound select would buy nothing.
-  const libraryPlaylists = useMemo<LibraryPlaylistRow[]>(() => {
-    const wanted = librarySource.source;
-    const rows: LibraryPlaylistRow[] = [];
-    if (wanted !== "remote") {
-      for (const playlist of userPlaylists) {
-        rows.push({
-          source: "local",
-          id: String(playlist.id),
-          name: playlist.name,
-          track_count: playlist.track_count,
-          total_duration_ms: playlist.total_duration_ms,
-          updated_at: playlist.updated_at,
-          position: playlist.position,
-          color_id: playlist.color_id,
-          icon_id: playlist.icon_id,
-          cover_path: playlist.cover_path,
-          pending_creation: false,
-        });
-      }
-    }
-    if (wanted !== "local" && remote.available) {
-      for (const playlist of remote.playlists) {
-        rows.push({
-          source: "remote",
-          id: playlist.id,
-          name: playlist.name,
-          track_count: playlist.track_count,
-          total_duration_ms: playlist.duration_ms,
-          // The server's summary carries neither; the grid files them last
-          // rather than reading a missing key as zero.
-          updated_at: null,
-          position: null,
-          color_id: "",
-          icon_id: null,
-          cover_path: null,
-          pending_creation: playlist.pending_creation,
-        });
-      }
-    }
-    return rows;
-  }, [
-    userPlaylists,
-    remote.available,
-    remote.playlists,
-    librarySource.source,
-  ]);
 
   // The albums tab can be empty for two different reasons, and they deserve
   // two different answers.

--- a/src/components/views/RemotePlaylistView.tsx
+++ b/src/components/views/RemotePlaylistView.tsx
@@ -68,23 +68,8 @@ import { notifyRemoteChanged } from "../../hooks/useRemoteSource";
 import { usePlayer } from "../../hooks/usePlayer";
 import { isRemoteTrack } from "../../lib/playerSources";
 import { PlayingIndicator } from "../common/PlayingIndicator";
-import { PLAYLIST_COLORS, type PlaylistColor } from "../../lib/playlistVisuals";
+import { colorForPlaylistId } from "../../lib/playlistVisuals";
 import { RemoteArtwork } from "../common/RemoteArtwork";
-
-/**
- * A remote playlist carries no `color_id`, but a plain library playlist
- * shows a per-playlist colour band + tile — so derive a stable colour
- * from the playlist id (same hash always maps to the same swatch). Keeps
- * the remote header visually 1:1 with a local one instead of a fixed
- * emerald that every remote playlist would share.
- */
-function remotePlaylistColor(id: string): PlaylistColor {
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) {
-    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
-  }
-  return PLAYLIST_COLORS[hash % PLAYLIST_COLORS.length];
-}
 
 /**
  * Display-only sort for the remote track table, mirroring the local
@@ -528,7 +513,7 @@ export function RemotePlaylistView({
   if (!remotePlaylistId) return null;
 
   const totalMs = tracks.reduce((sum, t) => sum + (t.duration_ms ?? 0), 0);
-  const color = remotePlaylistColor(remotePlaylistId);
+  const color = colorForPlaylistId(remotePlaylistId);
 
   return (
     <div className="space-y-8 animate-fade-in pb-20">

--- a/src/components/views/library/PlaylistGrid.tsx
+++ b/src/components/views/library/PlaylistGrid.tsx
@@ -5,21 +5,55 @@ import { ListMusic } from "lucide-react";
 
 import { usePageScroll } from "../../../hooks/usePageScroll";
 import { PlaylistIcon } from "../../../lib/PlaylistIcon";
-import { resolvePlaylistColor } from "../../../lib/playlistVisuals";
+import {
+  colorForPlaylistId,
+  resolvePlaylistColor,
+} from "../../../lib/playlistVisuals";
 import { resolveRemoteImage } from "../../../lib/tauri/artwork";
 import { formatDuration } from "../../../lib/tauri/track";
 import type { SortState } from "../../../hooks/useSortMemory";
-import type { Playlist } from "../../../lib/tauri/playlist";
+import type { LibrarySource } from "../../../lib/tauri/browse";
 import { EmptyState } from "../../common/EmptyState";
+
+/**
+ * A playlist of the library, from either source.
+ *
+ * Built in the view rather than fetched: unlike the other three tabs, the
+ * playlist grid already sorted in the browser, so there is no SQL ordering to
+ * unify and nothing to gain from a compound select. The two shapes are merged
+ * where they are read.
+ */
+export interface LibraryPlaylistRow {
+  source: LibrarySource;
+  /** Local rowid as text, or the server's playlist identifier. */
+  id: string;
+  name: string;
+  track_count: number;
+  total_duration_ms: number;
+  /** Local only: the server's summary carries no modification time. */
+  updated_at: number | null;
+  /** Local only: the sidebar's manual order. */
+  position: number | null;
+  color_id: string;
+  icon_id: string | null;
+  cover_path: string | null;
+  /** Remote only: created here and not yet sent to the server. */
+  pending_creation: boolean;
+}
 
 interface PlaylistGridProps {
   /** User playlists only — smart ones live in Home's "Made for you". */
-  playlists: Playlist[];
+  playlists: LibraryPlaylistRow[];
   /** Same `{ orderBy, direction }` shape the other library tabs use, so
    *  this tab gets `SortDropdown` + persisted sort for free. `custom` is
    *  the sidebar's own manual order (`playlist.position`). */
   sort: SortState;
   onOpen: (playlistId: number) => void;
+  /** A server playlist has no local rowid and opens its own view. */
+  onOpenRemote: (remotePlaylistId: string) => void;
+  /** Whether the list is empty because the source filter narrowed it, rather
+   *  than because there is nothing to show. Two different messages. */
+  sourceFiltered: boolean;
 }
 
 /**
@@ -34,7 +68,13 @@ interface PlaylistGridProps {
  * nesting its own `overflow-y-auto`, which is what keeps the app on a
  * single Spotify-style scrollbar.
  */
-export function PlaylistGrid({ playlists, sort, onOpen }: PlaylistGridProps) {
+export function PlaylistGrid({
+  playlists,
+  sort,
+  onOpen,
+  onOpenRemote,
+  sourceFiltered,
+}: PlaylistGridProps) {
   const { t, i18n } = useTranslation();
 
   const sorted = useMemo(() => {
@@ -42,19 +82,36 @@ export function PlaylistGrid({ playlists, sort, onOpen }: PlaylistGridProps) {
     const collator = new Intl.Collator(i18n.language, {
       sensitivity: "base",
     });
-    const ascending = (a: Playlist, b: Playlist): number => {
+    // Two of the sort keys exist on the local half only: the server's summary
+    // carries no modification time, and manual order is the sidebar's, which a
+    // server playlist is not in. Rather than reading a missing key as zero —
+    // which would file every remote playlist as the oldest, or first — they
+    // fall to the end of the list and settle among themselves by name. Same
+    // reading as the unratable tracks: absent is not smallest.
+    const missingLast = (
+      a: number | null,
+      b: number | null,
+      byName: number,
+    ): number => {
+      if (a == null && b == null) return byName;
+      if (a == null) return 1;
+      if (b == null) return -1;
+      return a - b;
+    };
+    const ascending = (a: LibraryPlaylistRow, b: LibraryPlaylistRow): number => {
+      const byName = collator.compare(a.name, b.name);
       switch (sort.orderBy) {
         case "name":
-          return collator.compare(a.name, b.name);
+          return byName;
         case "tracks":
           return a.track_count - b.track_count;
         case "duration":
           return a.total_duration_ms - b.total_duration_ms;
         case "updated":
-          return a.updated_at - b.updated_at;
+          return missingLast(a.updated_at, b.updated_at, byName);
         case "custom":
         default:
-          return a.position - b.position;
+          return missingLast(a.position, b.position, byName);
       }
     };
     const factor = sort.direction === "desc" ? -1 : 1;
@@ -131,7 +188,14 @@ export function PlaylistGrid({ playlists, sort, onOpen }: PlaylistGridProps) {
       <EmptyState
         icon={<ListMusic size={32} />}
         title={t("library.playlistsGrid.emptyTitle")}
-        description={t("library.playlistsGrid.emptyHint")}
+        // A narrowed source is a different emptiness from "you have not made
+        // any playlists yet", and telling the user to create one would not
+        // help: the half they are looking at is simply not this one.
+        description={t(
+          sourceFiltered
+            ? "library.empty.sourceFiltered.description"
+            : "library.playlistsGrid.emptyHint",
+        )}
       />
     );
   }
@@ -164,9 +228,10 @@ export function PlaylistGrid({ playlists, sort, onOpen }: PlaylistGridProps) {
             >
               {rowItems.map((playlist) => (
                 <PlaylistCard
-                  key={playlist.id}
+                  key={`${playlist.source}:${playlist.id}`}
                   playlist={playlist}
                   onOpen={onOpen}
+                  onOpenRemote={onOpenRemote}
                 />
               ))}
             </div>
@@ -180,12 +245,19 @@ export function PlaylistGrid({ playlists, sort, onOpen }: PlaylistGridProps) {
 function PlaylistCard({
   playlist,
   onOpen,
+  onOpenRemote,
 }: {
-  playlist: Playlist;
+  playlist: LibraryPlaylistRow;
   onOpen: (playlistId: number) => void;
+  onOpenRemote: (remotePlaylistId: string) => void;
 }) {
   const { t } = useTranslation();
-  const color = resolvePlaylistColor(playlist.color_id);
+  const remote = playlist.source === "remote";
+  // A server playlist carries no `color_id`; the colour is derived from its
+  // identifier so it is stable and not the same swatch for all of them.
+  const color = remote
+    ? colorForPlaylistId(playlist.id)
+    : resolvePlaylistColor(playlist.color_id);
   const coverUrl = resolveRemoteImage(playlist.cover_path, null);
 
   return (
@@ -194,7 +266,9 @@ function PlaylistCard({
     // without bolting a keydown handler onto a non-interactive element.
     <button
       type="button"
-      onClick={() => onOpen(playlist.id)}
+      onClick={() =>
+        remote ? onOpenRemote(playlist.id) : onOpen(Number(playlist.id))
+      }
       className="group flex flex-col space-y-2 text-left cursor-pointer rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
     >
       {coverUrl ? (
@@ -210,12 +284,20 @@ function PlaylistCard({
         <div
           className={`w-full aspect-square rounded-2xl flex items-center justify-center shadow-sm group-hover:shadow-md transition-shadow ${color.tileBg} ${color.tileText}`}
         >
-          <PlaylistIcon iconId={playlist.icon_id} size={44} />
+          {/* A server playlist has no icon of its own; the default one keeps
+              the tile from being an empty colour block. */}
+          <PlaylistIcon iconId={playlist.icon_id ?? "music"} size={44} />
         </div>
       )}
       <div className="min-w-0">
-        <div className="text-sm font-medium text-zinc-900 dark:text-white truncate">
-          {playlist.name}
+        <div className="text-sm font-medium text-zinc-900 dark:text-white truncate flex items-center gap-1.5">
+          <span className="truncate">{playlist.name}</span>
+          {/* One list, and every tile says where it comes from. */}
+          {remote && (
+            <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-zinc-200 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+              {t("library.source.remote")}
+            </span>
+          )}
         </div>
         <div className="text-xs text-zinc-500 dark:text-zinc-400 truncate">
           {t("library.playlistsGrid.meta", {

--- a/src/components/views/library/PlaylistGrid.tsx
+++ b/src/components/views/library/PlaylistGrid.tsx
@@ -88,25 +88,31 @@ export function PlaylistGrid({
     // which would file every remote playlist as the oldest, or first — they
     // fall to the end of the list and settle among themselves by name. Same
     // reading as the unratable tracks: absent is not smallest.
+    const factor = sort.direction === "desc" ? -1 : 1;
+    // The direction applies to the values, never to the missing-last rule.
+    // Multiplying the whole comparison by the factor would invert the
+    // sentinels too, and "last" would become "first" the moment someone
+    // reversed the sort — which is the same defect the track list had when
+    // its NULL ratings were left to the ORDER BY direction.
     const missingLast = (
       a: number | null,
       b: number | null,
       byName: number,
     ): number => {
-      if (a == null && b == null) return byName;
+      if (a == null && b == null) return factor * byName;
       if (a == null) return 1;
       if (b == null) return -1;
-      return a - b;
+      return factor * (a - b);
     };
-    const ascending = (a: LibraryPlaylistRow, b: LibraryPlaylistRow): number => {
+    const compare = (a: LibraryPlaylistRow, b: LibraryPlaylistRow): number => {
       const byName = collator.compare(a.name, b.name);
       switch (sort.orderBy) {
         case "name":
-          return byName;
+          return factor * byName;
         case "tracks":
-          return a.track_count - b.track_count;
+          return factor * (a.track_count - b.track_count);
         case "duration":
-          return a.total_duration_ms - b.total_duration_ms;
+          return factor * (a.total_duration_ms - b.total_duration_ms);
         case "updated":
           return missingLast(a.updated_at, b.updated_at, byName);
         case "custom":
@@ -114,10 +120,9 @@ export function PlaylistGrid({
           return missingLast(a.position, b.position, byName);
       }
     };
-    const factor = sort.direction === "desc" ? -1 : 1;
     // Sorting a copy: `playlists` comes straight from the context and is
     // shared with the sidebar, which renders it in `position` order.
-    return [...playlists].sort((a, b) => factor * ascending(a, b));
+    return [...playlists].sort(compare);
   }, [playlists, sort.orderBy, sort.direction, i18n.language]);
 
   const pageScrollRef = usePageScroll();

--- a/src/lib/playlistVisuals.ts
+++ b/src/lib/playlistVisuals.ts
@@ -161,3 +161,23 @@ export const PLAYLIST_ICONS: PlaylistIconEntry[] = [
 export function resolvePlaylistColor(colorId: string): PlaylistColor {
   return PLAYLIST_COLORS.find((c) => c.id === colorId) ?? PLAYLIST_COLORS[0];
 }
+
+/**
+ * A stable colour for a playlist that has no `color_id`.
+ *
+ * A server playlist carries none, but a local one shows a per-playlist band
+ * and tile — so the colour is derived from the identifier instead, the same
+ * hash always landing on the same swatch. A fixed emerald would make every
+ * remote playlist look like the same one.
+ *
+ * Shared between the remote playlist view and the library grid so the two
+ * agree: the same playlist must not be blue in one place and amber in the
+ * other.
+ */
+export function colorForPlaylistId(id: string): PlaylistColor {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  return PLAYLIST_COLORS[hash % PLAYLIST_COLORS.length];
+}


### PR DESCRIPTION
The last of the four tabs, and the only one that needed **no backend at all**.

The grid already sorted in the browser — locale-aware, through `Intl.Collator` — so there is no SQL ordering to unify and a compound select would have bought nothing. The two shapes are merged where they are read.

## Two sort keys exist on one half only

The server's summary carries no modification time, and manual order is the sidebar's, which a server playlist is not in. Reading a missing key as zero would file every remote playlist as the oldest, or first.

They fall to the end instead and settle among themselves by name — the same reading the track list gives an unratable row: **absent is not smallest**.

## Colour

A server playlist has no `color_id`, so the swatch is derived from its identifier, exactly as `RemotePlaylistView` already did. That derivation moved into the shared visuals module so the two agree: the same playlist must not be blue in one place and amber in the other.

## Empty state

The grid owns its own empty state and never falls through to the generic one, so it gains the filtered message itself. A narrowed source is a different emptiness from "you have not made any playlists yet", and telling someone to create one would not help when the half they are looking at is simply not this one.

## Checks

`typecheck`, `lint`, `cargo fmt --check`. No Rust touched — the diff is frontend and one RFC paragraph.

## Lot 1 after this

All four tabs read both sources through one filter. What remains is retiring the three twin views and the separate sidebar section they hang off — the redundancy this whole lot was aimed at.

https://claude.ai/code/session_01Ls4aG74DPcE4UUQtrPc5ji


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les playlists locales et distantes sont désormais réunies dans la Bibliothèque.
  * Ajout du filtrage par source et du tri des playlists.
  * Les playlists distantes peuvent être ouvertes directement depuis la Bibliothèque.
  * Elles disposent d’une couleur et d’une icône cohérentes.

* **Améliorations**
  * Les playlists distantes sans date ni ordre manuel sont placées en dernier et triées par nom.
  * Les onglets artistes, pistes et playlists partagent désormais le même filtre.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->