### PR TITLE
feat(remote): share one digest cache, and keep discovery apart from verification

### DIFF
--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -199,9 +199,30 @@ identical.
 Digests are an input to reconciliation, not a record that it ran. **Eligibility
 requires a completed reconciliation over the exact sets being evaluated**, and
 that is a distinct fact which nothing currently records. Adding it — a
-reconciliation frontier, per catalogue generation, in the sense below — is a
-prerequisite of this RFC, alongside routing reconciliation through
-`local_full_hash` so that the two paths stop hashing the same files twice.
+reconciliation frontier, per catalogue generation, in the sense below — remains
+a prerequisite of this RFC.
+
+The other half of that prerequisite is **done**: every discovery path now shares
+one digest cache — the reconciliation sweep, the upload survey, and an import's
+check for bytes the library already holds — so the same file is no longer read
+by each of them in turn.
+
+**But discovery reads the cache and verification never does**, and implementing
+that surfaced a distinction the frontier depends on. A reconciliation sweep does
+two jobs at once. It **discovers** pairs among unlinked tracks, which is what
+the cache is for. It also **re-verifies** the tracks that already carry a link,
+which is how a link whose bytes have changed becomes `stale` — and that job must
+read the file. `track.file_modified` moves when a *scan* re-reads a file, not
+when the file changes, so a track edited outside WaveFlow keeps its
+`(size, mtime)` and with them a cached digest describing bytes that are gone. A
+re-verification served from that would never catch the stale link it exists to
+catch.
+
+So the cache is offered only for tracks carrying no link, and the paths that
+verify immediately before an irreversible write — confirming a link, converting
+a playlist — always read the file. Stated once: **a caller asking what a file
+hashes to may use the cache; a caller asking whether it still hashes to that
+must not.**
 
 ### Completeness is versioned, and the version is per entity
 

--- a/src-tauri/crates/app/src/remote/hashing.rs
+++ b/src-tauri/crates/app/src/remote/hashing.rs
@@ -12,6 +12,27 @@
 //! reconciliation scan and a second upload sweep an hour later would otherwise
 //! each pay it in full.
 //!
+//! ## Knowing is not verifying
+//!
+//! Two kinds of caller ask for a whole-file digest and they must not share a
+//! path:
+//!
+//! - **Discovery** wants to *know* what a file hashes to — a reconciliation
+//!   sweep, an upload survey, an import checking whether the library already
+//!   holds some bytes. Thousands of files, and reading one twice buys nothing.
+//!   These go through [`full_hash`], which answers from the cache.
+//! - **Verification** wants to *check the bytes right now*, immediately before
+//!   acting on them: confirming a link, converting a playlist. The point is
+//!   precisely not to trust an earlier reading, so the cache would defeat it —
+//!   an entry stays valid while `(file_size, file_modified)` match, and the one
+//!   case that pair cannot see is a rewrite that preserved both. Those callers
+//!   read the file, and [`verify`] is the way to do it while keeping the cache
+//!   honest.
+//!
+//! Getting this backwards is silent in both directions: discovery through
+//! `verify` reads the library twice, and verification through `full_hash`
+//! confirms a link against bytes that may no longer be there.
+//!
 //! ## What invalidates an entry
 //!
 //! `(file_size, file_modified)` — the same pair the scanner's fast path trusts
