### PR TITLE
docs(remote): a null in a track correction is a removal, never an omission

### DIFF
--- a/src-tauri/crates/app/src/remote/drain.rs
+++ b/src-tauri/crates/app/src/remote/drain.rs
@@ -479,12 +479,14 @@ async fn send(
             disc_number,
         } => {
             let path = format!("/api/v2/tracks/{track_id}");
-            // Every field, nulls included, because this endpoint is
-            // wholesale: the body states the corrections the track
-            // should carry afterwards, so an omitted field and a null
-            // one both say "no correction here". Spelling the nulls out
-            // makes the request say what it means instead of leaving it
-            // to be inferred from what is missing.
+            // Every field, nulls included. The endpoint is a partial
+            // patch in three states: absent leaves a correction alone,
+            // `null` removes it, a value sets it. `None` here means the
+            // editor emptied the field, which is a removal, so it has to
+            // reach the server as `null` — skipped, it would read as
+            // "leave it alone" and keep the old correction. A server
+            // from before waveflow-server #177 erased absent fields
+            // instead; the explicit null means the same on both.
             let song = client
                 .send_json(client.mutate(reqwest::Method::PATCH, &path, op).json(
                     &serde_json::json!({

--- a/src-tauri/crates/app/src/remote/mutation.rs
+++ b/src-tauri/crates/app/src/remote/mutation.rs
@@ -159,37 +159,42 @@ pub enum Mutation {
     },
     /// Corrections for one server track.
     ///
-    /// ## `None` means the opposite of what it means above
+    /// ## `None` is a removal, and must never become an omission
     ///
     /// Every other update in this enum is incremental: a field left
     /// `None` is unchanged, and emptying one needs its own `clear_*`
     /// verb because the server coalesces an absent field with an
-    /// explicit null. `PATCH /tracks/{id}` is **wholesale** — the body
-    /// is the complete set of corrections the track should carry
-    /// afterwards, so a field left out is not a field left alone, it is
-    /// a correction *removed*. That is why there are no `clear_*` flags
-    /// here, and why there must never be any: the empty value already
-    /// says it.
+    /// explicit null.
     ///
-    /// The consequence for callers is that they may not send a diff.
-    /// The whole form goes, or the corrections it failed to mention are
-    /// silently dropped.
+    /// `PATCH /tracks/{id}` distinguishes the two
+    /// (waveflow-server #177): a field **absent** from the body leaves
+    /// that correction alone, an explicit **`null`** removes it, and a
+    /// value sets it. `None` here is sent as that explicit `null` —
+    /// `drain.rs` spells every field out — so in this variant `None`
+    /// means "remove the correction", which is what an emptied input in
+    /// the tag editor means.
+    ///
+    /// **Never skip `None` fields when serialising, and never turn this
+    /// into a diff that omits the unchanged ones.** The server reads an
+    /// omitted field as "leave it alone": an editor that emptied a box
+    /// and sent nothing for it would keep the old correction, silently.
+    /// That is also why there are no `clear_*` flags here — the
+    /// explicit `null` already says it.
     ///
     /// ## Why only six fields
     ///
     /// The server also stores `sort_title`, `comment` and
     /// `musicbrainz_recording_id`. They are absent here because the tag
-    /// editor has no input for them, and under wholesale semantics
-    /// sending a field we cannot show the user is indistinguishable
-    /// from clearing it.
+    /// editor has no input for them, and left out of the body they are
+    /// left alone — so a correction another client made to one of them
+    /// survives an edit made here.
     ///
-    /// **That is sound only while this application is the sole writer
-    /// of `track_override`** — which it is today: the server's own web
-    /// client sends no such patch. The day a second writer appears,
-    /// this quietly erases somebody else's corrections, and the fix is
-    /// a server route returning the raw overrides. The track endpoint
-    /// cannot stand in for it: it answers the *merged* values, in which
-    /// a correction is indistinguishable from what the file said.
+    /// A server from before #177 treated the body as the complete set
+    /// and *erased* an omitted field, which is how those three used to
+    /// be dropped. The explicit nulls behave the same on both. The raw
+    /// corrections, beside what the file says, are at
+    /// `GET /tracks/{id}/overrides` for an editor that has to show
+    /// which is which.
     UpdateTrackMetadata {
         track_id: String,
         title: Option<String>,


### PR DESCRIPTION
## Summary

- The server's `PATCH /tracks/{id}` becomes a partial patch in three states (InstaZDLL/waveflow-server#184, fixing InstaZDLL/waveflow-server#177): a field **absent** leaves its correction alone, **`null`** removes it, a **value** sets it.
- **This client's behaviour does not change.** `remote/drain.rs` already spells every field out, `null` included, so an emptied field still reaches the server as a removal — against the new server and an older one alike. The server PR replays this client's request exactly as `drain.rs` sends it.
- What changes is what the comments tell the next reader. They justified the explicit nulls by wholesale semantics, and read that way they invite skipping `None` fields — which against the new server would **silently keep a correction the user had just emptied**. They now say the nulls are load-bearing, and that the three fields the editor has no input for (`sort_title`, `comment`, `musicbrainz_recording_id`) are left alone rather than erased.

## How I tested

- The diff touches comment lines only: filtering every `//` line out of `git diff` leaves nothing.
- `rustfmt --edition 2021 --check` on both files, with the repository's `rustfmt.toml`: exit 0, so the doc-comment syntax is valid and the formatting unchanged.
- The behaviour the comments describe is tested on the server side in InstaZDLL/waveflow-server#184, proven by inverting each half of the change.

## Checklist

- [x] Title uses Conventional Commits (`type(scope): subject`, kebab-case scope)
- [ ] `bun run lint` + `bun run typecheck` — not run: no TypeScript touched
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --all-targets` — not run locally: comment-only change, syntax checked with `rustfmt --check` instead; CI runs the full check
- [ ] UI strings / locales — not applicable, none changed
- [ ] `CLAUDE.md` and `docs/` — not applicable, no cross-cutting pattern changed
- [ ] Breaking change — none, comment-only

## Linked issues

Refs InstaZDLL/waveflow-server#177
Refs InstaZDLL/waveflow-server#184

Best merged after InstaZDLL/waveflow-server#184: until then the comments describe server semantics that are not deployed yet. The rule they state — never omit a `None` field — is safe against either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correctifs**
  - Les mises à jour des métadonnées des pistes appliquent désormais correctement les modifications partielles.
  - L’envoi explicite d’une valeur vide supprime la correction correspondante.
  - Les champs omis restent inchangés, évitant la suppression involontaire de métadonnées existantes.
  - Les champs non pris en charge ne modifient pas les corrections ajoutées par d’autres clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->