### PR TITLE
feat(sidebar): one playlist list, not a server section beside it

### DIFF
--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -339,8 +339,19 @@ move, queues a full replace (`remove_indexes` for every position + `add` in the
 new order). `RemoteServerCard` in Settings is connection-only —
 identify, sign in, sync, sign out, forget. `CreatePlaylistModal` offers an "also
 create on the server" checkbox when one is connected. All of it self-hides when
-`sync_v2` is off (the frontend probes `remote_get_status`) and is intentionally
-unlocalized until the feature ships, matching `RemoteServerCard`.
+`sync_v2` is off — the frontend probes `remote_get_status`, since TypeScript
+cannot see a Cargo feature.
+
+It is **localized across all seventeen locales**, under a self-contained
+`remote.*` namespace. This paragraph said the opposite until now: the surface
+was deliberately left untranslated "until the feature ships", which was true
+while `sync_v2` was off by default and no released build could reach it. It went
+into the default feature set on 2026-08-17 and the surface was translated the
+same day; the sentence outlived both by nine days, and a comment repeating it
+sat above the sidebar's server section shipping hardcoded English the whole
+time. A claim that a surface needs no translation is only ever true of a
+surface nobody can reach, which makes it worth re-reading every time the reason
+it cannot be reached changes.
 
 **The queue panel** switches to a dedicated `RemoteQueueView` while a remote
 session plays (keyed on `isRemoteTrack`), reading `remote_get_play_queue` (an

--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -33,9 +33,15 @@ So the incoming projection cannot be written into `playlist`, `liked_track` or
 `track.rating`. Doing so would either fabricate local tracks for rows that only
 exist on the server, or silently drop every entry — the first corrupts the local
 library, the second makes sync look broken. The projection therefore lands in
-its **own tables** (`remote_*`), is presented as a distinct source in the
-sidebar, and is reconstructible: dropping it and re-fetching a snapshot is
-always a valid recovery.
+its **own tables** (`remote_*`) and is reconstructible: dropping it and
+re-fetching a snapshot is always a valid recovery.
+
+It was also, at first, presented as a distinct *place* — its own sidebar
+section, its own views. That reading has since been dropped: the tables stay
+separate because the entities are, but the navigation does not have to repeat
+the split, and one library with the source as a filter is what the sections
+below describe. Never merged still holds; never merged is not the same as
+shown apart.
 
 Matching a local file to a server track is **out of scope** and needs its own
 RFC. When it comes, the only automatic link allowed is an exact, unique
@@ -320,10 +326,12 @@ The orchestration (fill from projection, mint ticket, dispatch) lives in the
 `sync_v2`-gated `remote::playback`; the state and its clear/probe live in the
 always-compiled `remote_playback` so the control seams stay feature-clean.
 
-**UI.** The remote source is managed from the main UI, not Settings: a "Remote
-source" section at the bottom of the sidebar (headed by the server host, listing
-its playlists) and a `RemotePlaylistView` that plays, renames, deletes, removes
-tracks from, reorders and adds tracks to them like local playlists. Track edits
+**UI.** The remote source is managed from the main UI, not Settings. It began
+as a "Remote source" section at the bottom of the sidebar, headed by the server
+host and listing its playlists; that section is gone — its rows sit in the one
+playlist list, tagged, alongside the local ones. A `RemotePlaylistView` still
+plays, renames, deletes, removes tracks from, reorders and adds tracks to them
+like local playlists. Track edits
 go through the server's `UpdatePlaylist` mutation: add queues `add` (its hits
 come from a live `/api/v2/search`, cached into `remote_track` so titles render at
 once); removal queues `remove_indexes`; reorder, for which the mutation has no

--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -483,6 +483,18 @@ no context menu — because none of them can accept it, and it opens the remote
 detail view rather than the local one. The artists, tracks and playlists tabs
 work the same way, on the same filter.
 
