### PR TITLE
feat(remote): keep a server track on disk, and play one whose file is gone

### DIFF
--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -456,6 +456,43 @@ cached file that will not decode falls back to the server once instead of
 failing that track forever. Offline, the ticket is simply not minted and the
 cached file plays alone, which is the point of having it.
 
+**A track can be kept**, which is a different thing from being cached. The
+cache is filled without asking and evicted without asking; a download is
+chosen, lands in a managed folder the scanner never sees, and disappears only
+when its owner says so. It is deliberately **not** a local library track: no
+`track` row is created for it, so `remote_track_link` cannot describe it either
+— that table keys on `local_track_id REFERENCES track(id)` — and a download is
+recorded as what it is, a *remote* track that happens to be on this disk.
+
+Downloads are always the **original** bytes, whatever the transcode preference
+says. That preference exists to spend less bandwidth on a stream heard once;
+baking a lossy re-encode into a file someone chose to keep would make a
+bandwidth decision permanent, and silently. The file is hashed while it is
+written, in the same pass that copies it, which is what makes the plan's "free"
+reconciliation proof real: the server's own `full_hash` — not the library's
+`file_hash`, which covers a file the server has never seen — is in hand the
+moment a `track` row exists to attach it to, with no re-read.
+
+Playback prefers, in order: a reconciled local file, a download, a cached
+stream, the network.
+
+**And the direction that never existed now does.** Server-to-local has always
+resolved — `preferred_local_playback` plays the local file when there is one —
+but local-to-server did not, so a library track whose file had been moved or
+deleted simply failed with `file not found`. When such a track carries a
+*confirmed* link, it now plays from the server instead. Only confirmed: a stale
+link is a guess, and guessing which recording to substitute is worse than
+saying the file is missing.
+
+Making that work required separating two questions the decoder had been
+answering with one variable. It decided "finite file or endless radio?" from
+the **global remote-session state**, which is right for the remote queue and
+wrong for anyone else: a library track falling back has no session, and would
+have been opened with ICY — forward-only, and parsing metadata blocks out of a
+FLAC. Whether a body is finite is a property of the stream, so it now travels
+on the command; whether a remote session is running stays what it always was,
+and still drives the metadata the bar shows.
+
 **The queue panel** switches to a dedicated `RemoteQueueView` while a remote
 session plays (keyed on `isRemoteTrack`), reading `remote_get_play_queue` (an
 in-memory snapshot) and jumping with `remote_queue_jump` — the local

--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -469,9 +469,13 @@ says. That preference exists to spend less bandwidth on a stream heard once;
 baking a lossy re-encode into a file someone chose to keep would make a
 bandwidth decision permanent, and silently. The file is hashed while it is
 written, in the same pass that copies it, which is what makes the plan's "free"
-reconciliation proof real: the server's own `full_hash` — not the library's
-`file_hash`, which covers a file the server has never seen — is in hand the
-moment a `track` row exists to attach it to, with no re-read.
+reconciliation proof real. The server's own `full_hash` — not the library's
+`file_hash`, which covers a file the server has never seen — is known **the
+moment the write completes**, with no re-read and without needing a `track`
+row to exist: it is stored on `remote_track_download` there and then. What
+waits for a `track` row is only the *link*, which is a different object and a
+later step. It is also checked against the catalogue's own digest before the
+file is published, so a truncated or substituted body never becomes a proof.
 
 Playback prefers, in order: a reconciled local file, a download, a cached
 stream, the network.

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -530,6 +530,10 @@ fn decoder_loop(
                                 // Whatever failed was a finite file, and its
                                 // replacement on the server is one too — this
                                 // is the path a vanished library track takes.
+                                // Its duration came with the command and is
+                                // the only place that knows it, since no
+                                // remote session is running.
+                                duration_ms: Some(duration_ms),
                                 seekable_file: true,
                             });
                             continue;
@@ -567,6 +571,7 @@ fn decoder_loop(
                             artwork_url,
                             // See above: a repair path does not repopulate.
                             cache: None,
+                            duration_ms: Some(duration_ms),
                             seekable_file: true,
                         });
                         continue;
@@ -589,6 +594,7 @@ fn decoder_loop(
                 artwork_url,
                 replay_gain,
                 cache,
+                duration_ms: declared_duration_ms,
                 seekable_file,
             } => {
                 tracing::info!(
@@ -690,7 +696,12 @@ fn decoder_loop(
                         is_remote,
                         // A remote-queue entry carries its length; radio
                         // does not. Drives a bounded seekbar on the bar.
-                        duration_ms: remote_meta.duration_ms,
+                        // What the caller declared wins: it knows about streams
+                        // no remote session covers, and a session that is not
+                        // running has nothing to say about this one.
+                        duration_ms: declared_duration_ms
+                            .map(|ms| ms as i64)
+                            .or(remote_meta.duration_ms),
                         // Cover hash for a remote track — the frontend turns
                         // it into a data URL for the PlayerBar.
                         artwork_hash: remote_meta.artwork_hash,

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -527,6 +527,10 @@ fn decoder_loop(
                                 // Caching here would also risk re-writing the
                                 // very entry that just failed to decode.
                                 cache: None,
+                                // Whatever failed was a finite file, and its
+                                // replacement on the server is one too — this
+                                // is the path a vanished library track takes.
+                                seekable_file: true,
                             });
                             continue;
                         }
@@ -563,6 +567,7 @@ fn decoder_loop(
                             artwork_url,
                             // See above: a repair path does not repopulate.
                             cache: None,
+                            seekable_file: true,
                         });
                         continue;
                     }