@@ -84,6 +105,102 @@ pub async fn full_hash(
     .bind(chrono::Utc::now().timestamp_millis())
     .execute(pool)
     .await?;
+    Ok(Some(hash))
+}
+
+/// The cached digests of a set of tracks, in one query.
+///
+/// For the sweeps: asking per track would be one round trip per file across a
+/// whole library, and the point of the cache is to avoid exactly that shape of
+/// cost. Only entries still matching their `track` row's size and mtime come
+/// back, so a caller can treat a miss as "not known" without checking anything
+/// else.
+pub async fn cached_digests(
+    pool: &SqlitePool,
+    track_ids: &[i64],
+) -> AppResult<std::collections::HashMap<i64, String>> {
+    if track_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    // The candidate set is bounded by the library, and SQLite's variable limit
+    // is not, so the join carries the validity condition rather than an `IN`
+    // list: every valid entry is fetched and the caller keeps what it asked for.
+    let rows = sqlx::query(
+        "SELECT h.track_id, h.full_hash
+           FROM local_full_hash h
+           JOIN track t ON t.id = h.track_id
+          WHERE t.file_size = h.file_size AND t.file_modified = h.file_modified",
+    )
+    .fetch_all(pool)
+    .await?;
+    let wanted: std::collections::HashSet<i64> = track_ids.iter().copied().collect();
+    let mut out = std::collections::HashMap::new();
+    for row in rows {
+        let id: i64 = row.try_get("track_id")?;
+        if wanted.contains(&id) {
+            out.insert(id, row.try_get("full_hash")?);
+        }
+    }
+    Ok(out)
+}
+
+/// Persist a batch of freshly computed digests.
+///
+/// One transaction, because this runs after a sweep that may have hashed
+/// thousands of files and SQLite has a single writer: a row at a time would
+/// hold the write lock open across the whole batch for no gain.
+pub async fn remember(pool: &SqlitePool, entries: &[(i64, String, i64, i64)]) -> AppResult<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let now = chrono::Utc::now().timestamp_millis();
+    let mut tx = pool.begin().await?;
+    for (track_id, hash, size, modified) in entries {
+        sqlx::query(
+            "INSERT INTO local_full_hash
+                 (track_id, full_hash, file_size, file_modified, computed_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(track_id) DO UPDATE SET
+                 full_hash = excluded.full_hash,
+                 file_size = excluded.file_size,
+                 file_modified = excluded.file_modified,
+                 computed_at = excluded.computed_at",
+        )
+        .bind(track_id)
+        .bind(hash)
+        .bind(size)
+        .bind(modified)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Read the file **now** and record what it says.
+///
+/// For the callers that must not trust an earlier reading — confirming a link,
+/// converting a playlist — where the whole point is that the bytes are checked
+/// immediately before something irreversible happens. It refreshes the cache on
+/// the way past, so a verification also repairs a stale entry.
+pub async fn verify(
+    pool: &SqlitePool,
+    track_id: i64,
+    path: &str,
+    size: i64,
+    modified: i64,
+) -> AppResult<Option<String>> {
+    let owned = PathBuf::from(path);
+    let hashed = tokio::task::spawn_blocking(move || {
+        waveflow_core::scanner::hash_file_full(Path::new(&owned))
+    })
+    .await
+    .map_err(|err| AppError::Other(format!("hash task failed: {err}")))?;
+    let Ok(hash) = hashed else {
+        return Ok(None);
+    };
+    remember(pool, &[(track_id, hash.clone(), size, modified)]).await?;
     Ok(Some(hash))
 }
 
@@ -234,6 +351,67 @@ mod tests {
         // The entry is gone, so the file is read — and it is not there.
         std::fs::remove_file(&file).unwrap();
         assert!(full_hash(&pool, 1, &path, 3, 42).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_batch_read_returns_only_valid_entries() {
+        let file = temp_file(b"bytes");
+        let path = file.to_string_lossy().to_string();
+        let pool = pool().await;
+        seed(&pool, &path, 5, 42).await;
+        full_hash(&pool, 1, &path, 5, 42).await.unwrap().unwrap();
+
+        assert_eq!(cached_digests(&pool, &[1]).await.unwrap().len(), 1);
+        // A track the caller did not ask about is not returned even when cached.
+        assert!(cached_digests(&pool, &[2]).await.unwrap().is_empty());
+        assert!(cached_digests(&pool, &[]).await.unwrap().is_empty());
+
+        // The row says the file moved: the entry is no longer valid, and the
+        // batch read must not hand it back as if it described the new bytes.
+        sqlx::raw_sql("UPDATE track SET file_modified = 43 WHERE id = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(cached_digests(&pool, &[1]).await.unwrap().is_empty());
+        std::fs::remove_file(&file).ok();
+    }
+
+    /// The distinction the whole module exists for: discovery answers from the
+    /// cache, verification reads the file. A rewrite that preserves size and
+    /// mtime is the case that tells them apart — and the case a verification
+    /// exists to catch.
+    #[tokio::test]
+    async fn verification_reads_the_file_where_discovery_does_not() {
+        let file = temp_file(b"before");
+        let path = file.to_string_lossy().to_string();
+        let pool = pool().await;
+        seed(&pool, &path, 6, 42).await;
+        let first = full_hash(&pool, 1, &path, 6, 42).await.unwrap().unwrap();
+
+        // Same length, same recorded mtime, different bytes: the cache cannot
+        // see this, and is not meant to.
+        std::fs::write(&file, b"after!").unwrap();
+        let discovered = full_hash(&pool, 1, &path, 6, 42).await.unwrap().unwrap();
+        assert_eq!(discovered, first, "discovery must answer from the cache");
+
+        let verified = verify(&pool, 1, &path, 6, 42).await.unwrap().unwrap();
+        assert_ne!(verified, first, "verification must read the file");
+        // And it repaired the entry on the way past.
+        assert_eq!(
+            cached_digests(&pool, &[1]).await.unwrap().get(&1),
+            Some(&verified)
+        );
+        std::fs::remove_file(&file).ok();
+    }
+
+    #[tokio::test]
+    async fn verifying_a_missing_file_reports_rather_than_fails() {
+        let pool = pool().await;
+        seed(&pool, "/nowhere/at/all.flac", 1, 1).await;
+        assert!(verify(&pool, 1, "/nowhere/at/all.flac", 1, 1)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/remote/hashing.rs
+++ b/src-tauri/crates/app/src/remote/hashing.rs
@@ -104,7 +104,13 @@ pub async fn full_hash(
     .bind(modified)
     .bind(chrono::Utc::now().timestamp_millis())
     .execute(pool)
-    .await?;
+    .await
+    // Same reasoning as `remember_quietly`: the answer is already computed and
+    // the cache is an optimisation, so a failed write must not lose it.
+    .inspect_err(|err| {
+        tracing::warn!(track_id, ?err, "could not cache a full-file digest");
+    })
+    .ok();
     Ok(Some(hash))
 }
 
@@ -149,6 +155,14 @@ pub async fn cached_digests(
 /// One transaction, because this runs after a sweep that may have hashed
 /// thousands of files and SQLite has a single writer: a row at a time would
 /// hold the write lock open across the whole batch for no gain.
+///
+/// Takes the pool rather than a caller's `&mut SqliteConnection`, unlike the
+/// scanner's upsert helpers: those run *inside* a transaction their caller
+/// already owns, while every caller here is between transactions and would
+/// have to open one just to hand it over. Contention is left to sqlx's
+/// five-second `busy_timeout`, and a collision that outlasts it is not retried
+/// — see [`remember_quietly`] for why losing this batch is survivable in a way
+/// that losing a batch of computed loudness is not.
 pub async fn remember(pool: &SqlitePool, entries: &[(i64, String, i64, i64)]) -> AppResult<()> {
     if entries.is_empty() {
         return Ok(());
@@ -178,6 +192,27 @@ pub async fn remember(pool: &SqlitePool, entries: &[(i64, String, i64, i64)]) ->
     Ok(())
 }
 
+/// [`remember`], for the callers whose real work is already done.
+///
+/// A digest cache that could not be written is a slower next sweep, not a
+/// failure: everything in the batch is recomputable by reading the files
+/// again, which is exactly what the caller just did. Propagating the error
+/// would abort a reconciliation — or discard a verification's answer — over a
+/// write whose only purpose was to make the *next* run cheaper. That is also
+/// why there is no retry loop here, unlike the analysis flush: that one
+/// retries because a lost batch means recomputing an eight-second decode per
+/// track and it has no other copy, while these digests are one file read away
+/// and the sweep will simply pay it again.
+pub async fn remember_quietly(pool: &SqlitePool, entries: &[(i64, String, i64, i64)]) {
+    if let Err(err) = remember(pool, entries).await {
+        tracing::warn!(
+            rows = entries.len(),
+            ?err,
+            "could not cache full-file digests; the next sweep will re-read them"
+        );
+    }
+}
+
 /// Read the file **now** and record what it says.
 ///
 /// For the callers that must not trust an earlier reading — confirming a link,
@@ -200,7 +235,7 @@ pub async fn verify(
     let Ok(hash) = hashed else {
         return Ok(None);
     };
-    remember(pool, &[(track_id, hash.clone(), size, modified)]).await?;
+    remember_quietly(pool, &[(track_id, hash.clone(), size, modified)]).await;
     Ok(Some(hash))
 }
 

--- a/src-tauri/crates/app/src/remote/import.rs
+++ b/src-tauri/crates/app/src/remote/import.rs
@@ -494,8 +494,8 @@ async fn local_twin(pool: &SqlitePool, size: i64, expected_hash: &str) -> AppRes
     if size <= 0 || expected_hash.len() != 64 {
         return Ok(None);
     }
-    let candidates: Vec<(i64, String)> = sqlx::query_as(
-        "SELECT t.id, t.file_path
+    let candidates: Vec<(i64, String, i64)> = sqlx::query_as(
+        "SELECT t.id, t.file_path, t.file_modified
            FROM track t
           WHERE t.file_size = ? AND t.is_available = 1
             AND NOT EXISTS (SELECT 1 FROM remote_track_link l WHERE l.local_track_id = t.id)",
@@ -503,13 +503,12 @@ async fn local_twin(pool: &SqlitePool, size: i64, expected_hash: &str) -> AppRes
     .bind(size)
     .fetch_all(pool)
     .await?;
-    for (track_id, file_path) in candidates {
-        let path = PathBuf::from(file_path);
-        let hashed =
-            tokio::task::spawn_blocking(move || waveflow_core::scanner::hash_file_full(&path))
-                .await
-                .map_err(|err| AppError::Other(format!("import hash task failed: {err}")))?;
-        let Ok(hashed) = hashed else { continue };
+    for (track_id, file_path, modified) in candidates {
+        // Through the shared cache: this is discovery — "does the library
+        // already hold these bytes" — so a file another sweep has read does not
+        // need reading again, and one read here serves the next sweep too.
+        let hashed = super::hashing::full_hash(pool, track_id, &file_path, size, modified).await?;
+        let Some(hashed) = hashed else { continue };
         if hashed.eq_ignore_ascii_case(expected_hash) {
             return Ok(Some(track_id));
         }

--- a/src-tauri/crates/app/src/remote/mod.rs
+++ b/src-tauri/crates/app/src/remote/mod.rs
@@ -71,8 +71,12 @@
 //!   reaches it, since the mirror already knows which digests it holds.
 //!
 //! - [`hashing`] — the whole-file digest of a local track, computed
-//!   once and kept, because deciding what a server is missing means
-//!   reading the library.
+//!   once and shared by every path that needs one, because deciding
+//!   what a server is missing means reading the library. Keeps two
+//!   kinds of caller apart: *discovery* asks what a file hashes to and
+//!   may be answered from the cache; *verification* asks whether it
+//!   still hashes to that, immediately before an irreversible write,
+//!   and always reads the file.
 //!
 //! - [`reconciliation`] — pairing local files with server tracks after
 //!   the fact, which costs a full re-read; [`import`] is the one path

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -60,6 +60,10 @@ struct ReconcileProgress {
 /// Outcome of the blocking hash pass over the local candidates.
 struct HashScan {
     hashed: Vec<HashedLocalTrack>,
+    /// `(track id, digest, size, mtime)` for the files this sweep actually
+    /// read, so the caller can file them for the next one. Empty when every
+    /// candidate was already known.
+    computed: Vec<(i64, String, i64, i64)>,
     unreadable: usize,
     cancelled: bool,
 }
@@ -103,6 +107,9 @@ struct LocalTrack {
     album: Option<String>,
     file_path: String,
     size: i64,
+    /// Carried so a computed digest can be filed against the same
+    /// `(size, mtime)` the row had when it was read — see [`super::hashing`].
+    modified: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -345,11 +352,40 @@ async fn discover_inner(
 
     let local_tracks = load_local_candidates(pool).await?;
     let total = local_tracks.len();
+    // What a previous sweep — or an upload survey, or an import — already
+    // established about these exact files. Read once, before the blocking pass,
+    // because that pass has no pool and must not acquire one per file.
+    //
+    // **Only for tracks that carry no link yet.** This sweep does two jobs, and
+    // they are the two the digest cache exists to keep apart: it *discovers*
+    // pairs among unlinked tracks, and it *re-verifies* the tracks that already
+    // have a link, which is how a link whose bytes changed becomes `stale`.
+    // Serving that second job from the cache would defeat it — `file_modified`
+    // only moves when a scan re-reads the file, so a track edited outside
+    // WaveFlow keeps its `(size, mtime)` and its cached digest, and its stale
+    // link would never be caught. A linked track is therefore always read.
+    let unlinked: Vec<i64> = sqlx::query_scalar(
+        "SELECT t.id FROM track t
+          WHERE NOT EXISTS (SELECT 1 FROM remote_track_link l WHERE l.local_track_id = t.id)",
+    )
+    .fetch_all(pool)
+    .await?;
+    let unlinked: std::collections::HashSet<i64> = unlinked.into_iter().collect();
+    let ids: Vec<i64> = local_tracks
+        .iter()
+        .map(|track| track.id)
+        .filter(|id| unlinked.contains(id))
+        .collect();
+    let known = super::hashing::cached_digests(pool, &ids).await?;
     let scan = tokio::task::spawn_blocking(move || {
-        hash_local_tracks(local_tracks, app.as_ref(), total, cancellable)
+        hash_local_tracks(local_tracks, known, app.as_ref(), total, cancellable)
     })
     .await
     .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))?;
+    // Filed before the cancellation check below: these describe files, not
+    // decisions, so a run that was stopped still leaves the reading it paid for
+    // behind — which is the whole reason the next sweep is cheap.
+    super::hashing::remember(pool, &scan.computed).await?;
 
     if scan.cancelled {
         // A partial scan could auto-link the unique matches it happened to
@@ -398,7 +434,7 @@ async fn load_remote_tracks(pool: &SqlitePool) -> AppResult<Vec<RemoteTrack>> {
 
 async fn load_local_candidates(pool: &SqlitePool) -> AppResult<Vec<LocalTrack>> {
     let rows = sqlx::query(
-        "SELECT t.id, t.title, t.file_path, t.file_size, al.title AS album,
+        "SELECT t.id, t.title, t.file_path, t.file_size, t.file_modified, al.title AS album,
                 (SELECT GROUP_CONCAT(name, ', ') FROM (
                     SELECT ar.name
                       FROM track_artist ta
@@ -428,6 +464,7 @@ async fn load_local_candidates(pool: &SqlitePool) -> AppResult<Vec<LocalTrack>> 
                 album: row.try_get("album")?,
                 file_path: row.try_get("file_path")?,
                 size: row.try_get("file_size")?,
+                modified: row.try_get("file_modified")?,
             })
         })
         .collect()
@@ -435,6 +472,7 @@ async fn load_local_candidates(pool: &SqlitePool) -> AppResult<Vec<LocalTrack>> 
 
 fn hash_local_tracks(
     tracks: Vec<LocalTrack>,
+    known: HashMap<i64, String>,
     app: Option<&AppHandle>,
     total: usize,
     cancellable: bool,
@@ -442,15 +480,31 @@ fn hash_local_tracks(
     // The phase is only meaningful on the cancellable path; the no-progress/test
     // path must not read the shared phase (see `discover_inner`).
     let mut hashed = Vec::with_capacity(tracks.len());
+    let mut computed: Vec<(i64, String, i64, i64)> = Vec::new();
     let mut unreadable = 0;
     for track in tracks {
         // Poll for a cancel at the top of the loop so a click that lands
         // between two files is honoured before starting another full-file read.
         if cancellable && RECONCILE_PHASE.load(Ordering::Relaxed) == PHASE_CANCELLED {
-            return cancelled_scan(hashed, unreadable, total);
+            return cancelled_scan(hashed, computed, unreadable, total);
+        }
+        // Already known for this exact `(size, mtime)`: reading the file again
+        // would cost a full pass over the library to learn what the last one
+        // learned. Discovery wants to know the digest, not to re-check the
+        // bytes — the callers that need that use `hashing::verify`.
+        if let Some(full_hash) = known.get(&track.id).cloned() {
+            hashed.push(HashedLocalTrack { track, full_hash });
+            if let Some(app) = app {
+                let processed = hashed.len() + unreadable;
+                let _ = app.emit("reconcile:progress", ReconcileProgress { processed, total });
+            }
+            continue;
         }
         match waveflow_core::scanner::hash_file_full(Path::new(&track.file_path)) {
-            Ok(full_hash) => hashed.push(HashedLocalTrack { track, full_hash }),
+            Ok(full_hash) => {
+                computed.push((track.id, full_hash.clone(), track.size, track.modified));
+                hashed.push(HashedLocalTrack { track, full_hash });
+            }
             Err(err) => {
                 unreadable += 1;
                 tracing::warn!(
@@ -472,25 +526,43 @@ fn hash_local_tracks(
     // arbitration still happens at the pre-commit compare-exchange in
     // `reconcile`, which catches a cancel this relaxed load may have missed.
     if cancellable && RECONCILE_PHASE.load(Ordering::Relaxed) == PHASE_CANCELLED {
-        return cancelled_scan(hashed, unreadable, total);
+        return cancelled_scan(hashed, computed, unreadable, total);
     }
     HashScan {
         hashed,
+        computed,
         unreadable,
         cancelled: false,
     }
 }
 
-fn cancelled_scan(hashed: Vec<HashedLocalTrack>, unreadable: usize, total: usize) -> HashScan {
+fn cancelled_scan(
+    hashed: Vec<HashedLocalTrack>,
+    computed: Vec<(i64, String, i64, i64)>,
+    unreadable: usize,
+    total: usize,
+) -> HashScan {
     let processed = hashed.len() + unreadable;
     tracing::info!(processed, total, "reconciliation scan cancelled by user");
+    // A cancelled sweep persists no *links* — that is the invariant — but the
+    // digests it computed describe files, not decisions, and throwing them away
+    // would make a resumed run re-read everything it already read.
     HashScan {
         hashed,
+        computed,
         unreadable,
         cancelled: true,
     }
 }
 
+/// Re-read every local file behind a playlist conversion and say whether its
+/// bytes still match the proof its link was written from.
+///
+/// Deliberately *not* served from [`super::hashing`]'s cache. This is a
+/// verification, not a discovery: the caller is about to convert a playlist,
+/// and the question is what the file contains now — an entry that is valid for
+/// its `(size, mtime)` cannot answer that, since the one rewrite that pair
+/// cannot see is exactly the one this guards against.
 async fn playlist_link_freshness(proofs: Vec<PlaylistLinkProof>) -> AppResult<HashMap<i64, bool>> {
     tokio::task::spawn_blocking(move || {
         let mut freshness = HashMap::new();
@@ -767,7 +839,8 @@ pub async fn confirm_exact(
     remote_track_id: &str,
 ) -> AppResult<()> {
     let row = sqlx::query(
-        "SELECT t.file_path, t.file_size, rt.size AS remote_size, rt.full_hash
+        "SELECT t.file_path, t.file_size, t.file_modified,
+                rt.size AS remote_size, rt.full_hash
            FROM track t
            JOIN remote_track rt ON rt.remote_id = ?
           WHERE t.id = ? AND t.is_available = 1",
@@ -780,6 +853,7 @@ pub async fn confirm_exact(
 
     let file_path: String = row.try_get("file_path")?;
     let local_size: i64 = row.try_get("file_size")?;
+    let local_modified: i64 = row.try_get("file_modified")?;
     let remote_size: i64 = row.try_get("remote_size")?;
     let remote_hash: String = row.try_get("full_hash")?;
     if local_size != remote_size || !valid_full_hash(&remote_hash) {
@@ -788,11 +862,14 @@ pub async fn confirm_exact(
         ));
     }
 
-    let local_hash = tokio::task::spawn_blocking(move || {
-        waveflow_core::scanner::hash_file_full(Path::new(&file_path))
-    })
-    .await
-    .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))??;
+    // Reads the file, deliberately: this is a verification immediately before an
+    // irreversible write, and the cache exists to avoid re-reading during
+    // *discovery*. Going through `hashing::verify` rather than hashing directly
+    // means the fresh reading also repairs whatever the cache held.
+    let local_hash =
+        super::hashing::verify(pool, local_track_id, &file_path, local_size, local_modified)
+            .await?
+            .ok_or_else(|| AppError::Other("local file could not be read".into()))?;
     if !local_hash.eq_ignore_ascii_case(&remote_hash) {
         return Err(AppError::Other("track contents no longer match".into()));
     }
@@ -1567,6 +1644,47 @@ mod tests {
         RECONCILE_PHASE.store(PHASE_IDLE, Ordering::SeqCst);
     }
 
+    /// The sweep answers from the shared digest cache instead of reading the
+    /// file again — which is what makes RFC-006's completeness frontier mean
+    /// "examined" rather than "examined by whichever pass ran last".
+    ///
+    /// Proved by deleting the file after seeding the cache: a sweep that still
+    /// finds the digest cannot have read it.
+    #[tokio::test]
+    async fn the_sweep_reads_the_cache_rather_than_the_file() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local.flac");
+        fs::write(&path, b"same bytes").unwrap();
+        insert_local(&pool, 1, &path, "Local").await;
+        insert_remote(&pool, "remote-1", b"same bytes", "Remote").await;
+
+        let locals = load_local_candidates(&pool).await.unwrap();
+        let ids: Vec<i64> = locals.iter().map(|track| track.id).collect();
+        let scan = hash_local_tracks(locals, HashMap::new(), None, 0, false);
+        assert_eq!(scan.computed.len(), 1, "the first sweep reads the file");
+        super::super::hashing::remember(&pool, &scan.computed)
+            .await
+            .unwrap();
+
+        fs::remove_file(&path).unwrap();
+        let known = super::super::hashing::cached_digests(&pool, &ids)
+            .await
+            .unwrap();
+        let locals = load_local_candidates(&pool).await.unwrap();
+        let second = hash_local_tracks(locals, known, None, 0, false);
+        assert_eq!(
+            second.hashed.len(),
+            1,
+            "the file is gone, the digest is not"
+        );
+        assert_eq!(second.unreadable, 0);
+        assert!(
+            second.computed.is_empty(),
+            "nothing was read, so nothing is new to file"
+        );
+    }
+
     /// A cancel that lands after hashing finished, while `reconcile` is staging
     /// its writes, loses the pre-commit `STAGING → COMMITTING` transition and
     /// rolls the transaction back before commit, so no link row is written.
@@ -1583,7 +1701,7 @@ mod tests {
         // Hash to completion on the non-cancellable path (never reads the phase),
         // so the cancel below can only be caught by reconcile's pre-commit CAS.
         let locals = load_local_candidates(&pool).await.unwrap();
-        let scan = hash_local_tracks(locals, None, 0, false);
+        let scan = hash_local_tracks(locals, HashMap::new(), None, 0, false);
         assert_eq!(scan.hashed.len(), 1);
         let remotes = load_remote_tracks(&pool).await.unwrap();
 
@@ -1841,6 +1959,41 @@ mod tests {
         let report = discover(&pool).await.unwrap();
         assert_eq!(report.stale_links, 1);
         assert_eq!(links(&pool).await.unwrap()[0].status, "stale");
+    }
+
+    /// A linked track is re-read even when the digest cache holds an entry that
+    /// still looks valid.
+    ///
+    /// The sweep discovers *and* re-verifies, and only the first may be served
+    /// from the cache. `track.file_modified` moves when a scan re-reads a file,
+    /// not when the file changes, so a track edited outside WaveFlow keeps its
+    /// `(size, mtime)` — and with them a cached digest describing bytes that
+    /// are gone. Serving a re-verification from that is how a stale link would
+    /// never be caught.
+    #[tokio::test]
+    async fn a_linked_track_is_re_read_even_when_cached() {
+        let pool = pool().await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local.ogg");
+        fs::write(&path, b"aaaa").unwrap();
+        insert_local(&pool, 1, &path, "Local").await;
+        insert_remote(&pool, "remote-1", b"aaaa", "Remote").await;
+        assert_eq!(discover(&pool).await.unwrap().auto_linked, 1);
+
+        // The cache now holds the digest of "aaaa" against (4, 0). Rewriting to
+        // the same length leaves both unchanged, so the entry still reads as
+        // valid — and the link must go stale regardless.
+        fs::write(&path, b"bbbb").unwrap();
+        let cached = super::super::hashing::cached_digests(&pool, &[1])
+            .await
+            .unwrap();
+        assert!(
+            cached.contains_key(&1),
+            "the fixture must leave a still-valid entry, or this proves nothing"
+        );
+
+        let report = discover(&pool).await.unwrap();
+        assert_eq!(report.stale_links, 1);
     }
 
     #[tokio::test]

--- a/src-tauri/crates/app/src/remote/reconciliation.rs
+++ b/src-tauri/crates/app/src/remote/reconciliation.rs
@@ -384,8 +384,10 @@ async fn discover_inner(
     .map_err(|err| AppError::Other(format!("reconciliation hash task failed: {err}")))?;
     // Filed before the cancellation check below: these describe files, not
     // decisions, so a run that was stopped still leaves the reading it paid for
-    // behind — which is the whole reason the next sweep is cheap.
-    super::hashing::remember(pool, &scan.computed).await?;
+    // behind — which is the whole reason the next sweep is cheap. Failing to
+    // file them must not fail the reconciliation: the digests are an
+    // optimisation for the next run, and this run's answer is already in hand.
+    super::hashing::remember_quietly(pool, &scan.computed).await;
 
     if scan.cancelled {
         // A partial scan could auto-link the unique matches it happened to


### PR DESCRIPTION
RFC-006's first prerequisite, and the distinction implementing it uncovered.

## The problem

Reconciliation hashed on its own while only the upload survey filled `local_full_hash`. So the completeness frontier RFC-006 depends on — the one that turns "no link" into "no link, and we looked" — was only ever as complete as whichever pass ran last, and the same file was read by each path in turn.

## What changed

Every **discovery** path now shares the cache: the reconciliation sweep, the upload survey, and an import's check for bytes the library already holds.

The sweep loads what is known in **one query** before its blocking pass (that pass has no pool and must not acquire one per file), reads only the files nothing knows about, and files those at the end. Digests it computed survive a cancel — they describe files, not decisions, so a stopped run leaves behind the reading it paid for and the next sweep is cheap.

## The distinction, and the test that caught it

`changed_bytes_mark_a_confirmed_link_stale` failed, and it was right to.

A reconciliation sweep does **two jobs at once**:

- it **discovers** pairs among unlinked tracks — what the cache is for;
- it **re-verifies** tracks that already carry a link — how a link whose bytes changed becomes `stale`, and that job must read the file.

The reason is not a fixture artefact. `track.file_modified` moves when a *scan* re-reads a file, not when the file changes. A track edited outside WaveFlow therefore keeps its `(size, mtime)` — and with them a cached digest describing bytes that are gone. A re-verification served from that would never catch the stale link it exists to catch.

So:

- the cache is offered **only for tracks carrying no link**;
- `confirm_exact` goes through `hashing::verify`, which reads the file and repairs the cache entry on the way past;
- `playlist_link_freshness` keeps re-reading, with the reason written down rather than implied.

One rule, stated once in the module and once in the RFC: **a caller asking what a file hashes to may use the cache; a caller asking whether it still hashes to that must not.**

## Tests

Four new, two of them written to make this hard to undo by accident:

- `verification_reads_the_file_where_discovery_does_not` — same length, same recorded mtime, different bytes: discovery answers from the cache, verification does not, and the verification repairs the entry.
- `a_linked_track_is_re_read_even_when_cached` — asserts the cache entry is still valid *first*, so the test cannot pass vacuously, then requires the link to go stale anyway.
- `a_batch_read_returns_only_valid_entries` — including that a track the caller did not ask about is not returned.
- `the_sweep_reads_the_cache_rather_than_the_file` — proved by deleting the file after seeding the cache: a sweep that still finds the digest cannot have read it.

## Documentation

RFC-006 is updated to say what the implementation established rather than leaving the document describing a plan the code has moved past — the shared-cache half of its prerequisite is done, the reconciliation-frontier half is not, and the discovery/verification rule is now part of the RFC.

## Checks

`typecheck` · `lint` · `cargo fmt --check` · `clippy --workspace --all-targets -D warnings` · the same with `--no-default-features --features updater` · 439 + 226 tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * Accélération de la découverte, de l’import et de la réconciliation grâce au partage et à la réutilisation des empreintes calculées.
  * Vérification systématique des fichiers déjà associés avant toute opération irréversible, afin de détecter les modifications récentes.
  * Fiabilisation de la réconciliation entre les catalogues, y compris après l’interruption d’un balayage.
  * Les fichiers inaccessibles ou illisibles sont ignorés sans interrompre le traitement.
  * Renforcement de la détection des fichiers manquants et des associations devenues obsolètes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->