+The sidebar merges them too, and for the same reason it stopped having a
+section of its own: a "Remote source" heading beside the playlist list *was*
+the redundancy this lot was aimed at. Server playlists now sit in the one
+playlist list with a chip, and the filter deliberately does not reach there —
+the sidebar is navigation, not a filtered view, so narrowing a tab must not
+empty half of it.
+
+That section also carried hardcoded English. It was written when `sync_v2` was
+off by default and unreachable in a release, and the comment saying so outlived
+the feature flag flip that made it reachable — which is its own argument for not
+keeping a second surface that only one of the two halves passes through.
+
 Playlists are the one tab whose halves are merged **in the browser**. The grid
 already sorted there — locale-aware, with `Intl.Collator` — so there is no SQL
 ordering to unify and a compound select would buy nothing. Two of its sort keys

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,7 +15,6 @@ import {
   Sparkles,
   Headphones,
   Radio,
-  Server,
 } from "lucide-react";
 import type { ViewId, LibraryTab } from "../../types";
 import { NavItem } from "../common/NavItem";
@@ -27,7 +26,8 @@ import { useLibrary } from "../../hooks/useLibrary";
 import { usePlaylist } from "../../hooks/usePlaylist";
 import { usePluginAvailability } from "../../hooks/usePluginAvailability";
 import { useUiPlugins } from "../../hooks/useUiPlugins";
-import { useRemoteSource, notifyRemoteChanged } from "../../hooks/useRemoteSource";
+import { notifyRemoteChanged } from "../../hooks/useRemoteSource";
+import { useLibraryPlaylists } from "../../hooks/useLibraryPlaylists";
 import { remoteCreatePlaylist } from "../../lib/tauri/remoteServer";
 import { resolvePluginIcon } from "../../lib/pluginIcons";
 import { getProfileColor, profileInitial } from "../../lib/profileColors";
@@ -35,10 +35,13 @@ import { pickFile, pickFolder } from "../../lib/tauri/dialog";
 import { importPlaylistM3u } from "../../lib/tauri/playlist";
 import { getProfileStats, type ProfileStats } from "../../lib/tauri/browse";
 import { getProfileSetting } from "../../lib/tauri/profile";
-import { resolvePlaylistColor } from "../../lib/playlistVisuals";
+import {
+  colorForPlaylistId,
+  resolvePlaylistColor,
+} from "../../lib/playlistVisuals";
 import { PlaylistIcon } from "../../lib/PlaylistIcon";
 import { resolveRemoteImage } from "../../lib/tauri/artwork";