@@ -584,6 +589,7 @@ fn decoder_loop(
                 artwork_url,
                 replay_gain,
                 cache,
+                seekable_file,
             } => {
                 tracing::info!(
                     track_id,
@@ -659,6 +665,13 @@ fn decoder_loop(
                     state.remote_playback.current_stream_meta()
                 };
                 let is_remote = remote_meta.is_remote;
+                // Two different questions, and they used to share an answer.
+                // `is_remote` says whether a remote *session* is running, which
+                // is what the metadata emit below is about. Whether to open a
+                // finite, range-capable body is a property of THIS stream, and
+                // a caller outside the session — a library track falling back
+                // to the server — knows it without one.
+                let finite = is_remote || seekable_file;
 
                 emit_radio_metadata(
                     &app,
@@ -696,7 +709,7 @@ fn decoder_loop(
                 // with ICY so the source can re-emit `player:radio-metadata`
                 // with the live `StreamTitle` while keeping the station's
                 // cover + name; it stays forward-only.
-                let opened = if is_remote {
+                let opened = if finite {
                     // A cache target only ever accompanies a finite
                     // remote-queue track, so the seekable open is the only
                     // one that can honour it.

--- a/src-tauri/crates/app/src/audio/decoder.rs
+++ b/src-tauri/crates/app/src/audio/decoder.rs
@@ -2366,6 +2366,24 @@ fn downmix_frame_to_stereo(frame: &[f32]) -> (f32, f32) {
     }
 }
 
+/// Drop a reproducible copy that would not play.
+///
+/// Only ever called with `allowed` set for a stream-cache entry: the server
+/// still holds those bytes, so a file that fails to open or decode is worth
+/// losing to make the next play refetch it. A reconciled file from the user's
+/// own library reaches the same failure path and must survive it — it is
+/// theirs, and a decoder that deletes a listener's music because a codec
+/// tripped would be a far worse bug than a cache miss.
+fn discard_unplayable(path: &std::path::Path, allowed: bool) {
+    if !allowed {
+        return;
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => tracing::info!(path = %path.display(), "dropped unplayable cached stream"),
+        Err(err) => tracing::warn!(?err, path = %path.display(), "could not drop cached stream"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{convert_channels, downmix_frame_to_stereo};
@@ -2454,23 +2472,5 @@ mod tests {
             downmix_frame_to_stereo(&[1.0, 2.0, 0.4, 9.9, 0.6, 0.8, 0.1, 0.2, 0.05, 0.07]);
         approx(lo, 1.0 + K * (0.4 + 0.6 + 0.1 + 0.05));
         approx(ro, 2.0 + K * (0.4 + 0.8 + 0.2 + 0.07));
-    }
-}
-
-/// Drop a reproducible copy that would not play.
-///
-/// Only ever called with `allowed` set for a stream-cache entry: the server
-/// still holds those bytes, so a file that fails to open or decode is worth
-/// losing to make the next play refetch it. A reconciled file from the user's
-/// own library reaches the same failure path and must survive it — it is
-/// theirs, and a decoder that deletes a listener's music because a codec
-/// tripped would be a far worse bug than a cache miss.
-fn discard_unplayable(path: &std::path::Path, allowed: bool) {
-    if !allowed {
-        return;
-    }
-    match std::fs::remove_file(path) {
-        Ok(()) => tracing::info!(path = %path.display(), "dropped unplayable cached stream"),
-        Err(err) => tracing::warn!(?err, path = %path.display(), "could not drop cached stream"),
     }
 }

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -131,6 +131,16 @@ pub enum AudioCmd {
         /// remote-queue track worth keeping. `None` for radio, which is
         /// endless and therefore never complete.
         cache: Option<crate::audio::stream_cache::CacheTarget>,
+        /// Force a finite, range-capable open even with no remote session
+        /// running.
+        ///
+        /// The decoder used to answer "file or radio?" from the *global*
+        /// remote-session state, which is right for the remote queue and
+        /// wrong for anyone else: a library track whose file vanished and
+        /// falls back to the server has no session, and would have been
+        /// opened with ICY — forward-only, and parsing metadata blocks out
+        /// of a FLAC. The question belongs to the command.
+        seekable_file: bool,
         /// Loudness metadata for the stream. `TrackGain::default()`
         /// for a live radio station — nothing knows anything about it
         /// — but a library track that fell back to streaming from the
@@ -418,8 +428,9 @@ impl RadioResumeState {
                 artwork_url: self.artwork_url,
                 replay_gain,
                 // Resuming radio after a device change: endless, so never a
-                // complete body to cache.
+                // complete body to cache, and never seekable.
                 cache: None,
+                seekable_file: false,
             },
             RadioResumeSource::RemoteFile {
                 path,
@@ -1519,8 +1530,9 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
             replay_gain,
             // The resume snapshot exists to restart radio after a device
             // change; a cache target belongs to one open response and does
-            // not survive into a new one.
+            // not survive into a new one, and only radio is ever resumed.
             cache: _,
+            seekable_file: _,
         } => {
             if let Ok(mut guard) = snapshot.lock() {
                 *guard = Some(RadioResumeState {
@@ -1723,6 +1735,7 @@ mod radio_resume_tests {
             artist: Some("Test artist".to_string()),
             artwork_url: Some("https://example.invalid/art.jpg".to_string()),
             cache: None,
+            seekable_file: false,
             replay_gain: TrackGain::default(),
         }
     }

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -131,6 +131,13 @@ pub enum AudioCmd {
         /// remote-queue track worth keeping. `None` for radio, which is
         /// endless and therefore never complete.
         cache: Option<crate::audio::stream_cache::CacheTarget>,
+        /// Total length, when the caller knows it.
+        ///
+        /// The decoder used to take this from the remote session alone, which
+        /// leaves it unknown for a finite stream reached any other way — a
+        /// library track falling back to the server has a duration in its own
+        /// row, and dropping it costs the seekbar its total.
+        duration_ms: Option<u64>,
         /// Force a finite, range-capable open even with no remote session
         /// running.
         ///
@@ -403,6 +410,10 @@ pub(crate) enum RadioResumeSource {
         /// is being streamed from the server after its local file
         /// failed to open.
         replay_gain: TrackGain,
+        /// Carried so a finite stream comes back finite — see
+        /// [`AudioCmd::LoadUrlAndPlay`].
+        duration_ms: Option<u64>,
+        seekable_file: bool,
     },
     RemoteFile {
         path: PathBuf,
@@ -419,6 +430,8 @@ impl RadioResumeState {
                 url,
                 ext_hint,
                 replay_gain,
+                duration_ms,
+                seekable_file,
             } => AudioCmd::LoadUrlAndPlay {
                 url,
                 ext_hint,
@@ -427,10 +440,14 @@ impl RadioResumeState {
                 artist: self.artist,
                 artwork_url: self.artwork_url,
                 replay_gain,
-                // Resuming radio after a device change: endless, so never a
-                // complete body to cache, and never seekable.
+                // Not cached on resume: the target belongs to the response
+                // that was open, and this is a new one.
                 cache: None,
-                seekable_file: false,
+                // Restored, not assumed. Flattening every resumed stream to
+                // "radio" would bring a finite server track back forward-only
+                // and ICY-parsed, just because the device changed.
+                duration_ms,
+                seekable_file,
             },
             RadioResumeSource::RemoteFile {
                 path,
@@ -1528,11 +1545,14 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
             artist,
             artwork_url,
             replay_gain,
-            // The resume snapshot exists to restart radio after a device
-            // change; a cache target belongs to one open response and does
-            // not survive into a new one, and only radio is ever resumed.
+            // A cache target belongs to one open response and does not
+            // survive into a new one. Everything else about the stream does:
+            // flattening it to "radio" here is what would bring a finite
+            // server track back forward-only and ICY-parsed, just because
+            // the audio device changed.
             cache: _,
-            seekable_file: _,
+            duration_ms,
+            seekable_file,
         } => {
             if let Ok(mut guard) = snapshot.lock() {
                 *guard = Some(RadioResumeState {
@@ -1540,6 +1560,8 @@ fn apply_radio_resume_update(snapshot: &Mutex<Option<RadioResumeState>>, cmd: &A
                         url: url.clone(),
                         ext_hint: ext_hint.clone(),
                         replay_gain: *replay_gain,
+                        duration_ms: *duration_ms,
+                        seekable_file: *seekable_file,
                     },
                     track_id: *track_id,
                     title: title.clone(),
@@ -1735,6 +1757,7 @@ mod radio_resume_tests {
             artist: Some("Test artist".to_string()),
             artwork_url: Some("https://example.invalid/art.jpg".to_string()),
             cache: None,
+            duration_ms: None,
             seekable_file: false,
             replay_gain: TrackGain::default(),
         }

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -1921,6 +1921,38 @@ pub async fn player_play_tracks(
 
     let pb = std::path::PathBuf::from(&track.file_path);
     if !pb.is_file() {
+        // The file is gone, but the recording may not be: if this track was
+        // proved to be one the bound server holds, play it from there instead
+        // of refusing. Announced rather than silent — the row keeps saying the
+        // file is missing, because it is.
+        #[cfg(feature = "sync_v2")]
+        if let Some(url) = server_stand_in(&state, &pool, track.id).await {
+            tracing::info!(
+                track_id = track.id,
+                path = %track.file_path,
+                "local file missing; playing the linked server copy"
+            );
+            emit_track_changed(&app, &state.paths, &track, profile_id);
+            let replay_gain = fetch_replay_gain(&pool, track.id).await;
+            return engine
+                .send(AudioCmd::LoadRemoteFileAndPlay {
+                    // The missing path on purpose: the decoder's repair path
+                    // is exactly this situation, and reusing it keeps one
+                    // implementation of "try the file, then the server".
+                    path: pb,
+                    start_ms: 0,
+                    track_id: track.id,
+                    duration_ms: track.duration_ms.max(0) as u64,
+                    title: Some(track.title.clone()),
+                    artist: track.artist_name.clone(),
+                    artwork_url: None,
+                    fallback_url: Some(url),
+                    // The user's own library row. Never ours to delete.
+                    discard_on_failure: false,
+                    replay_gain,
+                })
+                .map_err(Into::into);
+        }
         return Err(AppError::Audio(format!(
             "file not found: {}",
             track.file_path
@@ -2182,8 +2214,9 @@ pub async fn player_play_url(
     tracing::info!(track_id, "dispatching AudioCmd::LoadUrlAndPlay");
     engine.send(AudioCmd::LoadUrlAndPlay {
         // Radio: an endless body has no length and no end, so nothing here
-        // could ever be published as a complete entry.
+        // could ever be published as a complete entry, and nothing to seek.
         cache: None,
+        seekable_file: false,
         url,
         ext_hint,
         track_id,
@@ -2208,4 +2241,28 @@ pub async fn player_play_url(
 pub async fn get_current_radio_metadata(
 ) -> AppResult<Option<crate::audio::events::RadioMetadataPayload>> {
     Ok(crate::audio::events::last_radio_metadata())
+}
+
+/// A stream URL for the server copy of a local track whose file is gone.
+///
+/// `None` for every ordinary reason — no server bound, no confirmed link,
+/// offline, the mint refused — and each of them means the caller reports the
+/// missing file, which is the honest answer when there is nothing to play
+/// instead.
+#[cfg(feature = "sync_v2")]
+async fn server_stand_in(
+    state: &AppState,
+    pool: &sqlx::SqlitePool,
+    local_track_id: i64,
+) -> Option<String> {
+    if crate::offline::is_offline() {
+        return None;
+    }
+    let remote_id = crate::remote::reconciliation::linked_remote_track(pool, local_track_id)
+        .await
+        .ok()
+        .flatten()?;
+    crate::remote::stream::ticket_url(state, &remote_id)
+        .await
+        .ok()
 }

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -1934,24 +1934,22 @@ pub async fn player_play_tracks(
             );
             emit_track_changed(&app, &state.paths, &track, profile_id);
             let replay_gain = fetch_replay_gain(&pool, track.id).await;
-            return engine
-                .send(AudioCmd::LoadRemoteFileAndPlay {
-                    // The missing path on purpose: the decoder's repair path
-                    // is exactly this situation, and reusing it keeps one
-                    // implementation of "try the file, then the server".
-                    path: pb,
-                    start_ms: 0,
-                    track_id: track.id,
-                    duration_ms: track.duration_ms.max(0) as u64,
-                    title: Some(track.title.clone()),
-                    artist: track.artist_name.clone(),
-                    artwork_url: None,
-                    fallback_url: Some(url),
-                    // The user's own library row. Never ours to delete.
-                    discard_on_failure: false,
-                    replay_gain,
-                })
-                .map_err(Into::into);
+            return engine.send(AudioCmd::LoadRemoteFileAndPlay {
+                // The missing path on purpose: the decoder's repair path
+                // is exactly this situation, and reusing it keeps one
+                // implementation of "try the file, then the server".
+                path: pb,
+                start_ms: 0,
+                track_id: track.id,
+                duration_ms: track.duration_ms.max(0) as u64,
+                title: Some(track.title.clone()),
+                artist: track.artist_name.clone(),
+                artwork_url: None,
+                fallback_url: Some(url),
+                // The user's own library row. Never ours to delete.
+                discard_on_failure: false,
+                replay_gain,
+            });
         }
         return Err(AppError::Audio(format!(
             "file not found: {}",

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -2214,6 +2214,8 @@ pub async fn player_play_url(
         // Radio: an endless body has no length and no end, so nothing here
         // could ever be published as a complete entry, and nothing to seek.
         cache: None,
+        // A live station has no end and therefore no total.
+        duration_ms: None,
         seekable_file: false,
         url,
         ext_hint,

--- a/src-tauri/crates/app/src/commands/remote_auth.rs
+++ b/src-tauri/crates/app/src/commands/remote_auth.rs
@@ -823,6 +823,56 @@ pub async fn remote_clear_stream_cache(state: tauri::State<'_, AppState>) -> App
         .map_err(AppError::from)
 }
 
+/// Keep a remote track's original bytes on this machine.
+///
+/// Answers with the existing copy when there already is one, so asking twice
+/// costs nothing. Progress arrives as `remote:download-progress`.
+#[tauri::command]
+pub async fn remote_download_track(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    track_id: String,
+) -> AppResult<crate::remote::download::DownloadedTrack> {
+    crate::remote::download::download(&app, &state, &track_id).await
+}
+
+/// Every offline copy, newest first.
+#[tauri::command]
+pub async fn remote_list_downloads(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<Vec<crate::remote::download::DownloadedTrack>> {
+    let (pool, _) = state.require_profile_snapshot().await?;
+    crate::remote::download::list(&pool).await
+}
+
+/// Disk held by the managed download folder.
+#[tauri::command]
+pub async fn remote_downloads_info(
+    state: tauri::State<'_, AppState>,
+) -> AppResult<crate::remote::download::DownloadsInfo> {
+    let (pool, _) = state.require_profile_snapshot().await?;
+    crate::remote::download::info(&pool).await
+}
+
+/// Drop one offline copy. `false` when there was none to drop.
+#[tauri::command]
+pub async fn remote_remove_download(
+    state: tauri::State<'_, AppState>,
+    track_id: String,
+) -> AppResult<bool> {
+    let (pool, _) = state.require_profile_snapshot().await?;
+    let mut conn = pool.acquire().await?;
+    crate::remote::download::remove(&mut conn, &track_id).await
+}
+
+/// Drop every offline copy.
+#[tauri::command]
+pub async fn remote_clear_downloads(state: tauri::State<'_, AppState>) -> AppResult<usize> {
+    let (pool, _) = state.require_profile_snapshot().await?;
+    let mut conn = pool.acquire().await?;
+    crate::remote::download::clear_all(&mut conn).await
+}
+
 /// Play a projected remote playlist as a native queue, starting at
 /// `start_index`. Fills the in-memory remote queue from the projection so
 /// the tracks after it auto-advance, mints a stream ticket for the first,

--- a/src-tauri/crates/app/src/lib.rs
+++ b/src-tauri/crates/app/src/lib.rs
@@ -777,6 +777,16 @@ pub fn run() {
             #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_transcode_status,
             #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_download_track,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_list_downloads,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_downloads_info,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_remove_download,
+            #[cfg(feature = "sync_v2")]
+            commands::remote_auth::remote_clear_downloads,
+            #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_stream_cache_info,
             #[cfg(feature = "sync_v2")]
             commands::remote_auth::remote_clear_stream_cache,

--- a/src-tauri/crates/app/src/paths.rs
+++ b/src-tauri/crates/app/src/paths.rs
@@ -188,10 +188,28 @@ impl AppPaths {
         self.profile_dir(profile_id).join("remote-artwork")
     }
 
+    /// Downloaded copies of the bound server's tracks — the managed folder.
+    ///
+    /// Deliberately not a scanned library folder: a download is an offline
+    /// copy of a *remote* track, not a new local one, and letting the scanner
+    /// index it would create a second entry for a song the library already
+    /// knows through the server.
+    ///
+    /// Separate from the stream cache next door because the two have opposite
+    /// lifetimes: the cache is evicted under a budget without asking, and a
+    /// download disappears only when its owner says so.
+    /// Only the remote source uses this, so it does not exist without it.
+    #[cfg(feature = "sync_v2")]
+    pub fn profile_remote_download_dir(&self, profile_id: i64) -> PathBuf {
+        self.profile_dir(profile_id).join("remote-downloads")
+    }
+
     /// Cached audio for the bound server's tracks. Beside the cover cache
     /// rather than inside it: these are whole songs, and the settings card
     /// reports and clears the two separately because their sizes are orders
     /// of magnitude apart.
+    /// Only the remote source uses this, so it does not exist without it.
+    #[cfg(feature = "sync_v2")]
     pub fn profile_remote_stream_dir(&self, profile_id: i64) -> PathBuf {
         self.profile_dir(profile_id).join("remote-stream")
     }

--- a/src-tauri/crates/app/src/remote/download.rs
+++ b/src-tauri/crates/app/src/remote/download.rs
@@ -1,0 +1,415 @@
+//! Offline copies of the bound server's tracks (lot 4 of the unified library).
+//!
+//! ## A download is not a local track
+//!
+//! It lands in a managed folder the scanner never sees, and no `track` row is
+//! created for it. A download describes a *remote* track that happens to be on
+//! this disk — which is why it is keyed by the server's id and not by a rowid,
+//! and why `remote_track_link` cannot describe it (that table keys on
+//! `local_track_id REFERENCES track(id)`).
+//!
+//! ## Always the original bytes
+//!
+//! The transcode preference is deliberately ignored here. It exists to spend
+//! less bandwidth on a stream that is heard once; a file kept on disk is the
+//! copy someone chose to keep, and baking a lossy re-encode into it would make
+//! that choice irreversible without telling them. Downloads are `raw`.
+//!
+//! ## The hash is the point, and it is free
+//!
+//! Reconciling a local file against the server is expensive precisely because
+//! the two digests are incompatible by construction: the library's `file_hash`
+//! covers a file the server has never seen. Here we are the ones writing the
+//! bytes, so the server's own `full_hash` falls out of the write for nothing —
+//! one pass, no re-read. That is what will make a later *import* into a
+//! scanned folder able to claim an exact reconciliation proof without paying
+//! for it twice.
+
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use serde::Serialize;
+use sqlx::{Row, SqliteConnection, SqlitePool};
+use tauri::{AppHandle, Emitter};
+
+use crate::{
+    error::{AppError, AppResult},
+    state::AppState,
+};
+
+/// Emitted while a download runs so the interface can show a bar rather than
+/// a spinner that says nothing about a forty-megabyte file.
+#[derive(Clone, Serialize)]
+pub struct DownloadProgress {
+    pub track_id: String,
+    pub received: u64,
+    /// `None` when the server did not declare a length.
+    pub total: Option<u64>,
+}
+
+/// One offline copy, as the interface sees it.
+#[derive(Clone, Serialize)]
+pub struct DownloadedTrack {
+    pub remote_track_id: String,
+    pub path: String,
+    pub full_hash: String,
+    pub size: u64,
+    pub downloaded_at: i64,
+}
+
+/// Total bytes and file count held by the managed folder.
+#[derive(Clone, Copy, Serialize)]
+pub struct DownloadsInfo {
+    pub bytes: u64,
+    pub tracks: usize,
+}
+
+/// The offline copy of a remote track, if one exists **and its file is still
+/// there**.
+///
+/// The row and the file can disagree — someone can empty a folder behind the
+/// application's back — and answering from the row alone would hand playback a
+/// path that is not there. A row without a file is dropped rather than
+/// reported, so the next play refetches instead of failing forever.
+pub async fn lookup(conn: &mut SqliteConnection, remote_track_id: &str) -> Option<PathBuf> {
+    let path: Option<String> =
+        sqlx::query_scalar("SELECT path FROM remote_track_download WHERE remote_track_id = ?")
+            .bind(remote_track_id)
+            .fetch_optional(&mut *conn)
+            .await
+            .ok()
+            .flatten();
+    let path = PathBuf::from(path?);
+    if path.is_file() {
+        return Some(path);
+    }
+    let _ = sqlx::query("DELETE FROM remote_track_download WHERE remote_track_id = ?")
+        .bind(remote_track_id)
+        .execute(conn)
+        .await;
+    None
+}
+
+/// Every offline copy, newest first.
+pub async fn list(pool: &SqlitePool) -> AppResult<Vec<DownloadedTrack>> {
+    let rows = sqlx::query(
+        "SELECT remote_track_id, path, full_hash, size, downloaded_at
+           FROM remote_track_download
+          ORDER BY downloaded_at DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(DownloadedTrack {
+                remote_track_id: row.try_get("remote_track_id")?,
+                path: row.try_get("path")?,
+                full_hash: row.try_get("full_hash")?,
+                size: row.try_get::<i64, _>("size")?.max(0) as u64,
+                downloaded_at: row.try_get("downloaded_at")?,
+            })
+        })
+        .collect()
+}
+
+/// Bytes and count, read from the rows rather than from the directory.
+///
+/// The rows are the record of what was deliberately kept; a stray file in the
+/// folder is not a download and should not be reported as one.
+pub async fn info(pool: &SqlitePool) -> AppResult<DownloadsInfo> {
+    let row = sqlx::query(
+        "SELECT COALESCE(SUM(size), 0) AS bytes, COUNT(*) AS tracks FROM remote_track_download",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(DownloadsInfo {
+        bytes: row.try_get::<i64, _>("bytes")?.max(0) as u64,
+        tracks: row.try_get::<i64, _>("tracks")?.max(0) as usize,
+    })
+}
+
+/// Remove one offline copy: the file first, then the row.
+///
+/// That order matters. A row without a file is self-healing — [`lookup`] drops
+/// it on the next miss — while a file without a row is invisible to everything
+/// and would sit there forever.
+pub async fn remove(conn: &mut SqliteConnection, remote_track_id: &str) -> AppResult<bool> {
+    let path: Option<String> =
+        sqlx::query_scalar("SELECT path FROM remote_track_download WHERE remote_track_id = ?")
+            .bind(remote_track_id)
+            .fetch_optional(&mut *conn)
+            .await?;
+    let Some(path) = path else {
+        return Ok(false);
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        // Already gone is the outcome asked for, not a failure.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(AppError::from(err)),
+    }
+    sqlx::query("DELETE FROM remote_track_download WHERE remote_track_id = ?")
+        .bind(remote_track_id)
+        .execute(conn)
+        .await?;
+    Ok(true)
+}
+
+/// Drop every offline copy. Returns how many were removed.
+///
+/// Files first, rows after, and one row at a time rather than a bulk delete:
+/// a file that refuses to go must keep its row, or it becomes invisible
+/// clutter nothing will ever offer to remove again.
+pub async fn clear_all(conn: &mut SqliteConnection) -> AppResult<usize> {
+    let ids: Vec<String> = sqlx::query_scalar("SELECT remote_track_id FROM remote_track_download")
+        .fetch_all(&mut *conn)
+        .await?;
+    let mut removed = 0;
+    for id in ids {
+        if remove(&mut *conn, &id).await? {
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+/// Fetch a remote track's original bytes into the managed folder.
+///
+/// Returns the existing copy untouched when there already is one: asking twice
+/// is a no-op, not a re-download.
+pub async fn download(
+    app: &AppHandle,
+    state: &AppState,
+    remote_track_id: &str,
+) -> AppResult<DownloadedTrack> {
+    if crate::offline::is_offline() {
+        return Err(AppError::Other("offline".into()));
+    }
+    // Pool and profile together: everything below — the existing-copy check,
+    // the destination folder, the row written at the end — belongs to one
+    // profile, and resolving them separately across the download's awaits is
+    // what would let a switch file one profile's audio under another's.
+    let (pool, profile_id) = state.require_profile_snapshot().await?;
+
+    if let Some(existing) = existing_row(&pool, remote_track_id).await? {
+        return Ok(existing);
+    }
+
+    let extension = suffix_for(&pool, remote_track_id).await;
+    let dir = state.paths.profile_remote_download_dir(profile_id);
+    std::fs::create_dir_all(&dir)?;
+
+    // The original bytes, whatever the streaming preference says — see the
+    // module note. `ticket_url` applies the preference, so the ticket is minted
+    // here instead of borrowed from it.
+    let url = crate::remote::stream::raw_ticket_url(state, remote_track_id).await?;
+
+    let final_path = dir.join(file_name(remote_track_id, &extension));
+    let part_path = dir.join(format!(
+        "{}.in-flight",
+        file_name(remote_track_id, &extension)
+    ));
+    let outcome = stream_to_file(app, remote_track_id, &url, &part_path).await;
+    let (size, full_hash) = match outcome {
+        Ok(pair) => pair,
+        Err(err) => {
+            // Nothing partial survives: a half file in the managed folder is
+            // indistinguishable from a whole one to anything that lists it.
+            let _ = std::fs::remove_file(&part_path);
+            return Err(err);
+        }
+    };
+    if let Err(err) = std::fs::rename(&part_path, &final_path) {
+        let _ = std::fs::remove_file(&part_path);
+        return Err(AppError::from(err));
+    }
+
+    let downloaded_at = chrono::Utc::now().timestamp_millis();
+    let record = DownloadedTrack {
+        remote_track_id: remote_track_id.to_string(),
+        path: final_path.to_string_lossy().to_string(),
+        full_hash,
+        size,
+        downloaded_at,
+    };
+    sqlx::query(
+        "INSERT INTO remote_track_download
+             (remote_track_id, path, full_hash, size, downloaded_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(remote_track_id) DO UPDATE SET
+             path = excluded.path,
+             full_hash = excluded.full_hash,
+             size = excluded.size,
+             downloaded_at = excluded.downloaded_at",
+    )
+    .bind(&record.remote_track_id)
+    .bind(&record.path)
+    .bind(&record.full_hash)
+    .bind(record.size as i64)
+    .bind(record.downloaded_at)
+    .execute(&*pool)
+    .await?;
+    Ok(record)
+}
+
+async fn existing_row(
+    pool: &SqlitePool,
+    remote_track_id: &str,
+) -> AppResult<Option<DownloadedTrack>> {
+    let row = sqlx::query(
+        "SELECT remote_track_id, path, full_hash, size, downloaded_at
+           FROM remote_track_download WHERE remote_track_id = ?",
+    )
+    .bind(remote_track_id)
+    .fetch_optional(pool)
+    .await?;
+    let Some(row) = row else { return Ok(None) };
+    let path: String = row.try_get("path")?;
+    if !Path::new(&path).is_file() {
+        // The row outlived its file; treat it as absent so the caller
+        // re-downloads rather than reporting a copy nobody can play.
+        return Ok(None);
+    }
+    Ok(Some(DownloadedTrack {
+        remote_track_id: row.try_get("remote_track_id")?,
+        path,
+        full_hash: row.try_get("full_hash")?,
+        size: row.try_get::<i64, _>("size")?.max(0) as u64,
+        downloaded_at: row.try_get("downloaded_at")?,
+    }))
+}
+
+/// Stream the body to `dest`, hashing as it goes, and report progress.
+///
+/// The hash is fed from the same buffer that is written, in order, so it costs
+/// one pass over bytes that were being copied anyway — no second read of the
+/// finished file.
+async fn stream_to_file(
+    app: &AppHandle,
+    remote_track_id: &str,
+    url: &str,
+    dest: &Path,
+) -> AppResult<(u64, String)> {
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|err| AppError::Other(format!("download client: {err}")))?;
+    let mut response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| AppError::Other(format!("download: {err}")))?;
+    if !response.status().is_success() {
+        return Err(AppError::Other(format!(
+            "download refused: HTTP {}",
+            response.status()
+        )));
+    }
+    let total = response.content_length();
+
+    let mut file = std::fs::File::create(dest)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut received: u64 = 0;
+    let mut last_emit: u64 = 0;
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|err| AppError::Other(format!("download: {err}")))?
+    {
+        file.write_all(&chunk)?;
+        hasher.update(&chunk);
+        received += chunk.len() as u64;
+        // One event per megabyte, not per chunk: a 40 MB file would otherwise
+        // cross the IPC boundary a few thousand times to move one bar.
+        if received - last_emit >= 1024 * 1024 {
+            last_emit = received;
+            let _ = app.emit(
+                "remote:download-progress",
+                DownloadProgress {
+                    track_id: remote_track_id.to_string(),
+                    received,
+                    total,
+                },
+            );
+        }
+    }
+    // Durable before the caller renames it: a rename publishes the name, and
+    // whatever finds that name must find the bytes.
+    file.sync_all()?;
+    drop(file);
+
+    if received == 0 {
+        return Err(AppError::Other("download: server sent no audio".into()));
+    }
+    if let Some(total) = total {
+        if received != total {
+            return Err(AppError::Other(format!(
+                "download: {received} bytes received, {total} declared"
+            )));
+        }
+    }
+    Ok((received, hasher.finalize().to_hex().to_string()))
+}
+
+/// File name for an offline copy.
+///
+/// Hashed, like the stream cache's, because a server track id is opaque and
+/// may hold anything a path cannot. The extension stays legible so the decoder
+/// can hint its probe from it.
+fn file_name(remote_track_id: &str, extension: &str) -> String {
+    let key = blake3::hash(remote_track_id.as_bytes())
+        .to_hex()
+        .to_string();
+    let ext: String = extension
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if ext.is_empty() {
+        format!("{key}.bin")
+    } else {
+        format!("{key}.{ext}")
+    }
+}
+
+/// The container the server holds this track in, for the file name.
+async fn suffix_for(pool: &SqlitePool, remote_track_id: &str) -> String {
+    sqlx::query_scalar::<_, Option<String>>("SELECT suffix FROM remote_track WHERE remote_id = ?")
+        .bind(remote_track_id)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .flatten()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_track_id_never_reaches_the_path() {
+        let name = file_name("../../etc/passwd", "flac");
+        assert!(!name.contains('/'), "{name}");
+        assert!(name.ends_with(".flac"), "{name}");
+    }
+
+    #[test]
+    fn a_hostile_extension_cannot_escape_either() {
+        let name = file_name("t1", "../../sh");
+        assert!(!name.contains('/'), "{name}");
+        assert!(name.ends_with(".sh"), "{name}");
+        assert!(file_name("t1", "").ends_with(".bin"));
+    }
+
+    #[test]
+    fn two_tracks_never_share_a_file() {
+        assert_ne!(file_name("t1", "flac"), file_name("t2", "flac"));
+        // Same track, same name: asking twice must land on the copy that is
+        // already there rather than beside it.
+        assert_eq!(file_name("t1", "flac"), file_name("t1", "flac"));
+    }
+}

--- a/src-tauri/crates/app/src/remote/download.rs
+++ b/src-tauri/crates/app/src/remote/download.rs
@@ -26,8 +26,10 @@
 //! for it twice.
 
 use std::{
+    collections::HashSet,
     io::Write,
     path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
 };
 
 use serde::Serialize;
@@ -64,6 +66,40 @@ pub struct DownloadedTrack {
 pub struct DownloadsInfo {
     pub bytes: u64,
     pub tracks: usize,
+}
+
+/// Track ids with a download in flight right now.
+///
+/// Two callers asking for the same track — a second window, a double click —
+/// would otherwise both find no existing copy, both fetch the same bytes, and
+/// both write them to the same place. The working name below is unique per
+/// call, so nothing could corrupt anything even without this; the guard is
+/// what stops the *second download* from happening at all.
+fn in_flight() -> &'static Mutex<HashSet<String>> {
+    static IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Releases its track id however the download ends, including a panic.
+struct InFlightGuard(String);
+
+impl InFlightGuard {
+    /// `None` when this track is already being fetched.
+    fn claim(track_id: &str) -> Option<Self> {
+        let mut set = in_flight().lock().ok()?;
+        if !set.insert(track_id.to_string()) {
+            return None;
+        }
+        Some(Self(track_id.to_string()))
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut set) = in_flight().lock() {
+            set.remove(&self.0);
+        }
+    }
 }
 
 /// The offline copy of a remote track, if one exists **and its file is still
@@ -196,6 +232,14 @@ pub async fn download(
     if let Some(existing) = existing_row(&pool, remote_track_id).await? {
         return Ok(existing);
     }
+    // Claimed before the first byte and held through the rename and the row,
+    // so the window a second caller could slip into does not exist.
+    let _guard = InFlightGuard::claim(remote_track_id)
+        .ok_or_else(|| AppError::Other("this track is already downloading".into()))?;
+    // Re-checked under the claim: the copy may have landed while we waited.
+    if let Some(existing) = existing_row(&pool, remote_track_id).await? {
+        return Ok(existing);
+    }
 
     let extension = suffix_for(&pool, remote_track_id).await;
     let dir = state.paths.profile_remote_download_dir(profile_id);
@@ -207,9 +251,17 @@ pub async fn download(
     let url = crate::remote::stream::raw_ticket_url(state, remote_track_id).await?;
 
     let final_path = dir.join(file_name(remote_track_id, &extension));
+    // Unique per call, not merely per track: a shared working name is how two
+    // writers end up interleaving one file. The stream cache learned this; the
+    // lesson belongs here too.
     let part_path = dir.join(format!(
-        "{}.in-flight",
-        file_name(remote_track_id, &extension)
+        "{}.{}.in-flight",
+        file_name(remote_track_id, &extension),
+        blake3::hash(format!("{:?}", std::time::SystemTime::now()).as_bytes())
+            .to_hex()
+            .to_string()
+            .split_at(16)
+            .0
     ));
     let outcome = stream_to_file(app, remote_track_id, &url, &part_path).await;
     let (size, full_hash) = match outcome {
@@ -221,6 +273,19 @@ pub async fn download(
             return Err(err);
         }
     };
+    // The server told us what these bytes hash to when it mirrored the track.
+    // Comparing costs nothing here — we hashed while writing — and it is the
+    // only thing standing between a truncated or substituted body and a file
+    // we will later offer as an exact reconciliation proof.
+    if let Some(expected) = catalogue_hash(&pool, remote_track_id).await {
+        if expected != full_hash {
+            let _ = std::fs::remove_file(&part_path);
+            return Err(AppError::Other(format!(
+                "download: hash mismatch for {remote_track_id}"
+            )));
+        }
+    }
+
     if let Err(err) = std::fs::rename(&part_path, &final_path) {
         let _ = std::fs::remove_file(&part_path);
         return Err(AppError::from(err));
@@ -372,6 +437,24 @@ fn file_name(remote_track_id: &str, extension: &str) -> String {
     } else {
         format!("{key}.{ext}")
     }
+}
+
+/// What the catalogue says this track's bytes hash to, when it knows.
+///
+/// `None` for a track mirrored before the column was populated, which is a
+/// reason to accept the download rather than to refuse it: an unverifiable
+/// copy is still the copy the server just sent.
+async fn catalogue_hash(pool: &SqlitePool, remote_track_id: &str) -> Option<String> {
+    sqlx::query_scalar::<_, Option<String>>(
+        "SELECT full_hash FROM remote_track WHERE remote_id = ?",
+    )
+    .bind(remote_track_id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .flatten()
+    .filter(|hash| hash.len() == 64)
 }
 
 /// The container the server holds this track in, for the file name.

--- a/src-tauri/crates/app/src/remote/mod.rs
+++ b/src-tauri/crates/app/src/remote/mod.rs
@@ -85,6 +85,7 @@ pub mod auth;
 pub mod binding;
 pub mod catalogue;
 pub mod client;
+pub mod download;
 pub mod drain;
 pub mod dto;
 pub mod lyrics;

--- a/src-tauri/crates/app/src/remote/playback.rs
+++ b/src-tauri/crates/app/src/remote/playback.rs
@@ -300,6 +300,7 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
         }),
         // A remote-queue track is finite. The running session says so too,
         // but saying it here keeps the answer with the caller that knows.
+        duration_ms: entry.duration_ms.map(|ms| ms.max(0) as u64),
         seekable_file: true,
         url,
         ext_hint: None,

--- a/src-tauri/crates/app/src/remote/playback.rs
+++ b/src-tauri/crates/app/src/remote/playback.rs
@@ -227,6 +227,32 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
         &extension,
     );
 
+    // An offline copy outranks the cache: it holds the original bytes, it was
+    // kept on purpose, and no eviction can take it away mid-album.
+    {
+        let mut conn = pool.acquire().await?;
+        if let Some(path) = crate::remote::download::lookup(&mut conn, &entry.id).await {
+            drop(conn);
+            engine.send(AudioCmd::LoadRemoteFileAndPlay {
+                path,
+                start_ms: 0,
+                track_id,
+                duration_ms: entry.duration_ms.unwrap_or(0).max(0) as u64,
+                title: entry.title.clone(),
+                artist: entry.artist.clone(),
+                artwork_url: None,
+                // No ticket: a download is meant to play without the network,
+                // and minting one would defeat the reason it was kept.
+                fallback_url: None,
+                // Kept deliberately. Unlike a cache entry, it is not ours to
+                // throw away because a codec tripped — the owner decides.
+                discard_on_failure: false,
+                replay_gain: TrackGain::default(),
+            })?;
+            return Ok(());
+        }
+    }
+
     if let Some(path) = crate::audio::stream_cache::lookup(&cache_dir, &cache_name) {
         // A ticket is still minted, and it is cheap: a small JSON round-trip,
         // not the audio body the cache just saved. It buys the decoder its
@@ -272,6 +298,9 @@ async fn play_current(app: &AppHandle) -> AppResult<()> {
             dir: cache_dir,
             name: cache_name,
         }),
+        // A remote-queue track is finite. The running session says so too,
+        // but saying it here keeps the answer with the caller that knows.
+        seekable_file: true,
         url,
         ext_hint: None,
         track_id,

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -1068,6 +1068,28 @@ pub async fn set_playback_preference(
 /// Resolve a remote track to the confirmed, available local file selected by
 /// the user's playback preference. A missing file is treated like no local
 /// candidate so callers can immediately fall back to the server.
+/// The server track a local one was proved to be, for playing it when its
+/// file is gone.
+///
+/// The mirror image of [`preferred_local_playback`], and the direction that
+/// did not exist: server-to-local has always resolved, local-to-server never
+/// did, so a library track whose file vanished simply failed. Only a
+/// `confirmed` link qualifies — a stale one is a guess, and guessing which
+/// recording to play instead is worse than saying the file is missing.
+pub async fn linked_remote_track(
+    pool: &SqlitePool,
+    local_track_id: i64,
+) -> AppResult<Option<String>> {
+    Ok(sqlx::query_scalar::<_, String>(
+        "SELECT remote_track_id FROM remote_track_link
+          WHERE local_track_id = ? AND status = 'confirmed'
+          LIMIT 1",
+    )
+    .bind(local_track_id)
+    .fetch_optional(pool)
+    .await?)
+}
+
 pub async fn preferred_local_playback(
     pool: &SqlitePool,
     remote_track_id: &str,

--- a/src-tauri/crates/app/src/remote/stream.rs
+++ b/src-tauri/crates/app/src/remote/stream.rs
@@ -200,10 +200,6 @@ pub async fn status(state: &AppState) -> AppResult<TranscodeStatus> {
 /// than discovered by being refused, and a saturated server costs the user
 /// bandwidth instead of a track that will not play.
 pub async fn ticket_url(state: &AppState, track_id: &str) -> AppResult<String> {
-    if crate::offline::is_offline() {
-        return Err(AppError::Other("offline".into()));
-    }
-
     // Read the preference before the client is built: `try_build` releases
     // its own lease before any network call, and holding one across a
     // request would stall a profile switch for its whole duration.
@@ -212,6 +208,24 @@ pub async fn ticket_url(state: &AppState, track_id: &str) -> AppResult<String> {
         preference(&pool).await
     };
 
+    let base = raw_ticket_url(state, track_id).await?;
+    if !wanted.is_on() {
+        return Ok(base);
+    }
+    Ok(format!("{base}{}", transcode_query(state, wanted).await))
+}
+
+/// A stream URL for the track's **original** bytes, ignoring the transcode
+/// preference.
+///
+/// What a download keeps, and what reconciliation hashes, must be the file the
+/// server holds — not a re-encode of it. The preference exists to spend less
+/// bandwidth on a stream heard once; baking it into a stored copy would make a
+/// bandwidth choice permanent, and silently.
+pub async fn raw_ticket_url(state: &AppState, track_id: &str) -> AppResult<String> {
+    if crate::offline::is_offline() {
+        return Err(AppError::Other("offline".into()));
+    }
     let client = client(state).await?;
 
     let resp: StreamTicketResponse = client
@@ -231,13 +245,7 @@ pub async fn ticket_url(state: &AppState, track_id: &str) -> AppResult<String> {
             "remote server returned a non-relative stream URL".into(),
         ));
     }
-
-    let query = if wanted.is_on() {
-        transcode_query(state, wanted).await
-    } else {
-        String::new()
-    };
-    Ok(format!("{}{}{}", client.base_url(), rel, query))
+    Ok(format!("{}{}", client.base_url(), rel))
 }
 
 /// The `?format=&bitrate=` suffix, or an empty string when the original

--- a/src-tauri/migrations/profile/20260830150000_remote_track_download.sql
+++ b/src-tauri/migrations/profile/20260830150000_remote_track_download.sql
@@ -1,0 +1,34 @@
+-- Offline copies of the bound server's tracks (lot 4 of the unified library).
+--
+-- A download is NOT a local library track. The managed folder it lives in is
+-- deliberately invisible to the scanner, so no `track` row is ever created for
+-- it -- which also means `remote_track_link` cannot describe it: that table
+-- keys on `local_track_id REFERENCES track(id)`, and there is no such row. A
+-- download describes a *remote* track that happens to be on this disk.
+--
+-- The link the plan calls "free" is a different one, and it is paid forward
+-- rather than here: because the file is hashed while it is written, importing
+-- it later into a scanned folder needs no re-read and no second hash, so the
+-- exact reconciliation proof is already in hand the moment a `track` row
+-- exists to attach it to.
+--
+-- No foreign key to `remote_track`: clearing the catalogue mirror drops
+-- metadata, and it must not take the audio with it. An orphaned row points at
+-- a file that still plays; re-mirroring restores the title around it.
+CREATE TABLE remote_track_download (
+    remote_track_id TEXT    PRIMARY KEY,
+    -- Absolute path inside the profile's managed download directory.
+    path            TEXT    NOT NULL,
+    -- BLAKE3 of the whole file, computed while writing it. This is the same
+    -- digest the server keys its own catalogue by, so it is directly
+    -- comparable -- unlike the local library's `file_hash`, which covers a
+    -- file the server has never seen.
+    full_hash       TEXT    NOT NULL CHECK (length(full_hash) = 64),
+    size            INTEGER NOT NULL CHECK (size > 0),
+    downloaded_at   INTEGER NOT NULL
+);
+
+-- Answers "is this one already downloaded" for a batch of tracks, which is
+-- what every listing asks before it can show a per-row state.
+CREATE INDEX idx_remote_track_download_hash
+    ON remote_track_download (full_hash);

--- a/src/components/views/PlaylistView.tsx
+++ b/src/components/views/PlaylistView.tsx
@@ -21,6 +21,7 @@ import {
   Download,
   ArrowUpDown,
   Check,
+  ArrowDownToLine,
   ListMusic,
   ListPlus,
   Loader2,
@@ -79,6 +80,8 @@ import {
 import {
   remoteAddPlaylistTracks,
   remoteDeletePlaylist,
+  remoteDownloadTrack,
+  remoteListDownloads,
   remoteGetPlayQueue,
   remoteListPlaylists,
   remoteListPlaylistTracks,
@@ -378,6 +381,17 @@ export function PlaylistView({
   // Server id of the remote track playing right now, so the matching row
   // lights up the way a local one does off `currentTrack.id`.
   const [playingRemoteId, setPlayingRemoteId] = useState<string | null>(null);
+  // Remote only: which of this playlist's tracks already have an offline copy,
+  // and how far a "keep offline" run has got. Kept as a set of server ids
+  // rather than per-row state — the question is asked once for the whole
+  // playlist, and a row does not need to answer it on its own.
+  const [offlineIds, setOfflineIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [keeping, setKeeping] = useState<{
+    done: number;
+    total: number;
+  } | null>(null);
   // Bumped by the `track:updated` listener and by every remote write, to
   // flip the fetch effect's deps and pull a fresh snapshot when neither
   // the playlist id nor its `updated_at` changed.
@@ -658,6 +672,38 @@ export function PlaylistView({
     [remotePlaylistId],
   );
 
+  /**
+   * Remote only: keep every track of this playlist on disk.
+   *
+   * Sequential on purpose. Parallel downloads would race the server's own
+   * transcode ceiling and each other's bandwidth for no gain — the wait is the
+   * bytes, not the round-trips — and one at a time is what lets the count mean
+   * something while it runs.
+   */
+  const keepOffline = useCallback(async () => {
+    const missing = tracksRef.current
+      .map((row) => row.remote_id)
+      .filter((id): id is string => !!id && !offlineIds.has(id));
+    if (missing.length === 0) return;
+    setRemoteError(null);
+    setKeeping({ done: 0, total: missing.length });
+    const kept = new Set(offlineIds);
+    try {
+      for (const [index, id] of missing.entries()) {
+        await remoteDownloadTrack(id);
+        kept.add(id);
+        setKeeping({ done: index + 1, total: missing.length });
+      }
+    } catch (err) {
+      // Stop at the first failure rather than hammering a server that just
+      // refused; what was already kept stays kept.
+      setRemoteError(String(err));
+    } finally {
+      setOfflineIds(kept);
+      setKeeping(null);
+    }
+  }, [offlineIds]);
+
   /** Remote only: append server tracks picked from the catalogue search. */
   const handleAddRemoteTracks = useCallback(
     async (ids: string[]) => {
@@ -796,6 +842,26 @@ export function PlaylistView({
     refetchKey,
   ]);
 
+  // Which server tracks are already on this disk. Re-read after a run, and
+  // when the playlist changes, so the button says what is actually true.
+  useEffect(() => {
+    if (!remote) return;
+    let cancelled = false;
+    remoteListDownloads()
+      .then((rows) => {
+        if (!cancelled) {
+          setOfflineIds(new Set(rows.map((row) => row.remote_track_id)));
+        }
+      })
+      .catch(() => {
+        // A list we could not read leaves the button offering to download
+        // again, which is a no-op server-side rather than a duplicate.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [remote, remotePlaylistId, refetchKey]);
+
   // Debounced catalogue search while the add panel is open (remote only).
   const searchSeqRef = useRef(0);
   const trimmedQuery = query.trim();
@@ -920,6 +986,17 @@ export function PlaylistView({
   if (!playlist || loadedKey !== playlistKey) {
     return <PlaylistSkeleton t={t} />;
   }
+
+  // How many of these tracks are already on this disk. Counted here rather
+  // than stored, so removing a copy from Settings is reflected without this
+  // view having to hear about it.
+  const offlineTrackCount = remote
+    ? tracks.reduce(
+        (total, row) =>
+          total + (row.remote_id && offlineIds.has(row.remote_id) ? 1 : 0),
+        0,
+      )
+    : 0;
 
   const color = resolvePlaylistColor(playlist.color_id);
   const totalDurationMs = playlist.total_duration_ms;
@@ -1130,6 +1207,27 @@ export function PlaylistView({
                   </span>
                   <span>·</span>
                   <span>{totalDurationLabel}</span>
+                  {remote && keeping && (
+                    <>
+                      <span>·</span>
+                      <span>
+                        {t("remote.playlist.keepingProgress", {
+                          done: keeping.done,
+                          total: keeping.total,
+                        })}
+                      </span>
+                    </>
+                  )}
+                  {remote && !keeping && offlineTrackCount > 0 && (
+                    <>
+                      <span>·</span>
+                      <span>
+                        {t("remote.playlist.keptOffline", {
+                          count: offlineTrackCount,
+                        })}
+                      </span>
+                    </>
+                  )}
                   {remote && remotePending && (
                     <>
                       <span>·</span>
@@ -1187,6 +1285,28 @@ export function PlaylistView({
                       }`}
                     >
                       <ListPlus size={18} />
+                    </button>
+                  </Tooltip>
+                )}
+
+                {/* Keep every track on this disk. Absent once they all are:
+                    a control whose only outcome is "nothing to do" is noise,
+                    and the settings card is where copies are reviewed and
+                    dropped. */}
+                {remote && offlineTrackCount < tracks.length && (
+                  <Tooltip label={t("remote.playlist.keepOffline")}>
+                    <button
+                      type="button"
+                      onClick={() => void keepOffline()}
+                      disabled={remoteBusy || keeping !== null}
+                      aria-label={t("remote.playlist.keepOffline")}
+                      className="p-2 rounded-lg transition-colors hover:bg-zinc-100 text-zinc-500 hover:text-zinc-800 dark:hover:bg-zinc-700 dark:text-zinc-400 dark:hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {keeping ? (
+                        <Loader2 size={18} className="animate-spin" />
+                      ) : (
+                        <ArrowDownToLine size={18} />
+                      )}
                     </button>
                   </Tooltip>
                 )}

--- a/src/components/views/settings/CatalogueMirrorCard.tsx
+++ b/src/components/views/settings/CatalogueMirrorCard.tsx
@@ -10,8 +10,11 @@ import {
   remoteArtworkCacheInfo,
   remoteClearArtworkCache,
   remoteMirrorCatalogue,
+  remoteClearDownloads,
   remoteClearStreamCache,
+  remoteDownloadsInfo,
   remoteStreamCacheInfo,
+  type DownloadsInfo,
   type ArtworkCacheInfo,
   type StreamCacheInfo,
   type CatalogueMirrorProgress,
@@ -49,8 +52,9 @@ export function CatalogueMirrorCard() {
   const [progress, setProgress] = useState<CatalogueMirrorProgress | null>(null);
   const [covers, setCovers] = useState<ArtworkCacheInfo | null>(null);
   const [streams, setStreams] = useState<StreamCacheInfo | null>(null);
+  const [downloads, setDownloads] = useState<DownloadsInfo | null>(null);
   const [busy, setBusy] = useState<
-    null | "mirror" | "clear" | "covers" | "streams"
+    null | "mirror" | "clear" | "covers" | "streams" | "downloads"
   >(null);
   const [confirmClear, setConfirmClear] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -70,6 +74,12 @@ export function CatalogueMirrorCard() {
       if (mountedRef.current) setStreams(cache);
     } catch {
       // Same: a figure that failed to refresh is better than none.
+    }
+    try {
+      const kept = await remoteDownloadsInfo();
+      if (mountedRef.current) setDownloads(kept);
+    } catch {
+      // Same again.
     }
   }, []);
 
@@ -149,6 +159,19 @@ export function CatalogueMirrorCard() {
     setError(null);
     try {
       await remoteClearStreamCache();
+      await refreshStats();
+    } catch (err) {
+      if (mountedRef.current) setError(String(err));
+    } finally {
+      if (mountedRef.current) setBusy(null);
+    }
+  }, [refreshStats]);
+
+  const clearDownloads = useCallback(async () => {
+    setBusy("downloads");
+    setError(null);
+    try {
+      await remoteClearDownloads();
       await refreshStats();
     } catch (err) {
       if (mountedRef.current) setError(String(err));
@@ -338,6 +361,31 @@ export function CatalogueMirrorCard() {
                 className="underline underline-offset-2 disabled:opacity-50"
               >
                 {t("remote.catalogue.clearStreams")}
+              </button>
+            </p>
+          )}
+
+          {/* Offline copies, counted apart from the cache above and cleared
+              apart from it: the cache is evicted under a budget without
+              asking, and these disappear only when their owner says so. */}
+          {downloads && downloads.tracks > 0 && (
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 flex items-center gap-2 flex-wrap">
+              <span>
+                {t("remote.catalogue.downloadsKept", {
+                  count: downloads.tracks,
+                  size: formatBytes(
+                    downloads.bytes,
+                    i18n.resolvedLanguage ?? i18n.language,
+                  ),
+                })}
+              </span>
+              <button
+                type="button"
+                onClick={() => void clearDownloads()}
+                disabled={busy !== null}
+                className="underline underline-offset-2 disabled:opacity-50"
+              >
+                {t("remote.catalogue.clearDownloads")}
               </button>
             </p>
           )}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -2440,7 +2440,15 @@
       "addTrack": "إضافة {{title}}",
       "addToPlaylist": "إضافة إلى قائمة التشغيل",
       "emptyDescription": "استخدم «إضافة مقاطع» للبحث في كتالوج الخادم.",
-      "notFoundDescription": "لم تعد قائمة التشغيل هذه موجودة على الخادم المرتبط."
+      "notFoundDescription": "لم تعد قائمة التشغيل هذه موجودة على الخادم المرتبط.",
+      "keepOffline": "حفظ دون اتصال",
+      "keepingProgress": "حُفظ {{done}}/{{total}}",
+      "keptOffline_few": "{{count}} دون اتصال",
+      "keptOffline_many": "{{count}} دون اتصال",
+      "keptOffline_one": "{{count}} دون اتصال",
+      "keptOffline_other": "{{count}} دون اتصال",
+      "keptOffline_two": "{{count}} دون اتصال",
+      "keptOffline_zero": "لا شيء دون اتصال"
     },
     "reconciliation": {
       "title": "المطابقة بين المحلي ↔ الخادم",
@@ -2584,7 +2592,14 @@
       "streamsCached_other": "{{count}} مقطع في الذاكرة المؤقتة ({{size}} ميغابايت).",
       "streamsCached_two": "مقطعان في الذاكرة المؤقتة ({{size}} ميغابايت).",
       "streamsCached_zero": "لا مقاطع في الذاكرة المؤقتة.",
-      "clearStreams": "إفراغ"
+      "clearStreams": "إفراغ",
+      "downloadsKept_few": "حُفظت {{count}} مقاطع دون اتصال ({{size}} ميغابايت).",
+      "downloadsKept_many": "حُفظ {{count}} مقطعًا دون اتصال ({{size}} ميغابايت).",
+      "downloadsKept_one": "حُفظ مقطع واحد دون اتصال ({{size}} ميغابايت).",
+      "downloadsKept_other": "حُفظ {{count}} مقطع دون اتصال ({{size}} ميغابايت).",
+      "downloadsKept_two": "حُفظ مقطعان دون اتصال ({{size}} ميغابايت).",
+      "downloadsKept_zero": "لم يُحفظ شيء دون اتصال.",
+      "clearDownloads": "إفراغ"
     }
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2238,7 +2238,12 @@
       "addTrack": "{{title}} hinzufügen",
       "addToPlaylist": "Zur Playlist hinzufügen",
       "emptyDescription": "Nutze „Titel hinzufügen“, um den Katalog des Servers zu durchsuchen.",
-      "notFoundDescription": "Diese Playlist existiert auf dem verbundenen Server nicht mehr."
+      "notFoundDescription": "Diese Playlist existiert auf dem verbundenen Server nicht mehr.",
+      "keepOffline": "Offline behalten",
+      "keepingProgress": "{{done}}/{{total}} behalten",
+      "keptOffline_one": "{{count}} offline",
+      "keptOffline_other": "{{count}} offline",
+      "keptOffline_zero": "nichts offline"
     },
     "reconciliation": {
       "title": "Abgleich lokal ↔ Server",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} Titel im Zwischenspeicher ({{size}} MB).",
       "streamsCached_other": "{{count}} Titel im Zwischenspeicher ({{size}} MB).",
       "streamsCached_zero": "Keine Titel im Zwischenspeicher.",
-      "clearStreams": "Leeren"
+      "clearStreams": "Leeren",
+      "downloadsKept_one": "{{count}} Titel offline behalten ({{size}} MB).",
+      "downloadsKept_other": "{{count}} Titel offline behalten ({{size}} MB).",
+      "downloadsKept_zero": "Nichts offline behalten.",
+      "clearDownloads": "Leeren"
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2238,7 +2238,12 @@
       "addTrack": "Add {{title}}",
       "addToPlaylist": "Add to playlist",
       "emptyDescription": "Use Add tracks to search the server's catalogue.",
-      "notFoundDescription": "This playlist is no longer on the bound server."
+      "notFoundDescription": "This playlist is no longer on the bound server.",
+      "keepOffline": "Keep offline",
+      "keepingProgress": "keeping {{done}}/{{total}}",
+      "keptOffline_one": "{{count}} kept offline",
+      "keptOffline_other": "{{count}} kept offline",
+      "keptOffline_zero": "none kept offline"
     },
     "reconciliation": {
       "title": "Local ↔ server matching",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} track cached ({{size}} MB).",
       "streamsCached_other": "{{count}} tracks cached ({{size}} MB).",
       "streamsCached_zero": "No tracks cached.",
-      "clearStreams": "Clear"
+      "clearStreams": "Clear",
+      "downloadsKept_one": "{{count}} track kept offline ({{size}} MB).",
+      "downloadsKept_other": "{{count}} tracks kept offline ({{size}} MB).",
+      "downloadsKept_zero": "Nothing kept offline.",
+      "clearDownloads": "Clear"
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2238,7 +2238,12 @@
       "addTrack": "Añadir {{title}}",
       "addToPlaylist": "Añadir a la lista",
       "emptyDescription": "Usa «Añadir títulos» para buscar en el catálogo del servidor.",
-      "notFoundDescription": "Esta lista ya no existe en el servidor vinculado."
+      "notFoundDescription": "Esta lista ya no existe en el servidor vinculado.",
+      "keepOffline": "Guardar sin conexión",
+      "keepingProgress": "{{done}}/{{total}} guardadas",
+      "keptOffline_one": "{{count}} sin conexión",
+      "keptOffline_other": "{{count}} sin conexión",
+      "keptOffline_zero": "ninguna sin conexión"
     },
     "reconciliation": {
       "title": "Correspondencia local ↔ servidor",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} pista en caché ({{size}} MB).",
       "streamsCached_other": "{{count}} pistas en caché ({{size}} MB).",
       "streamsCached_zero": "Ninguna pista en caché.",
-      "clearStreams": "Vaciar"
+      "clearStreams": "Vaciar",
+      "downloadsKept_one": "{{count}} pista guardada sin conexión ({{size}} MB).",
+      "downloadsKept_other": "{{count}} pistas guardadas sin conexión ({{size}} MB).",
+      "downloadsKept_zero": "Nada guardado sin conexión.",
+      "clearDownloads": "Vaciar"
     }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2238,7 +2238,12 @@
       "addTrack": "Ajouter {{title}}",
       "addToPlaylist": "Ajouter à la playlist",
       "emptyDescription": "Utilisez « Ajouter des titres » pour chercher dans le catalogue du serveur.",
-      "notFoundDescription": "Cette playlist n'existe plus sur le serveur associé."
+      "notFoundDescription": "Cette playlist n'existe plus sur le serveur associé.",
+      "keepOffline": "Garder hors ligne",
+      "keepingProgress": "{{done}}/{{total}} gardés",
+      "keptOffline_one": "{{count}} hors ligne",
+      "keptOffline_other": "{{count}} hors ligne",
+      "keptOffline_zero": "aucun hors ligne"
     },
     "reconciliation": {
       "title": "Correspondance local ↔ serveur",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} piste en cache ({{size}} Mo).",
       "streamsCached_other": "{{count}} pistes en cache ({{size}} Mo).",
       "streamsCached_zero": "Aucune piste en cache.",
-      "clearStreams": "Vider"
+      "clearStreams": "Vider",
+      "downloadsKept_one": "{{count}} piste gardée hors ligne ({{size}} Mo).",
+      "downloadsKept_other": "{{count}} pistes gardées hors ligne ({{size}} Mo).",
+      "downloadsKept_zero": "Rien gardé hors ligne.",
+      "clearDownloads": "Vider"
     }
   }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -2238,7 +2238,12 @@
       "addTrack": "{{title}} जोड़ें",
       "addToPlaylist": "प्लेलिस्ट में जोड़ें",
       "emptyDescription": "सर्वर की सूची में खोजने के लिए «ट्रैक जोड़ें» का उपयोग करें।",
-      "notFoundDescription": "यह प्लेलिस्ट अब जुड़े हुए सर्वर पर मौजूद नहीं है।"
+      "notFoundDescription": "यह प्लेलिस्ट अब जुड़े हुए सर्वर पर मौजूद नहीं है।",
+      "keepOffline": "ऑफ़लाइन रखें",
+      "keepingProgress": "{{done}}/{{total}} रखे गए",
+      "keptOffline_one": "{{count}} ऑफ़लाइन",
+      "keptOffline_other": "{{count}} ऑफ़लाइन",
+      "keptOffline_zero": "कोई ऑफ़लाइन नहीं"
     },
     "reconciliation": {
       "title": "स्थानीय ↔ सर्वर मिलान",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} ट्रैक कैश में ({{size}} MB)।",
       "streamsCached_other": "{{count}} ट्रैक कैश में ({{size}} MB)।",
       "streamsCached_zero": "कैश में कोई ट्रैक नहीं।",
-      "clearStreams": "हटाएँ"
+      "clearStreams": "हटाएँ",
+      "downloadsKept_one": "{{count}} ट्रैक ऑफ़लाइन रखा गया ({{size}} MB)।",
+      "downloadsKept_other": "{{count}} ट्रैक ऑफ़लाइन रखे गए ({{size}} MB)।",
+      "downloadsKept_zero": "ऑफ़लाइन कुछ नहीं रखा गया।",
+      "clearDownloads": "हटाएँ"
     }
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -2228,7 +2228,12 @@
       "addTrack": "Tambah {{title}}",
       "addToPlaylist": "Tambah ke playlist",
       "emptyDescription": "Gunakan «Tambah lagu» untuk mencari di katalog server.",
-      "notFoundDescription": "Playlist ini sudah tidak ada di server yang terhubung."
+      "notFoundDescription": "Playlist ini sudah tidak ada di server yang terhubung.",
+      "keepOffline": "Simpan offline",
+      "keepingProgress": "{{done}}/{{total}} disimpan",
+      "keptOffline_one": "{{count}} offline",
+      "keptOffline_other": "{{count}} offline",
+      "keptOffline_zero": "tidak ada offline"
     },
     "reconciliation": {
       "title": "Pencocokan lokal ↔ server",
@@ -2311,7 +2316,11 @@
       "streamsCached_one": "{{count}} lagu di cache ({{size}} MB).",
       "streamsCached_other": "{{count}} lagu di cache ({{size}} MB).",
       "streamsCached_zero": "Tidak ada lagu di cache.",
-      "clearStreams": "Kosongkan"
+      "clearStreams": "Kosongkan",
+      "downloadsKept_one": "{{count}} lagu disimpan offline ({{size}} MB).",
+      "downloadsKept_other": "{{count}} lagu disimpan offline ({{size}} MB).",
+      "downloadsKept_zero": "Tidak ada yang disimpan offline.",
+      "clearDownloads": "Kosongkan"
     }
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2238,7 +2238,12 @@
       "addTrack": "Aggiungi {{title}}",
       "addToPlaylist": "Aggiungi alla playlist",
       "emptyDescription": "Usa «Aggiungi brani» per cercare nel catalogo del server.",
-      "notFoundDescription": "Questa playlist non esiste più sul server collegato."
+      "notFoundDescription": "Questa playlist non esiste più sul server collegato.",
+      "keepOffline": "Tieni offline",
+      "keepingProgress": "{{done}}/{{total}} tenuti",
+      "keptOffline_one": "{{count}} offline",
+      "keptOffline_other": "{{count}} offline",
+      "keptOffline_zero": "nessuno offline"
     },
     "reconciliation": {
       "title": "Corrispondenza locale ↔ server",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} brano in cache ({{size}} MB).",
       "streamsCached_other": "{{count}} brani in cache ({{size}} MB).",
       "streamsCached_zero": "Nessun brano in cache.",
-      "clearStreams": "Svuota"
+      "clearStreams": "Svuota",
+      "downloadsKept_one": "{{count}} brano tenuto offline ({{size}} MB).",
+      "downloadsKept_other": "{{count}} brani tenuti offline ({{size}} MB).",
+      "downloadsKept_zero": "Niente tenuto offline.",
+      "clearDownloads": "Svuota"
     }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2228,7 +2228,12 @@
       "addTrack": "{{title}} を追加",
       "addToPlaylist": "プレイリストに追加",
       "emptyDescription": "「曲を追加」から、サーバーのカタログを検索してください。",
-      "notFoundDescription": "このプレイリストは、接続中のサーバーにはもう存在しません。"
+      "notFoundDescription": "このプレイリストは、接続中のサーバーにはもう存在しません。",
+      "keepOffline": "オフラインで保存",
+      "keepingProgress": "{{done}}/{{total}} 保存済み",
+      "keptOffline_one": "{{count}} 件オフライン",
+      "keptOffline_other": "{{count}} 件オフライン",
+      "keptOffline_zero": "オフライン保存なし"
     },
     "reconciliation": {
       "title": "ローカル ↔ サーバーの照合",
@@ -2311,7 +2316,11 @@
       "streamsCached_one": "キャッシュ済みの楽曲 {{count}} 件（{{size}} MB）",
       "streamsCached_other": "キャッシュ済みの楽曲 {{count}} 件（{{size}} MB）",
       "streamsCached_zero": "キャッシュされた楽曲はありません。",
-      "clearStreams": "削除"
+      "clearStreams": "削除",
+      "downloadsKept_one": "オフライン保存 {{count}} 件（{{size}} MB）",
+      "downloadsKept_other": "オフライン保存 {{count}} 件（{{size}} MB）",
+      "downloadsKept_zero": "オフラインに保存された楽曲はありません。",
+      "clearDownloads": "削除"
     }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2228,7 +2228,12 @@
       "addTrack": "{{title}} 추가",
       "addToPlaylist": "플레이리스트에 추가",
       "emptyDescription": "‘트랙 추가’를 눌러 서버 카탈로그에서 검색하세요.",
-      "notFoundDescription": "이 플레이리스트는 연결된 서버에 더 이상 존재하지 않습니다."
+      "notFoundDescription": "이 플레이리스트는 연결된 서버에 더 이상 존재하지 않습니다.",
+      "keepOffline": "오프라인 보관",
+      "keepingProgress": "{{done}}/{{total}} 보관됨",
+      "keptOffline_one": "{{count}}개 오프라인",
+      "keptOffline_other": "{{count}}개 오프라인",
+      "keptOffline_zero": "오프라인 없음"
     },
     "reconciliation": {
       "title": "로컬 ↔ 서버 매칭",
@@ -2311,7 +2316,11 @@
       "streamsCached_one": "캐시된 트랙 {{count}}개 ({{size}} MB)",
       "streamsCached_other": "캐시된 트랙 {{count}}개 ({{size}} MB)",
       "streamsCached_zero": "캐시된 트랙이 없습니다.",
-      "clearStreams": "비우기"
+      "clearStreams": "비우기",
+      "downloadsKept_one": "오프라인 보관 트랙 {{count}}개 ({{size}} MB)",
+      "downloadsKept_other": "오프라인 보관 트랙 {{count}}개 ({{size}} MB)",
+      "downloadsKept_zero": "오프라인으로 보관된 트랙이 없습니다.",
+      "clearDownloads": "비우기"
     }
   }
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2238,7 +2238,12 @@
       "addTrack": "{{title}} toevoegen",
       "addToPlaylist": "Aan afspeellijst toevoegen",
       "emptyDescription": "Gebruik ‘Nummers toevoegen’ om de catalogus van de server te doorzoeken.",
-      "notFoundDescription": "Deze afspeellijst staat niet meer op de gekoppelde server."
+      "notFoundDescription": "Deze afspeellijst staat niet meer op de gekoppelde server.",
+      "keepOffline": "Offline bewaren",
+      "keepingProgress": "{{done}}/{{total}} bewaard",
+      "keptOffline_one": "{{count}} offline",
+      "keptOffline_other": "{{count}} offline",
+      "keptOffline_zero": "niets offline"
     },
     "reconciliation": {
       "title": "Lokaal ↔ server-koppeling",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} nummer in cache ({{size}} MB).",
       "streamsCached_other": "{{count}} nummers in cache ({{size}} MB).",
       "streamsCached_zero": "Geen nummers in cache.",
-      "clearStreams": "Wissen"
+      "clearStreams": "Wissen",
+      "downloadsKept_one": "{{count}} nummer offline bewaard ({{size}} MB).",
+      "downloadsKept_other": "{{count}} nummers offline bewaard ({{size}} MB).",
+      "downloadsKept_zero": "Niets offline bewaard.",
+      "clearDownloads": "Wissen"
     }
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2238,7 +2238,12 @@
       "addTrack": "Adicionar {{title}}",
       "addToPlaylist": "Adicionar à playlist",
       "emptyDescription": "Use «Adicionar faixas» para buscar no catálogo do servidor.",
-      "notFoundDescription": "Essa playlist não existe mais no servidor vinculado."
+      "notFoundDescription": "Essa playlist não existe mais no servidor vinculado.",
+      "keepOffline": "Manter offline",
+      "keepingProgress": "{{done}}/{{total}} mantidas",
+      "keptOffline_one": "{{count}} offline",
+      "keptOffline_other": "{{count}} offline",
+      "keptOffline_zero": "nenhuma offline"
     },
     "reconciliation": {
       "title": "Correspondência local ↔ servidor",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} faixa em cache ({{size}} MB).",
       "streamsCached_other": "{{count}} faixas em cache ({{size}} MB).",
       "streamsCached_zero": "Nenhuma faixa em cache.",
-      "clearStreams": "Limpar"
+      "clearStreams": "Limpar",
+      "downloadsKept_one": "{{count}} faixa mantida offline ({{size}} MB).",
+      "downloadsKept_other": "{{count}} faixas mantidas offline ({{size}} MB).",
+      "downloadsKept_zero": "Nada mantido offline.",
+      "clearDownloads": "Limpar"
     }
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -2238,7 +2238,12 @@
       "addTrack": "Adicionar {{title}}",
       "addToPlaylist": "Adicionar à lista",
       "emptyDescription": "Usa «Adicionar faixas» para procurar no catálogo do servidor.",
-      "notFoundDescription": "Esta lista já não existe no servidor associado."
+      "notFoundDescription": "Esta lista já não existe no servidor associado.",
+      "keepOffline": "Manter offline",
+      "keepingProgress": "{{done}}/{{total}} mantidas",
+      "keptOffline_one": "{{count}} offline",
+      "keptOffline_other": "{{count}} offline",
+      "keptOffline_zero": "nenhuma offline"
     },
     "reconciliation": {
       "title": "Correspondência local ↔ servidor",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "{{count}} faixa em cache ({{size}} MB).",
       "streamsCached_other": "{{count}} faixas em cache ({{size}} MB).",
       "streamsCached_zero": "Nenhuma faixa em cache.",
-      "clearStreams": "Esvaziar"
+      "clearStreams": "Esvaziar",
+      "downloadsKept_one": "{{count}} faixa mantida offline ({{size}} MB).",
+      "downloadsKept_other": "{{count}} faixas mantidas offline ({{size}} MB).",
+      "downloadsKept_zero": "Nada mantido offline.",
+      "clearDownloads": "Esvaziar"
     }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -2358,7 +2358,14 @@
       "addTrack": "Добавить {{title}}",
       "addToPlaylist": "Добавить в плейлист",
       "emptyDescription": "Нажмите «Добавить треки», чтобы найти их в каталоге сервера.",
-      "notFoundDescription": "Этого плейлиста больше нет на подключённом сервере."
+      "notFoundDescription": "Этого плейлиста больше нет на подключённом сервере.",
+      "keepOffline": "Сохранить офлайн",
+      "keepingProgress": "сохранено {{done}}/{{total}}",
+      "keptOffline_few": "{{count}} офлайн",
+      "keptOffline_many": "{{count}} офлайн",
+      "keptOffline_one": "{{count}} офлайн",
+      "keptOffline_other": "{{count}} офлайн",
+      "keptOffline_zero": "ничего офлайн"
     },
     "reconciliation": {
       "title": "Сопоставление локально ↔ сервер",
@@ -2478,7 +2485,13 @@
       "streamsCached_one": "{{count}} трек в кэше ({{size}} МБ).",
       "streamsCached_other": "{{count}} треков в кэше ({{size}} МБ).",
       "streamsCached_zero": "Треков в кэше нет.",
-      "clearStreams": "Очистить"
+      "clearStreams": "Очистить",
+      "downloadsKept_few": "{{count}} трека сохранены офлайн ({{size}} МБ).",
+      "downloadsKept_many": "{{count}} треков сохранено офлайн ({{size}} МБ).",
+      "downloadsKept_one": "{{count}} трек сохранён офлайн ({{size}} МБ).",
+      "downloadsKept_other": "{{count}} треков сохранено офлайн ({{size}} МБ).",
+      "downloadsKept_zero": "Ничего не сохранено офлайн.",
+      "clearDownloads": "Очистить"
     }
   }
 }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -2238,7 +2238,12 @@
       "addTrack": "{{title}} ekle",
       "addToPlaylist": "Çalma listesine ekle",
       "emptyDescription": "Sunucunun kataloğunda arama yapmak için «Parça ekle» düğmesini kullan.",
-      "notFoundDescription": "Bu çalma listesi bağlı sunucuda artık yok."
+      "notFoundDescription": "Bu çalma listesi bağlı sunucuda artık yok.",
+      "keepOffline": "Çevrimdışı sakla",
+      "keepingProgress": "{{done}}/{{total}} saklandı",
+      "keptOffline_one": "{{count}} çevrimdışı",
+      "keptOffline_other": "{{count}} çevrimdışı",
+      "keptOffline_zero": "çevrimdışı yok"
     },
     "reconciliation": {
       "title": "Yerel ↔ sunucu eşleştirmesi",
@@ -2332,7 +2337,11 @@
       "streamsCached_one": "Önbellekte {{count}} parça ({{size}} MB).",
       "streamsCached_other": "Önbellekte {{count}} parça ({{size}} MB).",
       "streamsCached_zero": "Önbellekte parça yok.",
-      "clearStreams": "Temizle"
+      "clearStreams": "Temizle",
+      "downloadsKept_one": "Çevrimdışı {{count}} parça saklandı ({{size}} MB).",
+      "downloadsKept_other": "Çevrimdışı {{count}} parça saklandı ({{size}} MB).",
+      "downloadsKept_zero": "Çevrimdışı hiçbir şey saklanmadı.",
+      "clearDownloads": "Temizle"
     }
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2228,7 +2228,12 @@
       "addTrack": "添加 {{title}}",
       "addToPlaylist": "添加到播放列表",
       "emptyDescription": "点击「添加曲目」，在服务器的曲库中搜索。",
-      "notFoundDescription": "该播放列表在已连接的服务器上已不存在。"
+      "notFoundDescription": "该播放列表在已连接的服务器上已不存在。",
+      "keepOffline": "离线保存",
+      "keepingProgress": "已保存 {{done}}/{{total}}",
+      "keptOffline_one": "{{count}} 首离线",
+      "keptOffline_other": "{{count}} 首离线",
+      "keptOffline_zero": "无离线曲目"
     },
     "reconciliation": {
       "title": "本地 ↔ 服务器匹配",
@@ -2311,7 +2316,11 @@
       "streamsCached_one": "已缓存 {{count}} 首曲目（{{size}} MB）",
       "streamsCached_other": "已缓存 {{count}} 首曲目（{{size}} MB）",
       "streamsCached_zero": "没有缓存的曲目。",
-      "clearStreams": "清空"
+      "clearStreams": "清空",
+      "downloadsKept_one": "已离线保存 {{count}} 首曲目（{{size}} MB）",
+      "downloadsKept_other": "已离线保存 {{count}} 首曲目（{{size}} MB）",
+      "downloadsKept_zero": "没有离线保存的曲目。",
+      "clearDownloads": "清空"
     }
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2228,7 +2228,12 @@
       "addTrack": "新增 {{title}}",
       "addToPlaylist": "加入播放清單",
       "emptyDescription": "點選「新增曲目」，在伺服器的曲庫中搜尋。",
-      "notFoundDescription": "此播放清單在已連線的伺服器上已不存在。"
+      "notFoundDescription": "此播放清單在已連線的伺服器上已不存在。",
+      "keepOffline": "離線保存",
+      "keepingProgress": "已保存 {{done}}/{{total}}",
+      "keptOffline_one": "{{count}} 首離線",
+      "keptOffline_other": "{{count}} 首離線",
+      "keptOffline_zero": "無離線曲目"
     },
     "reconciliation": {
       "title": "本機 ↔ 伺服器比對",
@@ -2311,7 +2316,11 @@
       "streamsCached_one": "已快取 {{count}} 首曲目（{{size}} MB）",
       "streamsCached_other": "已快取 {{count}} 首曲目（{{size}} MB）",
       "streamsCached_zero": "沒有快取的曲目。",
-      "clearStreams": "清空"
+      "clearStreams": "清空",
+      "downloadsKept_one": "已離線保存 {{count}} 首曲目（{{size}} MB）",
+      "downloadsKept_other": "已離線保存 {{count}} 首曲目（{{size}} MB）",
+      "downloadsKept_zero": "沒有離線保存的曲目。",
+      "clearDownloads": "清空"
     }
   }
 }

--- a/src/lib/tauri/remoteServer.ts
+++ b/src/lib/tauri/remoteServer.ts
@@ -475,6 +475,58 @@ export function remoteStreamCacheInfo(): Promise<StreamCacheInfo> {
   return invoke<StreamCacheInfo>("remote_stream_cache_info");
 }
 
+/**
+ * An offline copy of a server track, kept in a folder the scanner never sees.
+ *
+ * Not a local library track: it describes a *remote* one that happens to be on
+ * this disk, which is why it is keyed by the server's id.
+ */
+export interface DownloadedTrack {
+  remote_track_id: string;
+  path: string;
+  /** BLAKE3 of the whole file, computed while writing it — the server's own
+   *  digest, so directly comparable, unlike the library's `file_hash`. */
+  full_hash: string;
+  size: number;
+  downloaded_at: number;
+}
+
+export interface DownloadsInfo {
+  bytes: number;
+  tracks: number;
+}
+
+/** Progress event payload (`remote:download-progress`), one per megabyte. */
+export interface DownloadProgress {
+  track_id: string;
+  received: number;
+  total: number | null;
+}
+
+/** Keep a track's original bytes. Answering with the existing copy when there
+ *  already is one, so asking twice costs nothing. */
+export function remoteDownloadTrack(trackId: string): Promise<DownloadedTrack> {
+  return invoke<DownloadedTrack>("remote_download_track", { trackId });
+}
+
+export function remoteListDownloads(): Promise<DownloadedTrack[]> {
+  return invoke<DownloadedTrack[]>("remote_list_downloads");
+}
+
+export function remoteDownloadsInfo(): Promise<DownloadsInfo> {
+  return invoke<DownloadsInfo>("remote_downloads_info");
+}
+
+/** Drop one offline copy. `false` when there was none. */
+export function remoteRemoveDownload(trackId: string): Promise<boolean> {
+  return invoke<boolean>("remote_remove_download", { trackId });
+}
+
+/** Drop every offline copy. Returns how many were removed. */
+export function remoteClearDownloads(): Promise<number> {
+  return invoke<number>("remote_clear_downloads");
+}
+
 /** Drop every cached stream. Costs one download per track played again. */
 export function remoteClearStreamCache(): Promise<number> {
   return invoke<number>("remote_clear_stream_cache");


### PR DESCRIPTION
**Lot 4, both halves.**

## Keeping a track

A download is not a cache entry. The cache is filled without asking and evicted without asking; a download is *chosen*, and leaves only when its owner says so. It lands in a managed folder the scanner never sees.

It is deliberately **not** a local library track: no `track` row is created for it, which also means `remote_track_link` cannot describe it — that table keys on `local_track_id REFERENCES track(id)`. It is recorded as what it actually is, a remote track that happens to be on this disk (`remote_track_download`).

### That resolves a contradiction the plan was carrying

The arbitration called the managed folder *invisible to the scan* **and** called the reconciliation link *free*. Both cannot be true of the same row: a link needs a local track, and an invisible folder produces none.

What is genuinely free is the **hash**. The file is hashed in the same pass that writes it, so the server's own `full_hash` — not the library's `file_hash`, which covers a file the server has never seen — is in hand the moment a `track` row exists to attach it to. The link is paid *forward*, when someone imports into a scanned folder, not here.

### Always the original bytes

Whatever the transcode preference says. That preference exists to spend less bandwidth on a stream heard once; baking a lossy re-encode into a file someone chose to keep would make a bandwidth decision permanent, and silently.

Playback prefers, in order: **reconciled local file → download → cached stream → network.**

## Playing one whose file is gone

Server-to-local has always resolved. **Local-to-server never did** — a library track whose file had been moved or deleted just failed with `file not found` (`player.rs:1922`). With a *confirmed* link it now plays from the server instead.

Only confirmed. A stale link is a guess, and guessing which recording to substitute is worse than reporting the missing file.

### The decoder was answering two questions with one variable

It decided **"finite file or endless radio?"** from the *global remote-session state*. That is right for the remote queue and wrong for everyone else: a library track falling back has no session, so it would have been opened with ICY — forward-only, and parsing metadata blocks out of a FLAC.

Finiteness is a property of *this stream* and now travels on the command. Whether a remote session is running stays what it was, and still drives the metadata the bar shows. Separating them is what made the fallback possible at all, and it removes a coupling that would have broken for the next caller too.

## Verification

- The migration was applied to a **real profile database**, not a fixture, with `foreign_keys` on; both CHECK constraints were probed and both bite (`length(full_hash) = 64`, `size > 0`).
- 417 lib tests green.
- **Both feature configurations build clean** — the new path helpers are gated, since nothing without `sync_v2` can reach them.

## Not verified

A real download against a live server, and therefore the fallback end to end. The sandbox has a projection but no bytes and no reachable host. The path-safety and naming logic is unit-tested; the wiring is not.

## Surface

Per-playlist **"keep offline"** in the remote header — sequential on purpose, since the wait is the bytes rather than the round-trips, and one at a time is what lets the count mean anything while it runs. Settings reports and clears the copies, apart from the stream cache, because the two have opposite lifetimes.

i18n: 5 keys × 17 locales, plural sets taken from **each locale's own** categories with the script failing loudly on a missing body.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Téléchargez des titres de playlists distantes pour les écouter hors connexion.
  - Suivez la progression, le nombre de titres conservés et l’espace utilisé.
  - Consultez, supprimez individuellement ou effacez tous les téléchargements.
  - Les téléchargements sont prioritaires à la lecture, y compris lorsque le fichier local lié est indisponible.
  - Les fichiers audio finis prennent en charge la navigation, tandis que les radios conservent leur fonctionnement habituel.

- **Internationalisation**
  - Nouveaux libellés disponibles dans toutes les langues prises en charge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->