### PR TITLE
feat(remote): one entry per release, and one per person

### DIFF
--- a/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
+++ b/docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md
@@ -198,9 +198,17 @@ identical.
 
 Digests are an input to reconciliation, not a record that it ran. **Eligibility
 requires a completed reconciliation over the exact sets being evaluated**, and
-that is a distinct fact which nothing currently records. Adding it — a
-reconciliation frontier, per catalogue generation, in the sense below — remains
-a prerequisite of this RFC.
+recording *that* — a per-entity generation, in the sense below — is still to be
+built.
+
+What is implemented is the part of the frontier the schema can already answer,
+and it turns out to carry most of the weight: a track is treated as examined
+only when `local_full_hash` holds a valid entry for it, and a server album only
+when `remote_album.mirrored_at` is set. Combined with Decision 2's demand that
+**every** track on both sides be linked, an unexamined track cannot pair
+anything — it has no link, so the bijection fails and the two entries stay
+apart. The generation is what remains to catch the narrower case: a set that was
+fully examined and has changed since.
 
 The other half of that prerequisite is **done**: every discovery path now shares
 one digest cache — the reconciliation sweep, the upload survey, and an import's

--- a/src-tauri/crates/app/src/commands/browse.rs
+++ b/src-tauri/crates/app/src/commands/browse.rs
@@ -871,15 +871,22 @@ macro_rules! album_pair_proven {
     () => {
         concat!(
             "ra.mirrored_at IS NOT NULL AND EXISTS (
-           SELECT 1 FROM album al
-            WHERE EXISTS (
-                    SELECT 1 FROM remote_track rt
-                      JOIN remote_track_link l
-                        ON l.remote_track_id = rt.remote_id AND l.status = 'confirmed'
-                      JOIN track t ON t.id = l.local_track_id
-                     WHERE rt.album_id = ra.remote_id AND rt.in_catalogue = 1
-                       AND t.album_id = al.id AND t.is_available = 1)
-              AND NOT EXISTS (
+           SELECT 1 FROM (
+                  -- The only albums that can possibly pair are those a
+                  -- confirmed link already reaches from this one. Ranging over
+                  -- every local album instead would be one scan of the local
+                  -- catalogue per server album, answering `false` for all but
+                  -- a handful. It also subsumes the non-empty requirement: a
+                  -- candidate exists only because a link does.
+                  SELECT DISTINCT t.album_id AS id
+                    FROM remote_track rt
+                    JOIN remote_track_link l
+                      ON l.remote_track_id = rt.remote_id AND l.status = 'confirmed'
+                    JOIN track t ON t.id = l.local_track_id
+                   WHERE rt.album_id = ra.remote_id AND rt.in_catalogue = 1
+                     AND t.is_available = 1 AND t.album_id IS NOT NULL
+                ) al
+            WHERE NOT EXISTS (
                     SELECT 1 FROM remote_track rt
                      WHERE rt.album_id = ra.remote_id AND rt.in_catalogue = 1
                        AND NOT EXISTS (
@@ -921,11 +928,40 @@ macro_rules! album_pair_proven {
 /// Both sides of the disagreement are checked. Looking only from the server
 /// side would fold a local *Various Artists* into a real artist whenever the
 /// compilation's own tracks happened to agree.
+///
+/// ## Why `primary_artist`, when the listing joins `track_artist`
+///
+/// The listing shows a local artist credited anywhere on a track; this
+/// predicate considers only the *primary* one, and the two are deliberately
+/// not the same set.
+///
+/// The mirror holds exactly one artist per server track — `remote_track` has
+/// an `artist_id` column and there is no remote participants table — so
+/// `primary_artist` is the only local column comparable to it. Joining
+/// `track_artist` instead would make every guest credit look like a
+/// disagreement: a featured artist would "own" a track the server attributes
+/// to the host, and the unanimity check would fire against an artist the
+/// server never mentioned.
+///
+/// The cost is a known false negative: an artist never credited as primary is
+/// never paired, so they appear twice. That is the direction this design
+/// always fails in — a visible duplicate rather than a hidden entity — and it
+/// resolves on its own if the mirror ever carries participants.
 macro_rules! artist_pair_proven {
     () => {
         concat!(
             "EXISTS (
-           SELECT 1 FROM artist la
+           SELECT 1 FROM (
+                  -- Same candidate narrowing as the albums': only an artist a
+                  -- confirmed link already reaches can pair.
+                  SELECT DISTINCT t.primary_artist AS id
+                    FROM remote_track rt
+                    JOIN remote_track_link l
+                      ON l.remote_track_id = rt.remote_id AND l.status = 'confirmed'
+                    JOIN track t ON t.id = l.local_track_id
+                   WHERE rt.artist_id = ra.remote_id AND rt.in_catalogue = 1
+                     AND t.is_available = 1 AND t.primary_artist IS NOT NULL
+                ) la
             WHERE (SELECT COUNT(*)
                      FROM remote_track rt
                      JOIN remote_track_link l
@@ -3314,6 +3350,61 @@ mod tests {
             names.len(),
             3,
             "a disagreeing link ends the question: {names:?}"
+        );
+    }
+
+    /// An artist credited on a track but never its primary is not paired, and
+    /// appears twice.
+    ///
+    /// The mirror holds one artist per server track, so `primary_artist` is
+    /// the only comparable local column; a guest credit would otherwise read
+    /// as a disagreement about an artist the server never mentioned. A visible
+    /// duplicate is the failure this design chooses.
+    #[tokio::test]
+    async fn a_guest_credit_alone_never_pairs_an_artist() {
+        let pool = pool().await;
+        seed(&pool).await;
+        // A second local artist, credited on both tracks but primary on
+        // neither — exactly what a featuring credit looks like.
+        sqlx::raw_sql("INSERT INTO artist (id, name, canonical_name) VALUES (2, 'Guest', 'guest')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::raw_sql(
+            "INSERT INTO track (id, library_id, file_path, file_hash, file_size, file_modified,
+                                title, album_id, duration_ms, added_at, is_available,
+                                primary_artist, hlc_wall, hlc_logical,
+                                rating_hlc_wall, rating_hlc_logical)
+             VALUES (2, 1, '/m/2.flac', 'h2', 2, 0, 'T2', 1, 300000, 500, 1, 1, 0, 0, 0, 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::raw_sql(
+            "INSERT INTO track_artist (track_id, artist_id, position)
+             VALUES (1, 2, 1), (2, 1, 0), (2, 2, 1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        examine(&pool, 1).await;
+        examine(&pool, 2).await;
+        link(&pool, 1, "t-1").await;
+        link(&pool, 2, "t-2").await;
+
+        let names: Vec<String> =
+            artists(&pool, None, None, library_artist_order_clause(None, None))
+                .await
+                .into_iter()
+                .map(|row| row.1)
+                .collect();
+        // Björk is primary on both linked tracks and pairs; Guest is credited
+        // on both and pairs with nothing, so it stays listed on its own.
+        assert!(names.contains(&"Guest".to_string()), "{names:?}");
+        assert_eq!(
+            names.iter().filter(|name| *name == "Björk").count(),
+            1,
+            "the primary artist still pairs: {names:?}"
         );
     }
 

--- a/src-tauri/crates/app/src/commands/browse.rs
+++ b/src-tauri/crates/app/src/commands/browse.rs
@@ -825,7 +825,140 @@ async fn expand_library_track_rows(
 /// Split out of the command so the SQL can be exercised on its own: the
 /// command needs an `AppState`, the query needs only a database, and the query
 /// is the part that can be wrong.
+/// A local track whose bytes have been read and recorded — RFC-006's
+/// "examined" side of the completeness frontier.
+///
+/// Without it, "no link" is ambiguous: it means either "different bytes" or
+/// "nobody has looked yet", and pairing on the second is how a rule hides
+/// something it has no evidence about. `local_full_hash` answers the
+/// difference, and only while its entry still describes the file on disk.
+macro_rules! track_examined {
+    ($track:literal) => {
+        concat!(
+            "EXISTS (SELECT 1 FROM local_full_hash h
+                      WHERE h.track_id = ",
+            $track,
+            ".id
+                        AND h.file_size = ",
+            $track,
+            ".file_size
+                        AND h.file_modified = ",
+            $track,
+            ".file_modified)"
+        )
+    };
+}
+
+/// A server album that is the same release as a local one, and may therefore
+/// be rendered once rather than twice — [RFC-006](../../../../docs/rfcs/RFC-006-deduplicating-the-two-catalogues.md)
+/// decisions 2 and 3.
+///
+/// A **complete, non-empty bijection** over examined sets: every track on each
+/// side confirmed-linked to one on the other, and at least one such link. The
+/// one-to-one part is free — `remote_track_link` is a primary key on the local
+/// id and `UNIQUE` on the remote one — so "each track has a partner" already
+/// means "exactly one".
+///
+/// Two links and unanimity would **not** do here, which is what an earlier
+/// draft of that RFC got wrong: a compilation sharing two recordings with an
+/// album satisfies it while being a different release. An album is a closed
+/// set, so the set is the evidence.
+///
+/// The emptiness guard is not decoration either: a bijection over two empty
+/// sets holds vacuously, so without it a local album would pair with a server
+/// walk that returned nothing.
+macro_rules! album_pair_proven {
+    () => {
+        concat!(
+            "ra.mirrored_at IS NOT NULL AND EXISTS (
+           SELECT 1 FROM album al
+            WHERE EXISTS (
+                    SELECT 1 FROM remote_track rt
+                      JOIN remote_track_link l
+                        ON l.remote_track_id = rt.remote_id AND l.status = 'confirmed'
+                      JOIN track t ON t.id = l.local_track_id
+                     WHERE rt.album_id = ra.remote_id AND rt.in_catalogue = 1
+                       AND t.album_id = al.id AND t.is_available = 1)
+              AND NOT EXISTS (
+                    SELECT 1 FROM remote_track rt
+                     WHERE rt.album_id = ra.remote_id AND rt.in_catalogue = 1
+                       AND NOT EXISTS (
+                             SELECT 1 FROM remote_track_link l
+                               JOIN track t ON t.id = l.local_track_id
+                              WHERE l.remote_track_id = rt.remote_id
+                                AND l.status = 'confirmed'
+                                AND t.album_id = al.id AND t.is_available = 1))
+              AND NOT EXISTS (
+                    SELECT 1 FROM track t
+                     WHERE t.album_id = al.id AND t.is_available = 1
+                       AND (NOT EXISTS (
+                              SELECT 1 FROM remote_track_link l
+                                JOIN remote_track rt ON rt.remote_id = l.remote_track_id
+                               WHERE l.local_track_id = t.id AND l.status = 'confirmed'
+                                AND rt.album_id = ra.remote_id AND rt.in_catalogue = 1)
+                            OR NOT ",
+            track_examined!("t"),
+            "))
+         )"
+        )
+    };
+}
+
+/// A server artist that is the same person as a local one — RFC-006 decision 2,
+/// and deliberately **not** the album rule.
+///
+/// An artist is an open grouping: nobody's discography is complete on either
+/// side, so demanding a bijection would pair nobody. The evidence is about the
+/// person, not the extent of their work, so a sample suffices — **unanimity,
+/// and at least two confirmed links**.
+///
+/// Unanimity disposes of *Various Artists* with no special case: a compilation
+/// has tracks linked to a dozen different server artists, so the second
+/// disagreeing link ends the question. Two links because one guest appearance,
+/// credited to the featured artist on one side and the host on the other, is a
+/// coincidence rather than evidence.
+///
+/// Both sides of the disagreement are checked. Looking only from the server
+/// side would fold a local *Various Artists* into a real artist whenever the
+/// compilation's own tracks happened to agree.
+macro_rules! artist_pair_proven {
+    () => {
+        concat!(
+            "EXISTS (
+           SELECT 1 FROM artist la
+            WHERE (SELECT COUNT(*)
+                     FROM remote_track rt
+                     JOIN remote_track_link l
+                       ON l.remote_track_id = rt.remote_id AND l.status = 'confirmed'
+                     JOIN track t ON t.id = l.local_track_id
+                    WHERE rt.artist_id = ra.remote_id AND rt.in_catalogue = 1
+                      AND t.primary_artist = la.id AND t.is_available = 1
+                      AND ",
+            track_examined!("t"),
+            ") >= 2
+              AND NOT EXISTS (
+                    SELECT 1 FROM remote_track rt
+                      JOIN remote_track_link l
+                        ON l.remote_track_id = rt.remote_id AND l.status = 'confirmed'
+                      JOIN track t ON t.id = l.local_track_id
+                     WHERE rt.artist_id = ra.remote_id AND rt.in_catalogue = 1
+                       AND t.is_available = 1
+                       AND (t.primary_artist IS NULL OR t.primary_artist != la.id))
+              AND NOT EXISTS (
+                    SELECT 1 FROM track t
+                      JOIN remote_track_link l
+                        ON l.local_track_id = t.id AND l.status = 'confirmed'
+                      JOIN remote_track rt ON rt.remote_id = l.remote_track_id
+                     WHERE t.primary_artist = la.id AND t.is_available = 1
+                       AND rt.in_catalogue = 1
+                       AND (rt.artist_id IS NULL OR rt.artist_id != ra.remote_id))
+         )"
+        )
+    };
+}
+
 fn library_albums_sql(order_clause: &str) -> String {
+    let album_pair = album_pair_proven!();
     format!(
         r#"
         SELECT source, id, title, artist_name, year, track_count, total_duration_ms,
@@ -873,6 +1006,10 @@ fn library_albums_sql(order_clause: &str) -> String {
              -- visible while the user has narrowed to one local library reads
              -- as the filter having failed.
              WHERE ? IS NULL
+             -- One release, one entry: a server album proven to be the same
+             -- release as a local one is rendered from the local half rather
+             -- than beside it. See `album_pair_proven!`.
+               AND NOT ({album_pair})
           )
          WHERE (? IS NULL OR source = ?)
          {order_clause}
@@ -1042,6 +1179,7 @@ fn library_artist_order_clause(order_by: Option<&str>, direction: Option<&str>) 
 /// command needs an `AppState`, the query needs only a database, and the query
 /// is the part that can be wrong.
 fn library_artists_sql(order_clause: &str) -> String {
+    let artist_pair = artist_pair_proven!();
     format!(
         r#"
         SELECT source, id, name, track_count, album_count,
@@ -1082,6 +1220,9 @@ fn library_artists_sql(order_clause: &str) -> String {
              -- A local library filter is a filter over local libraries; see
              -- `list_library_albums`.
              WHERE ? IS NULL
+             -- One person, one entry. See `artist_pair_proven!` — a different
+             -- rule from the albums', because an artist is an open grouping.
+               AND NOT ({artist_pair})
           )
          WHERE (? IS NULL OR source = ?)
          {order_clause}
@@ -2921,6 +3062,259 @@ mod tests {
             .map(|row| row.1)
             .collect();
         assert_eq!(gone, vec!["R1".to_string(), "R2".to_string()]);
+    }
+
+    /// Mark a local track as examined — RFC-006's completeness frontier. Every
+    /// pairing test needs this, because an unexamined track can never pair.
+    async fn examine(pool: &SqlitePool, track_id: i64) {
+        sqlx::query(
+            "INSERT INTO local_full_hash (track_id, full_hash, file_size, file_modified, computed_at)
+             SELECT t.id, ?, t.file_size, t.file_modified, 0 FROM track t WHERE t.id = ?",
+        )
+        .bind("a".repeat(64))
+        .bind(track_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn link(pool: &SqlitePool, local: i64, remote: &str) {
+        sqlx::query(
+            "INSERT INTO remote_track_link
+                 (local_track_id, remote_track_id, method, verified_full_hash,
+                  status, playback_preference, confirmed_at, verified_at)
+             VALUES (?, ?, 'exact_full_hash', ?, 'confirmed', 'local_first', 0, 0)",
+        )
+        .bind(local)
+        .bind(remote)
+        .bind("0".repeat(64))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// A local album and a server album whose track sets are in complete
+    /// bijection are one release, and the listing shows it once.
+    #[tokio::test]
+    async fn an_album_pairs_only_on_a_complete_bijection() {
+        let pool = pool().await;
+        seed(&pool).await;
+        // The fixture's local album holds one track; give the server album one
+        // too, so a bijection is possible at all.
+        sqlx::raw_sql("DELETE FROM remote_track WHERE remote_id = 't-2'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::raw_sql("UPDATE remote_album SET song_count = 1, mirrored_at = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Linked but not yet examined: still two entries, because "no link" on
+        // an unexamined track cannot be read as "different bytes".
+        link(&pool, 1, "t-1").await;
+        let titles: Vec<String> = albums(&pool, None, None, library_album_order_clause(None, None))
+            .await
+            .into_iter()
+            .map(|row| row.1)
+            .collect();
+        assert_eq!(titles, vec!["Drukqs".to_string(), "Vespertine".to_string()]);
+
+        examine(&pool, 1).await;
+        let titles: Vec<String> = albums(&pool, None, None, library_album_order_clause(None, None))
+            .await
+            .into_iter()
+            .map(|row| row.1)
+            .collect();
+        assert_eq!(
+            titles,
+            vec!["Vespertine".to_string()],
+            "one release, one entry"
+        );
+    }
+
+    /// The case that killed the RFC's first draft: two releases sharing
+    /// recordings are not the same release, however unanimous the links.
+    #[tokio::test]
+    async fn sharing_recordings_is_not_being_the_same_album() {
+        let pool = pool().await;
+        seed(&pool).await;
+        sqlx::raw_sql("UPDATE remote_album SET mirrored_at = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        // The server album keeps two tracks; the local one has a single track
+        // linked to one of them. A "unanimity plus links" rule would pair them.
+        link(&pool, 1, "t-1").await;
+        examine(&pool, 1).await;
+
+        let titles: Vec<String> = albums(&pool, None, None, library_album_order_clause(None, None))
+            .await
+            .into_iter()
+            .map(|row| row.1)
+            .collect();
+        assert_eq!(
+            titles,
+            vec!["Drukqs".to_string(), "Vespertine".to_string()],
+            "an unmatched server track must keep the albums apart"
+        );
+    }
+
+    /// A bijection over two empty sets holds vacuously. It must not pair.
+    #[tokio::test]
+    async fn an_album_with_no_tracks_never_pairs() {
+        let pool = pool().await;
+        seed(&pool).await;
+        sqlx::raw_sql("DELETE FROM remote_track")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::raw_sql("UPDATE remote_album SET song_count = 0, mirrored_at = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::raw_sql("DELETE FROM track")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let sources: Vec<String> =
+            albums(&pool, None, None, library_album_order_clause(None, None))
+                .await
+                .into_iter()
+                .map(|row| row.0)
+                .collect();
+        assert_eq!(
+            sources,
+            vec!["remote".to_string()],
+            "the empty pair must not collapse"
+        );
+    }
+
+    /// A server album still being walked is a prefix, not a set, so nothing
+    /// pairs against it however complete the links look.
+    #[tokio::test]
+    async fn an_unwalked_album_never_pairs() {
+        let pool = pool().await;
+        seed(&pool).await;
+        sqlx::raw_sql("DELETE FROM remote_track WHERE remote_id = 't-2'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        link(&pool, 1, "t-1").await;
+        examine(&pool, 1).await;
+        // `mirrored_at` left NULL: the walk has not finished.
+        let titles: Vec<String> = albums(&pool, None, None, library_album_order_clause(None, None))
+            .await
+            .into_iter()
+            .map(|row| row.1)
+            .collect();
+        assert_eq!(titles.len(), 2, "{titles:?}");
+    }
+
+    /// Artists pair on a sample, not on a set — but the sample has to be more
+    /// than one link, and unanimous.
+    #[tokio::test]
+    async fn an_artist_pairs_on_two_unanimous_links() {
+        let pool = pool().await;
+        seed(&pool).await;
+        // A second local track by the same artist, so two links are possible.
+        sqlx::raw_sql(
+            "INSERT INTO track (id, library_id, file_path, file_hash, file_size, file_modified,
+                                title, album_id, duration_ms, added_at, is_available,
+                                primary_artist, hlc_wall, hlc_logical,
+                                rating_hlc_wall, rating_hlc_logical)
+             VALUES (2, 1, '/m/2.flac', 'h2', 2, 0, 'T2', 1, 300000, 500, 1, 1, 0, 0, 0, 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        examine(&pool, 1).await;
+        examine(&pool, 2).await;
+
+        link(&pool, 1, "t-1").await;
+        let names: Vec<String> =
+            artists(&pool, None, None, library_artist_order_clause(None, None))
+                .await
+                .into_iter()
+                .map(|row| row.1)
+                .collect();
+        assert_eq!(names.len(), 2, "one link is a coincidence, not evidence");
+
+        link(&pool, 2, "t-2").await;
+        let names: Vec<String> =
+            artists(&pool, None, None, library_artist_order_clause(None, None))
+                .await
+                .into_iter()
+                .map(|row| row.1)
+                .collect();
+        assert_eq!(names, vec!["Björk".to_string()], "two unanimous links pair");
+    }
+
+    /// Unanimity is what disposes of Various Artists, with no `is_compilation`
+    /// special case: a compilation's links point at several server artists, so
+    /// the disagreeing one ends the question.
+    #[tokio::test]
+    async fn a_disagreeing_link_keeps_two_artists_apart() {
+        let pool = pool().await;
+        seed(&pool).await;
+        sqlx::raw_sql(
+            "INSERT INTO track (id, library_id, file_path, file_hash, file_size, file_modified,
+                                title, album_id, duration_ms, added_at, is_available,
+                                primary_artist, hlc_wall, hlc_logical,
+                                rating_hlc_wall, rating_hlc_logical)
+             VALUES (2, 1, '/m/2.flac', 'h2', 2, 0, 'T2', 1, 300000, 500, 1, 1, 0, 0, 0, 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        // A third server track credited to somebody else entirely.
+        sqlx::raw_sql(
+            "INSERT INTO remote_artist (remote_id, name, sort_key, mirrored_at)
+             VALUES ('ar-2', 'Someone Else', 'someone else', 1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::raw_sql(
+            "INSERT INTO remote_track (remote_id, title, artist_id, duration_ms, cached_at,
+                                       in_catalogue)
+             VALUES ('t-9', 'R9', 'ar-2', 0, 1, 1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        examine(&pool, 1).await;
+        examine(&pool, 2).await;
+
+        link(&pool, 1, "t-1").await;
+        link(&pool, 2, "t-2").await;
+        // Two unanimous links would pair — but this local artist also owns a
+        // track linked to a different server artist.
+        sqlx::raw_sql(
+            "INSERT INTO track (id, library_id, file_path, file_hash, file_size, file_modified,
+                                title, duration_ms, added_at, is_available,
+                                primary_artist, hlc_wall, hlc_logical,
+                                rating_hlc_wall, rating_hlc_logical)
+             VALUES (3, 1, '/m/3.flac', 'h3', 3, 0, 'T3', 300000, 500, 1, 1, 0, 0, 0, 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        examine(&pool, 3).await;
+        link(&pool, 3, "t-9").await;
+
+        let names: Vec<String> =
+            artists(&pool, None, None, library_artist_order_clause(None, None))
+                .await
+                .into_iter()
+                .map(|row| row.1)
+                .collect();
+        assert_eq!(
+            names.len(),
+            3,
+            "a disagreeing link ends the question: {names:?}"
+        );
     }
 
     /// Rating is local-only, so the remote half has none. Sorting by it must


### PR DESCRIPTION
RFC-006's derivation. An album or artist held on both sides now renders **once** instead of twice — on proof, never on resemblance. No name is compared anywhere.

## Albums: a complete, non-empty bijection

Every track on each side confirmed-linked to one on the other, and **at least one** such link.

The one-to-one part comes free: `remote_track_link` is a primary key on the local id and `UNIQUE` on the remote one, so "each track has a partner" already means "exactly one".

The emptiness guard is not decoration. A bijection over two empty sets holds vacuously, so without it a local album would pair with a server walk that returned nothing.

## Artists: unanimity plus two links

Deliberately **not** the album rule. An album is a closed set — a release *is* its track list — while an artist is an open grouping where no discography is complete on either side, so demanding a bijection would pair nobody.

Disagreement is checked **from both directions**. Looking only from the server side would fold a local *Various Artists* into a real artist whenever the compilation's own tracks happened to agree.

## The frontier carries more weight than expected

A track counts as examined only when `local_full_hash` holds a valid entry for it, and a server album only when `mirrored_at` is set.

Combined with Decision 2's demand that **every** track be linked, an unexamined track cannot pair anything: it has no link, so the bijection fails and the entries stay apart. That was not obvious when the RFC was written, and it changes what the missing piece has to do — the per-entity generation now only has to catch the narrower case of a set that *was* fully examined and has changed since. RFC-006 is updated to say that rather than to keep describing the whole frontier as unbuilt.

## Tests

Six, two of which exist to pin the rules that were hardest to get right:

- `sharing_recordings_is_not_being_the_same_album` — the counter-example that killed the RFC's first draft. A local album sharing one recording with a two-track server album must stay separate, however unanimous the link.
- `a_disagreeing_link_keeps_two_artists_apart` — Various Artists surviving with no `is_compilation` special case anywhere in the predicate.
- `an_album_with_no_tracks_never_pairs` — the vacuous bijection.
- `an_unwalked_album_never_pairs` — a walk in progress is a prefix, not a set.
- `an_album_pairs_only_on_a_complete_bijection` — including that a *linked but unexamined* track still keeps the two entries apart.
- `an_artist_pairs_on_two_unanimous_links` — one link is a coincidence.

## Shape

Both predicates are shared string literals (`macro_rules!` + `concat!`), the way the mirror's deletion predicate is, so the album and artist listings cannot drift from one definition. They are joins over already-indexed columns rather than a materialised table — what RFC-006 asks for: measure before caching something whose invalidation paths outnumber its query sites.

## Checks

`typecheck` · `lint` · `cargo fmt --check` · `clippy --workspace --all-targets -D warnings` · the same with `--no-default-features --features updater` · 445 + 226 tests green.

https://claude.ai/code/session_01AV7JiUFv9n2ef2CxrMGvND


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Amélioration de la déduplication entre les catalogues local et distant.
  * Les albums distants sont masqués uniquement après une correspondance complète, confirmée et vérifiée.
  * Les artistes distants sont regroupés après confirmation de plusieurs correspondances cohérentes.
  * Les pistes distantes correspondantes peuvent être masquées lorsqu’un fichier local est toujours disponible.

* **Corrections**
  * Les éléments incomplets, non vérifiés, obsolètes ou présentant des liens divergents restent désormais visibles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->