-import type { Playlist } from "../../lib/tauri/playlist";
+import type { LibraryPlaylistRow } from "../../hooks/useLibraryPlaylists";
 
 interface SidebarProps {
   activeView: ViewId;
@@ -109,7 +112,9 @@ export function Sidebar({
   // Remote source (RFC-005 sync_v2). Self-hides in stock builds — the
   // hook probes `remote_get_status`, which is unregistered when the
   // feature is off, and reports `available: false`.
-  const remote = useRemoteSource();
+  // The sidebar is navigation, not a filtered view: it always shows both
+  // halves, whatever the library tab is currently narrowed to.
+  const libraryPlaylists = useLibraryPlaylists(playlists, "all");
   // Per-profile toggle: hide the Spotify entry from the sidebar so
   // users who don't care about Spotify integration don't see it
   // every time. Default ON. Persisted in `ui.show_spotify`.
@@ -466,62 +471,40 @@ export function Sidebar({
               />
             ))}
 
-            {/* Real playlists */}
-            {playlists.map((pl) => (
+            {/* Real playlists, from the device and from the bound server.
+                One list: the server had its own section here, which is the
+                redundancy the unified library was aimed at — and it carried
+                hardcoded English, having been written when the feature was
+                off by default and unreachable in a release. */}
+            {libraryPlaylists.map((pl) => (
               <PlaylistSidebarRow
-                key={`pl-${pl.id}`}
+                key={`${pl.source}:${pl.id}`}
                 playlist={pl}
-                active={isPlaylistRowActive(pl.id)}
-                onClick={() => handleSelectPlaylist(pl.id)}
-                subtext={t("sidebar.myLibrary.playlistSubtext", {
-                  count: pl.track_count,
-                })}
+                active={
+                  pl.source === "remote"
+                    ? activeView === "remote-playlist" &&
+                      activeRemotePlaylistId === pl.id
+                    : isPlaylistRowActive(Number(pl.id))
+                }
+                onClick={() =>
+                  pl.source === "remote"
+                    ? navigateToRemotePlaylist(pl.id)
+                    : handleSelectPlaylist(Number(pl.id))
+                }
+                subtext={
+                  pl.pending_creation
+                    ? t("sidebar.myLibrary.playlistSubtextPending", {
+                        count: pl.track_count,
+                      })
+                    : t("sidebar.myLibrary.playlistSubtext", {
+                        count: pl.track_count,
+                      })
+                }
               />
             ))}
           </div>
         </div>
 
-        {/* ─── REMOTE SOURCE (sync_v2) ───
-            Only rendered when signed in to a native server. Header is the
-            server host; rows are its playlists, managed from the main UI
-            just like local ones. Not localized — it lives behind the same
-            off-by-default feature as RemoteServerCard, so no shipped build
-            reaches it and the seventeen locale files stay clean. */}
-        {remote.available && (
-          <div>
-            <div className="flex items-center gap-1.5 text-[10px] font-bold tracking-widest text-zinc-400 mb-1 px-2 uppercase">
-              <Server size={11} className="shrink-0" />
-              <span className="truncate">{remote.serverName ?? "Remote"}</span>
-            </div>
-            <div className="space-y-1">
-              {remote.playlists.length === 0 ? (
-                <p className="px-2 py-1 text-[11px] text-zinc-500">
-                  No playlists on this server yet.
-                </p>
-              ) : (
-                remote.playlists.map((pl) => (
-                  <SidebarRow
-                    key={`remote-${pl.id}`}
-                    icon={
-                      <div className="w-8 h-8 rounded-lg bg-emerald-100 text-emerald-600 flex items-center justify-center dark:bg-emerald-950/50 dark:text-emerald-400">
-                        <Server size={15} />
-                      </div>
-                    }
-                    label={pl.name}
-                    subtext={`${pl.track_count} tracks${
-                      pl.pending_creation ? " · not sent yet" : ""
-                    }`}
-                    active={
-                      activeView === "remote-playlist" &&
-                      activeRemotePlaylistId === pl.id
-                    }
-                    onClick={() => navigateToRemotePlaylist(pl.id)}
-                  />
-                ))
-              )}
-            </div>
-          </div>
-        )}
       </div>
 
       <CreatePlaylistModal
@@ -591,12 +574,17 @@ function PlaylistSidebarRow({
   onClick,
   subtext,
 }: {
-  playlist: Playlist;
+  playlist: LibraryPlaylistRow;
   active?: boolean;
   onClick?: () => void;
   subtext: string;
 }) {
-  const color = resolvePlaylistColor(playlist.color_id);
+  const remote = playlist.source === "remote";
+  // A server playlist carries no colour of its own; derived from its
+  // identifier, the same way the grid and the remote view do it.
+  const color = remote
+    ? colorForPlaylistId(playlist.id)
+    : resolvePlaylistColor(playlist.color_id);
   // Custom covers (today: smart playlists with a generated composite;
   // tomorrow: user-uploaded covers) preempt the icon + gradient tile.
   const coverUrl = resolveRemoteImage(playlist.cover_path, null);
@@ -611,7 +599,7 @@ function PlaylistSidebarRow({
     <div
       className={`w-8 h-8 rounded-lg flex items-center justify-center ${color.tileBg} ${color.tileText}`}
     >
-      <PlaylistIcon iconId={playlist.icon_id} size={16} />
+      <PlaylistIcon iconId={playlist.icon_id ?? "music"} size={16} />
     </div>
   );
   return (

--- a/src/components/views/LibraryView.tsx
+++ b/src/components/views/LibraryView.tsx
@@ -8,10 +8,8 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
-import {
-  PlaylistGrid,
-  type LibraryPlaylistRow,
-} from "./library/PlaylistGrid";
+import { PlaylistGrid } from "./library/PlaylistGrid";
+import { useLibraryPlaylists } from "../../hooks/useLibraryPlaylists";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   Music2,
@@ -214,9 +212,6 @@ export function LibraryView({
   const [tracks, setTracks] = useState<LibraryTrackRow[]>([]);
   const [albums, setAlbums] = useState<LibraryAlbumRow[]>([]);
   const librarySource = useLibrarySource();
-  // Read here as well as inside `SourceFilter`: the playlists tab merges the
-  // two halves in the browser and needs the remote one.
-  const remote = useRemoteSource();
   const [artists, setArtists] = useState<LibraryArtistRow[]>([]);
   const [genres, setGenres] = useState<GenreRow[]>([]);
   const [folders, setFolders] = useState<FolderRow[]>([]);
@@ -480,55 +475,12 @@ export function LibraryView({
       .catch((err) => console.error("[LibraryView] liked ids failed", err));
   }, [librariesSignature]);
 
-  // Playlists is the one tab whose two halves are merged in the browser: the
-  // grid already sorted there, so there is no SQL ordering to unify and a
-  // compound select would buy nothing.
-  const libraryPlaylists = useMemo<LibraryPlaylistRow[]>(() => {
-    const wanted = librarySource.source;
-    const rows: LibraryPlaylistRow[] = [];
-    if (wanted !== "remote") {
-      for (const playlist of userPlaylists) {
-        rows.push({
-          source: "local",
-          id: String(playlist.id),
-          name: playlist.name,
-          track_count: playlist.track_count,
-          total_duration_ms: playlist.total_duration_ms,
-          updated_at: playlist.updated_at,
-          position: playlist.position,
-          color_id: playlist.color_id,
-          icon_id: playlist.icon_id,
-          cover_path: playlist.cover_path,
-          pending_creation: false,
-        });
-      }
-    }
-    if (wanted !== "local" && remote.available) {
-      for (const playlist of remote.playlists) {
-        rows.push({
-          source: "remote",
-          id: playlist.id,
-          name: playlist.name,
-          track_count: playlist.track_count,
-          total_duration_ms: playlist.duration_ms,
-          // The server's summary carries neither; the grid files them last
-          // rather than reading a missing key as zero.
-          updated_at: null,
-          position: null,
-          color_id: "",
-          icon_id: null,
-          cover_path: null,
-          pending_creation: playlist.pending_creation,
-        });
-      }
-    }
-    return rows;
-  }, [
+  // Merged where they are read: both playlist surfaces already sorted in the
+  // browser, so there is nothing for a compound select to unify.
+  const libraryPlaylists = useLibraryPlaylists(
     userPlaylists,
-    remote.available,
-    remote.playlists,
     librarySource.source,
-  ]);
+  );
 
   // Per-tab header subtext uses the fetched data lengths since we
   // aggregate across all libraries (no single Library to read counts from).

--- a/src/components/views/library/PlaylistGrid.tsx
+++ b/src/components/views/library/PlaylistGrid.tsx
@@ -12,34 +12,8 @@ import {
 import { resolveRemoteImage } from "../../../lib/tauri/artwork";
 import { formatDuration } from "../../../lib/tauri/track";
 import type { SortState } from "../../../hooks/useSortMemory";
-import type { LibrarySource } from "../../../lib/tauri/browse";
+import type { LibraryPlaylistRow } from "../../../hooks/useLibraryPlaylists";
 import { EmptyState } from "../../common/EmptyState";
-
-/**
- * A playlist of the library, from either source.
- *
- * Built in the view rather than fetched: unlike the other three tabs, the
- * playlist grid already sorted in the browser, so there is no SQL ordering to
- * unify and nothing to gain from a compound select. The two shapes are merged
- * where they are read.
- */
-export interface LibraryPlaylistRow {
-  source: LibrarySource;
-  /** Local rowid as text, or the server's playlist identifier. */
-  id: string;
-  name: string;
-  track_count: number;
-  total_duration_ms: number;
-  /** Local only: the server's summary carries no modification time. */
-  updated_at: number | null;
-  /** Local only: the sidebar's manual order. */
-  position: number | null;
-  color_id: string;
-  icon_id: string | null;
-  cover_path: string | null;
-  /** Remote only: created here and not yet sent to the server. */
-  pending_creation: boolean;
-}
 
 interface PlaylistGridProps {
   /** User playlists only — smart ones live in Home's "Made for you". */

--- a/src/hooks/useLibraryPlaylists.ts
+++ b/src/hooks/useLibraryPlaylists.ts
@@ -1,0 +1,89 @@
+import { useMemo } from "react";
+import { useRemoteSource } from "./useRemoteSource";
+import type { LibrarySourceFilter } from "./useLibrarySource";
+import type { LibrarySource } from "../lib/tauri/browse";
+import type { Playlist } from "../lib/tauri/playlist";
+
+/**
+ * A playlist of the library, from either source.
+ *
+ * Built here rather than fetched: unlike the other three library tabs, both
+ * playlist surfaces already sorted in the browser, so there is no SQL ordering
+ * to unify and a compound select would buy nothing. The two shapes are merged
+ * where they are read.
+ */
+export interface LibraryPlaylistRow {
+  source: LibrarySource;
+  /** Local rowid as text, or the server's playlist identifier. */
+  id: string;
+  name: string;
+  track_count: number;
+  total_duration_ms: number;
+  /** Local only: the server's summary carries no modification time. */
+  updated_at: number | null;
+  /** Local only: the sidebar's manual order. */
+  position: number | null;
+  color_id: string;
+  icon_id: string | null;
+  cover_path: string | null;
+  /** Remote only: created here and not yet sent to the server. */
+  pending_creation: boolean;
+}
+
+/**
+ * The local playlists given, plus the bound server's, as one list.
+ *
+ * `localPlaylists` is passed in rather than read from the context because the
+ * two consumers want different sets: the library tab shows the user's own
+ * playlists only, the sidebar shows the smart ones too.
+ *
+ * `source` narrows the result. The sidebar passes `"all"` on purpose — it is
+ * navigation, not a filtered view, and hiding half of it because a tab is
+ * filtered would make the filter reach somewhere it was never pointed.
+ */
+export function useLibraryPlaylists(
+  localPlaylists: Playlist[],
+  source: LibrarySourceFilter,
+): LibraryPlaylistRow[] {
+  const remote = useRemoteSource();
+  return useMemo(() => {
+    const rows: LibraryPlaylistRow[] = [];
+    if (source !== "remote") {
+      for (const playlist of localPlaylists) {
+        rows.push({
+          source: "local",
+          id: String(playlist.id),
+          name: playlist.name,
+          track_count: playlist.track_count,
+          total_duration_ms: playlist.total_duration_ms,
+          updated_at: playlist.updated_at,
+          position: playlist.position,
+          color_id: playlist.color_id,
+          icon_id: playlist.icon_id,
+          cover_path: playlist.cover_path,
+          pending_creation: false,
+        });
+      }
+    }
+    if (source !== "local" && remote.available) {
+      for (const playlist of remote.playlists) {
+        rows.push({
+          source: "remote",
+          id: playlist.id,
+          name: playlist.name,
+          track_count: playlist.track_count,
+          total_duration_ms: playlist.duration_ms,
+          // The server's summary carries neither; consumers file them last
+          // rather than reading a missing key as zero.
+          updated_at: null,
+          position: null,
+          color_id: "",
+          icon_id: null,
+          cover_path: null,
+          pending_creation: playlist.pending_creation,
+        });
+      }
+    }
+    return rows;
+  }, [localPlaylists, remote.available, remote.playlists, source]);
+}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -222,7 +222,13 @@
       "playlistSubtext_other": "{{count}} مقطع",
       "playlistSubtext_two": "مقطعان",
       "playlistSubtext_few": "{{count}} مقاطع",
-      "playlistSubtext_many": "{{count}} مقطعًا"
+      "playlistSubtext_many": "{{count}} مقطعًا",
+      "playlistSubtextPending_zero": "0 مقطع · لم تُرسل بعد",
+      "playlistSubtextPending_one": "مقطع واحد · لم تُرسل بعد",
+      "playlistSubtextPending_other": "{{count}} مقطع · لم تُرسل بعد",
+      "playlistSubtextPending_two": "مقطعان · لم تُرسل بعد",
+      "playlistSubtextPending_few": "{{count}} مقاطع · لم تُرسل بعد",
+      "playlistSubtextPending_many": "{{count}} مقطعًا · لم تُرسل بعد"
     }
   },
   "topbar": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 Titel",
       "playlistSubtext_one": "{{count}} Titel",
-      "playlistSubtext_other": "{{count}} Titel"
+      "playlistSubtext_other": "{{count}} Titel",
+      "playlistSubtextPending_zero": "0 Titel · noch nicht gesendet",
+      "playlistSubtextPending_one": "{{count}} Titel · noch nicht gesendet",
+      "playlistSubtextPending_other": "{{count}} Titel · noch nicht gesendet"
     }
   },
   "topbar": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 tracks",
       "playlistSubtext_one": "{{count}} track",
-      "playlistSubtext_other": "{{count}} tracks"
+      "playlistSubtext_other": "{{count}} tracks",
+      "playlistSubtextPending_zero": "0 tracks · not sent yet",
+      "playlistSubtextPending_one": "{{count}} track · not sent yet",
+      "playlistSubtextPending_other": "{{count}} tracks · not sent yet"
     }
   },
   "topbar": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 pistas",
       "playlistSubtext_one": "{{count}} pista",
-      "playlistSubtext_other": "{{count}} pistas"
+      "playlistSubtext_other": "{{count}} pistas",
+      "playlistSubtextPending_zero": "0 pistas · aún sin enviar",
+      "playlistSubtextPending_one": "{{count}} pista · aún sin enviar",
+      "playlistSubtextPending_other": "{{count}} pistas · aún sin enviar"
     }
   },
   "topbar": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 titres",
       "playlistSubtext_one": "{{count}} titre",
-      "playlistSubtext_other": "{{count}} titres"
+      "playlistSubtext_other": "{{count}} titres",
+      "playlistSubtextPending_zero": "0 titres · pas encore envoyée",
+      "playlistSubtextPending_one": "{{count}} titre · pas encore envoyée",
+      "playlistSubtextPending_other": "{{count}} titres · pas encore envoyée"
     }
   },
   "topbar": {

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 ट्रैक",
       "playlistSubtext_one": "{{count}} ट्रैक",
-      "playlistSubtext_other": "{{count}} ट्रैक"
+      "playlistSubtext_other": "{{count}} ट्रैक",
+      "playlistSubtextPending_zero": "0 ट्रैक · अभी नहीं भेजी गई",
+      "playlistSubtextPending_one": "{{count}} ट्रैक · अभी नहीं भेजी गई",
+      "playlistSubtextPending_other": "{{count}} ट्रैक · अभी नहीं भेजी गई"
     }
   },
   "topbar": {

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 lagu",
       "playlistSubtext_one": "{{count}} lagu",
-      "playlistSubtext_other": "{{count}} lagu"
+      "playlistSubtext_other": "{{count}} lagu",
+      "playlistSubtextPending_zero": "0 lagu · belum dikirim",
+      "playlistSubtextPending_one": "{{count}} lagu · belum dikirim",
+      "playlistSubtextPending_other": "{{count}} lagu · belum dikirim"
     }
   },
   "topbar": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 brani",
       "playlistSubtext_one": "{{count}} brano",
