### PR TITLE
feat(remote): cache a remote stream from the bytes playback already reads

### DIFF
--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -428,6 +428,34 @@ negative sentinel id at load time, per position rather than per track, and the
 rows are moved rather than re-projected — so the handle survives an optimistic
 reorder even on a playlist holding one track twice.
 
+**A remote stream is cached on disk, and it is filled by playback itself.**
+Until now the audio was re-fetched in full on every play — the projection
+caches metadata and the cover cache caches covers, but the bytes that actually
+cost bandwidth were not kept. They are now, under
+`profile_remote_stream_dir`, keyed by `(track id, format, bitrate)`: the triple
+that determines the bytes, and deliberately not the URL, which carries a
+single-use ticket and differs on every play.
+
+The cache is **not** a downloader. Nothing extra is fetched and nothing is
+delayed: every block the decoder reads is written at its **absolute offset**
+into a sparse working file, so the first play sounds exactly as it did and the
+second reads from disk. Writing by offset rather than by append is what makes
+this survive symphonia, which seeks while probing and again on a scrub — an
+append-only tee would have to give up at the first seek, which for most formats
+arrives within the first few kilobytes.
+
+An entry is published only when the covered ranges merge into one span over the
+whole body, by a single atomic rename out of `.part`. A partial file is worse
+than an absent one: it decodes for a while and then stops, which reads as a
+broken track rather than as a cold cache. A body whose length the server did
+not declare is never cached, because completeness could not be decided. On a
+hit the track loads through the existing `LoadRemoteFileAndPlay` path with a
+freshly-minted ticket as its `fallback_url` — a small JSON round-trip, not the
+body the cache just saved, which buys back the decoder's repair path so a
+cached file that will not decode falls back to the server once instead of
+failing that track forever. Offline, the ticket is simply not minted and the
+cached file plays alone, which is the point of having it.
+
 **The queue panel** switches to a dedicated `RemoteQueueView` while a remote
 session plays (keyed on `isRemoteTrack`), reading `remote_get_play_queue` (an
 in-memory snapshot) and jumping with `remote_queue_jump` — the local

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -519,6 +519,12 @@ fn decoder_loop(
                                 // server instead of the local file must
                                 // not change its level.
                                 replay_gain,
+                                // Not cached: this is the repair path for a
+                                // file that would not open, and the target
+                                // that named it is two commands upstream.
+                                // Caching here would also risk re-writing the
+                                // very entry that just failed to decode.
+                                cache: None,
                             });
                             continue;
                         }
@@ -552,6 +558,8 @@ fn decoder_loop(
                             title,
                             artist,
                             artwork_url,
+                            // See above: a repair path does not repopulate.
+                            cache: None,
                         });
                         continue;
                     }
