### PR TITLE
docs(rfc): RFC-006 — deduplicating the two catalogues

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ Long-form design documents that lock in cross-cutting architectural decisions be
 | [RFC-003 — Sync architecture v2](rfcs/RFC-003-sync-architecture.md) | Superseded by RFC-005 | Backfill, HLC ordering, per-entity CRDT conflict resolution. **Not** the server's RFC-003 — see [RFC-005](rfcs/RFC-005-remote-source-and-sync-v2.md#the-rfc-003-naming-trap). |
 | [RFC-004 — Community-DB](rfcs/RFC-004-community-database.md)        | Draft    | Opt-in shared metadata pool (lyrics, bios, BPM, etc.), LRCLIB pattern. Schema + endpoints + privacy.     |
 | [RFC-005 — Remote source + sync v2](rfcs/RFC-005-remote-source-and-sync-v2.md) | Accepted | The server catalogue as a separate remote source, `MusicServer` / `SyncProvider` seam, PKCE, journal-based user-data sync. |
+| [RFC-006 — Deduplicating the two catalogues](rfcs/RFC-006-deduplicating-the-two-catalogues.md) | Proposed | What a content-proven track pair is allowed to change above the track: one entry per album and artist, derived from links and never from names. |
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Long-form design documents that lock in cross-cutting architectural decisions be
 | [RFC-003 — Sync architecture v2](rfcs/RFC-003-sync-architecture.md) | Superseded by RFC-005 | Backfill, HLC ordering, per-entity CRDT conflict resolution. **Not** the server's RFC-003 — see [RFC-005](rfcs/RFC-005-remote-source-and-sync-v2.md#the-rfc-003-naming-trap). |
 | [RFC-004 — Community-DB](rfcs/RFC-004-community-database.md)        | Draft    | Opt-in shared metadata pool (lyrics, bios, BPM, etc.), LRCLIB pattern. Schema + endpoints + privacy.     |
 | [RFC-005 — Remote source + sync v2](rfcs/RFC-005-remote-source-and-sync-v2.md) | Accepted | The server catalogue as a separate remote source, `MusicServer` / `SyncProvider` seam, PKCE, journal-based user-data sync. |
-| [RFC-006 — Deduplicating the two catalogues](rfcs/RFC-006-deduplicating-the-two-catalogues.md) | Accepted | What a content-proven track pair may change above the track. Albums pair on a complete bijection, artists on unanimity; nothing pairs before both sides have been examined. |
+| [RFC-006 — Deduplicating the two catalogues](rfcs/RFC-006-deduplicating-the-two-catalogues.md) | Accepted | What a content-proven track pair may change above the track. Albums pair on a complete non-empty bijection, artists on unanimity plus at least two confirmed links; nothing pairs before both sides have been reconciled. |
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Long-form design documents that lock in cross-cutting architectural decisions be
 | [RFC-003 — Sync architecture v2](rfcs/RFC-003-sync-architecture.md) | Superseded by RFC-005 | Backfill, HLC ordering, per-entity CRDT conflict resolution. **Not** the server's RFC-003 — see [RFC-005](rfcs/RFC-005-remote-source-and-sync-v2.md#the-rfc-003-naming-trap). |
 | [RFC-004 — Community-DB](rfcs/RFC-004-community-database.md)        | Draft    | Opt-in shared metadata pool (lyrics, bios, BPM, etc.), LRCLIB pattern. Schema + endpoints + privacy.     |
 | [RFC-005 — Remote source + sync v2](rfcs/RFC-005-remote-source-and-sync-v2.md) | Accepted | The server catalogue as a separate remote source, `MusicServer` / `SyncProvider` seam, PKCE, journal-based user-data sync. |
-| [RFC-006 — Deduplicating the two catalogues](rfcs/RFC-006-deduplicating-the-two-catalogues.md) | Proposed | What a content-proven track pair may change above the track. Albums pair on a complete bijection, artists on unanimity; nothing pairs before both sides have been examined. |
+| [RFC-006 — Deduplicating the two catalogues](rfcs/RFC-006-deduplicating-the-two-catalogues.md) | Accepted | What a content-proven track pair may change above the track. Albums pair on a complete bijection, artists on unanimity; nothing pairs before both sides have been examined. |
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Long-form design documents that lock in cross-cutting architectural decisions be
 | [RFC-003 — Sync architecture v2](rfcs/RFC-003-sync-architecture.md) | Superseded by RFC-005 | Backfill, HLC ordering, per-entity CRDT conflict resolution. **Not** the server's RFC-003 — see [RFC-005](rfcs/RFC-005-remote-source-and-sync-v2.md#the-rfc-003-naming-trap). |
 | [RFC-004 — Community-DB](rfcs/RFC-004-community-database.md)        | Draft    | Opt-in shared metadata pool (lyrics, bios, BPM, etc.), LRCLIB pattern. Schema + endpoints + privacy.     |
 | [RFC-005 — Remote source + sync v2](rfcs/RFC-005-remote-source-and-sync-v2.md) | Accepted | The server catalogue as a separate remote source, `MusicServer` / `SyncProvider` seam, PKCE, journal-based user-data sync. |
-| [RFC-006 — Deduplicating the two catalogues](rfcs/RFC-006-deduplicating-the-two-catalogues.md) | Proposed | What a content-proven track pair is allowed to change above the track: one entry per album and artist, derived from links and never from names. |
+| [RFC-006 — Deduplicating the two catalogues](rfcs/RFC-006-deduplicating-the-two-catalogues.md) | Proposed | What a content-proven track pair may change above the track. Albums pair on a complete bijection, artists on unanimity; nothing pairs before both sides have been examined. |
 
 ## Contributing
 

--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -46,12 +46,15 @@ shown apart.
 Matching a local file to a server track is **out of scope** and needs its own
 RFC. When it comes, the only automatic link allowed is an exact, unique
 content-hash match; a MusicBrainz identifier is a suggestion the user confirms;
-matching by title/artist/duration is explicitly forbidden. The matching layer
-shipped without an RFC of its own — it is `remote::reconciliation` and the
-`remote_track_link` table, which hold to every constraint stated above.
-[RFC-006](RFC-006-deduplicating-the-two-catalogues.md) is not that
-specification: it is the deduplication layer built on top of those proofs, and
-it adds no second way of matching.
+matching by title/artist/duration is explicitly forbidden.
+
+*Since accepted:* that layer was built directly, without a separate RFC — it is
+`remote::reconciliation` and the `remote_track_link` table, and it holds to
+every constraint the paragraph above sets. The RFC this paragraph anticipated
+never covered matching;
+[RFC-006](RFC-006-deduplicating-the-two-catalogues.md) is the deduplication
+layer built on top of those proofs and adds no second way of matching. The
+normative rules for matching remain the three sentences above.
 
 **What this costs.** Local playlists no longer travel between machines. That
 capability existed in the v1 design and is genuinely lost. It cannot be

--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -46,7 +46,10 @@ shown apart.
 Matching a local file to a server track is **out of scope** and needs its own
 RFC. When it comes, the only automatic link allowed is an exact, unique
 content-hash match; a MusicBrainz identifier is a suggestion the user confirms;
-matching by title/artist/duration is explicitly forbidden.
+matching by title/artist/duration is explicitly forbidden. That RFC is
+[RFC-006](RFC-006-deduplicating-the-two-catalogues.md); the matching layer
+itself shipped first, and RFC-006 decides what its proofs are allowed to change
+above the track.
 
 **What this costs.** Local playlists no longer travel between machines. That
 capability existed in the v1 design and is genuinely lost. It cannot be
@@ -696,7 +699,8 @@ list rather than a section beside it — which is the whole difference between a
 unified library and two tabs, and it changes nothing about Decision 1: an album
 held both locally and on the server appears **twice**, tagged twice. Unifying
 the navigation is not deduplicating the catalogue; that is reserved for its own
-RFC.
+RFC — now written, as
+[RFC-006](RFC-006-deduplicating-the-two-catalogues.md).
 
 Two things the query has to get right, and both are about the halves being
 comparable rather than merely concatenated:

--- a/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
+++ b/docs/rfcs/RFC-005-remote-source-and-sync-v2.md
@@ -46,10 +46,12 @@ shown apart.
 Matching a local file to a server track is **out of scope** and needs its own
 RFC. When it comes, the only automatic link allowed is an exact, unique
 content-hash match; a MusicBrainz identifier is a suggestion the user confirms;
-matching by title/artist/duration is explicitly forbidden. That RFC is
-[RFC-006](RFC-006-deduplicating-the-two-catalogues.md); the matching layer
-itself shipped first, and RFC-006 decides what its proofs are allowed to change
-above the track.
+matching by title/artist/duration is explicitly forbidden. The matching layer
+shipped without an RFC of its own — it is `remote::reconciliation` and the
+`remote_track_link` table, which hold to every constraint stated above.
+[RFC-006](RFC-006-deduplicating-the-two-catalogues.md) is not that
+specification: it is the deduplication layer built on top of those proofs, and
+it adds no second way of matching.
 
 **What this costs.** Local playlists no longer travel between machines. That
 capability existed in the v1 design and is genuinely lost. It cannot be

--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -5,13 +5,14 @@
 - **Authors**: @InstaZDLL
 - **Depends on**: [RFC-005](RFC-005-remote-source-and-sync-v2.md) — this RFC answers the question its Decision 1 deferred, and does not revisit anything else it settled.
 - **Implementation**: none yet.