-      "playlistSubtext_other": "{{count}} brani"
+      "playlistSubtext_other": "{{count}} brani",
+      "playlistSubtextPending_zero": "0 brani · non ancora inviata",
+      "playlistSubtextPending_one": "{{count}} brano · non ancora inviata",
+      "playlistSubtextPending_other": "{{count}} brani · non ancora inviata"
     }
   },
   "topbar": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0曲",
       "playlistSubtext_one": "{{count}}曲",
-      "playlistSubtext_other": "{{count}}曲"
+      "playlistSubtext_other": "{{count}}曲",
+      "playlistSubtextPending_zero": "0曲・未送信",
+      "playlistSubtextPending_one": "{{count}}曲・未送信",
+      "playlistSubtextPending_other": "{{count}}曲・未送信"
     }
   },
   "topbar": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0곡",
       "playlistSubtext_one": "{{count}}곡",
-      "playlistSubtext_other": "{{count}}곡"
+      "playlistSubtext_other": "{{count}}곡",
+      "playlistSubtextPending_zero": "0곡 · 아직 보내지 않음",
+      "playlistSubtextPending_one": "{{count}}곡 · 아직 보내지 않음",
+      "playlistSubtextPending_other": "{{count}}곡 · 아직 보내지 않음"
     }
   },
   "topbar": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 nummers",
       "playlistSubtext_one": "{{count}} nummer",