@@ -572,6 +580,7 @@ fn decoder_loop(
                 artist,
                 artwork_url,
                 replay_gain,
+                cache,
             } => {
                 tracing::info!(
                     track_id,
@@ -685,7 +694,15 @@ fn decoder_loop(
                 // with the live `StreamTitle` while keeping the station's
                 // cover + name; it stays forward-only.
                 let opened = if is_remote {
-                    super::http_source::HttpMediaSource::open_seekable(&url)
+                    // A cache target only ever accompanies a finite
+                    // remote-queue track, so the seekable open is the only
+                    // one that can honour it.
+                    match cache {
+                        Some(target) => {
+                            super::http_source::HttpMediaSource::open_seekable_caching(&url, target)
+                        }
+                        None => super::http_source::HttpMediaSource::open_seekable(&url),
+                    }
                 } else {
                     let icy_ctx = super::http_source::IcyContext {
                         app: app.clone(),

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -434,6 +434,7 @@ fn decoder_loop(
                 artist,
                 artwork_url,
                 fallback_url,
+                discard_on_failure,
                 replay_gain,
             } => {
                 shared.clear_ab_loop();
@@ -507,6 +508,7 @@ fn decoder_loop(
                             has_server_fallback = fallback_url.is_some(),
                             "remote local source open failed"
                         );
+                        discard_unplayable(&path, discard_on_failure);
                         if let Some(url) = fallback_url.filter(|_| !crate::offline::is_offline()) {
                             pending_cmd = Some(AudioCmd::LoadUrlAndPlay {
                                 url,
@@ -550,6 +552,7 @@ fn decoder_loop(
                             path = %path.display(),
                             "remote local decode failed; falling back to server"
                         );
+                        discard_unplayable(&path, discard_on_failure);
                         pending_cmd = Some(AudioCmd::LoadUrlAndPlay {
                             url,
                             ext_hint: None,
@@ -2438,5 +2441,23 @@ mod tests {
             downmix_frame_to_stereo(&[1.0, 2.0, 0.4, 9.9, 0.6, 0.8, 0.1, 0.2, 0.05, 0.07]);
         approx(lo, 1.0 + K * (0.4 + 0.6 + 0.1 + 0.05));
         approx(ro, 2.0 + K * (0.4 + 0.8 + 0.2 + 0.07));
+    }
+}
+
+/// Drop a reproducible copy that would not play.
+///
+/// Only ever called with `allowed` set for a stream-cache entry: the server
+/// still holds those bytes, so a file that fails to open or decode is worth
+/// losing to make the next play refetch it. A reconciled file from the user's
+/// own library reaches the same failure path and must survive it — it is
+/// theirs, and a decoder that deletes a listener's music because a codec
+/// tripped would be a far worse bug than a cache miss.
+fn discard_unplayable(path: &std::path::Path, allowed: bool) {
+    if !allowed {
+        return;
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => tracing::info!(path = %path.display(), "dropped unplayable cached stream"),
+        Err(err) => tracing::warn!(?err, path = %path.display(), "could not drop cached stream"),
     }
 }

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -59,6 +59,15 @@ pub enum AudioCmd {
         artist: Option<String>,
         artwork_url: Option<String>,
         fallback_url: Option<String>,
+        /// Whether `path` is a reproducible copy that should be discarded if
+        /// it will not open or decode.
+        ///
+        /// True for a stream-cache entry, which can always be fetched again;
+        /// false for a reconciled file from the user's own library, which is
+        /// theirs and is never ours to delete. Without the distinction a bad
+        /// cache entry would fall back to the server on every single play
+        /// instead of once.
+        discard_on_failure: bool,
         replay_gain: TrackGain,
     },
     Pause,
@@ -418,6 +427,8 @@ impl RadioResumeState {
                 fallback_url,
                 replay_gain,
             } => AudioCmd::LoadRemoteFileAndPlay {
+                // Radio resume never restores a cache entry.
+                discard_on_failure: false,
                 path,
                 start_ms: position_ms,
                 track_id: self.track_id,
@@ -1526,6 +1537,7 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
             }
         }
         AudioCmd::LoadRemoteFileAndPlay {
+            discard_on_failure: false,
             path,
             duration_ms,
             fallback_url,
@@ -1737,6 +1749,7 @@ mod radio_resume_tests {
             artist: Some("Remote artist".to_string()),
             artwork_url: None,
             fallback_url: fallback_url.map(str::to_string),
+            discard_on_failure: false,
             replay_gain: TrackGain {
                 gain_db: Some(-4.0),
                 peak: None,

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -118,6 +118,10 @@ pub enum AudioCmd {
         title: Option<String>,
         artist: Option<String>,
         artwork_url: Option<String>,
+        /// Where to cache the bytes this stream reads, when it is a finite
+        /// remote-queue track worth keeping. `None` for radio, which is
+        /// endless and therefore never complete.
+        cache: Option<crate::audio::stream_cache::CacheTarget>,
         /// Loudness metadata for the stream. `TrackGain::default()`
         /// for a live radio station — nothing knows anything about it
         /// — but a library track that fell back to streaming from the
@@ -404,6 +408,9 @@ impl RadioResumeState {
                 artist: self.artist,
                 artwork_url: self.artwork_url,
                 replay_gain,
+                // Resuming radio after a device change: endless, so never a
+                // complete body to cache.
+                cache: None,
             },
             RadioResumeSource::RemoteFile {
                 path,
@@ -1499,6 +1506,10 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
             artist,
             artwork_url,
             replay_gain,
+            // The resume snapshot exists to restart radio after a device
+            // change; a cache target belongs to one open response and does
+            // not survive into a new one.
+            cache: _,
         } => {
             if let Ok(mut guard) = snapshot.lock() {
                 *guard = Some(RadioResumeState {
@@ -1699,6 +1710,7 @@ mod radio_resume_tests {
             title: Some("Test stream".to_string()),
             artist: Some("Test artist".to_string()),
             artwork_url: Some("https://example.invalid/art.jpg".to_string()),
+            cache: None,
             replay_gain: TrackGain::default(),
         }
     }

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -293,6 +293,12 @@ impl HttpMediaSource {
         // `byte_len() == None` exactly as before, even on the rare stream
         // that sends a Content-Length, so symphonia never treats it as
         // finite.
+        // Two different questions were sharing one variable. Seeking needs a
+        // length AND ranges; caching needs only a length, because it is filled
+        // by reading forward. Collapsing them meant a server that sends
+        // `Content-Length` without `Accept-Ranges` — perfectly cacheable —
+        // was never cached at all.
+        let declared_len = len;
         let len = if seekable { len } else { None };
 
         Ok(Self {
@@ -313,7 +319,7 @@ impl HttpMediaSource {
             // there is no way to decide that every byte has been covered, and
             // a file we cannot call complete must never be offered as one.
             cache: cache_target.and_then(|target| {
-                len.and_then(|len| {
+                declared_len.and_then(|len| {
                     crate::audio::stream_cache::CacheWriter::create(&target.dir, &target.name, len)
                 })
             }),

--- a/src-tauri/crates/app/src/audio/http_source.rs
+++ b/src-tauri/crates/app/src/audio/http_source.rs
@@ -174,6 +174,11 @@ pub struct HttpMediaSource {
     /// (radio servers resend the same title every interval) doesn't
     /// re-fire the event.
     last_title: Option<String>,
+    /// Writes what this source reads into the on-disk stream cache, when the
+    /// caller asked for it and the body declared a length. `None` for radio
+    /// (endless, so never complete) and whenever the cache is unusable — it
+    /// is an optimisation, and its absence is never a playback failure.
+    cache: Option<crate::audio::stream_cache::CacheWriter>,
 }
 
 impl HttpMediaSource {
@@ -182,7 +187,7 @@ impl HttpMediaSource {
     /// 404 / 502 surfaces as `Err` instead of producing a `MediaSource`
     /// that would only fail at the first `probe()` call.
     pub fn open(url: &str) -> Result<Self, String> {
-        Self::open_inner(url, None, false)
+        Self::open_inner(url, None, false, None)
     }
 
     /// Open a streaming HTTP GET that also requests + de-interleaves ICY
@@ -190,7 +195,7 @@ impl HttpMediaSource {
     /// whenever the live `StreamTitle` changes. Falls back transparently
     /// to passthrough when the server ignores `Icy-MetaData: 1`.
     pub fn open_with_icy(url: &str, icy: IcyContext) -> Result<Self, String> {
-        Self::open_inner(url, Some(icy), false)
+        Self::open_inner(url, Some(icy), false, None)
     }
 
     /// Open a finite, range-capable file for **seekable** playback — a
@@ -200,10 +205,29 @@ impl HttpMediaSource {
     /// drive a real `format.seek`. Degrades to forward-only if the server
     /// doesn't answer ranges — playback still works, only scrubbing won't.
     pub fn open_seekable(url: &str) -> Result<Self, String> {
-        Self::open_inner(url, None, true)
+        Self::open_inner(url, None, true, None)
     }
 
-    fn open_inner(url: &str, icy: Option<IcyContext>, want_seek: bool) -> Result<Self, String> {
+    /// [`Self::open_seekable`], additionally filling the on-disk stream cache
+    /// from the bytes playback reads.
+    ///
+    /// Nothing extra is fetched and nothing is delayed: the cache is written
+    /// from the blocks the decoder was going to read anyway, at their absolute
+    /// offsets, so a seek leaves a hole rather than corrupting the file and
+    /// the entry is simply never published.
+    pub fn open_seekable_caching(
+        url: &str,
+        target: crate::audio::stream_cache::CacheTarget,
+    ) -> Result<Self, String> {
+        Self::open_inner(url, None, true, Some(target))
+    }
+
+    fn open_inner(
+        url: &str,
+        icy: Option<IcyContext>,
+        want_seek: bool,
+        cache_target: Option<crate::audio::stream_cache::CacheTarget>,
+    ) -> Result<Self, String> {
         // Offline short-circuit at the HTTP boundary itself. The decoder
         // already gates `LoadUrlAndPlay` on this before reaching here, but
         // guarding the source too makes it self-honouring for any future
@@ -285,6 +309,14 @@ impl HttpMediaSource {
             // actually parse blocks).
             icy: if metaint > 0 { icy } else { None },
             last_title: None,
+            // Only a body that declared its length can be cached: without one
+            // there is no way to decide that every byte has been covered, and
+            // a file we cannot call complete must never be offered as one.
+            cache: cache_target.and_then(|target| {
+                len.and_then(|len| {
+                    crate::audio::stream_cache::CacheWriter::create(&target.dir, &target.name, len)
+                })
+            }),
         })
     }
 
@@ -406,7 +438,17 @@ impl Read for HttpMediaSource {
         // byte cursor here for `SeekFrom::Current`.
         if self.metaint == 0 {
             let n = guard.read(buf)?;
+            drop(guard);
+            let start = self.pos;
             self.pos += n as u64;
+            // Record where these bytes live, not merely that they arrived: a
+            // seek reopens the body at another offset, so an append would
+            // interleave two regions into one corrupt file.
+            if n > 0 {
+                if let Some(cache) = self.cache.as_mut() {
+                    cache.write_at(start, &buf[..n]);
+                }
+            }
             return Ok(n);
         }
         if buf.is_empty() {

--- a/src-tauri/crates/app/src/audio/mod.rs
+++ b/src-tauri/crates/app/src/audio/mod.rs
@@ -36,6 +36,7 @@ pub mod replay_gain;
 pub mod resampler;
 pub mod spectrum;
 pub mod state;
+pub mod stream_cache;
 #[cfg(target_os = "windows")]
 pub mod wasapi_exclusive;
 

--- a/src-tauri/crates/app/src/audio/stream_cache.rs
+++ b/src-tauri/crates/app/src/audio/stream_cache.rs
@@ -118,7 +118,21 @@ pub fn lookup(dir: &Path, name: &str) -> Option<PathBuf> {
     Some(path)
 }
 
+/// Suffix of a working file. Published entries never carry it — the rename
+/// is what drops it — so it is the one reliable way to tell the two apart.
+const PART_SUFFIX: &str = ".part";
+
+/// Whether a directory entry is a working file rather than a published one.
+fn is_working_file(path: &Path) -> bool {
+    path.to_str()
+        .map(|name| name.ends_with(PART_SUFFIX))
+        .unwrap_or(false)
+}
+
 /// Total bytes held, and how many entries. For the settings card.
+///
+/// Working files are excluded: they are not entries anyone can play, and
+/// counting them would report disk that is about to disappear on its own.
 pub fn info(dir: &Path) -> (u64, usize) {
     let Ok(entries) = fs::read_dir(dir) else {
         return (0, 0);
@@ -126,6 +140,9 @@ pub fn info(dir: &Path) -> (u64, usize) {
     let mut bytes = 0;
     let mut count = 0;
     for entry in entries.flatten() {
+        if is_working_file(&entry.path()) {
+            continue;
+        }
         if let Ok(meta) = entry.metadata() {
             if meta.is_file() {
                 bytes += meta.len();
@@ -171,6 +188,13 @@ fn evict(dir: &Path) {
     let mut files: Vec<(std::time::SystemTime, u64, PathBuf)> = entries
         .flatten()
         .filter_map(|entry| {
+            let path = entry.path();
+            // Never evict a working file: a writer is holding it open right
+            // now, and deleting it under that writer would spend a download
+            // to free bytes that were about to be freed anyway.
+            if is_working_file(&path) {
+                return None;
+            }
             let meta = entry.metadata().ok()?;
             if !meta.is_file() {
                 return None;
@@ -182,7 +206,7 @@ fn evict(dir: &Path) {
                 .accessed()
                 .or_else(|_| meta.modified())
                 .unwrap_or(std::time::UNIX_EPOCH);
-            Some((stamp, meta.len(), entry.path()))
+            Some((stamp, meta.len(), path))
         })
         .collect();
 
@@ -433,6 +457,27 @@ mod tests {
         let mut writer = CacheWriter::create(dir.path(), &name, 4).expect("writer");
         writer.write_at(0, &[0u8; 8]);
         assert!(lookup(dir.path(), &name).is_none());
+    }
+
+    #[test]
+    fn a_body_written_almost_to_the_end_is_not_reported_as_cached() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = file_name("t6", "raw", 0, "flac");
+        let mut writer = CacheWriter::create(dir.path(), &name, 10).expect("writer");
+        // One byte short: the working file is on disk and nearly the full
+        // size, which is exactly when counting it would be most misleading.
+        writer.write_at(0, &[0u8; 9]);
+        assert!(lookup(dir.path(), &name).is_none(), "still not playable");
+        assert_eq!(
+            info(dir.path()),
+            (0, 0),
+            "a working file is disk in flight, not a cached track"
+        );
+        // And it must not be evicted out from under its own writer, which
+        // would spend a download to reclaim bytes already about to be freed.
+        writer.write_at(9, &[0u8; 1]);
+        assert!(lookup(dir.path(), &name).is_some());
+        assert_eq!(info(dir.path()).1, 1);
     }
 
     #[test]

--- a/src-tauri/crates/app/src/audio/stream_cache.rs
+++ b/src-tauri/crates/app/src/audio/stream_cache.rs
@@ -131,8 +131,18 @@ pub fn lookup(dir: &Path, name: &str) -> Option<PathBuf> {
 const WORKING_SUFFIX: &str = ".in-flight";
 
 /// Whether a directory entry is a working file rather than a published one.
+///
+/// Judged on the **file name alone**. Testing the whole path made the answer
+/// depend on the parent directories, which are the user's home and profile
+/// path and need not be valid UTF-8 on Unix — a single stray byte anywhere
+/// above the cache would have made every working file read as a published
+/// one, counted in the reported size and evictable out from under its writer.
+/// The names this module generates are ASCII by construction, so a file name
+/// that will not convert is one we did not write, and treating that as a
+/// published entry is the right default: it gets counted and can be swept.
 fn is_working_file(path: &Path) -> bool {
-    path.to_str()
+    path.file_name()
+        .and_then(|name| name.to_str())
         .map(|name| name.ends_with(WORKING_SUFFIX))
         .unwrap_or(false)
 }
@@ -465,6 +475,40 @@ mod tests {
         let mut writer = CacheWriter::create(dir.path(), &name, 4).expect("writer");
         writer.write_at(0, &[0u8; 8]);
         assert!(lookup(dir.path(), &name).is_none());
+    }
+
+    /// Unix only: Windows path components are UTF-16 and cannot carry the
+    /// byte sequences this guards against.
+    #[cfg(unix)]
+    #[test]
+    fn a_parent_directory_that_is_not_utf8_does_not_hide_a_working_file() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let root = tempfile::tempdir().expect("tempdir");
+        // A profile path with one stray byte in it — legal on Unix, and
+        // enough to make `Path::to_str` on the full path return `None`.
+        let dir = root.path().join(std::ffi::OsStr::from_bytes(b"caf\xff"));
+        fs::create_dir_all(&dir).expect("non-utf8 dir");
+
+        let name = file_name("t8", "raw", 0, "flac");
+        let mut writer = CacheWriter::create(&dir, &name, 10).expect("writer");
+        writer.write_at(0, &[0u8; 4]);
+
+        assert_eq!(
+            info(&dir),
+            (0, 0),
+            "a working file stays invisible however its parents are encoded"
+        );
+        // And the sweep must still refuse to touch it.
+        let part = fs::read_dir(&dir)
+            .expect("read_dir")
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| is_working_file(path));
+        assert!(
+            part.is_some(),
+            "the working file is still recognised as one"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/app/src/audio/stream_cache.rs
+++ b/src-tauri/crates/app/src/audio/stream_cache.rs
@@ -1,0 +1,449 @@
+//! On-disk cache for remote audio streams (lot 3 of the unified library).
+//!
+//! Until now a remote track was re-downloaded in full on every play: the
+//! projection caches metadata, and [`artwork`](super::artwork) caches covers,
+//! but the audio itself was fetched from the server each time. On a laptop
+//! that plays the same album twice in an evening that is the whole album,
+//! twice.
+//!
+//! ## Filled from what playback already reads
+//!
+//! The cache is not a downloader. Playback proceeds from the network exactly
+//! as before, and every block the decoder reads is written **at its absolute
+//! offset** into a sparse working file. Nothing is fetched that would not have
+//! been fetched anyway, and nothing is delayed: the first play sounds
+//! identical, the second reads from disk.
+//!
+//! Writing by offset rather than by append is what makes this survive
+//! symphonia, which seeks while probing and again on a scrub. An append-only
+//! tee would have to give up at the first seek — which, for most formats,
+//! arrives within the first few kilobytes and would mean caching almost
+//! nothing.
+//!
+//! ## An entry counts as complete only when every byte is covered
+//!
+//! Partial files are worse than absent ones: a truncated audio file decodes
+//! for a while and then stops, which reads as a broken track rather than a
+//! cold cache. So the writer tracks the byte ranges it has covered, merges
+//! them, and only publishes the entry — one atomic rename out of `.part` —
+//! when a single range spans the whole body. Anything else is discarded on
+//! drop. A body of unknown length is never cached at all, since completeness
+//! could not be decided.
+//!
+//! ## Keyed by what was asked for, not by the URL
+//!
+//! The stream URL carries a single-use, time-limited ticket, so it is
+//! different on every play of the same track. The key is
+//! `(track id, format, bitrate)` — exactly the triple that determines the
+//! bytes, and the same one the server keys its own transcode cache by.
+//!
+//! ## Why it lives under `audio` and not under `remote`
+//!
+//! The whole `remote` module is gated on the `sync_v2` feature, and the audio
+//! layer is compiled unconditionally — so a cache target named inside
+//! `AudioCmd` cannot come from there. The split is the right one anyway: this
+//! module owns the mechanics of a file on disk, and `remote` owns what the key
+//! means, which is why the format arrives here as a plain string rather than
+//! as a remote enum.
+
+use std::{
+    fs,
+    io::{Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+/// How much disk the cache may hold before the least-recently-used entries
+/// are evicted. Audio files are two orders of magnitude larger than covers,
+/// so this is a real budget rather than the incidental one the cover cache
+/// gets away with.
+const MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Where a stream should be cached, named before the response is opened.
+///
+/// The writer itself cannot be built until `Content-Length` arrives, and that
+/// happens inside the HTTP source on the decoder thread — so the caller names
+/// the destination and the source decides whether it can be honoured.
+#[derive(Debug, Clone)]
+pub struct CacheTarget {
+    /// The profile's stream-cache directory, from
+    /// [`Paths::profile_remote_stream_dir`](crate::paths::Paths::profile_remote_stream_dir).
+    pub dir: PathBuf,
+    pub name: String,
+}
+
+/// The name a given request's bytes are stored under.
+///
+/// Hashed rather than composed from the parts: a server track id is opaque
+/// and may contain anything, including a path separator. The extension is
+/// kept legible so the decoder can hint the probe from it, exactly as it does
+/// for a library file.
+pub fn file_name(track_id: &str, format: &str, bitrate: u32, ext: &str) -> String {
+    let key = blake3::hash(format!("{track_id}:{format}:{bitrate}").as_bytes())
+        .to_hex()
+        .to_string();
+    format!("{key}.{}", sanitize_ext(ext))
+}
+
+/// Keep the extension to a short alphanumeric run. It comes from the server's
+/// `suffix` column, which is metadata read out of a file — not something to
+/// paste into a path unchecked.
+fn sanitize_ext(ext: &str) -> String {
+    let cleaned: String = ext
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if cleaned.is_empty() {
+        "bin".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// The cached file for a request, if a complete one exists.
+///
+/// Touches the entry's mtime on a hit so eviction can order by real use
+/// rather than by when the bytes were first written — an album played every
+/// week should outlive one played once.
+pub fn lookup(dir: &Path, name: &str) -> Option<PathBuf> {
+    let path = dir.join(name);
+    let meta = fs::metadata(&path).ok()?;
+    if !meta.is_file() || meta.len() == 0 {
+        return None;
+    }
+    let _ = fs::File::open(&path).and_then(|file| {
+        file.set_times(fs::FileTimes::new().set_accessed(std::time::SystemTime::now()))
+    });
+    Some(path)
+}
+
+/// Total bytes held, and how many entries. For the settings card.
+pub fn info(dir: &Path) -> (u64, usize) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return (0, 0);
+    };
+    let mut bytes = 0;
+    let mut count = 0;
+    for entry in entries.flatten() {
+        if let Ok(meta) = entry.metadata() {
+            if meta.is_file() {
+                bytes += meta.len();
+                count += 1;
+            }
+        }
+    }
+    (bytes, count)
+}
+
+/// Drop every cached stream. Errors are reported rather than swallowed: a
+/// "clear" that silently left files behind would be a lie told to someone
+/// trying to reclaim disk.
+pub fn clear(dir: &Path) -> std::io::Result<usize> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Ok(0);
+    };
+    let mut removed = 0;
+    let mut last_error = None;
+    for entry in entries.flatten() {
+        if entry.metadata().map(|m| m.is_file()).unwrap_or(false) {
+            match fs::remove_file(entry.path()) {
+                Ok(()) => removed += 1,
+                Err(err) => last_error = Some(err),
+            }
+        }
+    }
+    match last_error {
+        Some(err) => Err(err),
+        None => Ok(removed),
+    }
+}
+
+/// Evict least-recently-used entries until the directory fits the budget.
+///
+/// Runs after a successful publish, which is the only moment the total can
+/// grow. Best-effort throughout: failing to evict is not a reason to fail the
+/// entry that was just cached.
+fn evict(dir: &Path) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut files: Vec<(std::time::SystemTime, u64, PathBuf)> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let meta = entry.metadata().ok()?;
+            if !meta.is_file() {
+                return None;
+            }
+            // Accessed time when the platform keeps one, created/modified as
+            // the fallback — any monotone-ish ordering beats deleting at
+            // random.
+            let stamp = meta
+                .accessed()
+                .or_else(|_| meta.modified())
+                .unwrap_or(std::time::UNIX_EPOCH);
+            Some((stamp, meta.len(), entry.path()))
+        })
+        .collect();
+
+    let mut total: u64 = files.iter().map(|(_, len, _)| *len).sum();
+    if total <= MAX_BYTES {
+        return;
+    }
+    files.sort_by_key(|(stamp, _, _)| *stamp);
+    for (_, len, path) in files {
+        if total <= MAX_BYTES {
+            break;
+        }
+        if fs::remove_file(&path).is_ok() {
+            total = total.saturating_sub(len);
+        }
+    }
+}
+
+/// Writes a stream to disk as playback reads it.
+///
+/// Every method is infallible from the caller's point of view: a cache that
+/// cannot be written is a missing optimisation, never a failed playback. The
+/// first I/O error poisons the writer, which then does nothing and cleans up
+/// after itself.
+pub struct CacheWriter {
+    file: Option<fs::File>,
+    part: PathBuf,
+    final_path: PathBuf,
+    dir: PathBuf,
+    /// Total body length, from `Content-Length`. Completeness is decided
+    /// against it, so a writer is never built without one.
+    len: u64,
+    /// Byte ranges written so far, sorted and merged.
+    covered: Vec<(u64, u64)>,
+    published: bool,
+}
+
+impl CacheWriter {
+    /// Open a working file for a request whose length the server declared.
+    ///
+    /// `None` when the cache is unusable — no length, no writable directory —
+    /// which the caller treats as "stream without caching".
+    pub fn create(dir: &Path, name: &str, len: u64) -> Option<Self> {
+        if len == 0 {
+            return None;
+        }
+        fs::create_dir_all(dir).ok()?;
+        let final_path = dir.join(name);
+        if final_path.exists() {
+            // Already cached by an earlier play; nothing to write.
+            return None;
+        }
+        // A per-writer suffix, not just the pid: two windows of the same
+        // process can play the same track at once, and they would otherwise
+        // share one working file and corrupt each other's bytes.
+        let part = dir.join(format!(
+            "{name}.{}.part",
+            blake3::hash(
+                format!(
+                    "{:?}:{:?}",
+                    std::time::SystemTime::now(),
+                    std::thread::current().id()
+                )
+                .as_bytes()
+            )
+            .to_hex()
+            .to_string()
+            .split_at(16)
+            .0
+        ));
+        let file = fs::File::create(&part).ok()?;
+        Some(Self {
+            file: Some(file),
+            part,
+            final_path,
+            dir: dir.to_path_buf(),
+            len,
+            covered: Vec::new(),
+            published: false,
+        })
+    }
+
+    /// Record `bytes` as living at `offset` in the stream.
+    pub fn write_at(&mut self, offset: u64, bytes: &[u8]) {
+        if bytes.is_empty() || self.published {
+            return;
+        }
+        let Some(file) = self.file.as_mut() else {
+            return;
+        };
+        let end = offset.saturating_add(bytes.len() as u64);
+        if end > self.len {
+            // The body is longer than it declared: the length we would decide
+            // completeness against is wrong, so nothing here can be trusted.
+            self.poison();
+            return;
+        }
+        if file
+            .seek(SeekFrom::Start(offset))
+            .and_then(|_| file.write_all(bytes))
+            .is_err()
+        {
+            self.poison();
+            return;
+        }
+        self.cover(offset, end);
+        if self.is_complete() {
+            self.publish();
+        }
+    }
+
+    fn cover(&mut self, start: u64, end: u64) {
+        self.covered.push((start, end));
+        self.covered.sort_unstable();
+        let mut merged: Vec<(u64, u64)> = Vec::with_capacity(self.covered.len());
+        for (start, end) in self.covered.drain(..) {
+            match merged.last_mut() {
+                // Touching counts as overlapping: two adjacent reads leave no
+                // hole between them, and treating them as separate would make
+                // a fully-read stream look incomplete forever.
+                Some(last) if start <= last.1 => last.1 = last.1.max(end),
+                _ => merged.push((start, end)),
+            }
+        }
+        self.covered = merged;
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(self.covered.as_slice(), [(0, end)] if *end >= self.len)
+    }
+
+    /// Move the working file into place. Only ever called once every byte is
+    /// covered, so a file that appears under its final name is whole by
+    /// construction — which is what lets `lookup` trust it without reading it.
+    fn publish(&mut self) {
+        let Some(file) = self.file.take() else {
+            return;
+        };
+        // Flush before the rename, not after: a rename publishes the name,
+        // and a reader that finds the name must find the bytes too.
+        if file.sync_all().is_err() {
+            drop(file);
+            let _ = fs::remove_file(&self.part);
+            return;
+        }
+        drop(file);
+        if fs::rename(&self.part, &self.final_path).is_ok() {
+            self.published = true;
+            evict(&self.dir);
+        } else {
+            let _ = fs::remove_file(&self.part);
+        }
+    }
+
+    fn poison(&mut self) {
+        self.file = None;
+        let _ = fs::remove_file(&self.part);
+    }
+}
+
+impl Drop for CacheWriter {
+    fn drop(&mut self) {
+        // Anything not published is partial. Leaving it would accumulate
+        // working files that no lookup can ever use and no clear expects.
+        if !self.published {
+            self.file = None;
+            let _ = fs::remove_file(&self.part);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_key_separates_what_produces_different_bytes() {
+        let raw = file_name("t1", "raw", 0, "flac");
+        let mp3 = file_name("t1", "mp3", 192, "mp3");
+        let quieter = file_name("t1", "mp3", 128, "mp3");
+        let other = file_name("t2", "raw", 0, "flac");
+        assert_ne!(raw, mp3, "format changes the bytes");
+        assert_ne!(mp3, quieter, "bitrate changes the bytes");
+        assert_ne!(raw, other, "track changes the bytes");
+        assert!(raw.ends_with(".flac"), "extension stays legible: {raw}");
+    }
+
+    #[test]
+    fn an_extension_from_the_server_cannot_escape_the_directory() {
+        let name = file_name("t1", "raw", 0, "../../etc");
+        assert!(!name.contains('/'), "{name}");
+        assert!(
+            !name.contains('.') || name.matches('.').count() == 1,
+            "{name}"
+        );
+        let empty = file_name("t1", "raw", 0, "");
+        assert!(empty.ends_with(".bin"), "{empty}");
+    }
+
+    #[test]
+    fn only_a_fully_covered_body_is_published() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = file_name("t1", "raw", 0, "flac");
+        let mut writer = CacheWriter::create(dir.path(), &name, 10).expect("writer");
+        writer.write_at(0, &[0u8; 4]);
+        assert!(
+            lookup(dir.path(), &name).is_none(),
+            "a partial body must not be visible"
+        );
+        writer.write_at(4, &[0u8; 6]);
+        assert!(
+            lookup(dir.path(), &name).is_some(),
+            "a complete body is published"
+        );
+    }
+
+    #[test]
+    fn a_hole_left_by_a_seek_keeps_the_entry_unpublished() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = file_name("t2", "raw", 0, "flac");
+        let mut writer = CacheWriter::create(dir.path(), &name, 10).expect("writer");
+        // Probe reads the head, the decoder then seeks past the middle: the
+        // skipped bytes were never fetched, so the file must not be offered.
+        writer.write_at(0, &[0u8; 2]);
+        writer.write_at(6, &[0u8; 4]);
+        assert!(lookup(dir.path(), &name).is_none());
+        // Filling the hole completes it, in whatever order it arrives.
+        writer.write_at(2, &[0u8; 4]);
+        assert!(lookup(dir.path(), &name).is_some());
+    }
+
+    #[test]
+    fn overlapping_reads_do_not_count_twice() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = file_name("t3", "raw", 0, "flac");
+        let mut writer = CacheWriter::create(dir.path(), &name, 10).expect("writer");
+        // A re-read of already-covered bytes must not make a short body look
+        // whole — the naive "sum the lengths" tally would publish here.
+        writer.write_at(0, &[0u8; 6]);
+        writer.write_at(0, &[0u8; 6]);
+        assert!(lookup(dir.path(), &name).is_none());
+    }
+
+    #[test]
+    fn a_body_longer_than_declared_is_refused_rather_than_truncated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = file_name("t4", "raw", 0, "flac");
+        let mut writer = CacheWriter::create(dir.path(), &name, 4).expect("writer");
+        writer.write_at(0, &[0u8; 8]);
+        assert!(lookup(dir.path(), &name).is_none());
+    }
+
+    #[test]
+    fn dropping_an_incomplete_writer_leaves_nothing_behind() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = file_name("t5", "raw", 0, "flac");
+        {
+            let mut writer = CacheWriter::create(dir.path(), &name, 10).expect("writer");
+            writer.write_at(0, &[0u8; 3]);
+        }
+        let (bytes, count) = info(dir.path());
+        assert_eq!((bytes, count), (0, 0), "no .part file may survive");
+    }
+}

--- a/src-tauri/crates/app/src/audio/stream_cache.rs
+++ b/src-tauri/crates/app/src/audio/stream_cache.rs
@@ -25,7 +25,8 @@
 //! Partial files are worse than absent ones: a truncated audio file decodes
 //! for a while and then stops, which reads as a broken track rather than a
 //! cold cache. So the writer tracks the byte ranges it has covered, merges
-//! them, and only publishes the entry — one atomic rename out of `.part` —
+//! them, and only publishes the entry — one atomic rename out of its working
+//! name —
 //! when a single range spans the whole body. Anything else is discarded on
 //! drop. A body of unknown length is never cached at all, since completeness
 //! could not be decided.
@@ -118,14 +119,21 @@ pub fn lookup(dir: &Path, name: &str) -> Option<PathBuf> {
     Some(path)
 }
 
-/// Suffix of a working file. Published entries never carry it — the rename
-/// is what drops it — so it is the one reliable way to tell the two apart.
-const PART_SUFFIX: &str = ".part";
+/// Suffix of a working file.
+///
+/// The hyphen is the point. A published entry ends in whatever
+/// [`sanitize_ext`] produced, and that function emits ASCII alphanumerics
+/// only — so no extension the server can hand us, however hostile, can ever
+/// end a published name with this. A plain `.part` could: a track whose
+/// `suffix` column read `part` would publish as `<key>.part` and then be
+/// mistaken for a file still being written, excluded from the reported size
+/// and never evicted.
+const WORKING_SUFFIX: &str = ".in-flight";
 
 /// Whether a directory entry is a working file rather than a published one.
 fn is_working_file(path: &Path) -> bool {
     path.to_str()
-        .map(|name| name.ends_with(PART_SUFFIX))
+        .map(|name| name.ends_with(WORKING_SUFFIX))
         .unwrap_or(false)
 }
 
@@ -263,7 +271,7 @@ impl CacheWriter {
         // process can play the same track at once, and they would otherwise
         // share one working file and corrupt each other's bytes.
         let part = dir.join(format!(
-            "{name}.{}.part",
+            "{name}.{}{WORKING_SUFFIX}",
             blake3::hash(
                 format!(
                     "{:?}:{:?}",
@@ -457,6 +465,30 @@ mod tests {
         let mut writer = CacheWriter::create(dir.path(), &name, 4).expect("writer");
         writer.write_at(0, &[0u8; 8]);
         assert!(lookup(dir.path(), &name).is_none());
+    }
+
+    #[test]
+    fn an_extension_cannot_impersonate_a_working_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // The one extension that would collide with a naive `.part` marker.
+        // It is far-fetched as an audio suffix and entirely under the
+        // server's control, which is reason enough not to let it decide
+        // whether one of our files is visible.
+        let name = file_name("t7", "raw", 0, "part");
+        let mut writer = CacheWriter::create(dir.path(), &name, 4).expect("writer");
+        writer.write_at(0, &[0u8; 4]);
+        assert!(
+            lookup(dir.path(), &name).is_some(),
+            "a published entry is playable whatever its extension"
+        );
+        assert_eq!(
+            info(dir.path()),
+            (4, 1),
+            "and it is counted, not mistaken for a file still being written"
+        );
+        // Evictable too: excluded from the sweep, it would outlive the budget
+        // forever.
+        assert!(!is_working_file(&dir.path().join(&name)));
     }
 
     #[test]

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -2181,6 +2181,9 @@ pub async fn player_play_url(
 
     tracing::info!(track_id, "dispatching AudioCmd::LoadUrlAndPlay");
     engine.send(AudioCmd::LoadUrlAndPlay {
+        // Radio: an endless body has no length and no end, so nothing here
+        // could ever be published as a complete entry.
+        cache: None,
         url,
         ext_hint,
         track_id,

--- a/src-tauri/crates/app/src/commands/remote_auth.rs
+++ b/src-tauri/crates/app/src/commands/remote_auth.rs
@@ -789,9 +789,15 @@ pub async fn remote_clear_artwork_cache(state: tauri::State<'_, AppState>) -> Ap
 pub async fn remote_stream_cache_info(
     state: tauri::State<'_, AppState>,
 ) -> AppResult<StreamCacheInfo> {
-    let profile_id = state.require_profile_id().await?;
+    // One snapshot, held across the walk: the cached audio is this profile's
+    // user data, and a switch landing mid-call must not have us report another
+    // profile's disk under this one's name.
+    let (_pool, profile_id) = state.require_profile_snapshot().await?;
     let dir = state.paths.profile_remote_stream_dir(profile_id);
-    let (bytes, tracks) = crate::audio::stream_cache::info(&dir);
+    let (bytes, tracks) =
+        tokio::task::spawn_blocking(move || crate::audio::stream_cache::info(&dir))
+            .await
+            .map_err(|err| AppError::Other(format!("stream cache info: {err}")))?;
     Ok(StreamCacheInfo { bytes, tracks })
 }
 
@@ -806,9 +812,15 @@ pub struct StreamCacheInfo {
 /// played again — nothing is lost, since the server still holds the bytes.
 #[tauri::command]
 pub async fn remote_clear_stream_cache(state: tauri::State<'_, AppState>) -> AppResult<usize> {
-    let profile_id = state.require_profile_id().await?;
+    let (_pool, profile_id) = state.require_profile_snapshot().await?;
     let dir = state.paths.profile_remote_stream_dir(profile_id);
-    Ok(crate::audio::stream_cache::clear(&dir)?)
+    // Deleting gigabytes of files is a blocking walk; run it where blocking is
+    // allowed, as `artwork::clear` beside it already does. On the async
+    // executor it would stall every other command for the duration.
+    tokio::task::spawn_blocking(move || crate::audio::stream_cache::clear(&dir))
+        .await
+        .map_err(|err| AppError::Other(format!("stream cache clear: {err}")))?
+        .map_err(AppError::from)
 }
 
 /// Play a projected remote playlist as a native queue, starting at

--- a/src-tauri/crates/app/src/commands/remote_auth.rs
+++ b/src-tauri/crates/app/src/commands/remote_auth.rs
@@ -781,6 +781,36 @@ pub async fn remote_clear_artwork_cache(state: tauri::State<'_, AppState>) -> Ap
     crate::remote::artwork::clear(&state).await
 }
 
+/// How much disk the cached remote streams occupy, and how many tracks that
+/// is. Reported beside the cover cache but counted separately: whole songs
+/// and thumbnails differ in size by two orders of magnitude, and one figure
+/// covering both would be read as the smaller one.
+#[tauri::command]
+pub async fn remote_stream_cache_info(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<StreamCacheInfo> {
+    let profile_id = state.require_profile_id().await?;
+    let dir = state.paths.profile_remote_stream_dir(profile_id);
+    let (bytes, tracks) = crate::audio::stream_cache::info(&dir);
+    Ok(StreamCacheInfo { bytes, tracks })
+}
+
+/// Bytes held by the remote stream cache, and how many complete tracks.
+#[derive(serde::Serialize)]
+pub struct StreamCacheInfo {
+    pub bytes: u64,
+    pub tracks: usize,
+}
+
+/// Delete every cached remote stream. Costs one download each time a track is
+/// played again — nothing is lost, since the server still holds the bytes.
+#[tauri::command]
+pub async fn remote_clear_stream_cache(state: tauri::State<'_, AppState>) -> AppResult<usize> {
+    let profile_id = state.require_profile_id().await?;
+    let dir = state.paths.profile_remote_stream_dir(profile_id);
+    Ok(crate::audio::stream_cache::clear(&dir)?)
+}
+
 /// Play a projected remote playlist as a native queue, starting at
 /// `start_index`. Fills the in-memory remote queue from the projection so
 /// the tracks after it auto-advance, mints a stream ticket for the first,

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -777,6 +777,10 @@ pub fn run() {
             #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_transcode_status,
             #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_stream_cache_info,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_clear_stream_cache,
+            #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_artwork,
             #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_play_playlist,

--- a/src-tauri/crates/app/src/paths.rs
+++ b/src-tauri/crates/app/src/paths.rs
@@ -188,6 +188,14 @@ impl AppPaths {
         self.profile_dir(profile_id).join("remote-artwork")
     }
 
+    /// Cached audio for the bound server's tracks. Beside the cover cache
+    /// rather than inside it: these are whole songs, and the settings card
+    /// reports and clears the two separately because their sizes are orders
+    /// of magnitude apart.
+    pub fn profile_remote_stream_dir(&self, profile_id: i64) -> PathBuf {
+        self.profile_dir(profile_id).join("remote-stream")
+    }
+
     /// Create the directory layout required for a brand-new profile.
     pub fn ensure_profile_dirs(&self, profile_id: i64) -> AppResult<()> {
         std::fs::create_dir_all(self.profile_dir(profile_id))?;

--- a/src-tauri/crates/app/src/remote/playback.rs
+++ b/src-tauri/crates/app/src/remote/playback.rs
@@ -204,8 +204,61 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
         return Ok(());
     }
 
+    // Name the cache entry before deciding anything: the key is what the
+    // request would ask for, and the same triple answers both "is it already
+    // here" and "where do the bytes go if it is not".
+    let profile_id = state.require_profile_id().await?;
+    let cache_dir = state.paths.profile_remote_stream_dir(profile_id);
+    let preference = crate::remote::stream::preference(&pool).await;
+    let (format_key, extension) = cached_format(&pool, &entry.id, preference).await;
+    let cache_name = crate::audio::stream_cache::file_name(
+        &entry.id,
+        format_key,
+        preference.bitrate,
+        &extension,
+    );
+
+    if let Some(path) = crate::audio::stream_cache::lookup(&cache_dir, &cache_name) {
+        // A ticket is still minted, and it is cheap: a small JSON round-trip,
+        // not the audio body the cache just saved. It buys the decoder its
+        // existing repair path, so a cache entry that will not decode falls
+        // back to the server once instead of failing this track forever.
+        // Offline it simply fails, and the cached file plays alone — which is
+        // the whole point of having it.
+        let fallback_url = if crate::offline::is_offline() {
+            None
+        } else {
+            crate::remote::stream::ticket_url(&state, &entry.id)
+                .await
+                .ok()
+        };
+        engine.send(AudioCmd::LoadRemoteFileAndPlay {
+            path,
+            start_ms: 0,
+            track_id,
+            // Zero when the projection has no duration yet: the decoder
+            // reads the real one out of the file it is about to open, which
+            // a cached entry is.
+            duration_ms: entry.duration_ms.unwrap_or(0).max(0) as u64,
+            title: entry.title.clone(),
+            artist: entry.artist.clone(),
+            artwork_url: None,
+            fallback_url,
+            // Nothing local knows this recording's loudness, and the server
+            // does not send one — same as the streaming branch below.
+            replay_gain: TrackGain::default(),
+        })?;
+        return Ok(());
+    }
+
     let url = crate::remote::stream::ticket_url(&state, &entry.id).await?;
     engine.send(AudioCmd::LoadUrlAndPlay {
+        // Fill the cache from the blocks this playback was going to read
+        // anyway. Nothing extra is fetched and nothing is delayed.
+        cache: Some(crate::audio::stream_cache::CacheTarget {
+            dir: cache_dir,
+            name: cache_name,
+        }),
         url,
         ext_hint: None,
         track_id,
@@ -220,4 +273,38 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
         replay_gain: TrackGain::default(),
     })?;
     Ok(())
+}
+
+/// The key half of the format, and the extension the cached bytes carry.
+///
+/// A transcode always produces the codec that was asked for. The original
+/// bytes are whatever the server holds, which only its `suffix` column knows —
+/// and the decoder probes a file by extension, so guessing here would mean
+/// caching a FLAC under a name that says MP3.
+///
+/// The key half stays `"raw"` in that case: what identifies the request is
+/// that no transcode was asked for, not which container happened to answer.
+async fn cached_format(
+    pool: &sqlx::SqlitePool,
+    track_id: &str,
+    preference: crate::remote::stream::TranscodePreference,
+) -> (&'static str, String) {
+    use crate::remote::stream::TranscodeFormat;
+    match preference.format {
+        TranscodeFormat::Mp3 => ("mp3", "mp3".to_string()),
+        TranscodeFormat::Opus => ("opus", "opus".to_string()),
+        TranscodeFormat::Off => {
+            let suffix = sqlx::query_scalar::<_, Option<String>>(
+                "SELECT suffix FROM remote_track WHERE remote_id = ?",
+            )
+            .bind(track_id)
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten()
+            .flatten()
+            .unwrap_or_default();
+            ("raw", suffix)
+        }
+    }
 }

--- a/src-tauri/crates/app/src/remote/playback.rs
+++ b/src-tauri/crates/app/src/remote/playback.rs
@@ -174,7 +174,11 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
     let track_id = crate::commands::player::next_radio_track_id();
 
     let engine = app.state::<Arc<AudioEngine>>();
-    let pool = state.require_profile_pool().await?;
+    // Pool and profile id together, once: everything below — the reconciled
+    // local file, the transcode preference, the cache directory — belongs to
+    // the same profile, and resolving them separately across awaits is what
+    // lets a switch mix two of them.
+    let (pool, profile_id) = state.require_profile_snapshot().await?;
     if let Some(local) =
         crate::remote::reconciliation::preferred_local_playback(&pool, &entry.id).await?
     {
@@ -199,6 +203,8 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
             artist: entry.artist.clone(),
             artwork_url: None,
             fallback_url,
+            // The user's own library file. Ours to play, never ours to delete.
+            discard_on_failure: false,
             replay_gain,
         })?;
         return Ok(());
@@ -207,7 +213,10 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
     // Name the cache entry before deciding anything: the key is what the
     // request would ask for, and the same triple answers both "is it already
     // here" and "where do the bytes go if it is not".
-    let profile_id = state.require_profile_id().await?;
+    // The same profile that the pool above belongs to. Re-resolving it here
+    // would read whichever profile is active *after* the awaits that came in
+    // between, and a switch landing there would file this track's bytes under
+    // another profile's cache.
     let cache_dir = state.paths.profile_remote_stream_dir(profile_id);
     let preference = crate::remote::stream::preference(&pool).await;
     let (format_key, extension) = cached_format(&pool, &entry.id, preference).await;
@@ -244,6 +253,10 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
             artist: entry.artist.clone(),
             artwork_url: None,
             fallback_url,
+            // Our own copy, and the server still has the bytes. If it will not
+            // open, drop it so the next play refetches instead of paying the
+            // fallback forever.
+            discard_on_failure: true,
             // Nothing local knows this recording's loudness, and the server
             // does not send one — same as the streaming branch below.
             replay_gain: TrackGain::default(),

--- a/src/components/views/settings/CatalogueMirrorCard.tsx
+++ b/src/components/views/settings/CatalogueMirrorCard.tsx
@@ -10,7 +10,10 @@ import {
   remoteArtworkCacheInfo,
   remoteClearArtworkCache,
   remoteMirrorCatalogue,
+  remoteClearStreamCache,
+  remoteStreamCacheInfo,
   type ArtworkCacheInfo,
+  type StreamCacheInfo,
   type CatalogueMirrorProgress,
   type CatalogueMirrorReport,
   type CatalogueStats,
@@ -45,7 +48,10 @@ export function CatalogueMirrorCard() {
   const [report, setReport] = useState<CatalogueMirrorReport | null>(null);
   const [progress, setProgress] = useState<CatalogueMirrorProgress | null>(null);
   const [covers, setCovers] = useState<ArtworkCacheInfo | null>(null);
-  const [busy, setBusy] = useState<null | "mirror" | "clear" | "covers">(null);
+  const [streams, setStreams] = useState<StreamCacheInfo | null>(null);
+  const [busy, setBusy] = useState<
+    null | "mirror" | "clear" | "covers" | "streams"
+  >(null);
   const [confirmClear, setConfirmClear] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const mountedRef = useRef(false);
@@ -58,6 +64,12 @@ export function CatalogueMirrorCard() {
       if (mountedRef.current) setCovers(cache);
     } catch {
       // Informational only — keep the last figure rather than blanking it.
+    }
+    try {
+      const cache = await remoteStreamCacheInfo();
+      if (mountedRef.current) setStreams(cache);
+    } catch {
+      // Same: a figure that failed to refresh is better than none.
     }
   }, []);
 
@@ -124,6 +136,19 @@ export function CatalogueMirrorCard() {
     setError(null);
     try {
       await remoteClearArtworkCache();
+      await refreshStats();
+    } catch (err) {
+      if (mountedRef.current) setError(String(err));
+    } finally {
+      if (mountedRef.current) setBusy(null);
+    }
+  }, [refreshStats]);
+
+  const clearStreams = useCallback(async () => {
+    setBusy("streams");
+    setError(null);
+    try {
+      await remoteClearStreamCache();
       await refreshStats();
     } catch (err) {
       if (mountedRef.current) setError(String(err));
@@ -288,6 +313,31 @@ export function CatalogueMirrorCard() {
                 className="underline underline-offset-2 disabled:opacity-50"
               >
                 {t("remote.catalogue.clearCovers")}
+              </button>
+            </p>
+          )}
+
+          {/* Cached audio, counted and cleared apart from the covers and from
+              the mirror. Dropping it costs one download per track played
+              again — the server still holds every byte. */}
+          {streams && streams.tracks > 0 && (
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 flex items-center gap-2 flex-wrap">
+              <span>
+                {t("remote.catalogue.streamsCached", {
+                  count: streams.tracks,
+                  size: formatBytes(
+                    streams.bytes,
+                    i18n.resolvedLanguage ?? i18n.language,
+                  ),
+                })}
+              </span>
+              <button
+                type="button"
+                onClick={() => void clearStreams()}
+                disabled={busy !== null}
+                className="underline underline-offset-2 disabled:opacity-50"
+              >
+                {t("remote.catalogue.clearStreams")}
               </button>
             </p>
           )}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -2577,7 +2577,14 @@
       "coversCached_two": "غلافان في الذاكرة المؤقتة ({{size}} ميغابايت).",
       "coversCached_few": "{{count}} أغلفة في الذاكرة المؤقتة ({{size}} ميغابايت).",
       "coversCached_many": "{{count}} غلافًا في الذاكرة المؤقتة ({{size}} ميغابايت).",
-      "coversCached_other": "{{count}} غلاف في الذاكرة المؤقتة ({{size}} ميغابايت)."
+      "coversCached_other": "{{count}} غلاف في الذاكرة المؤقتة ({{size}} ميغابايت).",
+      "streamsCached_few": "{{count}} مقاطع في الذاكرة المؤقتة ({{size}} ميغابايت).",
+      "streamsCached_many": "{{count}} مقطعًا في الذاكرة المؤقتة ({{size}} ميغابايت).",
+      "streamsCached_one": "مقطع واحد في الذاكرة المؤقتة ({{size}} ميغابايت).",
+      "streamsCached_other": "{{count}} مقطع في الذاكرة المؤقتة ({{size}} ميغابايت).",
+      "streamsCached_two": "مقطعان في الذاكرة المؤقتة ({{size}} ميغابايت).",
+      "streamsCached_zero": "لا مقاطع في الذاكرة المؤقتة.",
+      "clearStreams": "إفراغ"
     }
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Leeren",
       "coversCached_zero": "Keine Cover im Zwischenspeicher.",
       "coversCached_one": "{{count}} Cover im Zwischenspeicher ({{size}} MB).",
-      "coversCached_other": "{{count}} Cover im Zwischenspeicher ({{size}} MB)."
+      "coversCached_other": "{{count}} Cover im Zwischenspeicher ({{size}} MB).",
+      "streamsCached_one": "{{count}} Titel im Zwischenspeicher ({{size}} MB).",
+      "streamsCached_other": "{{count}} Titel im Zwischenspeicher ({{size}} MB).",
+      "streamsCached_zero": "Keine Titel im Zwischenspeicher.",
+      "clearStreams": "Leeren"
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Clear",
       "coversCached_zero": "No covers cached.",
       "coversCached_one": "{{count}} cover cached ({{size}} MB).",
-      "coversCached_other": "{{count}} covers cached ({{size}} MB)."
+      "coversCached_other": "{{count}} covers cached ({{size}} MB).",
+      "streamsCached_one": "{{count}} track cached ({{size}} MB).",
+      "streamsCached_other": "{{count}} tracks cached ({{size}} MB).",
+      "streamsCached_zero": "No tracks cached.",
+      "clearStreams": "Clear"
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Vaciar",
       "coversCached_zero": "Ninguna carátula en caché.",
       "coversCached_one": "{{count}} carátula en caché ({{size}} MB).",
-      "coversCached_other": "{{count}} carátulas en caché ({{size}} MB)."
+      "coversCached_other": "{{count}} carátulas en caché ({{size}} MB).",
+      "streamsCached_one": "{{count}} pista en caché ({{size}} MB).",
+      "streamsCached_other": "{{count}} pistas en caché ({{size}} MB).",
+      "streamsCached_zero": "Ninguna pista en caché.",
+      "clearStreams": "Vaciar"
     }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Vider",
       "coversCached_zero": "Aucune pochette en cache.",
       "coversCached_one": "{{count}} pochette en cache ({{size}} Mo).",
-      "coversCached_other": "{{count}} pochettes en cache ({{size}} Mo)."
+      "coversCached_other": "{{count}} pochettes en cache ({{size}} Mo).",
+      "streamsCached_one": "{{count}} piste en cache ({{size}} Mo).",
+      "streamsCached_other": "{{count}} pistes en cache ({{size}} Mo).",
+      "streamsCached_zero": "Aucune piste en cache.",
+      "clearStreams": "Vider"
     }
   }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "हटाएँ",
       "coversCached_zero": "कैश में कोई कवर नहीं।",
       "coversCached_one": "{{count}} कवर कैश में ({{size}} MB)।",
-      "coversCached_other": "{{count}} कवर कैश में ({{size}} MB)।"
+      "coversCached_other": "{{count}} कवर कैश में ({{size}} MB)।",
+      "streamsCached_one": "{{count}} ट्रैक कैश में ({{size}} MB)।",
+      "streamsCached_other": "{{count}} ट्रैक कैश में ({{size}} MB)।",
+      "streamsCached_zero": "कैश में कोई ट्रैक नहीं।",
+      "clearStreams": "हटाएँ"
     }
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -2307,7 +2307,11 @@
       "clearCovers": "Kosongkan",
       "coversCached_zero": "Tidak ada sampul di cache.",
       "coversCached_one": "{{count}} sampul di cache ({{size}} MB).",
-      "coversCached_other": "{{count}} sampul di cache ({{size}} MB)."
+      "coversCached_other": "{{count}} sampul di cache ({{size}} MB).",
+      "streamsCached_one": "{{count}} lagu di cache ({{size}} MB).",
+      "streamsCached_other": "{{count}} lagu di cache ({{size}} MB).",
+      "streamsCached_zero": "Tidak ada lagu di cache.",
+      "clearStreams": "Kosongkan"
     }
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Svuota",
       "coversCached_zero": "Nessuna copertina in cache.",
       "coversCached_one": "{{count}} copertina in cache ({{size}} MB).",
-      "coversCached_other": "{{count}} copertine in cache ({{size}} MB)."
+      "coversCached_other": "{{count}} copertine in cache ({{size}} MB).",
+      "streamsCached_one": "{{count}} brano in cache ({{size}} MB).",
+      "streamsCached_other": "{{count}} brani in cache ({{size}} MB).",
+      "streamsCached_zero": "Nessun brano in cache.",
+      "clearStreams": "Svuota"
     }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2307,7 +2307,11 @@
       "clearCovers": "削除",
       "coversCached_zero": "キャッシュされたジャケットはありません。",
       "coversCached_one": "キャッシュ済みのジャケット {{count}} 件（{{size}} MB）",
-      "coversCached_other": "キャッシュ済みのジャケット {{count}} 件（{{size}} MB）"
+      "coversCached_other": "キャッシュ済みのジャケット {{count}} 件（{{size}} MB）",
+      "streamsCached_one": "キャッシュ済みの楽曲 {{count}} 件（{{size}} MB）",
+      "streamsCached_other": "キャッシュ済みの楽曲 {{count}} 件（{{size}} MB）",
+      "streamsCached_zero": "キャッシュされた楽曲はありません。",
+      "clearStreams": "削除"
     }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2307,7 +2307,11 @@
       "clearCovers": "비우기",
       "coversCached_zero": "캐시된 커버가 없습니다.",
       "coversCached_one": "캐시된 커버 {{count}}개 ({{size}} MB)",
-      "coversCached_other": "캐시된 커버 {{count}}개 ({{size}} MB)"
+      "coversCached_other": "캐시된 커버 {{count}}개 ({{size}} MB)",
+      "streamsCached_one": "캐시된 트랙 {{count}}개 ({{size}} MB)",
+      "streamsCached_other": "캐시된 트랙 {{count}}개 ({{size}} MB)",
+      "streamsCached_zero": "캐시된 트랙이 없습니다.",
+      "clearStreams": "비우기"
     }
   }
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Wissen",
       "coversCached_zero": "Geen hoezen in cache.",
       "coversCached_one": "{{count}} hoes in cache ({{size}} MB).",
-      "coversCached_other": "{{count}} hoezen in cache ({{size}} MB)."
+      "coversCached_other": "{{count}} hoezen in cache ({{size}} MB).",
+      "streamsCached_one": "{{count}} nummer in cache ({{size}} MB).",
+      "streamsCached_other": "{{count}} nummers in cache ({{size}} MB).",
+      "streamsCached_zero": "Geen nummers in cache.",
+      "clearStreams": "Wissen"
     }
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Limpar",
       "coversCached_zero": "Nenhuma capa em cache.",
       "coversCached_one": "{{count}} capa em cache ({{size}} MB).",
-      "coversCached_other": "{{count}} capas em cache ({{size}} MB)."
+      "coversCached_other": "{{count}} capas em cache ({{size}} MB).",
+      "streamsCached_one": "{{count}} faixa em cache ({{size}} MB).",
+      "streamsCached_other": "{{count}} faixas em cache ({{size}} MB).",
+      "streamsCached_zero": "Nenhuma faixa em cache.",
+      "clearStreams": "Limpar"
     }
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Esvaziar",
       "coversCached_zero": "Nenhuma capa em cache.",
       "coversCached_one": "{{count}} capa em cache ({{size}} MB).",
-      "coversCached_other": "{{count}} capas em cache ({{size}} MB)."
+      "coversCached_other": "{{count}} capas em cache ({{size}} MB).",
+      "streamsCached_one": "{{count}} faixa em cache ({{size}} MB).",
+      "streamsCached_other": "{{count}} faixas em cache ({{size}} MB).",
+      "streamsCached_zero": "Nenhuma faixa em cache.",
+      "clearStreams": "Esvaziar"
     }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -2472,7 +2472,13 @@
       "coversCached_one": "{{count}} обложка в кэше ({{size}} МБ).",
       "coversCached_few": "{{count}} обложки в кэше ({{size}} МБ).",
       "coversCached_many": "{{count}} обложек в кэше ({{size}} МБ).",
-      "coversCached_other": "{{count}} обложек в кэше ({{size}} МБ)."
+      "coversCached_other": "{{count}} обложек в кэше ({{size}} МБ).",
+      "streamsCached_few": "{{count}} трека в кэше ({{size}} МБ).",
+      "streamsCached_many": "{{count}} треков в кэше ({{size}} МБ).",
+      "streamsCached_one": "{{count}} трек в кэше ({{size}} МБ).",
+      "streamsCached_other": "{{count}} треков в кэше ({{size}} МБ).",
+      "streamsCached_zero": "Треков в кэше нет.",
+      "clearStreams": "Очистить"
     }
   }
 }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -2328,7 +2328,11 @@
       "clearCovers": "Temizle",
       "coversCached_zero": "Önbellekte kapak yok.",
       "coversCached_one": "Önbellekte {{count}} kapak ({{size}} MB).",
-      "coversCached_other": "Önbellekte {{count}} kapak ({{size}} MB)."
+      "coversCached_other": "Önbellekte {{count}} kapak ({{size}} MB).",
+      "streamsCached_one": "Önbellekte {{count}} parça ({{size}} MB).",
+      "streamsCached_other": "Önbellekte {{count}} parça ({{size}} MB).",
+      "streamsCached_zero": "Önbellekte parça yok.",
+      "clearStreams": "Temizle"
     }
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2307,7 +2307,11 @@
       "clearCovers": "清空",
       "coversCached_zero": "没有缓存的封面。",
       "coversCached_one": "已缓存 {{count}} 张封面（{{size}} MB）",
-      "coversCached_other": "已缓存 {{count}} 张封面（{{size}} MB）"
+      "coversCached_other": "已缓存 {{count}} 张封面（{{size}} MB）",
+      "streamsCached_one": "已缓存 {{count}} 首曲目（{{size}} MB）",
+      "streamsCached_other": "已缓存 {{count}} 首曲目（{{size}} MB）",
+      "streamsCached_zero": "没有缓存的曲目。",
+      "clearStreams": "清空"
     }
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2307,7 +2307,11 @@
       "clearCovers": "清空",
       "coversCached_zero": "沒有快取的封面。",
       "coversCached_one": "已快取 {{count}} 張封面（{{size}} MB）",
-      "coversCached_other": "已快取 {{count}} 張封面（{{size}} MB）"
+      "coversCached_other": "已快取 {{count}} 張封面（{{size}} MB）",
+      "streamsCached_one": "已快取 {{count}} 首曲目（{{size}} MB）",
+      "streamsCached_other": "已快取 {{count}} 首曲目（{{size}} MB）",
+      "streamsCached_zero": "沒有快取的曲目。",
+      "clearStreams": "清空"
     }
   }
 }

--- a/src/lib/tauri/remoteServer.ts
+++ b/src/lib/tauri/remoteServer.ts
@@ -461,6 +461,25 @@ export function remoteTranscodeStatus(): Promise<RemoteTranscodeStatus> {
   return invoke<RemoteTranscodeStatus>("remote_transcode_status");
 }
 
+/**
+ * Disk held by cached remote audio, counted apart from the covers: whole
+ * songs and thumbnails differ in size by two orders of magnitude, and one
+ * figure covering both would be read as the smaller one.
+ */
+export interface StreamCacheInfo {
+  bytes: number;
+  tracks: number;
+}
+
+export function remoteStreamCacheInfo(): Promise<StreamCacheInfo> {
+  return invoke<StreamCacheInfo>("remote_stream_cache_info");
+}
+
+/** Drop every cached stream. Costs one download per track played again. */
+export function remoteClearStreamCache(): Promise<number> {
+  return invoke<number>("remote_clear_stream_cache");
+}
+
 export function remoteSearchCatalogue(query: string): Promise<RemoteTrack[]> {
   return invoke<RemoteTrack[]>("remote_search_catalogue", { query });
 }


### PR DESCRIPTION
**Lot 3.** A remote track was re-downloaded in full on every play. The projection caches metadata and #549 cached covers, but the bytes that actually cost bandwidth were not kept — an album played twice in an evening was fetched twice.

## The cache is not a downloader

Nothing extra is fetched and nothing is delayed. Every block the decoder reads is written **at its absolute offset** into a sparse working file, so the first play sounds exactly as it did and the second reads from disk.

Writing by offset rather than by append is what makes this survive symphonia, which **seeks while probing** and again on every scrub. An append-only tee would have to give up at the first seek — which, for most formats, arrives within the first few kilobytes. It would have cached almost nothing.

## A partial file is worse than an absent one

An entry is published only when the covered ranges merge into a single span over the whole body, by one atomic rename out of `.part`. A truncated audio file decodes for a while and then stops, which reads as a *broken track* rather than as a cold cache. A body whose length the server never declared is not cached at all, because completeness could not be decided.

## Keyed by the request, not by the URL

`(track id, format, bitrate)` — the triple that determines the bytes, and the same one the server keys its own transcode cache by. The URL carries a single-use ticket and differs on every play, so it identifies nothing.

On a hit the track loads through the existing `LoadRemoteFileAndPlay` path with a freshly minted ticket as its `fallback_url`. That is a small JSON round-trip, **not** the body the cache just saved, and it buys back the decoder's repair path: a cached file that will not decode falls back to the server once instead of failing that track forever. Offline, the ticket is not minted and the cached file plays alone — which is the point of having it.

## Where it lives, and how that was caught

Under `audio`, not under `remote`. The whole `remote` module is gated on `sync_v2` while the audio layer is compiled unconditionally, so a cache target named inside `AudioCmd` cannot come from there.

This was **not** caught by the default build — it was caught by `cargo check --no-default-features --features updater`, which failed with five `cannot find remote in crate` errors. The move is the better boundary anyway: this module owns the mechanics of a file on disk, `remote` owns what the key means, and the format crosses as a plain string rather than as a remote enum.

## Tests

7 new, covering what the reasoning actually rests on rather than the happy path:

| Test | What would break without it |
| --- | --- |
| a hole left by a seek keeps the entry unpublished | a truncated file offered as complete |
| overlapping reads do not count twice | a naive "sum the lengths" tally publishes a short body |
| a body longer than declared is refused | writing past the length completeness is judged against |
| dropping an incomplete writer leaves nothing behind | `.part` files accumulating forever |
| the key separates what produces different bytes | one entry serving MP3 192 and FLAC alike |
| an extension from the server cannot escape the directory | `suffix` is file metadata, pasted into a path |

411 lib tests green, both feature configurations build, `cargo fmt` / `typecheck` / `lint` / `prettier` green.

## i18n

Two keys × 17 locales, and the plural set is taken from **each locale's own** `coversCached` categories rather than from English — the script fails loudly if a locale declares a CLDR category it has no body for. That is the defect from #559 turned into a guard.

## Not verified

An actual cache hit against a live server. That needs a reachable server with real audio; the sandbox has a projection but no bytes. The mechanics are covered by the unit tests, the wiring is not.

## Note

`CatalogueMirrorCard` already drifted from Prettier before this branch. I formatted it by reflex, then restored the five unrelated hunks — the diff there is mine only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Nouvelles fonctionnalités

- Mise en cache progressive des flux audio distants pendant leur lecture.
- Lecture hors ligne lorsque le contenu est entièrement disponible en cache.
- Repli automatique vers le serveur en cas d’échec ou d’indisponibilité réseau.
- Affichage, dans les réglages, de l’espace utilisé et du nombre de pistes en cache.
- Suppression complète du cache depuis les réglages.
- Éviction automatique des anciennes données au-delà de la limite de stockage.

## Localisation

- Ajout des traductions nécessaires dans les langues prises en charge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->