+- **Revised** after external review, before any implementation. What the first draft proposed for albums is kept below, as [the rule that was withdrawn](#the-album-rule-that-was-withdrawn), because the reason it fails is the most useful thing in this document.
 
 ---
 
 ## The question this RFC answers
 
 [RFC-005](RFC-005-remote-source-and-sync-v2.md) closed a door and named the RFC
-that would reopen it. Twice, in the same words:
+that would reopen it. Twice:
 
 > Matching a local file to a server track is **out of scope** and needs its own
 > RFC.
@@ -38,7 +39,8 @@ RFC-005 got right.
 reconstructible: dropping it and re-fetching a snapshot is always a valid
 recovery. Writing server rows into `album` or `artist` would fabricate local
 entities for things that exist only on a server, which is precisely the
-corruption Decision 1 exists to prevent. Nothing below writes across that line.
+corruption RFC-005's own Decision 1 exists to prevent. Nothing below writes
+across that line.
 
 **It is not choosing a winner.** "The local album wins" and "the server album
 wins" both discard something the user has: local artwork they picked, or server
@@ -48,13 +50,13 @@ tracks their local copy does not contain. A pair is not a conflict to resolve.
 already exists and is the only one this project accepts — identical bytes. What
 follows derives everything from that proof and adds no second way of guessing.
 
-## Decision 1 — deduplication is derived from tracks, never from names
+## Decision 1 — metadata may refuse an identity, never establish one
 
 An album is deduplicated because its tracks are, and for no other reason. Same
-for an artist. There is no name comparison anywhere in this design.
+for an artist.
 
-The temptation is real and worth naming, because the data is sitting right
-there: `remote_artist.sort_key` already holds the output of
+The temptation to do otherwise is real and worth naming, because the data is
+sitting right there: `remote_artist.sort_key` already holds the output of
 `name_match::normalize_name`, the same function that produces
 `artist.canonical_name` locally. A join on one column would pair most artists in
 most libraries, today, with no new table.
@@ -64,79 +66,179 @@ title, artist and duration is "explicitly forbidden" there; the reasons do not
 weaken as the entity grows, they compound. *Greatest Hits* is not one album.
 *John Williams* is not one artist — the film composer and the classical
 guitarist share a canonical name, and a library holding both would fold them
-into one page with no way for its owner to say otherwise. A normalised name is a
-good **sort key**, which is what it was introduced for, and it is not evidence.
+into one page with no way for its owner to say otherwise.
 
-Deriving from tracks costs a join and nothing else. `track.album_id` names the
-local album; `remote_track.album_id` names the server album; a row in
-`remote_track_link` sits between them. The same shape gives artists, through
-`track.primary_artist` and `remote_track.artist_id`.
+The rule is therefore directional rather than absolute, and the direction is the
+whole of it:
 
-## Decision 2 — unanimity, and at least two links
+> **Names and metadata may never establish an identity. They may withhold one,
+> and they may feed a suggestion a person confirms.**
 
-Two entities are the same when **every link that touches either one agrees**,
-and there are **at least two of them**.
+Symmetry would be a mistake here. Evidence that two things are the same must be
+content; evidence that they are *not* can be anything, because refusing to merge
+costs nothing that Decision 5 is not already prepared to pay. A future revision
+may well want to say "these two releases share two files but one is called
+*Greatest Hits* and the other is not, so do not fold them silently" — a veto,
+not a proof. Nothing in this RFC uses such a veto yet, and nothing in it
+forecloses one.
 
-Both halves earn their place.
+## Decision 2 — albums and artists do not get the same rule
 
-**Unanimity**, because a contradiction is the only reliable signal that
-something is not what it looks like. If the local album's linked tracks point at
-two different server albums, the pairing is not merely uncertain — it is
-observably wrong for at least one of them, and neither is worth guessing at.
+They are not the same kind of object, and one predicate for both is what made
+the first draft of this document wrong.
 
-Unanimity also disposes of the hardest case for free, which is why it is
-preferred over any threshold. A local *Various Artists* compilation has tracks
-linked to a dozen different server artists; a "majority of links" rule would
-have to be taught about compilations to avoid folding VA into whichever artist
-happened to win the count. Unanimity never gets there: the second disagreeing
-link ends the question. No special case, no `is_compilation` check, nothing to
-keep in sync with the album-grouping rules.
+**An album is a closed set.** A release is its track list; that is nearly all a
+release is. So the question "are these the same album?" is answerable by
+comparing sets, and anything less than the set is not an answer.
 
-**At least two links**, because one is a coincidence waiting to happen. A single
-track can legitimately belong to an album, a single, and three compilations; one
-link between an album of eleven tracks and an album of nine proves that the two
-share a song, which is not the same claim. The exception is the case where there
-is nothing else to confuse: when both sides hold exactly one track, one link is
-every link there is, and the rule reads as unanimity over a set of size one.
+**An artist is an open grouping.** Nobody's discography is ever complete on
+either side, and demanding that it be would mean never pairing an artist at all.
+The question "is this the same artist?" is answerable from a sample, because the
+sample is evidence about the *person*, not about the extent of their work.
 
-**The threshold is deliberately not a proportion.** "Half the tracks" and
-"eighty percent" invite the same objection from opposite directions: an album
-whose deluxe edition doubles its track count would fail a proportional test
-while being obviously the same record, and a two-track EP would pass one on a
-single link. Counting agreements and disagreements needs no denominator.
+### Albums: a complete bijection over examined sets
 
-## Decision 3 — a pair is presented as one, not stored as one
+Two albums are the same when **every track of each is confirmed-linked to a
+track of the other**, one to one, over sets both of which are
+[eligible](#decision-3--nothing-is-paired-until-both-sides-have-been-examined).
 
-This is what keeps Decision 2's threshold from being dangerous.
+Ten local tracks against ten server tracks, all linked: the same album. Ten
+against eighteen: **not** automatically the same album, however many links
+agree.
+
+That second case is a real record — a standard edition and its deluxe — and
+refusing it is a deliberate cost. It is refused because a rule loose enough to
+accept it also accepts things that are not records at all, and because
+presenting them together is a *different claim* than saying they are the same
+release. See [What stays out of scope](#what-stays-out-of-scope): the grouping
+of editions is a concept this RFC declines to invent in passing.
+
+### Artists: unanimity, and at least two links
+
+Two artists are the same when **every link touching either one agrees**, and
+there are **at least two**.
+
+Unanimity because a contradiction is the only reliable signal that something is
+not what it looks like — and because it disposes of the hardest case for free. A
+local *Various Artists* compilation has tracks linked to a dozen different
+server artists; a "majority of links" rule would have to be taught about
+compilations to avoid folding VA into whichever artist won the count. Unanimity
+never gets there: the second disagreeing link ends the question. No special
+case, no `is_compilation` check, nothing to keep in sync with the album-grouping
+rules.
+
+At least two, because one is a coincidence waiting to happen: a single guest
+appearance, credited to the featured artist on one side and to the host on the
+other, is one link and no evidence.
+
+### The album rule that was withdrawn
+
+The first draft of this document applied the artist rule to albums as well:
+unanimity, and at least two links. It is written here rather than deleted,
+because the counter-example is the clearest statement of what a link does and
+does not prove.
+
+```
+Local: "Greatest Hits"          Remote: "Album X"
+  Song A  ──────────────────────►  Song A
+  Song B  ──────────────────────►  Song B
+  Song C                            Song E
+  Song D                            Song F
+```
+
+Two links. Unanimous. No contradiction. The withdrawn rule concludes that
+*Greatest Hits* **is** *Album X*, and hides one of them.
+
+Two links prove that two releases share two recordings. Sharing recordings is
+what compilations, singles, soundtracks and reissues are *for*. The withdrawn
+rule mistook evidence about tracks for evidence about the set that contains
+them — which is exactly the confusion Decision 1 is meant to prevent, committed
+one level up instead of by name.
+
+It also failed its own Decision 5. During a mirror walk the links appear one at
+a time: two agreeing links arrive, the pair forms, an entity is hidden — and a
+third link contradicting them arrives a second later and un-hides it. A rule
+that can hide something on incomplete evidence is not made safe by eventually
+correcting itself.
+
+## Decision 3 — nothing is paired until both sides have been examined
+
+The withdrawn rule had a second flaw, and it survives any threshold: **the
+absence of a link is ambiguous**. It means either "these bytes differ" or "this
+pair has not been looked at yet", and a predicate that cannot tell them apart is
+deciding on evidence it does not have.
+
+So pairing requires an explicit **completeness frontier**, and the pleasant
+discovery is that the columns to compute it already exist:
+
+- **A server album is fully discovered** when `remote_album.mirrored_at` is set.
+  Until then its track list is a prefix, not a set.
+- **A server track is examinable** when `remote_track.full_hash` is present. A
+  row mirrored before that column was populated cannot be compared at all.
+- **A local track has been examined** when `local_full_hash` holds a valid entry
+  for it — the digest cache added in lot 5, valid while `(file_size,
+  file_modified)` still match. That table is what turns "no link" into "no link,
+  and we looked".
+
+A pair is eligible only when every track on both sides clears the matching
+condition. Absence of a link between two examined tracks then means what it
+should: different bytes. `remote_track_match_rejection` already records the
+stronger statement — a candidate a person examined and refused — and it
+continues to mean what it means.
+
+**This makes reconciliation's use of `local_full_hash` a prerequisite rather
+than an optimisation.** Today only the upload survey fills that cache;
+reconciliation still hashes on its own. Until both go through it, the
+completeness frontier is only as complete as whatever last ran, and pairing
+would be eligible in fewer cases than it should be — conservative, so not
+dangerous, but not the intended behaviour either.
+
+## Decision 4 — a pair is presented as one, not stored as one
 
 A deduplicated pair remains **two rows in two tables**. What changes is that
 browses render it **once**, and that the single entry they render is composed
-rather than chosen:
+rather than chosen.
 
-- **Identity and presentation come from the local half.** Its title, its
-  artwork, its year. Not because it is more correct, but because it is the half
-  the user can change: they may have retagged it, and they certainly picked its
-  cover. A server value that overrode a local edit would make the edit look
-  broken. Where the local half has nothing — no cover — the server's is shown
-  instead; that fallback does not exist today and is part of what this RFC
-  proposes, not a description of current behaviour.
-- **Contents are the union of both halves**, with the rule the track listing
-  already applies: a track proven to exist on both sides appears once, from its
-  local row, and a track that exists on one side appears with that side's badge.
-  So a deluxe edition mirrored on the server shows its eight extra tracks inside
-  the album the user has locally, each marked as coming from the server, and
-  each playable there.
-- **Gestures stay addressed to the half that can carry them.** Rating and the
-  cover picker write to local rows; starring the album writes to whichever
-  half's favourites the gesture came from. Nothing acquires a capability it did
-  not have; the entry simply stops being two entries.
+**Identity and presentation come from the local half.** Its title, its artwork,
+its year, its added-at date. Not because it is more correct, but because it is
+the half the user can change: they may have retagged it, and they certainly
+picked its cover. A server value that overrode a local edit would make the edit
+look broken. Where the local half has nothing — no cover — the server's is shown
+instead; that fallback does not exist today and is proposed here, not described.
 
-The union is the reason this design does not need to decide which album is
-"really" the album. There is no fusion to get wrong, and no migration that
-rewrites anyone's library. Turning deduplication off — a preference, a bug, a
-future RFC — restores the two entries by changing a query.
+The added-at date is the local one for the same reason, and one more: an album
+the server has held for three years and this machine acquired today belongs at
+the top of *recently added*, not buried three years back. A remote-only entry
+naturally keeps the server's date; there is no pair to reconcile.
 
-## Decision 4 — asymmetric caution, stated as a rule
+**Contents are ordered, not merely concatenated.** With Decision 2's bijection
+the two track sets coincide, so the union is the set itself — but the rule still
+has to be written, because a *presentation* built from two rows needs a total
+order or two renders can disagree. It is: `disc_number`, then `track_number`,
+then local before remote, then the stable identifier. The last two exist to make
+the order total, not to express a preference.
+
+**Actions have one meaning, decided here.** "Whichever half the gesture came
+from" is not an answer once the user sees one card: they cannot tell which half
+they clicked, and they should not have to.
+
+- **Starring applies to both representations that can carry it**, and the entry
+  reads as starred when either is. Un-starring clears both. The server half
+  travels through the outbound mutation queue like any other remote write, so
+  this works offline and lands when the queue drains.
+- **Rating and the cover picker write to local rows only.** They have no server
+  counterpart in this protocol; nothing is silently dropped because nothing was
+  ever offered.
+- **Nothing acquires a capability it did not have.** The entry stops being two
+  entries; it does not become a third kind of object with powers neither half
+  had.
+
+The union-of-presentation is the reason this design does not need to decide
+which album is "really" the album. There is no fusion to get wrong, and no
+migration that rewrites anyone's library. Turning deduplication off — a
+preference, a bug, a future RFC — restores the two entries by changing a query.
+
+## Decision 5 — asymmetric caution, stated as a rule
 
 Getting this wrong in the two directions does not cost the same thing.
 
@@ -148,18 +250,28 @@ disappears into a server album that is not it, or the reverse; what they see is
 not a duplicate they can reason about but an absence they have no reason to
 suspect.
 
-So every rule here fails towards showing too much, and the ones already shipped
-say so out loud. The track listing hides a remote row only on a `confirmed`
-link — never on a `stale` one, because a stale link is a guess — and only while
-the local row is `is_available = 1`, because when the local file is gone the
-local half has already filtered itself out and hiding the remote half too would
-remove the recording from the library while the server can still play it.
+So every rule here fails towards showing too much. Two consequences, and the
+first is already shipped:
 
-**Those two narrowings are hereby the general rule**, not a detail of one query:
-deduplication follows `confirmed` links only, and never removes the last
-reachable representation of anything.
+**Only `confirmed` links count.** A `stale` link is a guess, and hiding on a
+guess loses the entity.
 
-## Decision 5 — local playlists travel again
+**Deduplication never suppresses the last representation of anything.** The
+track listing states this today as `is_available = 1` on the local row, which is
+the right check for the case it faces and too narrow as a principle. What the
+rule means is that a representation may only be hidden while **another one
+remains renderable and playable**, and local availability is one of several ways
+that can fail: a server track deleted upstream, an account signed out, a
+permission withdrawn.
+
+One distinction has to be made explicit or this rule causes the flicker it was
+written to prevent: **it is about existence, not about momentary reach.** A
+server that is unreachable right now, or offline mode being on, must not
+re-expand every pair in the library — the representation still exists, it is
+merely not answering. Only a representation that has *ceased to exist* releases
+its partner from being hidden.
+
+## Decision 6 — a local playlist becomes exactly representable
 
 RFC-005 recorded a loss and its precondition in one paragraph:
 
@@ -169,66 +281,81 @@ RFC-005 recorded a loss and its precondition in one paragraph:
 > nothing in the protocol can name those on another install.
 
 The matching layer is here, and lot 5 added the missing piece: what has no name
-on the server can be given one, by uploading it. A local playlist whose every
-track carries a `confirmed` link is expressible in server identifiers, exactly,
-with no guessing — which is the standard RFC-005 set.
+on the server can be given one, by uploading it.
 
-The rule is **all or nothing, and never silently**. A playlist of forty tracks
-with three unlinked ones does not travel as a playlist of thirty-seven: a list
-missing three songs is worse than a list that did not sync, because it looks
-complete. The three are named, and the offer is to upload them — the operation
-lot 5 already implements, whose commit hands back the track id and digest that
-write the missing links. Then the playlist travels whole.
+What this RFC decides is narrower than "playlists sync again", and the
+distinction matters. It decides **representability**:
 
-This is the first place where the seven lots visibly compound rather than merely
-follow one another, and it is the reason this RFC waited for lot 5 rather than
-being written after lot 4 as originally planned.
+> A local playlist whose every entry carries a `confirmed` link can be projected
+> into server track identifiers exactly, with no guessing. Publication happens
+> only when every entry is representable.
+
+All or nothing, and never silently. A playlist of forty tracks with three
+unlinked ones does not travel as a playlist of thirty-seven: a list missing
+three songs is worse than a list that did not sync, because it looks complete.
+The three are named, and the offer is to upload them — the operation lot 5
+implements, whose commit hands back the track id and digest that write the
+missing links. Then the playlist travels whole. The uploads themselves are
+resumable and partial; it is the playlist's *visibility* that is transactional.
+
+**What this RFC does not decide** is how a published playlist then behaves:
+identity across machines, ordering semantics, duplicates, renames, deletions,
+concurrent edits, ownership, and what happens when the server's copy changes.
+Those belong to a playlist protocol, not to a deduplication rule, and calling
+this "playlists travel again" would promise all of them. It restores the
+mapping; it does not solve the sync.
 
 ## What this costs
 
 **A derivation that has to be maintained.** The pairing is a function of
-`remote_track_link`, and that table changes — an import writes a row, a
-reconciliation pass writes several, deleting a local track cascades one away.
-Whether the derivation is a view, a materialised table refreshed on those
-events, or a join inside each browse is an implementation question this RFC does
-not settle; what it does settle is that the derivation has exactly one
-definition, expressed once, the way the mirror's shared predicate is.
+`remote_track_link` and of the completeness frontier, and both change — an
+import writes a link, a reconciliation pass writes several, deleting a local
+track cascades one away, a mirror walk sets `mirrored_at`. Whatever form the
+derivation takes, it has exactly one definition, expressed once, the way the
+mirror's shared predicate is.
+
+**It should start as a view, not as a materialised table.** The inputs are
+links, their status, and availability on both sides; a cache over that has more
+invalidation paths than it has query sites, and is the shape most likely to rot.
+Both directions of `remote_track_link` are already indexed — `local_track_id` is
+the primary key and `remote_track_id` is `UNIQUE` — so the joins have what they
+need. Measure, then materialise only if the measurement asks for it.
 
 **Browses get more expensive.** Every listing that ranges over albums or artists
 gains a correlated existence check. The track listing already pays it and the
 cost is one indexed lookup per row, but the album and artist listings are the
 compound ones — the fixture that exercises them describes a select over fourteen
-tables — and the measurement belongs to the implementation rather than to this
-document.
+tables — and the measurement belongs to the implementation.
 
-**Partial pairs will look odd before they look right.** A library mirrored
-halfway — the walk is resumable and long — holds albums whose tracks are only
-partly mirrored, so pairs will form as the mirror progresses. That is correct
-behaviour and it will read as flicker. The `mirrored_at` column already
-distinguishes a walked album from an un-walked one; whether deduplication should
-wait for a complete walk is left open below.
+**Eligibility is strict, so early libraries will look un-deduplicated.** Until a
+mirror walk completes and a reconciliation pass has hashed the local side,
+almost nothing is eligible. That is the intended behaviour under Decision 5 and
+it will read as the feature not working. It should be visible in the interface —
+"not yet compared" is a different statement from "compared, and different".
 
 ## What stays out of scope
 
+- **Grouping editions of one record.** A standard edition and its deluxe are two
+  releases that share recordings, and presenting them together is a genuinely
+  useful thing this RFC deliberately does not do — because saying "these two are
+  the same release" and "these two are close enough to show together" are
+  different claims, and the first draft conflated them. A future RFC can
+  introduce an explicit album-family concept; it would sit above this one and
+  consume the same links.
 - **Deduplicating against anything but the bound server.** Two servers, or a
   second profile, are not in this design.
-- **Genres, moods, years.** They are labels, not entities; they were never
-  doubled in a way anyone noticed.
+- **Genres, moods, years.** They are labels, not entities.
 - **A user-facing merge tool.** The reconciliation surface already lets a person
-  confirm or reject a *track* pair, and everything here derives from those. If
-  an album pair needs overriding by hand, the right gesture is on the track it
-  disagrees about.
+  confirm or reject a *track* pair, and everything here derives from those. If a
+  pair is wrong, the right gesture is on the track it disagrees about.
 - **MusicBrainz as a second proof.** RFC-005 allows it as *a suggestion the user
-  confirms* for tracks. Nothing here extends it to albums or artists, and doing
-  so later is a change to the link layer, not to this one.
+  confirms* for tracks. Nothing here extends it to albums or artists.
 
 ## Open questions
 
-- **Does deduplication wait for a complete mirror walk?** Suppressing pairs
-  until `remote_album.mirrored_at` is set would trade early correctness for
-  fewer visible transitions. Both defensible; unmeasured.
-- **Where the derivation lives** — view, materialised table, or per-query join —
-  and what that costs on a library of tens of thousands of albums.
-- **Whether a deduplicated album's "recently added" date is the local one or the
-  earlier of the two.** The local one is simpler; the earlier one is arguably
-  what the user means by when they got the record.
+- **Whether an ineligible pair should say so.** The cost section argues it
+  should; where that surfaces without cluttering a library view is unresolved.
+- **Whether artists should also require a completeness frontier.** Decision 3 is
+  written for both, but an artist is an open grouping, so "both sides examined"
+  is a stronger demand there than the evidence needs. Leaving it uniform is the
+  conservative choice and may prove too strict in practice.

--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -286,6 +286,26 @@ That is strict, and it is the same asymmetry as Decision 5: a pair that is not
 yet eligible costs a visible duplicate, and a pair wrongly eligible hides
 something on a proof that has quietly stopped being true.
 
+### Two invariants the matrix implies
+
+Neither is a further decision; both are places where a straightforward
+implementation of the rules above goes wrong.
+
+**A reconciliation pass records the generation it produced, not the one it
+started from.** It writes links itself, and a new `confirmed` link advances the
+generation — so a pass that stored the value it read at the start would mark the
+entity dirty the instant it finished, for ever. Reconciling an entity,
+writing its links, and recording the resulting generation belong to one
+transaction.
+
+**`mirror::drop_vanished` must dirty before it deletes.** Removing a
+`remote_track` changes its album's and its artist's membership, which the matrix
+says invalidates both — but once the row is gone, nothing says which album and
+which artist those were. The identifiers have to be captured in the same
+transaction as the delete. When they cannot be established, the conservative
+answer is the one Decision 5 always gives: the affected pairs are ineligible
+until a full reconciliation says otherwise.
+
 ### The corpus is what is observed, not what exists
 
 Artists get the same frontier as albums, with the meaning that makes it
@@ -404,13 +424,22 @@ first is already shipped:
 **Only `confirmed` links count.** A `stale` link is a guess, and hiding on a
 guess loses the entity.
 
-**Deduplication never suppresses the last representation of anything.** The
-track listing states this today as `is_available = 1` on the local row, which is
-the right check for the case it faces and too narrow as a principle. What the
-rule means is that a representation may only be hidden while **another one
-remains renderable and playable**, and local availability is one of several ways
-that can fail: a server track deleted upstream, an account signed out, a
-permission withdrawn.
+**Deduplication never suppresses the last representation that still exists for
+this user.** The track listing states this today as `is_available = 1` on the
+local row, which is the right check for the case it faces and too narrow as a
+principle: a server track deleted upstream, an account signed out and a
+permission withdrawn all end a representation without touching that flag.
+
+*Exists* — not *plays*. Requiring the survivor to be playable would contradict
+the two rules on either side of this one: Decision 4 keeps the entry shown when
+the local file is gone and the server is briefly unreachable, and the table
+below keeps the pair collapsed through an outage. Both would be impossible if
+playability gated suppression. The two questions are answered by different
+things and neither answers the other:
+
+> **Existence decides whether the pair stays collapsed. Reachability decides
+> whether it can play right now.** A temporary inability to render or play the
+> surviving representation never dissolves an otherwise proven pair.
 
 One distinction has to be made explicit or this rule causes the flicker it was
 written to prevent: **transient unreachability is not loss.** A server that is
@@ -434,7 +463,7 @@ as transient would leave a user looking at a library that quietly lost entries
 they still hold locally, which is the exact harm this decision exists to
 prevent.
 
-## Decision 6 — a local playlist becomes exactly representable
+## Decision 6 — what playlist conversion still has to establish
 
 RFC-005 recorded a loss and its precondition in one paragraph:
 
@@ -443,61 +472,63 @@ RFC-005 recorded a loss and its precondition in one paragraph:
 > matching layer above, because a local playlist is a list of local files and
 > nothing in the protocol can name those on another install.
 
-The matching layer is here, and lot 5 added the missing piece: what has no name
-on the server can be given one, by uploading it.
+**An earlier draft of this section claimed to restore that, and was wrong about
+the starting point.** Conversion already exists: `remote::reconciliation`
+exposes `preview_playlist_conversion` and `convert_playlist`, both registered as
+commands, and they already hold the all-or-nothing invariant this RFC would
+otherwise have introduced — only `confirmed` links convert, while stale, missing
+and ambiguous entries stay visible in place and *block* the conversion. The
+local side is even validated positively rather than trusted:
+`playlist_link_freshness` re-reads and re-hashes each local file, so a link
+whose bytes have changed since it was written does not convert.
 
-What this RFC decides is narrower than "playlists sync again", and the
-distinction matters. It decides **representability**:
+So this decision is not a new capability. It states the rule the existing
+mechanism follows, and names the half of it that is missing.
 
-> A local playlist whose every entry carries a `confirmed` link can be projected
-> into server track identifiers exactly, with no guessing. Publication happens
-> only when every entry is representable.
+**The invariant, stated normatively.** A local playlist is publishable only when
+**every** entry is exactly representable. Forty tracks with three unlinked ones
+do not travel as thirty-seven: a list missing three songs is worse than a list
+that did not sync, because it looks complete. The three are named, and the offer
+is to upload them — the lot 5 operation whose commit hands back the track id and
+digest that write the missing links. Then the playlist travels whole. The
+uploads themselves are resumable and partial; it is the playlist's *visibility*
+that is transactional.
 
-A `confirmed` link is necessary and not sufficient: the same
-existence-versus-reach distinction applies. A link naming a server track that
-will not resolve — deleted upstream, or on a library this account may no longer
-read — is not representable, however confirmed the proof once was. Being unable
-to reach the server *right now* is not that, and does not make a playlist
-unrepresentable.
+**What is missing is the symmetric check on the server side.** The local half is
+revalidated by re-hashing; the remote half is taken on the link's word. Three
+facts have to be established positively about the target, and none of them can
+be inferred from a flag:
 
-**`in_catalogue` does not answer this question, and must not be read as if it
-did.** The flag records what the last mirror walk saw. A row can lose it because
-the track was cached from user data and never walked; a track deleted upstream
-is not flagged at all but *deleted*, by `mirror::drop_vanished`. And
-`remote_track_link.remote_track_id` carries no foreign key, so a link can
-outlive the row it names — an orphan that still reads as `confirmed`.
+- **it still exists.** `in_catalogue` does not answer this — it records what the
+  last walk saw, and a track deleted upstream is not flagged but *removed*, by
+  `mirror::drop_vanished`. Since `remote_track_link.remote_track_id` carries no
+  foreign key, a link can outlive the row it names and still read as
+  `confirmed`. Conversion does not consult `in_catalogue` today, and consulting
+  it would not be enough.
+- **this account may read it.** A membership or permission the server answers
+  for, and whose withdrawal RFC-005 deliberately makes indistinguishable from
+  absence — both are a 404.
+- **the answer is current.** A positive result is scoped to the entity's
+  generation, in the sense of Decision 3: whatever invalidates the identity
+  frontier invalidates this too. It is not a fact with a lifetime of its own.
 
-Resolvability and authorisation are therefore separate facts a client has to
-establish, not flags it can infer:
+**A failure to reach the server is *unknown*, not *invalid*.** The distinction
+Decision 5 draws applies here unchanged: a server that is not answering has told
+us nothing about whether these tracks exist. Publication does not proceed on an
+unknown — nothing is published while the server is unreachable anyway — but
+nothing is concluded from it either, and the playlist is not marked
+unrepresentable. Only a definite answer, deletion or refusal, does that.
 
-- **the target still exists** — the link resolves to a catalogue row, or the
-  server says so when asked;
-- **this account may read it** — a membership or permission the server answers
-  for, and whose withdrawal a 404 deliberately does not distinguish from
-  absence (RFC-005's own rule);
-- **the server is answering** — reachability, which is transient and gates
-  nothing here.
+**A reference that fails is never dropped from the local playlist.** The local
+list is unchanged and remains the source of truth; what it loses is
+publishability, which the upload path can often restore — a track missing
+upstream is a track this machine can offer back.
 
-A reference that fails the first two is not dropped from the playlist. The local
-playlist is unchanged and remains the source of truth; what it loses is
-*publishability* until the entry can be named again — which the upload path can
-often restore, since a track missing upstream is a track this machine can offer
-back.
-
-All or nothing, and never silently. A playlist of forty tracks with three
-unlinked ones does not travel as a playlist of thirty-seven: a list missing
-three songs is worse than a list that did not sync, because it looks complete.
-The three are named, and the offer is to upload them — the operation lot 5
-implements, whose commit hands back the track id and digest that write the
-missing links. Then the playlist travels whole. The uploads themselves are
-resumable and partial; it is the playlist's *visibility* that is transactional.
-
-**What this RFC does not decide** is how a published playlist then behaves:
-identity across machines, ordering semantics, duplicates, renames, deletions,
-concurrent edits, ownership, and what happens when the server's copy changes.
-Those belong to a playlist protocol, not to a deduplication rule, and calling
-this "playlists travel again" would promise all of them. It restores the
-mapping; it does not solve the sync.
+**What this RFC still does not decide** is how a published playlist then
+behaves: identity across machines, ordering semantics, duplicates, renames,
+deletions, concurrent edits, ownership, and what happens when the server's copy
+changes. Those belong to a playlist protocol. This one makes the mapping exact
+and says what must be true before it is used.
 
 ## What this costs
 
@@ -551,5 +582,7 @@ it will read as the feature not working. It should be visible in the interface �
   should; where that surfaces without cluttering a library view is unresolved.
 - **How an entity is marked dirty from an event.** Decision 3 enumerates *what*
   advances a generation; mapping each library event onto the albums and artists
-  it touches — a track moving between albums touches two of each — is an
-  implementation shape this document does not fix.
+  **whose identity inputs it changes** is an implementation shape this document
+  does not fix. An album move dirties the old and the new album and leaves the
+  artist alone when `primary_artist` is unchanged; an artist reassignment
+  dirties the old and the new artist; one event may do both.

--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -203,7 +203,7 @@ reconciliation frontier, per catalogue generation, in the sense below — is a
 prerequisite of this RFC, alongside routing reconciliation through
 `local_full_hash` so that the two paths stop hashing the same files twice.
 
-### Completeness is versioned, not a timestamp
+### Completeness is versioned, and the version is per entity
 
 `remote_album.mirrored_at` says a walk finished. It does not say the set has not
 changed since:
@@ -214,23 +214,77 @@ changed since:
 ```
 
 A closed set that reopened is not a closed set, so the frontier is attached to a
-**generation of the catalogue** rather than to a moment. Eligibility holds while
-the reconciled generation equals the current one; anything that changes either
-side's membership advances the current generation and makes the pair ineligible
-until reconciliation catches up.
+**generation of that entity's identity inputs** rather than to a moment.
+Eligibility holds while the reconciled generation equals the current one.
 
-The desktop has a weak form of this already and no strong one.
-`remote_album.song_count` is the mirror's own freshness check — an album whose
-count is unchanged is skipped without a fetch — so `(song_count, mirrored_at)`
-detects the common case of a track arriving or leaving. It does not detect a
-track being *replaced*, and it depends on a walk to notice anything at all.
+**Per entity, and not a global counter.** A single number for the whole
+catalogue would make an unrelated change invalidate everything: someone stars
+one album, the number moves, and five thousand pairs go ineligible until a
+reconciliation pass has walked the entire library. Conservative, and unusable.
 
-The strong form is the server's library event stream (its RFC-007), which
-carries a monotonic `cursor` and is already live. **The desktop consumes none of
-it** — there is no cursor anywhere in `remote/mirror.rs` — which makes this
-RFC's frontier one more consumer for the work lot 6 has to do anyway. Until
-then, `(song_count, mirrored_at)` is the available approximation, and it is an
-approximation on the conservative side only for additions and removals.
+```
+album A   generation 17   reconciled 17   → eligible
+album B   generation  9   reconciled  8   → ineligible, and only B
+```
+
+**A generation advances only when an identity input changed.** Presentation and
+reachability never advance it — that distinction is the whole point of having
+two frontiers rather than one:
+
+| Change | Album | Artist | Why |
+| --- | --- | --- | --- |
+| Track added or removed | invalidates | invalidates | different corpus |
+| `full_hash` changed (file replaced or retagged upstream) | invalidates | invalidates | different content proof |
+| Track moved to another album | both albums | — | different set |
+| `primary_artist` changed | — | both artists | different grouping |
+| A link becomes `stale`, or is rejected | invalidates | invalidates | the proof is gone |
+| A new `confirmed` link | invalidates | invalidates | the result may differ |
+| Album or track title, year, artwork | no | no | presentation |
+| `disc_number` / `track_number` | no | no | order only |
+| Star, rating, play count | no | no | user state |
+| Server unreachable, offline mode | no | no | reachability, not identity |
+| Local `is_available` flips | no | no | Decision 5 picks which representation shows |
+| Signed out, permission withdrawn | no | no | reachability, not a new proof |
+
+The last three rows matter as much as the first six. A pair whose local file has
+gone is still a *proven* pair; what changes is which half can be rendered, which
+is Decision 5's business and requires no reconciliation at all.
+
+### The server cursor is a watermark, not a generation
+
+The server's library event stream (its RFC-007) carries a monotonic `cursor`,
+and it is the right input — but it is **not** the generation. Comparing a stored
+cursor against the server's latest would invalidate the whole library every time
+anything anywhere changed, including the star in the table above.
+
+The cursor answers "how far have I observed the server?". The generation answers
+"which version of *this entity's* identity inputs have I examined?". So an event
+is received, the entities it affects are marked, and only those are reconciled
+again.
+
+The stream is well suited to this: a track upsert **carries the track's
+`full_hash`**, which the server added precisely because nothing else tells a
+client that a file was retagged outside the API. That is the one identity input
+a client cannot otherwise observe without re-walking.
+
+**The desktop consumes none of this** — there is no cursor anywhere in
+`remote/mirror.rs` — so this RFC's frontier is one more consumer for the work
+lot 6 has to do anyway.
+
+Until then the only signal available is `remote_album.song_count`, the mirror's
+own freshness check. It detects additions and removals and **cannot detect a
+replacement**: a server track whose file was swapped keeps its identifier and
+its count, so a `confirmed` link built on the old bytes stays confirmed while
+being false. So the approximation is admitted in one direction only:
+
+> `(song_count, mirrored_at)` may **withdraw** eligibility. It may never
+> **grant** it. Until an entity's identity inputs have been re-examined —
+> today by a reconciliation pass that actually re-read them, later by the
+> event stream — the pair is not eligible.
+
+That is strict, and it is the same asymmetry as Decision 5: a pair that is not
+yet eligible costs a visible duplicate, and a pair wrongly eligible hides
+something on a proof that has quietly stopped being true.
 
 ### The corpus is what is observed, not what exists
 
@@ -285,8 +339,25 @@ can list a track twice.
 `remote_track_link.playback_preference` — `local_first` by default,
 `server_first` when the user says so — which exists precisely so that which
 copy plays is a property of the *pair* rather than of whichever half a listing
-happened to render. A row shown from the local half can still play from the
-server, and does when the local file has gone.
+happened to render.
+
+**When the local file is gone, the row is the server's.** The pair is still
+proven — a missing file is not a disproof — so the entry stays one entry and
+takes its identity from the surviving half. Three cases, and none of them
+removes the album from the library:
+
+| Local file | Server | The row |
+| --- | --- | --- |
+| present | either | local, plays per the pair's preference |
+| missing | reachable | server, plays from the server |
+| missing | unreachable right now | server, and it does not play |
+
+The last is the case worth stating out loud, because the two rules could be read
+as fighting: Decision 5 keeps the pair collapsed through a transient outage, and
+the local half has filtered itself out. The entry is therefore *shown and not
+playable*, which is correct — the music is still in the user's library, and
+saying so while failing to play is far better than making the album disappear
+because a server did not answer.
 
 **The order is total.** `disc_number`, then `track_number`, then the stable
 identifier. There is no local-before-remote tiebreak, because after the two
@@ -354,7 +425,7 @@ representation can be expected to come back **for this user**:
 | --- | --- |
 | Network down, server asleep, offline mode on | Yes — it will answer again |
 | Local file missing (`is_available = 0`) | No — the local half already filtered itself out |
-| Track gone from the server's catalogue (`in_catalogue = 0`) | No |
+| Server track deleted upstream | No |
 | Signed out, or the binding forgotten | No |
 | Membership or permission withdrawn upstream | No |
 
@@ -383,11 +454,35 @@ distinction matters. It decides **representability**:
 > only when every entry is representable.
 
 A `confirmed` link is necessary and not sufficient: the same
-existence-versus-reach distinction applies. A link whose server track has left
-the catalogue (`in_catalogue = 0`), or whose server is no longer one this
-account may read, names something that will not resolve — the entry is not
-representable, however confirmed the proof once was. Being unable to reach the
-server *right now* is not that, and does not make a playlist unrepresentable.
+existence-versus-reach distinction applies. A link naming a server track that
+will not resolve — deleted upstream, or on a library this account may no longer
+read — is not representable, however confirmed the proof once was. Being unable
+to reach the server *right now* is not that, and does not make a playlist
+unrepresentable.
+
+**`in_catalogue` does not answer this question, and must not be read as if it
+did.** The flag records what the last mirror walk saw. A row can lose it because
+the track was cached from user data and never walked; a track deleted upstream
+is not flagged at all but *deleted*, by `mirror::drop_vanished`. And
+`remote_track_link.remote_track_id` carries no foreign key, so a link can
+outlive the row it names — an orphan that still reads as `confirmed`.
+
+Resolvability and authorisation are therefore separate facts a client has to
+establish, not flags it can infer:
+
+- **the target still exists** — the link resolves to a catalogue row, or the
+  server says so when asked;
+- **this account may read it** — a membership or permission the server answers
+  for, and whose withdrawal a 404 deliberately does not distinguish from
+  absence (RFC-005's own rule);
+- **the server is answering** — reachability, which is transient and gates
+  nothing here.
+
+A reference that fails the first two is not dropped from the playlist. The local
+playlist is unchanged and remains the source of truth; what it loses is
+*publishability* until the entry can be named again — which the upload path can
+often restore, since a track missing upstream is a track this machine can offer
+back.
 
 All or nothing, and never silently. A playlist of forty tracks with three
 unlinked ones does not travel as a playlist of thirty-seven: a list missing
@@ -454,7 +549,7 @@ it will read as the feature not working. It should be visible in the interface �
 
 - **Whether an ineligible pair should say so.** The cost section argues it
   should; where that surfaces without cluttering a library view is unresolved.
-- **What advances a catalogue generation, exactly.** Decision 3 requires one;
-  `(song_count, mirrored_at)` approximates it today and the library event
-  stream's cursor is the real answer, but which changes must invalidate a
-  frontier — a retag upstream, a track becoming unavailable — is unenumerated.
+- **How an entity is marked dirty from an event.** Decision 3 enumerates *what*
+  advances a generation; mapping each library event onto the albums and artists
+  it touches — a track moving between albums touches two of each — is an
+  implementation shape this document does not fix.

--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -1,0 +1,234 @@
+# RFC-006 — Deduplicating the two catalogues
+
+- **Status**: Proposed
+- **Date**: 2026-08-31
+- **Authors**: @InstaZDLL
+- **Depends on**: [RFC-005](RFC-005-remote-source-and-sync-v2.md) — this RFC answers the question its Decision 1 deferred, and does not revisit anything else it settled.
+- **Implementation**: none yet.
+
+---
+
+## The question this RFC answers
+
+[RFC-005](RFC-005-remote-source-and-sync-v2.md) closed a door and named the RFC
+that would reopen it. Twice, in the same words:
+
+> Matching a local file to a server track is **out of scope** and needs its own
+> RFC.
+
+> An album held both locally and on the server appears **twice**, tagged twice.
+> Unifying the navigation is not deduplicating the catalogue; that is reserved
+> for its own RFC.
+
+The first half has since been built: `remote_track_link` holds exact,
+content-proven pairs, written by a reconciliation pass, by an import, and by an
+upload. The second half has not. Two collections that describe the same music
+still present it as two of everything above the track: two albums, two artists,
+two entries in every browse that ranges over them.
+
+This RFC decides what a proven pair is allowed to change, and what it is not.
+
+## What deduplication is not
+
+Three readings are ruled out before the decisions start, because each has been
+proposed at some point in this project's life and each would undo something
+RFC-005 got right.
+
+**It is not merging the tables.** The projection lands in `remote_*` and stays
+reconstructible: dropping it and re-fetching a snapshot is always a valid
+recovery. Writing server rows into `album` or `artist` would fabricate local
+entities for things that exist only on a server, which is precisely the
+corruption Decision 1 exists to prevent. Nothing below writes across that line.
+
+**It is not choosing a winner.** "The local album wins" and "the server album
+wins" both discard something the user has: local artwork they picked, or server
+tracks their local copy does not contain. A pair is not a conflict to resolve.
+
+**It is not a new matching algorithm.** The proof that two things are the same
+already exists and is the only one this project accepts — identical bytes. What
+follows derives everything from that proof and adds no second way of guessing.
+
+## Decision 1 — deduplication is derived from tracks, never from names
+
+An album is deduplicated because its tracks are, and for no other reason. Same
+for an artist. There is no name comparison anywhere in this design.
+
+The temptation is real and worth naming, because the data is sitting right
+there: `remote_artist.sort_key` already holds the output of
+`name_match::normalize_name`, the same function that produces
+`artist.canonical_name` locally. A join on one column would pair most artists in
+most libraries, today, with no new table.
+
+It would also be exactly what RFC-005 forbids one level down. Matching tracks by
+title, artist and duration is "explicitly forbidden" there; the reasons do not
+weaken as the entity grows, they compound. *Greatest Hits* is not one album.
+*John Williams* is not one artist — the film composer and the classical
+guitarist share a canonical name, and a library holding both would fold them
+into one page with no way for its owner to say otherwise. A normalised name is a
+good **sort key**, which is what it was introduced for, and it is not evidence.
+
+Deriving from tracks costs a join and nothing else. `track.album_id` names the
+local album; `remote_track.album_id` names the server album; a row in
+`remote_track_link` sits between them. The same shape gives artists, through
+`track.primary_artist` and `remote_track.artist_id`.
+
+## Decision 2 — unanimity, and at least two links
+
+Two entities are the same when **every link that touches either one agrees**,
+and there are **at least two of them**.
+
+Both halves earn their place.
+
+**Unanimity**, because a contradiction is the only reliable signal that
+something is not what it looks like. If the local album's linked tracks point at
+two different server albums, the pairing is not merely uncertain — it is
+observably wrong for at least one of them, and neither is worth guessing at.
+
+Unanimity also disposes of the hardest case for free, which is why it is
+preferred over any threshold. A local *Various Artists* compilation has tracks
+linked to a dozen different server artists; a "majority of links" rule would
+have to be taught about compilations to avoid folding VA into whichever artist
+happened to win the count. Unanimity never gets there: the second disagreeing
+link ends the question. No special case, no `is_compilation` check, nothing to
+keep in sync with the album-grouping rules.
+
+**At least two links**, because one is a coincidence waiting to happen. A single
+track can legitimately belong to an album, a single, and three compilations; one
+link between an album of eleven tracks and an album of nine proves that the two
+share a song, which is not the same claim. The exception is the case where there
+is nothing else to confuse: when both sides hold exactly one track, one link is
+every link there is, and the rule reads as unanimity over a set of size one.
+
+**The threshold is deliberately not a proportion.** "Half the tracks" and
+"eighty percent" invite the same objection from opposite directions: an album
+whose deluxe edition doubles its track count would fail a proportional test
+while being obviously the same record, and a two-track EP would pass one on a
+single link. Counting agreements and disagreements needs no denominator.
+
+## Decision 3 — a pair is presented as one, not stored as one
+
+This is what keeps Decision 2's threshold from being dangerous.
+
+A deduplicated pair remains **two rows in two tables**. What changes is that
+browses render it **once**, and that the single entry they render is composed
+rather than chosen:
+
+- **Identity and presentation come from the local half.** Its title, its
+  artwork, its year. Not because it is more correct, but because it is the half
+  the user can change: they may have retagged it, and they certainly picked its
+  cover. A server value that overrode a local edit would make the edit look
+  broken. Where the local half has nothing — no cover — the server's is shown
+  instead; that fallback does not exist today and is part of what this RFC
+  proposes, not a description of current behaviour.
+- **Contents are the union of both halves**, with the rule the track listing
+  already applies: a track proven to exist on both sides appears once, from its
+  local row, and a track that exists on one side appears with that side's badge.
+  So a deluxe edition mirrored on the server shows its eight extra tracks inside
+  the album the user has locally, each marked as coming from the server, and
+  each playable there.
+- **Gestures stay addressed to the half that can carry them.** Rating and the
+  cover picker write to local rows; starring the album writes to whichever
+  half's favourites the gesture came from. Nothing acquires a capability it did
+  not have; the entry simply stops being two entries.
+
+The union is the reason this design does not need to decide which album is
+"really" the album. There is no fusion to get wrong, and no migration that
+rewrites anyone's library. Turning deduplication off — a preference, a bug, a
+future RFC — restores the two entries by changing a query.
+
+## Decision 4 — asymmetric caution, stated as a rule
+
+Getting this wrong in the two directions does not cost the same thing.
+
+A pair left un-deduplicated shows the user two entries for one record. It is
+untidy, it is visible, and nothing is lost.
+
+A pair deduplicated wrongly **hides an entity the user has**. Their local album
+disappears into a server album that is not it, or the reverse; what they see is
+not a duplicate they can reason about but an absence they have no reason to
+suspect.
+
+So every rule here fails towards showing too much, and the ones already shipped
+say so out loud. The track listing hides a remote row only on a `confirmed`
+link — never on a `stale` one, because a stale link is a guess — and only while
+the local row is `is_available = 1`, because when the local file is gone the
+local half has already filtered itself out and hiding the remote half too would
+remove the recording from the library while the server can still play it.
+
+**Those two narrowings are hereby the general rule**, not a detail of one query:
+deduplication follows `confirmed` links only, and never removes the last
+reachable representation of anything.
+
+## Decision 5 — local playlists travel again
+
+RFC-005 recorded a loss and its precondition in one paragraph:
+
+> Local playlists no longer travel between machines. That capability existed in
+> the v1 design and is genuinely lost. It cannot be recovered without the
+> matching layer above, because a local playlist is a list of local files and
+> nothing in the protocol can name those on another install.
+
+The matching layer is here, and lot 5 added the missing piece: what has no name
+on the server can be given one, by uploading it. A local playlist whose every
+track carries a `confirmed` link is expressible in server identifiers, exactly,
+with no guessing — which is the standard RFC-005 set.
+
+The rule is **all or nothing, and never silently**. A playlist of forty tracks
+with three unlinked ones does not travel as a playlist of thirty-seven: a list
+missing three songs is worse than a list that did not sync, because it looks
+complete. The three are named, and the offer is to upload them — the operation
+lot 5 already implements, whose commit hands back the track id and digest that
+write the missing links. Then the playlist travels whole.
+
+This is the first place where the seven lots visibly compound rather than merely
+follow one another, and it is the reason this RFC waited for lot 5 rather than
+being written after lot 4 as originally planned.
+
+## What this costs
+
+**A derivation that has to be maintained.** The pairing is a function of
+`remote_track_link`, and that table changes — an import writes a row, a
+reconciliation pass writes several, deleting a local track cascades one away.
+Whether the derivation is a view, a materialised table refreshed on those
+events, or a join inside each browse is an implementation question this RFC does
+not settle; what it does settle is that the derivation has exactly one
+definition, expressed once, the way the mirror's shared predicate is.
+
+**Browses get more expensive.** Every listing that ranges over albums or artists
+gains a correlated existence check. The track listing already pays it and the
+cost is one indexed lookup per row, but the album and artist listings are the
+compound ones — the fixture that exercises them describes a select over fourteen
+tables — and the measurement belongs to the implementation rather than to this
+document.
+
+**Partial pairs will look odd before they look right.** A library mirrored
+halfway — the walk is resumable and long — holds albums whose tracks are only
+partly mirrored, so pairs will form as the mirror progresses. That is correct
+behaviour and it will read as flicker. The `mirrored_at` column already
+distinguishes a walked album from an un-walked one; whether deduplication should
+wait for a complete walk is left open below.
+
+## What stays out of scope
+
+- **Deduplicating against anything but the bound server.** Two servers, or a
+  second profile, are not in this design.
+- **Genres, moods, years.** They are labels, not entities; they were never
+  doubled in a way anyone noticed.
+- **A user-facing merge tool.** The reconciliation surface already lets a person
+  confirm or reject a *track* pair, and everything here derives from those. If
+  an album pair needs overriding by hand, the right gesture is on the track it
+  disagrees about.
+- **MusicBrainz as a second proof.** RFC-005 allows it as *a suggestion the user
+  confirms* for tracks. Nothing here extends it to albums or artists, and doing
+  so later is a change to the link layer, not to this one.
+
+## Open questions
+
+- **Does deduplication wait for a complete mirror walk?** Suppressing pairs
+  until `remote_album.mirrored_at` is set would trade early correctness for
+  fewer visible transitions. Both defensible; unmeasured.
+- **Where the derivation lives** — view, materialised table, or per-query join —
+  and what that costs on a library of tens of thousands of albums.
+- **Whether a deduplicated album's "recently added" date is the local one or the
+  earlier of the two.** The local one is simpler; the earlier one is arguably
+  what the user means by when they got the record.

--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -100,7 +100,15 @@ sample is evidence about the *person*, not about the extent of their work.
 
 Two albums are the same when **every track of each is confirmed-linked to a
 track of the other**, one to one, over sets both of which are
-[eligible](#decision-3--nothing-is-paired-until-both-sides-have-been-examined).
+[eligible](#decision-3--nothing-is-paired-until-both-sides-have-been-reconciled)
+— and when there is **at least one such link**.
+
+That last clause is not redundant. A bijection over two empty sets holds
+vacuously: every track of each is linked to a track of the other, because there
+are none. Two albums with no tracks would pair, and so would a local album with
+an empty server response — a walk that returned nothing, a release whose files
+are all unavailable upstream. An album with no tracks is not evidence of
+anything, and it never pairs.
 
 Ten local tracks against ten server tracks, all linked: the same album. Ten
 against eighteen: **not** automatically the same album, however many links
@@ -161,37 +169,92 @@ third link contradicting them arrives a second later and un-hides it. A rule
 that can hide something on incomplete evidence is not made safe by eventually
 correcting itself.
 
-## Decision 3 — nothing is paired until both sides have been examined
+## Decision 3 — nothing is paired until both sides have been reconciled
 
 The withdrawn rule had a second flaw, and it survives any threshold: **the
 absence of a link is ambiguous**. It means either "these bytes differ" or "this
 pair has not been looked at yet", and a predicate that cannot tell them apart is
 deciding on evidence it does not have.
 
-So pairing requires an explicit **completeness frontier**, and the pleasant
-discovery is that the columns to compute it already exist:
+So pairing requires an explicit **completeness frontier**. Three properties
+have to hold together, and the second is the one that is easy to get wrong.
 
-- **A server album is fully discovered** when `remote_album.mirrored_at` is set.
-  Until then its track list is a prefix, not a set.
-- **A server track is examinable** when `remote_track.full_hash` is present. A
-  row mirrored before that column was populated cannot be compared at all.
-- **A local track has been examined** when `local_full_hash` holds a valid entry
-  for it — the digest cache added in lot 5, valid while `(file_size,
-  file_modified)` still match. That table is what turns "no link" into "no link,
-  and we looked".
+### Hashed is not reconciled
 
-A pair is eligible only when every track on both sides clears the matching
-condition. Absence of a link between two examined tracks then means what it
-should: different bytes. `remote_track_match_rejection` already records the
-stronger statement — a candidate a person examined and refused — and it
-continues to mean what it means.
+The obvious frontier — both sides have a digest, therefore both sides have been
+examined — is **wrong**, and it is wrong today rather than hypothetically:
 
-**This makes reconciliation's use of `local_full_hash` a prerequisite rather
-than an optimisation.** Today only the upload survey fills that cache;
-reconciliation still hashes on its own. Until both go through it, the
-completeness frontier is only as complete as whatever last ran, and pairing
-would be eligible in fewer cases than it should be — conservative, so not
-dangerous, but not the intended behaviour either.
+```
+local track   local_full_hash = ABC123      (written by the upload survey)
+remote track  full_hash       = ABC123      (written by the mirror)
+remote_track_link             = no row
+```
+
+Both files are hashed. Both digests are equal. No link exists, because nothing
+has yet compared them — the upload survey fills the cache, and reconciliation
+still hashes on its own rather than reading it. A frontier built on "both sides
+hashed" reads that absence as *different bytes*, about two files that are
+identical.
+
+Digests are an input to reconciliation, not a record that it ran. **Eligibility
+requires a completed reconciliation over the exact sets being evaluated**, and
+that is a distinct fact which nothing currently records. Adding it — a
+reconciliation frontier, per catalogue generation, in the sense below — is a
+prerequisite of this RFC, alongside routing reconciliation through
+`local_full_hash` so that the two paths stop hashing the same files twice.
+
+### Completeness is versioned, not a timestamp
+
+`remote_album.mirrored_at` says a walk finished. It does not say the set has not
+changed since:
+
+```
+12:00  walk completes            mirrored_at = 12:00
+12:05  the server adds a track   mirrored_at = 12:00, and now lying
+```
+
+A closed set that reopened is not a closed set, so the frontier is attached to a
+**generation of the catalogue** rather than to a moment. Eligibility holds while
+the reconciled generation equals the current one; anything that changes either
+side's membership advances the current generation and makes the pair ineligible
+until reconciliation catches up.
+
+The desktop has a weak form of this already and no strong one.
+`remote_album.song_count` is the mirror's own freshness check — an album whose
+count is unchanged is skipped without a fetch — so `(song_count, mirrored_at)`
+detects the common case of a track arriving or leaving. It does not detect a
+track being *replaced*, and it depends on a walk to notice anything at all.
+
+The strong form is the server's library event stream (its RFC-007), which
+carries a monotonic `cursor` and is already live. **The desktop consumes none of
+it** — there is no cursor anywhere in `remote/mirror.rs` — which makes this
+RFC's frontier one more consumer for the work lot 6 has to do anyway. Until
+then, `(song_count, mirrored_at)` is the available approximation, and it is an
+approximation on the conservative side only for additions and removals.
+
+### The corpus is what is observed, not what exists
+
+Artists get the same frontier as albums, with the meaning that makes it
+possible: complete does **not** mean "we know this artist's entire discography",
+which is unachievable and would pair nobody. It means **every track currently
+observed for that artist, on both sides, has been reconciled**.
+
+```
+snapshot N        local: A B C      remote: A B D      all reconciled
+                  A ↔ A,  B ↔ B,  no contradiction    → eligible
+
+snapshot N+1      a track E appears                    → ineligible until
+                                                          reconciled again
+```
+
+Without this, artists reproduce the withdrawn rule's failure at smaller scale:
+two links arrive and the artist is hidden, a third contradicts them and it comes
+back. Decision 5 explains why that behaviour is worse than never hiding it at
+all, and the explanation does not stop applying because the entity is an artist.
+
+`remote_track_match_rejection` already records the stronger statement — a
+candidate a person examined and refused — and it continues to mean what it
+means.
 
 ## Decision 4 — a pair is presented as one, not stored as one
 
@@ -211,12 +274,23 @@ the server has held for three years and this machine acquired today belongs at
 the top of *recently added*, not buried three years back. A remote-only entry
 naturally keeps the server's date; there is no pair to reconcile.
 
-**Contents are ordered, not merely concatenated.** With Decision 2's bijection
-the two track sets coincide, so the union is the set itself — but the rule still
-has to be written, because a *presentation* built from two rows needs a total
-order or two renders can disagree. It is: `disc_number`, then `track_number`,
-then local before remote, then the stable identifier. The last two exist to make
-the order total, not to express a preference.
+**One pair, one row — and the row is the local one.** With Decision 2's
+bijection the two track sets coincide, so a deduplicated album shows each
+recording exactly once, rendered from its local row. This is the rule the track
+listing already applies, and stating it here removes the reading the earlier
+draft invited: nothing produces two rows for one pair, so no deduplicated album
+can list a track twice.
+
+**Playback is not decided by the row.** It follows
+`remote_track_link.playback_preference` — `local_first` by default,
+`server_first` when the user says so — which exists precisely so that which
+copy plays is a property of the *pair* rather than of whichever half a listing
+happened to render. A row shown from the local half can still play from the
+server, and does when the local file has gone.
+
+**The order is total.** `disc_number`, then `track_number`, then the stable
+identifier. There is no local-before-remote tiebreak, because after the two
+previous rules there is no pair of rows for it to arbitrate.
 
 **Actions have one meaning, decided here.** "Whichever half the gesture came
 from" is not an answer once the user sees one card: they cannot tell which half
@@ -225,7 +299,10 @@ they clicked, and they should not have to.
 - **Starring applies to both representations that can carry it**, and the entry
   reads as starred when either is. Un-starring clears both. The server half
   travels through the outbound mutation queue like any other remote write, so
-  this works offline and lands when the queue drains.
+  this works offline and lands when the queue drains — and the entry reads from
+  the projection, which `remote::write` updates in the *same transaction* as it
+  queues the mutation. That is what keeps an offline un-star from looking like
+  a button that did nothing until the network returns.
 - **Rating and the cover picker write to local rows only.** They have no server
   counterpart in this protocol; nothing is silently dropped because nothing was
   ever offered.
@@ -265,11 +342,26 @@ that can fail: a server track deleted upstream, an account signed out, a
 permission withdrawn.
 
 One distinction has to be made explicit or this rule causes the flicker it was
-written to prevent: **it is about existence, not about momentary reach.** A
-server that is unreachable right now, or offline mode being on, must not
-re-expand every pair in the library — the representation still exists, it is
-merely not answering. Only a representation that has *ceased to exist* releases
-its partner from being hidden.
+written to prevent: **transient unreachability is not loss.** A server that is
+not answering right now, or offline mode being on, must not re-expand every pair
+in the library — the representation still exists and will answer again.
+
+But "only actual deletion counts" is too narrow in the other direction, because
+some failures are durable without being deletions. The line is whether the
+representation can be expected to come back **for this user**:
+
+| Condition | Still hidden? |
+| --- | --- |
+| Network down, server asleep, offline mode on | Yes — it will answer again |
+| Local file missing (`is_available = 0`) | No — the local half already filtered itself out |
+| Track gone from the server's catalogue (`in_catalogue = 0`) | No |
+| Signed out, or the binding forgotten | No |
+| Membership or permission withdrawn upstream | No |
+
+The last three are not outages: nothing about waiting fixes them. Treating them
+as transient would leave a user looking at a library that quietly lost entries
+they still hold locally, which is the exact harm this decision exists to
+prevent.
 
 ## Decision 6 — a local playlist becomes exactly representable
 
@@ -289,6 +381,13 @@ distinction matters. It decides **representability**:
 > A local playlist whose every entry carries a `confirmed` link can be projected
 > into server track identifiers exactly, with no guessing. Publication happens
 > only when every entry is representable.
+
+A `confirmed` link is necessary and not sufficient: the same
+existence-versus-reach distinction applies. A link whose server track has left
+the catalogue (`in_catalogue = 0`), or whose server is no longer one this
+account may read, names something that will not resolve — the entry is not
+representable, however confirmed the proof once was. Being unable to reach the
+server *right now* is not that, and does not make a playlist unrepresentable.
 
 All or nothing, and never silently. A playlist of forty tracks with three
 unlinked ones does not travel as a playlist of thirty-seven: a list missing
@@ -355,7 +454,7 @@ it will read as the feature not working. It should be visible in the interface �
 
 - **Whether an ineligible pair should say so.** The cost section argues it
   should; where that surfaces without cluttering a library view is unresolved.
-- **Whether artists should also require a completeness frontier.** Decision 3 is
-  written for both, but an artist is an open grouping, so "both sides examined"
-  is a stronger demand there than the evidence needs. Leaving it uniform is the
-  conservative choice and may prove too strict in practice.
+- **What advances a catalogue generation, exactly.** Decision 3 requires one;
+  `(song_count, mirrored_at)` approximates it today and the library event
+  stream's cursor is the real answer, but which changes must invalidate a
+  frontier — a retag upstream, a track becoming unavailable — is unenumerated.

--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -1,11 +1,11 @@
 # RFC-006 — Deduplicating the two catalogues
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-08-31
 - **Authors**: @InstaZDLL
 - **Depends on**: [RFC-005](RFC-005-remote-source-and-sync-v2.md) — this RFC answers the question its Decision 1 deferred, and does not revisit anything else it settled.
 - **Implementation**: none yet.
-- **Revised** after external review, before any implementation. What the first draft proposed for albums is kept below, as [the rule that was withdrawn](#the-album-rule-that-was-withdrawn), because the reason it fails is the most useful thing in this document.
+- **Revised** after external review and accepted on 2026-08-31, before any implementation. What the first draft proposed for albums is kept below, as [the rule that was withdrawn](#the-album-rule-that-was-withdrawn), because the reason it fails is the most useful thing in this document.
 
 ---
 


### PR DESCRIPTION
Docs only. Answers the question [RFC-005](https://github.com/InstaZDLL/WaveFlow/blob/main/docs/rfcs/RFC-005-remote-source-and-sync-v2.md) deferred twice by name, now that its precondition has shipped: `remote_track_link` holds content-proven pairs, written by reconciliation, by an import and by an upload. Above the track, the two catalogues still show two of everything.

Accepted after external review. No implementation.

## The six decisions

1. **Metadata may refuse an identity, never establish one.** Directional rather than absolute: content proves sameness, anything may prove difference. The temptation is concrete — `remote_artist.sort_key` already holds the same normalised form as `artist.canonical_name`, so a one-column join would pair most artists today — and it is exactly what RFC-005 forbids one level down. *Greatest Hits* is not one album; *John Williams* is not one artist.
2. **Albums and artists do not share a predicate.** An album is a **closed set** — a release *is* its track list — so it pairs on a complete bijection of confirmed links: ten against ten, yes; ten against an eighteen-track deluxe, no. An artist is an **open grouping**, where no discography is complete on either side, so unanimity plus at least two links stands — which also disposes of *Various Artists* with no `is_compilation` special case, since the second disagreeing link ends the question.
3. **Nothing pairs until both sides have been examined.** The absence of a link is ambiguous — "different bytes" or "not looked at yet" — and a predicate that cannot tell them apart decides on evidence it does not have.
4. **A pair is presented as one, not stored as one.** Two rows, one rendered entry: local metadata with a server fallback, a stated total order, and deterministic actions.
5. **Asymmetric caution.** A missed pair is untidy and visible; a wrong pair hides something the user has. `confirmed` links only, and never the last representation.
6. **A local playlist becomes exactly representable** — not "playlist sync is solved".

## The rule that was withdrawn, and why it is still in the document

The first draft applied the artist rule to albums too. The review's counter-example breaks it:

```
Local "Greatest Hits"        Remote "Album X"
  Song A ────────────────────► Song A
  Song B ────────────────────► Song B
  Song C                       Song E
  Song D                       Song F
```

Two links, unanimous, no contradiction — and the rule concludes the two are the same album and hides one. Two links prove that two releases share two recordings, which is what compilations, singles, soundtracks and reissues are *for*. It mistook evidence about tracks for evidence about the set containing them: the same confusion Decision 1 forbids by name, committed one level up.

It is kept in the RFC rather than deleted because that counter-example is the clearest available statement of what a link does and does not prove.

## What the desktop already has for decision 3

The completeness frontier needs no new column. `remote_album.mirrored_at` says a server album is fully discovered; `remote_track.full_hash` says a server track is comparable; and **`local_full_hash`** — the digest cache lot 5 added — is what turns "no link" into "no link, and we looked". `remote_track_match_rejection` already records the stronger statement.

One consequence is written into the RFC rather than left implicit: **routing reconciliation through that cache becomes a prerequisite**, not the optimisation it was previously noted as. Today only the upload survey fills it.

## Also settled here

- **The derivation starts as a view.** Both directions of `remote_track_link` are already indexed (`local_track_id` is the primary key, `remote_track_id` is `UNIQUE`), so measure before materialising anything.
- **A merged album's added-at date is the local one** — otherwise an album the server has held three years and this machine got today sits three years back in *recently added*.
- **Starring applies to both halves**; rating and the cover picker stay local. "Whichever half the gesture came from" stops being an answer once the user sees one card.
- **The last-representation rule is about existence, not reach.** A briefly unreachable server, or offline mode, must not re-expand every pair in the library.

## Deliberately left out

Grouping a standard edition with its deluxe. It is genuinely useful and it is a **different claim** — "the same release" versus "close enough to show together" — which the first draft conflated. A future album-family RFC would sit above this one and consume the same links.

Two narrower open questions remain, both stated in the text: whether an ineligible pair should say so in the interface, and whether artists really need the completeness frontier that albums do.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Ajout du RFC-006 accepté sur la déduplication réversible des catalogues local et distant.
  * Précision des règles d’identification des albums et artistes, de complétude et de provenance des métadonnées.
  * Documentation de la présentation des éléments associés, des favoris, évaluations, couvertures et playlists locales.
  * Définition des conditions de publication atomique des playlists et des téléversements reprenables.
  * Mise à jour du RFC-005 et de l’index des RFC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->