-      "playlistSubtext_other": "{{count}} nummers"
+      "playlistSubtext_other": "{{count}} nummers",
+      "playlistSubtextPending_zero": "0 nummers · nog niet verstuurd",
+      "playlistSubtextPending_one": "{{count}} nummer · nog niet verstuurd",
+      "playlistSubtextPending_other": "{{count}} nummers · nog niet verstuurd"
     }
   },
   "topbar": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 faixas",
       "playlistSubtext_one": "{{count}} faixa",
-      "playlistSubtext_other": "{{count}} faixas"
+      "playlistSubtext_other": "{{count}} faixas",
+      "playlistSubtextPending_zero": "0 faixas · ainda não enviada",
+      "playlistSubtextPending_one": "{{count}} faixa · ainda não enviada",
+      "playlistSubtextPending_other": "{{count}} faixas · ainda não enviada"
     }
   },
   "topbar": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 faixas",
       "playlistSubtext_one": "{{count}} faixa",
-      "playlistSubtext_other": "{{count}} faixas"
+      "playlistSubtext_other": "{{count}} faixas",
+      "playlistSubtextPending_zero": "0 faixas · ainda não enviada",
+      "playlistSubtextPending_one": "{{count}} faixa · ainda não enviada",
+      "playlistSubtextPending_other": "{{count}} faixas · ainda não enviada"
     }
   },
   "topbar": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -217,7 +217,12 @@
       "playlistSubtext_one": "{{count}} трек",
       "playlistSubtext_few": "{{count}} трека",
       "playlistSubtext_other": "{{count}} треков",
