### PR TITLE
fix: start the resume point when play comes from mpd or the os media controls

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -66,7 +66,9 @@ That sequence was copy-pasted in `lib.rs` and `media_controls.rs` until #471 (th
 
 They're `async` and await rather than spawn: sync callers (souvlaki, tray, taskbar buttons) wrap in `tauri::async_runtime::spawn` themselves, async ones report the outcome back to their client. `player_actions::toggle_play_pause`, shared by the tray and the taskbar buttons, is sync: it pauses or resumes directly, and only spawns `player_actions::resume_last` from `Idle` / `Ended`. From those states the decoder has no track open and drops `AudioCmd::Resume`, so resuming means loading the persisted resume point — what the in-app Play button does through `player_resume_last`.
 
-`player_actions::play` is the same shape for surfaces with a *separate* Play button (the OS media overlay, MPD's `play` / `pause 0`): it resumes or loads the resume point and never pauses, so Play on a playing track does nothing instead of pausing it. Sending `AudioCmd::Resume` straight to the engine from those surfaces is what #609 was.
+`player_actions::play` is the same shape for surfaces with a _separate_ Play button (the OS media overlay, MPD's `play` / `pause 0`): it resumes or loads the resume point and never pauses, so Play on a playing track does nothing instead of pausing it. Sending `AudioCmd::Resume` straight to the engine from those surfaces is what #609 was.
+
+Both funnel into `resume_last`, which holds a one-at-a-time guard (`AudioEngine::begin_resume`, released on every exit path). Two Play events landing together would otherwise each read `Idle`, each await the database, and the second would restart the track the first had just started.
 
 ---
 

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -66,6 +66,8 @@ That sequence was copy-pasted in `lib.rs` and `media_controls.rs` until #471 (th
 
 They're `async` and await rather than spawn: sync callers (souvlaki, tray, taskbar buttons) wrap in `tauri::async_runtime::spawn` themselves, async ones report the outcome back to their client. `player_actions::toggle_play_pause`, shared by the tray and the taskbar buttons, is sync: it pauses or resumes directly, and only spawns `player_actions::resume_last` from `Idle` / `Ended`. From those states the decoder has no track open and drops `AudioCmd::Resume`, so resuming means loading the persisted resume point — what the in-app Play button does through `player_resume_last`.
 
+`player_actions::play` is the same shape for surfaces with a *separate* Play button (the OS media overlay, MPD's `play` / `pause 0`): it resumes or loads the resume point and never pauses, so Play on a playing track does nothing instead of pausing it. Sending `AudioCmd::Resume` straight to the engine from those surfaces is what #609 was.
+
 ---
 
 ## Database

--- a/docs/features/mpd.md
+++ b/docs/features/mpd.md
@@ -38,6 +38,8 @@ For contrast: a player whose audio lives in the webview (an `<audio>` element) h
 
 `next` / `previous` / `play <pos>` go through [`player_actions`](../../src-tauri/crates/app/src/player_actions.rs), shared with the tray menu and the OS media controls. That sequence (advance the queue → `emit_track_changed` → `emit_queue_changed` → hand the track to the decoder) used to be copy-pasted in `lib.rs` and `media_controls.rs`; MPD would have made it a third copy, each free to forget an emit and desync a surface. Any new non-frontend control surface should call into that module rather than re-deriving it.
 
+`play` / `playid` with no argument, `pause 0` and a bare `pause` go through it too. They used to send `AudioCmd::Resume` to the engine, which the decoder drops when no track is open, so `mpc play` did nothing after a launch or at the end of the queue (#609).
+
 ## Configuration
 
 Persisted in the global `app_setting` table — the listener is process-wide, not per-profile.

--- a/docs/features/playback.md
+++ b/docs/features/playback.md
@@ -127,6 +127,8 @@ Initialised after the main window exists (needs an HWND on Windows). State trans
 
 Play and Toggle from the overlay go through [`player_actions`](../../src-tauri/crates/app/src/player_actions.rs) rather than sending `AudioCmd::Resume` to the engine. The decoder only handles `Resume` inside its pause loop, so with nothing open it was dropped and Play did nothing at all — after a launch, and at the end of the queue (#609). `player_actions::play` resumes or loads the persisted resume point and never pauses; Toggle follows the tray's rule.
 
+The overlay also learns about the restored track **at launch**: `player_get_state` publishes it paused, at its persisted position, starting no audio — and only while the engine holds nothing, since once a track is loaded the decoder's own transitions own the overlay, and that command runs again on profile switch and re-hydration. Before that the only caller of `update_metadata` outside live radio was `emit_track_changed`, on an actual track start, so there was no session for Play to appear on (#609). What the `PlatformConfig` souvlaki is given here cannot express is advertising Previous / Next only when they would do something.
+
 The same `transition_state()` hook also feeds [`discord_presence.rs`](../../src-tauri/crates/app/src/discord_presence.rs) so the user's Discord profile mirrors the playing/paused state. Documented separately under [Integrations → Discord Rich Presence](integrations.md#discord-rich-presence).
 
 ## Playback speed (0.5× – 2×)

--- a/docs/features/playback.md
+++ b/docs/features/playback.md
@@ -125,6 +125,8 @@ Every failure path that ends with no output thread at all publishes `exclusive_o
 
 Initialised after the main window exists (needs an HWND on Windows). State transitions are driven through `transition_state()` so the OS overlay flips at the same instant as the in-app controls; the brief `Loading` state is skipped to avoid a 50 ms "controls flash off" between tracks.
 
+Play and Toggle from the overlay go through [`player_actions`](../../src-tauri/crates/app/src/player_actions.rs) rather than sending `AudioCmd::Resume` to the engine. The decoder only handles `Resume` inside its pause loop, so with nothing open it was dropped and Play did nothing at all — after a launch, and at the end of the queue (#609). `player_actions::play` resumes or loads the persisted resume point and never pauses; Toggle follows the tray's rule.
+
 The same `transition_state()` hook also feeds [`discord_presence.rs`](../../src-tauri/crates/app/src/discord_presence.rs) so the user's Discord profile mirrors the playing/paused state. Documented separately under [Integrations → Discord Rich Presence](integrations.md#discord-rich-presence).
 
 ## Playback speed (0.5× – 2×)

--- a/src-tauri/crates/app/src/audio/engine.rs
+++ b/src-tauri/crates/app/src/audio/engine.rs
@@ -357,6 +357,12 @@ pub struct AudioEngine {
     /// flap would otherwise queue two concurrent rebuilds that
     /// each interrupt the same track.
     rebuild_in_progress: std::sync::atomic::AtomicBool,
+    /// One resume at a time (#609). Two Play events landing together — a
+    /// double tap on the OS overlay, a client sending `play` twice — both
+    /// read `Idle` and both spawn `player_actions::resume_last`, which
+    /// awaits the database before sending its `LoadAndPlay`. The second
+    /// would restart the track the first just started.
+    resume_in_flight: std::sync::atomic::AtomicBool,
     /// Session-only kill switch for exclusive output after a flap storm
     /// (#322). Once tripped, every rebuild / hot-swap stays on cpal
     /// shared regardless of the `exclusive_output` preference, so a
@@ -553,6 +559,7 @@ impl AudioEngine {
             exclusive_output: std::sync::atomic::AtomicBool::new(exclusive_output),
             exclusive_output_active: std::sync::atomic::AtomicBool::new(exclusive_output_active),
             rebuild_in_progress: std::sync::atomic::AtomicBool::new(false),
+            resume_in_flight: std::sync::atomic::AtomicBool::new(false),
             exclusive_suppressed: std::sync::atomic::AtomicBool::new(false),
             exclusive_flaps: Mutex::new(FlapWindow::default()),
             rebuild_gate: Mutex::new(RebuildGate::default()),
@@ -586,6 +593,22 @@ impl AudioEngine {
     /// has played since.
     fn snapshot_radio_resume(&self) -> Option<RadioResumeState> {
         self.radio_resume.lock().ok().and_then(|g| g.clone())
+    }
+
+    /// Claim the right to run one resume, or `None` when another is
+    /// already in flight (#609).
+    ///
+    /// The guard clears the slot on every exit path, including the `?`
+    /// returns inside [`crate::player_actions::resume_last`] and a panic.
+    /// A leaked slot would leave Play dead for the rest of the session,
+    /// which is worse than the double load it prevents.
+    pub fn begin_resume(&self) -> Option<ResumeGuard<'_>> {
+        use std::sync::atomic::Ordering;
+        if self.resume_in_flight.swap(true, Ordering::AcqRel) {
+            None
+        } else {
+            Some(ResumeGuard(&self.resume_in_flight))
+        }
     }
 
     /// Borrow the shared atomic state — used by commands that need to read
@@ -1692,6 +1715,15 @@ impl AudioEngine {
     }
 }
 
+/// Releases the slot [`AudioEngine::begin_resume`] took, when dropped.
+pub struct ResumeGuard<'a>(&'a std::sync::atomic::AtomicBool);
+
+impl Drop for ResumeGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
 /// Whether the old output has to be released *before* the new one is
 /// opened, rather than the other way round. `old_is_exclusive` is `None`
 /// when there is no stream installed at all.
@@ -1889,6 +1921,29 @@ mod reopen_order_tests {
     #[test]
     fn shared_to_shared_has_nothing_to_reorder() {
         assert!(!must_release_before_reopening(Some(false), false));
+    }
+}
+
+#[cfg(test)]
+mod resume_guard_tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::ResumeGuard;
+
+    #[test]
+    fn the_slot_is_taken_once_and_released_on_drop() {
+        let slot = AtomicBool::new(false);
+        // The first Play claims it.
+        assert!(!slot.swap(true, Ordering::AcqRel));
+        {
+            let _guard = ResumeGuard(&slot);
+            // A second Play landing while the first resume is still
+            // awaiting the database finds the slot taken and backs off.
+            assert!(slot.swap(true, Ordering::AcqRel));
+        }
+        // Released on drop, including the `?` paths inside `resume_last`:
+        // a leaked slot would leave Play dead for the whole session.
+        assert!(!slot.load(Ordering::Acquire));
     }
 }
 

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -464,6 +464,7 @@ pub(crate) async fn emit_options_changed(app: &AppHandle, pool: &sqlx::SqlitePoo
 /// state without auto-playing.
 #[tauri::command]
 pub async fn player_get_state(
+    app: AppHandle,
     state: tauri::State<'_, AppState>,
     engine: tauri::State<'_, Arc<AudioEngine>>,
 ) -> AppResult<PlayerStateSnapshot> {
@@ -762,6 +763,33 @@ pub async fn player_get_state(
     if snapshot.state == "idle" && snapshot.position_ms == 0 {
         snapshot.position_ms = resumed_position;
     }
+
+    // Hand that restored track to the OS media overlay (#609). Until now
+    // the overlay showed no WaveFlow session at all before something
+    // played, so its Play button — which starts the resume point since
+    // this release — had nothing to appear on after a launch.
+    //
+    // Only while the engine holds nothing: once a track is loaded the
+    // decoder's own transitions own the overlay, and this command also
+    // runs on profile switch and re-hydration. Paused, at the persisted
+    // position, and nothing is started — the session describes exactly
+    // what Play would resume.
+    if snapshot.state == "idle" {
+        if let (Some(track), Some(controls)) = (
+            snapshot.current_track.as_ref(),
+            app.try_state::<crate::media_controls::MediaControlsHandle>(),
+        ) {
+            controls.update_metadata(
+                track.title.clone(),
+                track.artist_name.clone(),
+                track.album_title.clone(),
+                track.artwork_path.clone(),
+                track.duration_ms,
+            );
+            controls.update_playback(crate::audio::PlayerState::Paused, snapshot.position_ms);
+        }
+    }
+
     Ok(snapshot)
 }
 

--- a/src-tauri/crates/app/src/commands/player.rs
+++ b/src-tauri/crates/app/src/commands/player.rs
@@ -779,14 +779,22 @@ pub async fn player_get_state(
             snapshot.current_track.as_ref(),
             app.try_state::<crate::media_controls::MediaControlsHandle>(),
         ) {
-            controls.update_metadata(
-                track.title.clone(),
-                track.artist_name.clone(),
-                track.album_title.clone(),
-                track.artwork_path.clone(),
-                track.duration_ms,
-            );
-            controls.update_playback(crate::audio::PlayerState::Paused, snapshot.position_ms);
+            // Re-read the engine immediately before publishing. This
+            // command has just spent its time in the database, and a
+            // surface outside the window — a media key, MPD — can have
+            // started playback since the snapshot was taken. Laying a
+            // stale "restored track, paused" over a session that is
+            // already playing is worse than publishing nothing at all.
+            if engine.shared().state() == crate::audio::PlayerState::Idle {
+                controls.update_metadata(
+                    track.title.clone(),
+                    track.artist_name.clone(),
+                    track.album_title.clone(),
+                    track.artwork_path.clone(),
+                    track.duration_ms,
+                );
+                controls.update_playback(crate::audio::PlayerState::Paused, snapshot.position_ms);
+            }
         }
     }
 

--- a/src-tauri/crates/app/src/media_controls.rs
+++ b/src-tauri/crates/app/src/media_controls.rs
@@ -358,21 +358,18 @@ fn push_metadata(controls: &mut MediaControls, cached: &CachedMetadata) {
 /// profile DB pool is dispatched onto Tauri's tokio runtime.
 fn handle_event(event: MediaControlEvent, app: AppHandle) {
     match event {
-        MediaControlEvent::Play => {
-            let engine = app.state::<Arc<AudioEngine>>();
-            let _ = engine.send(AudioCmd::Resume);
-        }
+        // Both go through `player_actions`: a bare `AudioCmd::Resume` is
+        // dropped by the decoder when no track is open, which left Play
+        // dead on the overlay after a launch and at the end of the queue
+        // (#609). `play` resumes or loads the resume point and never
+        // pauses; `toggle_play_pause` is the rule the tray follows.
+        MediaControlEvent::Play => crate::player_actions::play(&app, "media_controls"),
         MediaControlEvent::Pause => {
             let engine = app.state::<Arc<AudioEngine>>();
             let _ = engine.send(AudioCmd::Pause);
         }
         MediaControlEvent::Toggle => {
-            let engine = app.state::<Arc<AudioEngine>>();
-            let cmd = match engine.shared().state() {
-                PlayerState::Playing => AudioCmd::Pause,
-                _ => AudioCmd::Resume,
-            };
-            let _ = engine.send(cmd);
+            crate::player_actions::toggle_play_pause(&app, "media_controls")
         }
         MediaControlEvent::Stop => {
             let engine = app.state::<Arc<AudioEngine>>();

--- a/src-tauri/crates/app/src/mpd/commands.rs
+++ b/src-tauri/crates/app/src/mpd/commands.rs
@@ -458,9 +458,10 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
 
         Command::Play(pos) => {
             match pos {
-                None => {
-                    let _ = ctx.engine().send(AudioCmd::Resume);
-                }
+                // Bare `play` resumes. Through `player_actions` because a
+                // bare `AudioCmd::Resume` is dropped when no track is
+                // open, so `mpc play` did nothing after a launch (#609).
+                None => player_actions::play(&ctx.app, SURFACE),
                 Some(p) => {
                     // A position past the end is an argument error in MPD, not
                     // a silent no-op / clamp. One snapshot for the bounds check
@@ -487,9 +488,8 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
 
         Command::PlayId(id) => {
             match id {
-                None => {
-                    let _ = ctx.engine().send(AudioCmd::Resume);
-                }
+                // Bare `playid` resumes, same as bare `play` (#609).
+                None => player_actions::play(&ctx.app, SURFACE),
                 Some(id) => {
                     // One snapshot for the id→position lookup AND the jump, so
                     // the position can't be resolved against one profile then
@@ -515,18 +515,17 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
         }
 
         Command::Pause(want) => {
-            let engine = ctx.engine();
-            let cmd = match want {
-                Some(true) => AudioCmd::Pause,
-                Some(false) => AudioCmd::Resume,
-                // Bare `pause` toggles, which is what a remote's single
-                // play/pause button sends.
-                None => match engine.shared().state() {
-                    PlayerState::Playing => AudioCmd::Pause,
-                    _ => AudioCmd::Resume,
-                },
-            };
-            let _ = engine.send(cmd);
+            match want {
+                Some(true) => {
+                    let _ = ctx.engine().send(AudioCmd::Pause);
+                }
+                // `pause 0` is an explicit resume; a bare `pause` toggles,
+                // which is what a remote's single play/pause button sends.
+                // Both go through `player_actions` so they start the resume
+                // point when the decoder has nothing open (#609).
+                Some(false) => player_actions::play(&ctx.app, SURFACE),
+                None => player_actions::toggle_play_pause(&ctx.app, SURFACE),
+            }
             ctx.idle.notify(Subsystem::Player);
             Ok(Response::new())
         }

--- a/src-tauri/crates/app/src/mpd/commands.rs
+++ b/src-tauri/crates/app/src/mpd/commands.rs
@@ -461,7 +461,16 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
                 // Bare `play` resumes. Through `player_actions` because a
                 // bare `AudioCmd::Resume` is dropped when no track is
                 // open, so `mpc play` did nothing after a launch (#609).
-                None => player_actions::play(&ctx.app, SURFACE),
+                None => {
+                    // Awaited, not spawned: MPD answers its client once the
+                    // work is done, so `status` and the `idle` notification
+                    // below describe the load that actually happened. A
+                    // failure is logged rather than ACKed — real MPD answers
+                    // OK to a bare `play` with nothing to play.
+                    if let Err(err) = player_actions::play_and_wait(&ctx.app).await {
+                        tracing::warn!(%err, surface = SURFACE, "mpd play: resume failed");
+                    }
+                }
                 Some(p) => {
                     // A position past the end is an argument error in MPD, not
                     // a silent no-op / clamp. One snapshot for the bounds check
@@ -489,7 +498,16 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
         Command::PlayId(id) => {
             match id {
                 // Bare `playid` resumes, same as bare `play` (#609).
-                None => player_actions::play(&ctx.app, SURFACE),
+                None => {
+                    // Awaited, not spawned: MPD answers its client once the
+                    // work is done, so `status` and the `idle` notification
+                    // below describe the load that actually happened. A
+                    // failure is logged rather than ACKed — real MPD answers
+                    // OK to a bare `play` with nothing to play.
+                    if let Err(err) = player_actions::play_and_wait(&ctx.app).await {
+                        tracing::warn!(%err, surface = SURFACE, "mpd play: resume failed");
+                    }
+                }
                 Some(id) => {
                     // One snapshot for the id→position lookup AND the jump, so
                     // the position can't be resolved against one profile then
@@ -523,7 +541,16 @@ pub async fn dispatch(ctx: &Ctx, session: &mut Session, cmd: Command) -> Result<
                 // which is what a remote's single play/pause button sends.
                 // Both go through `player_actions` so they start the resume
                 // point when the decoder has nothing open (#609).
-                Some(false) => player_actions::play(&ctx.app, SURFACE),
+                Some(false) => {
+                    // Awaited, not spawned: MPD answers its client once the
+                    // work is done, so `status` and the `idle` notification
+                    // below describe the load that actually happened. A
+                    // failure is logged rather than ACKed — real MPD answers
+                    // OK to a bare `play` with nothing to play.
+                    if let Err(err) = player_actions::play_and_wait(&ctx.app).await {
+                        tracing::warn!(%err, surface = SURFACE, "mpd play: resume failed");
+                    }
+                }
                 None => player_actions::toggle_play_pause(&ctx.app, SURFACE),
             }
             ctx.idle.notify(Subsystem::Player);

--- a/src-tauri/crates/app/src/player_actions.rs
+++ b/src-tauri/crates/app/src/player_actions.rs
@@ -153,7 +153,17 @@ pub async fn resume_last(app: &AppHandle) -> AppResult<()> {
     };
     commands::player::emit_track_changed(app, &state.paths, &track, Some(profile_id));
     let replay_gain = commands::player::fetch_replay_gain(&pool, track.id).await;
-    engine.send(AudioCmd::LoadAndPlay {
+    // The guard above can't cover the last stretch: once the command is in
+    // the channel, the decoder still has to pick it up, and until it
+    // transitions to `Loading` a Play landing in between reads `Idle` and
+    // starts a second resume. Publishing `Loading` here closes that window
+    // for every surface that gates on the state — `play`, the tray's
+    // `toggle_play_pause` — and the decoder emits the matching
+    // `player:state` a beat later. Restored if the send fails, so a dead
+    // channel can't leave the player claiming to load forever.
+    let previous = engine.shared().state();
+    engine.shared().set_state(PlayerState::Loading);
+    let sent = engine.send(AudioCmd::LoadAndPlay {
         path: track.as_path(),
         start_ms: position_ms,
         track_id: track.id,
@@ -161,7 +171,11 @@ pub async fn resume_last(app: &AppHandle) -> AppResult<()> {
         source_type: "manual".into(),
         source_id: None,
         replay_gain,
-    })
+    });
+    if sent.is_err() {
+        engine.shared().set_state(previous);
+    }
+    sent
 }
 
 /// Hand a track to the decoder and tell every listener about it.

--- a/src-tauri/crates/app/src/player_actions.rs
+++ b/src-tauri/crates/app/src/player_actions.rs
@@ -16,9 +16,9 @@
 //! sync callback thread (souvlaki, the tray) wrap these in
 //! `tauri::async_runtime::spawn` themselves, and callers already inside
 //! a task (MPD) just await, which lets them report success back to
-//! their client. [`toggle_play_pause`] is the exception: a menu item or
-//! a window message calls it, so it is sync and spawns the one branch
-//! that needs the database.
+//! their client. [`play`] and [`toggle_play_pause`] are the exceptions:
+//! a menu item, a window message or an OS-overlay callback calls them,
+//! so they are sync and spawn the one branch that needs the database.
 
 use std::sync::Arc;
 
@@ -49,6 +49,46 @@ pub enum Moved {
     Restarted,
     /// Nothing to move to — empty queue, or at an edge with repeat off.
     Nothing,
+}
+
+/// Start playing: resume a paused track, or load the resume point when
+/// nothing is open. Never pauses.
+///
+/// The counterpart of [`toggle_play_pause`] for surfaces that expose a
+/// *separate* Play button — the OS media overlay, MPD's `play` and
+/// `pause 0` — where a toggle would pause a playing track instead of
+/// doing nothing.
+///
+/// Those surfaces used to send `AudioCmd::Resume` straight to the engine.
+/// The decoder only handles it inside the pause loop, so with nothing
+/// open it was dropped and Play did nothing at all: after a launch, and
+/// at the end of the queue (#609).
+pub fn play(app: &AppHandle, label: &str) {
+    let Some(engine) = app.try_state::<Arc<AudioEngine>>() else {
+        return;
+    };
+    match engine.shared().state() {
+        // Already playing, or a track is already on its way: Play is a
+        // no-op here, not a restart.
+        PlayerState::Playing | PlayerState::Loading => {}
+        PlayerState::Paused => {
+            if let Err(err) = engine.send(AudioCmd::Resume) {
+                tracing::warn!(%err, "{label} play: send failed");
+            }
+        }
+        // No track open: `AudioCmd::Resume` would be dropped, so load the
+        // persisted resume point instead — what the in-app Play button
+        // does through `player_resume_last`.
+        PlayerState::Idle | PlayerState::Ended => {
+            let app = app.clone();
+            let label = label.to_owned();
+            tauri::async_runtime::spawn(async move {
+                if let Err(err) = resume_last(&app).await {
+                    tracing::warn!(%err, "{label} play: resume failed");
+                }
+            });
+        }
+    }
 }
 
 /// Pause when playing, resume when paused, otherwise start the resume

--- a/src-tauri/crates/app/src/player_actions.rs
+++ b/src-tauri/crates/app/src/player_actions.rs
@@ -63,31 +63,34 @@ pub enum Moved {
 /// The decoder only handles it inside the pause loop, so with nothing
 /// open it was dropped and Play did nothing at all: after a launch, and
 /// at the end of the queue (#609).
+/// Sync wrapper for callback threads (souvlaki, the tray): spawns
+/// [`play_and_wait`] and logs what it returns. A caller already inside a
+/// task awaits that directly instead, and can answer its client.
 pub fn play(app: &AppHandle, label: &str) {
+    let app = app.clone();
+    let label = label.to_owned();
+    tauri::async_runtime::spawn(async move {
+        if let Err(err) = play_and_wait(&app).await {
+            tracing::warn!(%err, "{label} play: failed");
+        }
+    });
+}
+
+/// [`play`]'s rule, awaited, so MPD can answer its client once the work
+/// is done rather than once it is queued.
+pub async fn play_and_wait(app: &AppHandle) -> AppResult<()> {
     let Some(engine) = app.try_state::<Arc<AudioEngine>>() else {
-        return;
+        return Ok(());
     };
     match engine.shared().state() {
         // Already playing, or a track is already on its way: Play is a
         // no-op here, not a restart.
-        PlayerState::Playing | PlayerState::Loading => {}
-        PlayerState::Paused => {
-            if let Err(err) = engine.send(AudioCmd::Resume) {
-                tracing::warn!(%err, "{label} play: send failed");
-            }
-        }
+        PlayerState::Playing | PlayerState::Loading => Ok(()),
+        PlayerState::Paused => engine.send(AudioCmd::Resume),
         // No track open: `AudioCmd::Resume` would be dropped, so load the
         // persisted resume point instead — what the in-app Play button
         // does through `player_resume_last`.
-        PlayerState::Idle | PlayerState::Ended => {
-            let app = app.clone();
-            let label = label.to_owned();
-            tauri::async_runtime::spawn(async move {
-                if let Err(err) = resume_last(&app).await {
-                    tracing::warn!(%err, "{label} play: resume failed");
-                }
-            });
-        }
+        PlayerState::Idle | PlayerState::Ended => resume_last(app).await,
     }
 }
 

--- a/src-tauri/crates/app/src/player_actions.rs
+++ b/src-tauri/crates/app/src/player_actions.rs
@@ -134,6 +134,17 @@ pub fn toggle_play_pause(app: &AppHandle, label: &str) {
 pub async fn resume_last(app: &AppHandle) -> AppResult<()> {
     let state = app.state::<AppState>();
     let engine = app.state::<Arc<AudioEngine>>();
+    // One resume at a time (#609). Two Play events landing together — a
+    // double tap on the OS overlay, a client sending `play` twice — both
+    // read `Idle` and both land here, and each awaits the database below
+    // before sending its `LoadAndPlay`, so the second would restart the
+    // track the first just started. Guarding here rather than in `play`
+    // covers every caller: the tray, the taskbar buttons and the in-app
+    // button through `player_resume_last`.
+    let Some(_resume) = engine.begin_resume() else {
+        tracing::debug!("resume already in flight; ignoring this play");
+        return Ok(());
+    };
     // One lock for both: two awaits could straddle a profile switch and
     // pair one profile's resume point with the other's id.
     let (pool, profile_id) = state.require_profile_snapshot().await?;


### PR DESCRIPTION
Closes #609.

## What was broken

Two halves, both about Play outside the window.

**Play did nothing.** The decoder only handles `AudioCmd::Resume` inside `play_track`'s pause loop; its idle loop drops every other command. In `Idle` or `Ended` no track is open, so a bare `Resume` went nowhere — right after a launch, and at the end of the queue. The in-app Play button has always loaded the persisted resume point in those states, and #608 gave the tray and the taskbar thumbnail buttons the same treatment. The OS media controls and MPD were still sending a bare `Resume`.

**The overlay showed nothing at launch.** `player_get_state` restores the last track for the PlayerBar, but the only caller of `MediaControlsHandle::update_metadata` outside live radio is `emit_track_changed`, on an actual track start. So the media flyout held no WaveFlow session until something played — and Play had nothing to appear on.

## The fix

`player_actions` gains **`play`**, the counterpart of `toggle_play_pause` for surfaces with a *separate* Play button:

| State | `play` |
| --- | --- |
| `Playing` / `Loading` | nothing — a Play is not a restart, and not a pause either |
| `Paused` | `AudioCmd::Resume` |
| `Idle` / `Ended` | `resume_last`, the persisted resume point |

Wired into the **OS media controls** (`Play` through `play`, `Toggle` through `toggle_play_pause` — it used to send `Resume` for every state but `Playing`, so it had the same hole) and into **MPD** (bare `play`, bare `playid`, `pause 0`, and the bare `pause` toggle). `handle_event` serves SMTC, MPRIS and MediaRemote alike.

And `player_get_state` now publishes the restored track to the overlay, **paused, at its persisted position, starting no audio** — only while the engine holds nothing, since once a track is loaded the decoder's own transitions own the overlay, and that command also runs on profile switch and re-hydration.

### One resume at a time

Raised in review: two Play events landing together both read `Idle` and both spawn `resume_last`, which awaits the database before sending its `LoadAndPlay`, so the second would restart the track the first had just started. `resume_last` now takes a one-at-a-time slot from the engine (`begin_resume`), released by an RAII guard on every exit path — a leaked slot would leave Play dead for the session, which is worse than the double load it prevents. It also publishes `Loading` before the send, closing the remaining window between the channel and the decoder's own transition, and restores the previous state if the send fails.

It guards `resume_last` rather than `play` so every caller is covered: the tray, the taskbar buttons and the in-app button could already race themselves the same way, before this PR.

## Deliberately not here

- **Ordering between different load producers.** A resume that started earlier can still land after a newer selection, because 17 places in the crate send a load command and each prepares asynchronously first. Serialising only the two functions this PR touches would read as a guarantee while fifteen other paths still reorder. Tracked as #622, with a generation taken when the intent starts and arbitrated in `AudioEngine::send`.
- **Advertising Previous / Next only when they would do something.** The `PlatformConfig` souvlaki is given here has no per-control availability.

## Verification

- `cargo fmt --check`, clippy on Windows with `-D warnings --all-targets`, and 490 app-crate tests green in CI, including the new `resume_guard_tests`.
- No frontend change: `player_get_state` gains an `AppHandle`, which Tauri injects.
- Manual smoke test still to do: `mpc play`, and the Windows flyout's Play on a restored track.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Les commandes Play des contrôles multimédias et de l’interface MPD reprennent la lecture sans mettre en pause un morceau déjà en cours.
  - La lecture peut reprendre un morceau en pause ou charger le dernier point de reprise lorsqu’aucune piste n’est active.
  - Le bouton Toggle applique désormais le même comportement.
  - Les reprises simultanées sont évitées.
  - Au démarrage, la piste restaurée apparaît comme pausée dans l’overlay multimédia, à sa position précédente.

- **Documentation**
  - Documentation mise à jour sur le comportement des contrôles multimédias et des commandes MPD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->