-      "playlistSubtext_many": "{{count}} треков"
+      "playlistSubtext_many": "{{count}} треков",
+      "playlistSubtextPending_zero": "0 треков · ещё не отправлен",
+      "playlistSubtextPending_one": "{{count}} трек · ещё не отправлен",
+      "playlistSubtextPending_few": "{{count}} трека · ещё не отправлен",
+      "playlistSubtextPending_other": "{{count}} треков · ещё не отправлен",
+      "playlistSubtextPending_many": "{{count}} треков · ещё не отправлен"
     }
   },
   "topbar": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 parça",
       "playlistSubtext_one": "{{count}} parça",
-      "playlistSubtext_other": "{{count}} parça"
+      "playlistSubtext_other": "{{count}} parça",
+      "playlistSubtextPending_zero": "0 parça · henüz gönderilmedi",
+      "playlistSubtextPending_one": "{{count}} parça · henüz gönderilmedi",
+      "playlistSubtextPending_other": "{{count}} parça · henüz gönderilmedi"
     }
   },
   "topbar": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 首曲目",
       "playlistSubtext_one": "{{count}} 首曲目",
-      "playlistSubtext_other": "{{count}} 首曲目"
+      "playlistSubtext_other": "{{count}} 首曲目",
+      "playlistSubtextPending_zero": "0 首曲目 · 尚未发送",
+      "playlistSubtextPending_one": "{{count}} 首曲目 · 尚未发送",
+      "playlistSubtextPending_other": "{{count}} 首曲目 · 尚未发送"
     }
   },
   "topbar": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -207,7 +207,10 @@
     "myLibrary": {
       "playlistSubtext_zero": "0 首曲目",
       "playlistSubtext_one": "{{count}} 曲目",
-      "playlistSubtext_other": "{{count}} 曲目"
+      "playlistSubtext_other": "{{count}} 曲目",
+      "playlistSubtextPending_zero": "0 首曲目 · 尚未傳送",
+      "playlistSubtextPending_one": "{{count}} 曲目 · 尚未傳送",
+      "playlistSubtextPending_other": "{{count}} 曲目 · 尚未傳送"
     }
   },
   "topbar": {


### PR DESCRIPTION
The first piece of the redundancy this lot was aimed at.

The sidebar had a **"Remote source" heading** with the server's playlists under it, beside the list holding the local ones — two lists of the same kind of thing, which is exactly what unifying the navigation was supposed to end. Server playlists now sit in the one playlist list, with the same chip the library grid uses and a colour derived from their identifier, as the grid and the remote view already did.

## The filter deliberately does not reach the sidebar

It is navigation, not a filtered view. Narrowing a tab to one source must not empty half of the thing you navigate with.

## A shipped bug the section was hiding

That section carried **hardcoded English** — "No playlists on this server yet", "N tracks", "not sent yet" — behind a comment explaining that localisation was unnecessary because the feature was off by default and no released build could reach it.

The comment outlived the flag flip that put `sync_v2` in the default feature set on 17 August. Nothing pointed it out because that section was the only surface those strings had. The pending-creation subtext is now a key, and it carries exactly the plural categories each locale already declares for the count phrasing it extends — derived from each file rather than guessed.

## Shared merge

The merge moved into a hook the sidebar and the library tab share, so the two cannot drift on what a playlist row is. They pass different local lists on purpose: the tab shows the user's own playlists, the sidebar shows the smart ones too.

## Checks

`typecheck`, `lint`, `cargo fmt --check`. No Rust touched.

## What is left of lot 1

The three twin detail views — `RemoteAlbumView`, `RemoteArtistView`, `RemotePlaylistView`, 1 713 lines between them. Those need the local views to accept a source, which is a larger change than this one and belongs in its own PR per view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les playlists locales et distantes sont regroupées dans une liste unique dans la barre latérale.
  * Les playlists distantes sont identifiées par une puce et une couleur distincte.
  * Le filtre de source reste limité aux vues de bibliothèque.

* **Améliorations**
  * Affichage du nombre de pistes et de l’état de synchronisation en attente.
  * Ajout des traductions correspondantes dans les langues prises en charge.
  * Suppression de la section « Remote source » dédiée.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->